### PR TITLE
feat: examples, dashboard redesign, SDK polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <p align="center">
-  <img src="docs/patter-logo-banner.svg" alt="Patter" width="400" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/PatterAI/Patter/main/docs/patter-logo-banner.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/PatterAI/Patter/main/docs/patter-logo-banner.svg" />
+    <img src="https://raw.githubusercontent.com/PatterAI/Patter/main/docs/patter-logo-banner.svg" alt="Patter" width="400" />
+  </picture>
   <br />
-  <em>Connect AI agents to phone numbers with ~10 lines of code</em>
+  <em>Connect AI agents to phone numbers with 10 lines of code</em>
 </p>
 
 <p align="center">

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: "Connect AI agents to phone calls with ~10 lines of code"
+description: "Connect AI agents to phone calls with 10 lines of code"
 ---
 
 # What is Patter?
@@ -18,7 +18,7 @@ Your agent receives transcribed speech as text and returns a text response. Patt
 ## Key features
 
 <CardGroup cols={2}>
-  <Card title="~10 lines of code" icon="code">
+  <Card title="10 lines of code" icon="code">
     Write an async handler. Patter does the rest.
   </Card>
   <Card title="Python & TypeScript" icon="language">

--- a/docs/python-sdk/overview.mdx
+++ b/docs/python-sdk/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Python SDK"
-description: "Connect AI agents to phone numbers with ~10 lines of Python."
+description: "Connect AI agents to phone numbers with 10 lines of Python."
 ---
 
 # Python SDK

--- a/docs/typescript-sdk/overview.mdx
+++ b/docs/typescript-sdk/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "TypeScript SDK"
-description: "Connect AI agents to phone numbers with ~10 lines of TypeScript."
+description: "Connect AI agents to phone numbers with 10 lines of TypeScript."
 ---
 
 # TypeScript SDK

--- a/examples/developer/basic_inbound.py
+++ b/examples/developer/basic_inbound.py
@@ -1,0 +1,55 @@
+"""
+Basic Inbound Agent
+====================
+Minimal inbound voice agent that answers incoming calls as a friendly
+restaurant reservation assistant. Uses OpenAI Realtime under the hood --
+no custom STT/TTS configuration required.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise the Patter client ──────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Define the voice agent ────────────────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a friendly reservation assistant for La Dolce Vita, "
+        "an Italian restaurant in downtown San Francisco. Help callers "
+        "make, modify, or cancel reservations. Ask for the date, time, "
+        "party size, and a name for the reservation. Be warm and concise."
+    ),
+    voice="nova",
+    first_message=(
+        "Thanks for calling La Dolce Vita! "
+        "How can I help you with a reservation today?"
+    ),
+)
+
+# ── Start the server ──────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000))

--- a/examples/developer/basic_inbound.ts
+++ b/examples/developer/basic_inbound.ts
@@ -1,0 +1,47 @@
+/**
+ * @file basic_inbound.ts
+ * @description Minimal inbound voice agent using Patter SDK with OpenAI Realtime.
+ *
+ * A friendly restaurant reservation assistant that handles incoming calls.
+ * Listens on port 8000 for Twilio webhooks and connects callers to the
+ * OpenAI Realtime voice model.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - A Twilio phone number pointed at your webhook URL
+ *
+ * Usage:
+ *   npx ts-node basic_inbound.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a friendly reservation assistant for "La Cucina Bella",
+an Italian restaurant. Help callers book tables, answer questions about the menu,
+and provide directions. Be warm, concise, and professional. If the caller asks
+about availability, suggest the next open slot. Always confirm the reservation
+details before ending the call.`,
+  voice: "nova",
+  firstMessage:
+    "Hello! Thank you for calling La Cucina Bella. How can I help you today?",
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+  console.log("Inbound agent listening on port 8000");
+}
+
+main();

--- a/examples/developer/basic_outbound.py
+++ b/examples/developer/basic_outbound.py
@@ -1,0 +1,82 @@
+"""
+Basic Outbound Call
+====================
+Place an outbound call with answering-machine detection. If a voicemail
+is detected the agent leaves a pre-recorded message and hangs up.
+Includes on_call_start and on_call_end lifecycle callbacks.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise the Patter client ──────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Lifecycle callbacks ───────────────────────────────────────────────
+
+async def on_call_start(call):
+    """Fires when the call is connected."""
+    print(f"[started] Call {call.id} connected to {call.to}")
+
+
+async def on_call_end(call):
+    """Fires when the call ends (either party hangs up)."""
+    print(f"[ended]   Call {call.id} — duration {call.duration}s")
+
+
+# ── Define the voice agent ────────────────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are calling to remind the patient about their upcoming "
+        "dental appointment on Friday at 2:30 PM with Dr. Patel. "
+        "Confirm their attendance, offer to reschedule if needed, "
+        "and remind them to bring their insurance card. Be polite "
+        "and keep the call under one minute."
+    ),
+    voice="nova",
+    first_message=(
+        "Hi, this is a friendly reminder from Bright Smile Dental. "
+        "You have an appointment this Friday at 2:30 PM with Dr. Patel. "
+        "Will you be able to make it?"
+    ),
+)
+
+# ── Place the outbound call ───────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(
+        phone.call(
+            to="+15551234567",  # Replace with the recipient's number
+            agent=agent,
+            machine_detection=True,
+            voicemail_message=(
+                "Hi, this is Bright Smile Dental reminding you about your "
+                "appointment this Friday at 2:30 PM with Dr. Patel. "
+                "Please call us back at 555-987-6543 to confirm. Thank you!"
+            ),
+            on_call_start=on_call_start,
+            on_call_end=on_call_end,
+        )
+    )

--- a/examples/developer/basic_outbound.ts
+++ b/examples/developer/basic_outbound.ts
@@ -1,0 +1,60 @@
+/**
+ * @file basic_outbound.ts
+ * @description Outbound voice call with answering machine detection (AMD).
+ *
+ * Places a single outbound call using Patter SDK. When AMD detects a voicemail,
+ * the agent leaves a pre-configured message. Lifecycle callbacks log call start
+ * and end events.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - A verified Twilio phone number
+ *
+ * Usage:
+ *   npx ts-node basic_outbound.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a polite appointment reminder assistant for Dr. Smith's
+dental office. Remind the patient of their upcoming appointment, confirm the date
+and time, and ask if they need to reschedule. Keep the call brief and friendly.`,
+  voice: "nova",
+  firstMessage:
+    "Hi! This is a friendly reminder from Dr. Smith's dental office about your upcoming appointment.",
+});
+
+async function main(): Promise<void> {
+  const call = await phone.call({
+    to: "+15551234567",
+    agent,
+    machineDetection: true,
+    voicemailMessage:
+      "Hi, this is Dr. Smith's office calling to remind you of your upcoming appointment. Please call us back at your earliest convenience. Thank you!",
+    onCallStart: (event) => {
+      console.log(`Call started — SID: ${event.callSid}`);
+    },
+    onCallEnd: (event) => {
+      console.log(
+        `Call ended — duration: ${event.duration}s, status: ${event.status}`
+      );
+    },
+  });
+
+  console.log(`Outbound call placed — SID: ${call.sid}`);
+}
+
+main();

--- a/examples/developer/guardrails.py
+++ b/examples/developer/guardrails.py
@@ -1,0 +1,69 @@
+"""
+Output Guardrails
+==================
+Demonstrate how to attach guardrails that filter or replace agent
+output in real time. Two guardrail types are shown:
+
+1. **Blocked terms** -- a simple deny-list that scrubs competitor names.
+2. **Custom check** -- a callable that inspects each output chunk and
+   substitutes a safe replacement when the check fails.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise the Patter client ──────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Guardrail 1: block competitor mentions ────────────────────────────
+phone.guardrail(
+    name="no-competitors",
+    blocked_terms=["CompetitorA", "CompetitorB"],
+)
+
+# ── Guardrail 2: prevent specific pricing disclosure ─────────────────
+phone.guardrail(
+    name="no-pricing",
+    check=lambda text: "$" not in text,
+    replacement="I can't discuss specific pricing on this call.",
+)
+
+# ── Define the voice agent with both guardrails applied ───────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a sales representative for Acme Widgets. Answer "
+        "questions about our products, features, and general pricing "
+        "tiers (e.g. 'Starter', 'Pro', 'Enterprise'). Never mention "
+        "competitor products by name and never quote exact dollar amounts."
+    ),
+    voice="nova",
+    first_message="Hi there! I'm happy to tell you about Acme Widgets. What would you like to know?",
+    guardrails=["no-competitors", "no-pricing"],
+)
+
+# ── Start the server ──────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000))

--- a/examples/developer/guardrails.ts
+++ b/examples/developer/guardrails.ts
@@ -1,0 +1,60 @@
+/**
+ * @file guardrails.ts
+ * @description Voice agent with output guardrails.
+ *
+ * Demonstrates two guardrail types:
+ *   1. Blocked-terms guardrail — prevents the agent from mentioning competitors.
+ *   2. Custom-check guardrail — strips pricing information from responses.
+ *
+ * Guardrails run on every agent response before it reaches the caller, ensuring
+ * compliance without modifying the system prompt.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *
+ * Usage:
+ *   npx ts-node guardrails.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const noCompetitors = Patter.guardrail({
+  name: "no-competitors",
+  blockedTerms: ["CompetitorA", "CompetitorB", "RivalCorp"],
+});
+
+const noPricing = Patter.guardrail({
+  name: "no-pricing",
+  check: (text: string) => !text.includes("$"),
+  replacement:
+    "I'm not able to share specific pricing over the phone. I can email you a detailed quote — would that work?",
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a sales assistant for Acme Corp. Answer product questions,
+highlight features, and help callers understand how Acme solutions fit their needs.
+Never mention competitor products or share specific dollar amounts on the call.`,
+  voice: "nova",
+  firstMessage:
+    "Welcome to Acme Corp! I'd love to help you find the right solution. What are you looking for?",
+  guardrails: [noCompetitors, noPricing],
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+  console.log("Guardrails agent listening on port 8000");
+}
+
+main();

--- a/examples/developer/test_mode.py
+++ b/examples/developer/test_mode.py
@@ -1,0 +1,68 @@
+"""
+Test Mode
+==========
+Run the voice agent locally without telephony for rapid iteration.
+Messages are exchanged via the terminal. Useful for testing prompts,
+tools, and conversation flow before connecting a real phone number.
+
+Interactive commands (type in the terminal):
+    /quit      - End the test session
+    /transfer  - Simulate a call transfer
+    /hangup    - Simulate the caller hanging up
+    /history   - Print the full conversation history
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY - OpenAI API key
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise in local mode (no Twilio credentials needed) ───────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+)
+
+# ── Lifecycle callbacks ───────────────────────────────────────────────
+
+async def on_call_start(data: dict) -> None:
+    """Fires when the test call begins."""
+    print(f"  Call started: {data.get('call_id')}")
+
+
+async def on_call_end(data: dict) -> None:
+    """Fires when the test call ends."""
+    transcript = data.get("transcript", [])
+    print(f"  Call ended — {len(transcript)} messages exchanged")
+
+
+# ── Define the voice agent ────────────────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a helpful customer support agent for Acme Corp. "
+        "Answer questions about orders, returns, and shipping. "
+        "If you cannot help, offer to transfer the caller to a human agent."
+    ),
+    voice="nova",
+    first_message="Hello! Thanks for contacting Acme Corp support. How can I help you?",
+)
+
+# ── Run in test mode (terminal I/O, no telephony) ────────────────────
+if __name__ == "__main__":
+    asyncio.run(
+        phone.test(
+            agent,
+            on_call_start=on_call_start,
+            on_call_end=on_call_end,
+        )
+    )

--- a/examples/developer/test_mode.ts
+++ b/examples/developer/test_mode.ts
@@ -1,0 +1,53 @@
+/**
+ * @file test_mode.ts
+ * @description Test mode for local development without telephony.
+ *
+ * Runs the agent in an interactive terminal session. No Twilio credentials
+ * are required — type messages directly and see agent responses in real time.
+ *
+ * Special commands in test mode:
+ *   /quit     — end the session
+ *   /transfer — simulate a call transfer
+ *   /hangup   — simulate the caller hanging up
+ *   /history  — print the full conversation transcript
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY in .env
+ *
+ * Usage:
+ *   npx ts-node test_mode.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a helpful customer support agent for an e-commerce store.
+Assist customers with order status, returns, and product questions. Be concise
+and empathetic.`,
+  voice: "nova",
+  firstMessage: "Hi there! How can I help you with your order today?",
+});
+
+async function main(): Promise<void> {
+  await phone.test(agent, {
+    onMessage: (message) => {
+      console.log(`[${message.role}]: ${message.content}`);
+    },
+    onCallStart: () => {
+      console.log("--- Test session started ---");
+    },
+    onCallEnd: (event) => {
+      console.log(`--- Test session ended (${event.duration}s) ---`);
+    },
+  });
+}
+
+main();

--- a/examples/developer/tool_calling.py
+++ b/examples/developer/tool_calling.py
@@ -1,0 +1,105 @@
+"""
+Tool Calling
+=============
+Voice agent with in-process tool handlers. The agent can check
+availability and book appointments by invoking locally defined
+Python functions during the conversation.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise the Patter client ──────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Tool handlers ────────────────────────────────────────────────────
+# Replace these with real database queries in production.
+
+async def check_availability(arguments: dict, context: dict) -> str:
+    """Check if a given date/time slot is available."""
+    date = arguments.get("date", "")
+    time = arguments.get("time", "")
+    # Connect to your booking system here
+    booked = {"2026-04-12 14:00", "2026-04-12 15:00"}
+    available = f"{date} {time}" not in booked
+    if available:
+        return f"The slot on {date} at {time} is available."
+    return f"Sorry, {date} at {time} is already booked. Try another time."
+
+
+async def book_appointment(arguments: dict, context: dict) -> str:
+    """Book an appointment for the caller."""
+    name = arguments.get("name", "")
+    date = arguments.get("date", "")
+    time = arguments.get("time", "")
+    # Write to your database here
+    return f"Appointment confirmed for {name} on {date} at {time}. Confirmation code: APT-{date.replace('-', '')}-001."
+
+
+# ── Define the voice agent with tools ─────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a scheduling assistant for Bright Smile Dental. "
+        "Use the check_availability tool to see if a slot is open, "
+        "then use book_appointment to confirm the booking. Always "
+        "confirm the details with the caller before booking."
+    ),
+    voice="nova",
+    first_message="Hi! I can help you schedule a dental appointment. What date works for you?",
+    tools=[
+        Patter.tool(
+            name="check_availability",
+            description="Check whether a specific date and time slot is available.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "date": {"type": "string", "description": "Date in YYYY-MM-DD format"},
+                    "time": {"type": "string", "description": "Time in HH:MM format (24h)"},
+                },
+                "required": ["date", "time"],
+            },
+            handler=check_availability,
+        ),
+        Patter.tool(
+            name="book_appointment",
+            description="Book an appointment for a customer at the given date and time.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Customer's full name"},
+                    "date": {"type": "string", "description": "Date in YYYY-MM-DD format"},
+                    "time": {"type": "string", "description": "Time in HH:MM format (24h)"},
+                },
+                "required": ["name", "date", "time"],
+            },
+            handler=book_appointment,
+        ),
+    ],
+)
+
+# ── Start the server ──────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000))

--- a/examples/developer/tool_calling.ts
+++ b/examples/developer/tool_calling.ts
@@ -1,0 +1,85 @@
+/**
+ * @file tool_calling.ts
+ * @description In-process tool handlers for a scheduling voice agent.
+ *
+ * Registers two tools — checkAvailability and bookAppointment — that the voice
+ * agent can invoke mid-conversation. Tool results are fed back into the model
+ * so the agent can respond naturally with live data.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *
+ * Usage:
+ *   npx tsx tool_calling.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+// Replace these with real database queries in production.
+const BOOKED_SLOTS = new Set(["2026-04-12 14:00", "2026-04-12 15:00"]);
+
+const agent = phone.agent({
+  systemPrompt: `You are a scheduling assistant for a dental clinic. Use the
+checkAvailability tool to look up open slots and the bookAppointment tool to
+confirm bookings. Always verify the patient's preferred date before booking.`,
+  voice: "nova",
+  firstMessage: "Hello! I can help you schedule an appointment. What date works best for you?",
+  tools: [
+    Patter.tool({
+      name: "checkAvailability",
+      description: "Check available appointment slots for a given date and time.",
+      parameters: {
+        type: "object",
+        properties: {
+          date: { type: "string", description: "Date in YYYY-MM-DD format" },
+          time: { type: "string", description: "Time in HH:MM format (24h)" },
+        },
+        required: ["date", "time"],
+      },
+      handler: async ({ date, time }: { date: string; time: string }) => {
+        // Connect to your booking system here
+        const slot = `${date} ${time}`;
+        if (BOOKED_SLOTS.has(slot)) {
+          return `Sorry, ${date} at ${time} is already booked. Try another time.`;
+        }
+        return `The slot on ${date} at ${time} is available.`;
+      },
+    }),
+    Patter.tool({
+      name: "bookAppointment",
+      description: "Book an appointment at a specific date and time.",
+      parameters: {
+        type: "object",
+        properties: {
+          date: { type: "string", description: "Date in YYYY-MM-DD format" },
+          time: { type: "string", description: "Time slot in HH:MM format (24h)" },
+          name: { type: "string", description: "Patient full name" },
+        },
+        required: ["date", "time", "name"],
+      },
+      handler: async ({ date, time, name }: { date: string; time: string; name: string }) => {
+        // Write to your database here
+        const code = `APT-${date.replace(/-/g, "")}-001`;
+        return `Appointment confirmed for ${name} on ${date} at ${time}. Confirmation: ${code}.`;
+      },
+    }),
+  ],
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+}
+
+main();

--- a/examples/enterprise/custom_llm.py
+++ b/examples/enterprise/custom_llm.py
@@ -1,0 +1,97 @@
+"""
+Custom LLM Integration (Anthropic Claude)
+==========================================
+Use your own LLM instead of OpenAI Realtime. Patter handles STT, TTS,
+and telephony while you control the brain. This example uses Anthropic
+Claude via the Messages API, but any LLM works — OpenAI, Mistral,
+LLaMA, or your own fine-tuned model.
+
+Requirements:
+    pip install patter python-dotenv httpx
+
+Environment variables (.env):
+    ANTHROPIC_API_KEY    - Your Anthropic API key
+    DEEPGRAM_API_KEY     - Deepgram key for speech-to-text
+    ELEVENLABS_API_KEY   - ElevenLabs key for text-to-speech
+    TWILIO_ACCOUNT_SID   - Twilio account SID
+    TWILIO_AUTH_TOKEN    - Twilio auth token
+    TWILIO_PHONE_NUMBER  - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL          - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+SYSTEM_PROMPT = (
+    "You are a concise, friendly phone assistant for Acme Corp. "
+    "Help callers with account questions, billing, and general inquiries. "
+    "Keep responses under two sentences — this is a phone call, not a chat."
+)
+
+
+async def on_message(data: dict) -> str:
+    """Called each time the caller finishes speaking.
+
+    Patter transcribes speech via Deepgram (STT), passes the text here,
+    and synthesises your return value via ElevenLabs (TTS).
+
+    Args:
+        data: {"text": str, "history": [{"role": "user"|"assistant", "text": str}],
+               "call_id": str, "caller": str}
+    """
+    history = data["history"]
+
+    # Build the messages payload for Claude
+    messages = [{"role": m["role"], "content": m["text"]} for m in history]
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            "https://api.anthropic.com/v1/messages",
+            headers={
+                "x-api-key": ANTHROPIC_API_KEY,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 256,
+                "system": SYSTEM_PROMPT,
+                "messages": messages,
+            },
+        )
+        response.raise_for_status()
+        result = response.json()
+
+    return result["content"][0]["text"]
+
+
+# ── Initialise Patter in pipeline mode ───────────────────────────────
+phone = Patter(
+    mode="local",
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# Pipeline mode: Patter does STT + TTS, you provide the LLM
+agent = phone.agent(
+    provider="pipeline",
+    system_prompt=SYSTEM_PROMPT,
+    stt=Patter.deepgram(api_key=os.environ["DEEPGRAM_API_KEY"]),
+    tts=Patter.elevenlabs(api_key=os.environ["ELEVENLABS_API_KEY"], voice="aria"),
+    language="en",
+)
+
+# ── Start the server ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    print("Listening for calls (pipeline mode with Claude)...")
+    asyncio.run(phone.serve(agent, port=8000, on_message=on_message))

--- a/examples/enterprise/custom_llm.ts
+++ b/examples/enterprise/custom_llm.ts
@@ -1,0 +1,86 @@
+/**
+ * @file custom_llm.ts
+ * @description Bring your own LLM with Patter's pipeline mode.
+ *
+ * Patter handles speech-to-text and text-to-speech while you control the
+ * "brain" — any LLM, fine-tuned model, or deterministic logic. This example
+ * uses Anthropic Claude via a simple fetch call, but the pattern works with
+ * any HTTP-accessible model (OpenAI, Mistral, Llama, etc.).
+ *
+ * How it works:
+ *   1. Caller speaks -> Patter transcribes via Deepgram STT
+ *   2. Transcript arrives in your onMessage handler
+ *   3. You call your own LLM and return the response string
+ *   4. Patter speaks the response via ElevenLabs TTS
+ *
+ * Prerequisites:
+ *   - ANTHROPIC_API_KEY in .env (or whichever LLM you use)
+ *   - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER in .env
+ *   - DEEPGRAM_API_KEY, ELEVENLABS_API_KEY in .env
+ *   - WEBHOOK_URL pointing to this server (e.g. ngrok)
+ *
+ * Usage:
+ *   npx ts-node custom_llm.ts
+ */
+
+import { Patter, deepgram, elevenlabs } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: "You are a helpful enterprise support agent.",
+  provider: "pipeline",
+  stt: deepgram({ apiKey: process.env.DEEPGRAM_API_KEY! }),
+  tts: elevenlabs({ apiKey: process.env.ELEVENLABS_API_KEY!, voice: "rachel" }),
+  firstMessage: "Hello, how can I assist you today?",
+});
+
+/** Call your own LLM — replace with any model or routing logic. */
+async function callAnthropic(userMessage: string): Promise<string> {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": process.env.ANTHROPIC_API_KEY!,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 256,
+      system: agent.systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    }),
+  });
+
+  const body = (await response.json()) as Record<string, unknown>;
+  const content = body.content as Array<{ text: string }>;
+  return content[0].text;
+}
+
+async function main(): Promise<void> {
+  await phone.serve({
+    agent,
+    port: 8000,
+    onMessage: async (data) => {
+      const transcript = data.transcript as string;
+      console.log(`User said: ${transcript}`);
+
+      const reply = await callAnthropic(transcript);
+      console.log(`LLM replied: ${reply}`);
+      return reply;
+    },
+  });
+
+  console.log("Custom LLM agent listening on port 8000");
+}
+
+main();

--- a/examples/enterprise/dashboard_monitoring.py
+++ b/examples/enterprise/dashboard_monitoring.py
@@ -1,0 +1,122 @@
+"""
+Dashboard and Analytics Monitoring
+===================================
+Enable the built-in Patter dashboard for real-time call monitoring and
+use lifecycle callbacks to persist metrics to your own database.
+
+The dashboard is served at ``http://localhost:8000/dashboard`` and
+exposes a REST API for programmatic access.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY       - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID   - Twilio account SID
+    TWILIO_AUTH_TOKEN    - Twilio auth token
+    TWILIO_PHONE_NUMBER  - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL          - Public URL where Twilio can reach this server
+    DASHBOARD_TOKEN      - Secret token for dashboard authentication
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+DASHBOARD_TOKEN = os.getenv("DASHBOARD_TOKEN", "change-me-in-production")
+
+
+async def on_call_start(call: dict) -> None:
+    """Fires when a call connects. Log to your database."""
+    print(
+        f"[call:start] {call.get('call_id')} "
+        f"from {call.get('caller', 'unknown')} "
+        f"at {datetime.now(timezone.utc).isoformat()}"
+    )
+    # db.calls.insert({"call_id": call["call_id"], "started_at": utcnow(), ...})
+
+
+async def on_call_end(call: dict) -> None:
+    """Fires when a call ends. Save duration, transcript, and cost."""
+    print(
+        f"[call:end]   {call.get('call_id')} "
+        f"duration={call.get('duration', 0)}s "
+        f"turns={call.get('turns', 0)}"
+    )
+    # db.calls.update(
+    #     {"call_id": call["call_id"]},
+    #     {"ended_at": utcnow(), "duration": call["duration"],
+    #      "transcript": call.get("transcript"), "cost": call.get("cost")},
+    # )
+
+
+async def on_metrics(metrics: dict) -> None:
+    """Fires after each call with detailed cost and latency breakdown."""
+    print(
+        f"[metrics]    call={metrics.get('call_id')} "
+        f"cost=${metrics.get('cost', {}).get('total', 0):.4f} "
+        f"latency_avg={metrics.get('latency_avg', {}).get('total_ms', 0):.0f}ms"
+    )
+    # datadog.gauge("patter.call.cost", metrics["cost"]["total"])
+    # datadog.gauge("patter.call.latency_p95", metrics["latency_p95"]["total_ms"])
+
+
+# ── Dashboard REST API reference ─────────────────────────────────────
+#
+# All dashboard endpoints require the Authorization header when
+# dashboard_token is set:
+#   Authorization: Bearer <DASHBOARD_TOKEN>
+#
+# GET  /api/v1/calls                  — List recent calls (paginated)
+# GET  /api/v1/calls/:id              — Single call with transcript
+# GET  /api/v1/analytics/overview     — Aggregate stats (total calls,
+#                                        avg duration, avg cost, etc.)
+#
+# Example — fetch analytics with httpx:
+#
+#   import httpx
+#   resp = httpx.get(
+#       "http://localhost:8000/api/v1/analytics/overview",
+#       headers={"Authorization": f"Bearer {DASHBOARD_TOKEN}"},
+#   )
+#   print(resp.json())
+
+# ── Initialise Patter ────────────────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+agent = phone.agent(
+    system_prompt=(
+        "You are a helpful customer support agent for Acme Corp. "
+        "Answer questions about orders, billing, and account settings."
+    ),
+    voice="nova",
+    first_message="Hello, thank you for calling Acme Corp. How can I help?",
+)
+
+# ── Start with dashboard enabled ─────────────────────────────────────
+if __name__ == "__main__":
+    print(f"Dashboard: http://localhost:8000/dashboard (token: {DASHBOARD_TOKEN})")
+    asyncio.run(
+        phone.serve(
+            agent,
+            port=8000,
+            dashboard=True,
+            dashboard_token=DASHBOARD_TOKEN,
+            on_call_start=on_call_start,
+            on_call_end=on_call_end,
+            on_metrics=on_metrics,
+        )
+    )

--- a/examples/enterprise/dashboard_monitoring.ts
+++ b/examples/enterprise/dashboard_monitoring.ts
@@ -1,0 +1,83 @@
+/**
+ * @file dashboard_monitoring.ts
+ * @description Built-in dashboard and analytics for monitoring call quality.
+ *
+ * Patter ships with a dashboard UI and REST API for real-time observability.
+ * Enable it with a single flag and protect it with a bearer token.
+ *
+ * Dashboard endpoints (served automatically):
+ *   GET  /dashboard          — Web UI with live call feed and charts
+ *   GET  /api/calls          — JSON list of all calls with metrics
+ *   GET  /api/calls/:id      — Single call detail with transcript
+ *   GET  /api/export/csv     — Export calls as CSV
+ *   GET  /api/export/json    — Export calls as JSON
+ *   GET  /api/sse            — Server-Sent Events stream for live updates
+ *
+ * All /api/* routes require:
+ *   Authorization: Bearer <dashboardToken>
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - TWILIO_PHONE_NUMBER, WEBHOOK_URL in .env
+ *   - DASHBOARD_TOKEN in .env (any secret string)
+ *
+ * Usage:
+ *   npx ts-node dashboard_monitoring.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a customer success agent for Acme Corp.
+Help customers with billing, account, and product questions.`,
+  voice: "nova",
+  firstMessage: "Welcome to Acme Corp support. How can I help?",
+});
+
+async function main(): Promise<void> {
+  await phone.serve({
+    agent,
+    port: 8000,
+    dashboard: true,
+    dashboardToken: process.env.DASHBOARD_TOKEN ?? "change-me-in-production",
+
+    onCallEnd: async (data) => {
+      // Save metrics to your own data warehouse alongside the dashboard
+      const metrics = {
+        callId: data.callId,
+        duration: data.duration,
+        turns: data.turns,
+        avgLatency: data.avgLatency,
+        cost: data.cost,
+        timestamp: new Date().toISOString(),
+      };
+      console.log("Call metrics:", JSON.stringify(metrics));
+      // await dataWarehouse.insert("call_metrics", metrics);
+    },
+
+    onMetrics: async (data) => {
+      // Per-turn metrics — useful for latency alerting
+      if ((data.latencyMs as number) > 2000) {
+        console.warn(`High latency detected: ${data.latencyMs}ms on turn ${data.turn}`);
+        // await alerting.send("patter-latency", data);
+      }
+    },
+  });
+
+  console.log("Dashboard available at http://localhost:8000/dashboard");
+  console.log("API available at http://localhost:8000/api/calls");
+}
+
+main();

--- a/examples/enterprise/full_production.py
+++ b/examples/enterprise/full_production.py
@@ -1,0 +1,200 @@
+"""
+Full Production Setup
+=====================
+Complete production configuration with custom LLM, guardrails, tools,
+dynamic variables, recording, dashboard, and all lifecycle callbacks.
+Use this as a starting point for production deployments.
+
+Requirements:
+    pip install patter python-dotenv httpx
+
+Environment variables (.env):
+    ANTHROPIC_API_KEY    - Anthropic API key for Claude
+    DEEPGRAM_API_KEY     - Deepgram key for speech-to-text
+    ELEVENLABS_API_KEY   - ElevenLabs key for text-to-speech
+    TWILIO_ACCOUNT_SID   - Twilio account SID
+    TWILIO_AUTH_TOKEN    - Twilio auth token
+    TWILIO_PHONE_NUMBER  - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL          - Public URL where Twilio can reach this server
+    DASHBOARD_TOKEN      - Secret token for dashboard authentication
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+logger = logging.getLogger("production")
+
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+DASHBOARD_TOKEN = os.getenv("DASHBOARD_TOKEN", "change-me-in-production")
+
+SYSTEM_PROMPT = (
+    "You are a professional customer service agent for Acme Corp. "
+    "The caller's name is {customer_name} and their account ID is {account_id}. "
+    "Help with orders, billing, and account questions. "
+    "Never discuss competitor products or give medical/legal advice. "
+    "Keep responses concise — this is a phone call."
+)
+
+
+# ── Lifecycle callbacks ──────────────────────────────────────────────
+
+async def on_call_start(call: dict) -> dict | None:
+    """Log call start and optionally return variable overrides."""
+    logger.info("Call started: %s from %s", call.get("call_id"), call.get("caller"))
+    # Look up caller in your CRM and inject variables into the system prompt
+    # customer = await crm.lookup(call["caller"])
+    return {
+        "customer_name": "Jane Doe",   # Replace with CRM lookup
+        "account_id": "ACME-12345",    # Replace with CRM lookup
+    }
+
+
+async def on_call_end(call: dict) -> None:
+    """Save transcript and metrics to database."""
+    logger.info(
+        "Call ended: %s duration=%ss turns=%s",
+        call.get("call_id"),
+        call.get("duration", 0),
+        call.get("turns", 0),
+    )
+    # db.calls.insert({
+    #     "call_id": call["call_id"],
+    #     "caller": call.get("caller"),
+    #     "duration": call["duration"],
+    #     "transcript": call.get("transcript"),
+    #     "cost": call.get("cost"),
+    #     "ended_at": datetime.now(timezone.utc),
+    # })
+
+
+async def on_metrics(metrics: dict) -> None:
+    """Forward metrics to your monitoring system."""
+    cost = metrics.get("cost", {})
+    latency = metrics.get("latency_p95", {})
+    logger.info(
+        "Metrics: call=%s cost=$%.4f p95_latency=%dms",
+        metrics.get("call_id"),
+        cost.get("total", 0),
+        latency.get("total_ms", 0),
+    )
+    # datadog.gauge("patter.cost.total", cost["total"])
+    # datadog.gauge("patter.latency.p95", latency["total_ms"])
+
+
+async def on_message(data: dict) -> str:
+    """Custom LLM handler with fallback on error."""
+    history = data["history"]
+    messages = [{"role": m["role"], "content": m["text"]} for m in history]
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key": ANTHROPIC_API_KEY,
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                json={
+                    "model": "claude-sonnet-4-20250514",
+                    "max_tokens": 256,
+                    "system": SYSTEM_PROMPT,
+                    "messages": messages,
+                },
+            )
+            response.raise_for_status()
+            return response.json()["content"][0]["text"]
+    except Exception:
+        logger.exception("LLM request failed, returning fallback")
+        return (
+            "I'm sorry, I'm having a brief technical issue. "
+            "Could you repeat that, or I can transfer you to a human agent?"
+        )
+
+
+# ── Initialise Patter ────────────────────────────────────────────────
+
+phone = Patter(
+    mode="local",
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+    pricing={
+        "stt_per_minute": 0.0059,       # Deepgram Nova-2
+        "tts_per_1k_chars": 0.30,       # ElevenLabs
+        "llm_input_per_1k_tokens": 0.003,
+        "llm_output_per_1k_tokens": 0.015,
+        "telephony_per_minute": 0.014,   # Twilio
+    },
+)
+
+agent = phone.agent(
+    provider="pipeline",
+    system_prompt=SYSTEM_PROMPT,
+    stt=Patter.deepgram(api_key=os.environ["DEEPGRAM_API_KEY"]),
+    tts=Patter.elevenlabs(api_key=os.environ["ELEVENLABS_API_KEY"], voice="aria"),
+    language="en",
+    first_message="Hello {customer_name}, thanks for calling Acme Corp. How can I help?",
+    variables={
+        "customer_name": "Valued Customer",   # Default; overridden by on_call_start
+        "account_id": "unknown",
+    },
+    guardrails=[
+        Patter.guardrail(
+            name="no_competitor_mentions",
+            blocked_terms=["competitor", "rival product", "switch providers"],
+            replacement="I'd love to focus on how Acme can help you. What do you need?",
+        ),
+        Patter.guardrail(
+            name="no_medical_legal",
+            check=lambda text: any(
+                term in text.lower()
+                for term in ["diagnosis", "prescription", "legal advice", "lawsuit"]
+            ),
+            replacement="I'm not qualified to advise on that. Let me transfer you.",
+        ),
+    ],
+    tools=[
+        Patter.tool(
+            name="check_order_status",
+            description="Check the status of a customer order by order ID",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "order_id": {"type": "string", "description": "The order ID"},
+                },
+                "required": ["order_id"],
+            },
+            webhook_url="https://api.yourcompany.com/orders/status",
+        ),
+    ],
+)
+
+# ── Start the production server ──────────────────────────────────────
+if __name__ == "__main__":
+    logger.info("Starting production server on port 8000...")
+    logger.info("Dashboard: http://localhost:8000/dashboard")
+    asyncio.run(
+        phone.serve(
+            agent,
+            port=8000,
+            recording=True,
+            dashboard=True,
+            dashboard_token=DASHBOARD_TOKEN,
+            on_call_start=on_call_start,
+            on_call_end=on_call_end,
+            on_metrics=on_metrics,
+            on_message=on_message,
+        )
+    )

--- a/examples/enterprise/full_production.ts
+++ b/examples/enterprise/full_production.ts
@@ -1,0 +1,179 @@
+/**
+ * @file full_production.ts
+ * @description Complete production-ready Patter setup with all features enabled.
+ *
+ * This example demonstrates every major SDK capability in one file:
+ *   - Pipeline mode with custom LLM (Anthropic Claude)
+ *   - Tools (function calling) with local handlers
+ *   - Output guardrails for compliance
+ *   - Dynamic variables for per-call personalization
+ *   - Call recording via Twilio
+ *   - Dashboard with token authentication
+ *   - Custom pricing overrides for accurate cost tracking
+ *   - All lifecycle callbacks: onCallStart, onCallEnd, onMetrics, onMessage
+ *
+ * Prerequisites:
+ *   - All credentials in .env (see below)
+ *   - WEBHOOK_URL pointing to this server (e.g. ngrok or load balancer)
+ *
+ * Usage:
+ *   npx ts-node full_production.ts
+ */
+
+import { Patter, deepgram, elevenlabs } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a senior account manager for {company_name}.
+The caller is {caller_name} (account #{account_id}).
+Help them with billing, upgrades, and technical questions.
+Never discuss competitor pricing. Never share internal metrics.`,
+  provider: "pipeline",
+  stt: deepgram({ apiKey: process.env.DEEPGRAM_API_KEY! }),
+  tts: elevenlabs({ apiKey: process.env.ELEVENLABS_API_KEY!, voice: "rachel" }),
+  voice: "rachel",
+  firstMessage: "Hi {caller_name}, thanks for calling {company_name}. How can I help?",
+  variables: {
+    company_name: "Acme Corp",
+    caller_name: "Valued Customer",
+    account_id: "000000",
+  },
+  tools: [
+    {
+      name: "lookup_account",
+      description: "Look up a customer account by phone number or email.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Phone number or email" },
+        },
+        required: ["query"],
+      },
+      handler: async (args) => {
+        // Replace with your CRM / database lookup
+        console.log(`Tool: lookup_account("${args.query}")`);
+        return JSON.stringify({ name: "Jane Doe", plan: "Enterprise", balance: "$0.00" });
+      },
+    },
+    {
+      name: "create_ticket",
+      description: "Create a support ticket in the ticketing system.",
+      parameters: {
+        type: "object",
+        properties: {
+          subject: { type: "string" },
+          priority: { type: "string", enum: ["low", "medium", "high"] },
+        },
+        required: ["subject"],
+      },
+      handler: async (args) => {
+        console.log(`Tool: create_ticket("${args.subject}", ${args.priority})`);
+        return JSON.stringify({ ticketId: "TK-4821", status: "created" });
+      },
+    },
+  ],
+  guardrails: [
+    {
+      name: "competitor-mention",
+      blockedTerms: ["competitor-x", "rival-corp"],
+      replacement: "I can only discuss our own products and services.",
+    },
+    {
+      name: "pii-filter",
+      check: (text: string) => /\b\d{3}-\d{2}-\d{4}\b/.test(text),
+      replacement: "I'm not able to share sensitive personal information over the phone.",
+    },
+  ],
+});
+
+/** Call Anthropic Claude — swap with any LLM endpoint. */
+async function callLLM(transcript: string, callId: string): Promise<string> {
+  try {
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": process.env.ANTHROPIC_API_KEY!,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 300,
+        system: agent.systemPrompt,
+        messages: [{ role: "user", content: transcript }],
+      }),
+    });
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const content = body.content as Array<{ text: string }>;
+    return content[0].text;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown LLM error";
+    console.error(`LLM call failed for ${callId}: ${message}`);
+    return "I'm sorry, I'm experiencing a temporary issue. Please hold.";
+  }
+}
+
+async function main(): Promise<void> {
+  await phone.serve({
+    agent,
+    port: 8000,
+    recording: true,
+    dashboard: true,
+    dashboardToken: process.env.DASHBOARD_TOKEN!,
+
+    pricing: {
+      deepgram: { pricePerMinute: 0.0059 },
+      elevenlabs: { pricePerCharacter: 0.00003 },
+      twilio: { pricePerMinute: 0.014 },
+    },
+
+    onCallStart: async (data) => {
+      console.log(`[START] Call ${data.callId} from ${data.caller}`);
+      // Return overrides to personalize the agent per-call
+      // e.g. look up caller in CRM and inject their name
+    },
+
+    onCallEnd: async (data) => {
+      console.log(`[END] Call ${data.callId} — ${data.duration}s, ${data.turns} turns`);
+      // Save transcript and metrics to your data store
+      // await db.insert("call_logs", {
+      //   callId: data.callId,
+      //   transcript: data.transcript,
+      //   duration: data.duration,
+      //   cost: data.cost,
+      //   endedAt: new Date().toISOString(),
+      // });
+    },
+
+    onMetrics: async (data) => {
+      // Forward per-turn metrics to your monitoring stack
+      // await prometheus.gauge("patter_latency_ms", data.latencyMs);
+      // await prometheus.counter("patter_turns_total").inc();
+      if ((data.latencyMs as number) > 3000) {
+        console.warn(`[ALERT] High latency: ${data.latencyMs}ms on call ${data.callId}`);
+      }
+    },
+
+    onMessage: async (data) => {
+      const transcript = data.transcript as string;
+      const callId = data.callId as string;
+      return callLLM(transcript, callId);
+    },
+  });
+
+  console.log("Production agent running on port 8000");
+  console.log("Dashboard: http://localhost:8000/dashboard");
+}
+
+main();

--- a/examples/enterprise/multi_agent.py
+++ b/examples/enterprise/multi_agent.py
@@ -1,0 +1,113 @@
+"""
+Multi-Agent Setup (Multiple Numbers)
+=====================================
+Run multiple voice agents on separate phone numbers. Each agent has its
+own system prompt, voice, and tools — ideal for routing sales and
+support to different numbers within the same process.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY        - OpenAI API key with Realtime access
+    TWILIO_ACCOUNT_SID    - Twilio account SID
+    TWILIO_AUTH_TOKEN     - Twilio auth token
+    SALES_PHONE_NUMBER    - Phone number for the sales agent (E.164)
+    SUPPORT_PHONE_NUMBER  - Phone number for the support agent (E.164)
+    WEBHOOK_URL_SALES     - Public URL for the sales server
+    WEBHOOK_URL_SUPPORT   - Public URL for the support server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Sales agent ──────────────────────────────────────────────────────
+
+sales_phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("SALES_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL_SALES"),
+)
+
+sales_agent = sales_phone.agent(
+    system_prompt=(
+        "You are a persuasive but honest sales agent for Acme SaaS. "
+        "Help callers understand pricing plans, schedule demos, and "
+        "close deals. Always ask for their email to send a follow-up."
+    ),
+    voice="echo",
+    first_message="Hey there! Thanks for calling Acme Sales. What can I help you with?",
+    tools=[
+        Patter.tool(
+            name="schedule_demo",
+            description="Schedule a product demo for the caller",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "email": {"type": "string", "description": "Caller's email"},
+                    "preferred_date": {"type": "string", "description": "Preferred date"},
+                },
+                "required": ["email"],
+            },
+            webhook_url="https://api.yourcompany.com/demos/schedule",
+        ),
+    ],
+)
+
+# ── Support agent ────────────────────────────────────────────────────
+
+support_phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("SUPPORT_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL_SUPPORT"),
+)
+
+support_agent = support_phone.agent(
+    system_prompt=(
+        "You are a patient and knowledgeable support agent for Acme SaaS. "
+        "Help callers troubleshoot issues, check account status, and "
+        "escalate to a human when needed. Be empathetic and thorough."
+    ),
+    voice="nova",
+    first_message="Hi, you've reached Acme Support. What issue can I help you with?",
+    tools=[
+        Patter.tool(
+            name="lookup_account",
+            description="Look up a customer account by email or phone number",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "email": {"type": "string"},
+                    "phone": {"type": "string"},
+                },
+            },
+            webhook_url="https://api.yourcompany.com/accounts/lookup",
+        ),
+    ],
+)
+
+
+# ── Run both servers concurrently ────────────────────────────────────
+async def main() -> None:
+    print("Starting sales agent on port 8000...")
+    print("Starting support agent on port 8001...")
+    await asyncio.gather(
+        sales_phone.serve(sales_agent, port=8000),
+        support_phone.serve(support_agent, port=8001),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/enterprise/multi_agent.ts
+++ b/examples/enterprise/multi_agent.ts
@@ -1,0 +1,85 @@
+/**
+ * @file multi_agent.ts
+ * @description Run multiple agents on different phone numbers.
+ *
+ * Spin up separate Patter instances — each with its own phone number, prompt,
+ * and voice — on different ports. This pattern works well for:
+ *   - Routing sales and support to different numbers
+ *   - Running multilingual agents (English on one, Spanish on another)
+ *   - A/B testing different prompts on live traffic
+ *
+ * Each instance is fully independent: its own Twilio number, webhook URL,
+ * dashboard, and metrics.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY in .env
+ *   - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - Two phone numbers: SALES_PHONE_NUMBER, SUPPORT_PHONE_NUMBER
+ *   - Two webhook URLs: SALES_WEBHOOK_URL, SUPPORT_WEBHOOK_URL
+ *
+ * Usage:
+ *   npx ts-node multi_agent.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+// --- Sales agent ---
+const salesPhone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.SALES_PHONE_NUMBER!,
+  webhookUrl: process.env.SALES_WEBHOOK_URL!,
+});
+
+const salesAgent = salesPhone.agent({
+  systemPrompt: `You are a persuasive but honest sales representative for Acme Corp.
+Qualify leads, explain pricing tiers, and book demos. Never make promises
+the product cannot keep.`,
+  voice: "alloy",
+  firstMessage: "Thanks for calling Acme sales! What can I help you explore today?",
+});
+
+// --- Support agent ---
+const supportPhone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.SUPPORT_PHONE_NUMBER!,
+  webhookUrl: process.env.SUPPORT_WEBHOOK_URL!,
+});
+
+const supportAgent = supportPhone.agent({
+  systemPrompt: `You are a patient and thorough technical support agent for Acme Corp.
+Troubleshoot issues step by step, escalate to a human when needed,
+and always confirm the customer's problem is resolved before ending.`,
+  voice: "nova",
+  firstMessage: "Hello! You've reached Acme support. What issue are you experiencing?",
+});
+
+async function main(): Promise<void> {
+  await Promise.all([
+    salesPhone.serve({
+      agent: salesAgent,
+      port: 8000,
+      dashboard: true,
+      dashboardToken: process.env.SALES_DASHBOARD_TOKEN,
+    }),
+    supportPhone.serve({
+      agent: supportAgent,
+      port: 8001,
+      dashboard: true,
+      dashboardToken: process.env.SUPPORT_DASHBOARD_TOKEN,
+    }),
+  ]);
+
+  console.log("Sales agent   -> port 8000");
+  console.log("Support agent -> port 8001");
+}
+
+main();

--- a/examples/enterprise/remote_webhook.py
+++ b/examples/enterprise/remote_webhook.py
@@ -1,0 +1,89 @@
+"""
+Remote Webhook Handler
+======================
+Offload conversation logic to an external service. Instead of a local
+Python function, pass a URL as ``on_message`` — Patter POSTs each
+transcribed utterance to your backend and speaks the response.
+
+This is ideal for microservice architectures where the LLM / business
+logic runs on a separate server (e.g., behind a load balancer).
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    DEEPGRAM_API_KEY     - Deepgram key for speech-to-text
+    ELEVENLABS_API_KEY   - ElevenLabs key for text-to-speech
+    TWILIO_ACCOUNT_SID   - Twilio account SID
+    TWILIO_AUTH_TOKEN    - Twilio auth token
+    TWILIO_PHONE_NUMBER  - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL          - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+phone = Patter(
+    mode="local",
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+agent = phone.agent(
+    provider="pipeline",
+    system_prompt="You are a helpful assistant.",  # Used as fallback context
+    stt=Patter.deepgram(api_key=os.environ["DEEPGRAM_API_KEY"]),
+    tts=Patter.elevenlabs(api_key=os.environ["ELEVENLABS_API_KEY"], voice="aria"),
+    language="en",
+)
+
+# ── Remote webhook as on_message ─────────────────────────────────────
+#
+# When on_message is a URL string, Patter POSTs a JSON payload to it:
+#
+#   POST https://api.yourcompany.com/patter/message
+#   Headers:
+#     Content-Type: application/json
+#     X-Patter-Signature: sha256=<HMAC-SHA256 of body using your webhook secret>
+#
+#   Body:
+#     {
+#       "text": "What are your business hours?",
+#       "call_id": "CA1234567890abcdef",
+#       "caller": "+15551234567",
+#       "history": [
+#         {"role": "user", "text": "Hi there"},
+#         {"role": "assistant", "text": "Hello! How can I help?"},
+#         {"role": "user", "text": "What are your business hours?"}
+#       ]
+#     }
+#
+#   Expected response: {"text": "We're open Monday to Friday, 9 AM to 5 PM."}
+#
+# Verify the X-Patter-Signature header to ensure the request came from
+# Patter. Compute HMAC-SHA256 of the raw request body using your webhook
+# secret and compare with the header value.
+#
+# For low-latency streaming, use a WebSocket URL instead:
+#   on_message="wss://api.yourcompany.com/patter/stream"
+#
+# Patter sends the same JSON payload over the WebSocket and reads the
+# response as a single text frame.
+
+if __name__ == "__main__":
+    print("Listening for calls (remote webhook mode)...")
+    asyncio.run(
+        phone.serve(
+            agent,
+            port=8000,
+            on_message="https://api.yourcompany.com/patter/message",
+        )
+    )

--- a/examples/enterprise/remote_webhook.ts
+++ b/examples/enterprise/remote_webhook.ts
@@ -1,0 +1,75 @@
+/**
+ * @file remote_webhook.ts
+ * @description Route onMessage to a remote webhook or WebSocket endpoint.
+ *
+ * Instead of running LLM logic in-process, point onMessage at an external URL.
+ * Patter POSTs user transcripts to your server and speaks whatever your
+ * endpoint returns. This is ideal for:
+ *   - Keeping LLM logic behind your own firewall
+ *   - Sharing one message handler across multiple Patter instances
+ *   - Environments where you cannot run custom code alongside Patter
+ *
+ * Webhook contract:
+ *   POST https://api.yourcompany.com/patter/message
+ *   Headers:  Content-Type: application/json
+ *             X-Patter-Signature: <HMAC-SHA256 of body with your secret>
+ *   Body:     { "transcript": "...", "callId": "...", "caller": "..." }
+ *   Response: { "reply": "text to speak" }
+ *
+ * WebSocket alternative:
+ *   Pass a "wss://..." URL instead. Patter opens a persistent socket and
+ *   sends JSON frames with the same shape. Your server responds with
+ *   { "reply": "..." } frames.
+ *
+ * Prerequisites:
+ *   - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER in .env
+ *   - DEEPGRAM_API_KEY, ELEVENLABS_API_KEY in .env
+ *   - WEBHOOK_URL pointing to this server (e.g. ngrok)
+ *
+ * Usage:
+ *   npx ts-node remote_webhook.ts
+ */
+
+import { Patter, deepgram, elevenlabs } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: "You are an enterprise sales assistant.",
+  provider: "pipeline",
+  stt: deepgram({ apiKey: process.env.DEEPGRAM_API_KEY! }),
+  tts: elevenlabs({ apiKey: process.env.ELEVENLABS_API_KEY!, voice: "rachel" }),
+  firstMessage: "Hi there! I'd love to help you find the right plan.",
+});
+
+async function main(): Promise<void> {
+  // Pass a URL string as onMessage — Patter handles HTTP POST / WebSocket
+  // negotiation automatically. Your endpoint receives the transcript and
+  // returns the reply text.
+  await phone.serve({
+    agent,
+    port: 8000,
+    onMessage: "https://api.yourcompany.com/patter/message",
+    // WebSocket alternative:
+    // onMessage: "wss://api.yourcompany.com/patter/ws",
+    onCallStart: async (data) => {
+      console.log(`Call started — ID: ${data.callId}`);
+    },
+    onCallEnd: async (data) => {
+      console.log(`Call ended — duration: ${data.duration}s`);
+    },
+  });
+
+  console.log("Remote webhook agent listening on port 8000");
+}
+
+main();

--- a/examples/startup/call_transfer.py
+++ b/examples/startup/call_transfer.py
@@ -1,0 +1,78 @@
+"""
+Call Transfer
+=============
+Dynamic call transfer and hangup using CallControl. The on_message handler
+receives a CallControl object as its second argument, enabling mid-call
+actions like transferring to a human agent or ending the conversation.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+HUMAN_AGENT_NUMBER = "+15550001111"
+
+# ── Initialise ───────────────────────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Agent ────────────────────────────────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a friendly first-line support agent. Try to resolve the "
+        "caller's issue yourself. If they ask to speak to a human or a "
+        "manager, let them know you're transferring them. If they say "
+        "goodbye, wish them well and end the call."
+    ),
+    voice="alloy",
+    first_message="Hi there! I'm here to help — what can I do for you?",
+)
+
+
+# ── Message handler with call control ────────────────────────────────
+async def on_message(data: dict, call_control) -> str | None:
+    """Handle user messages with the ability to transfer or hang up."""
+    user_text = data.get("text", "").lower()
+
+    # Check if the call has already ended (transfer or hangup)
+    if call_control.ended:
+        return None
+
+    # Transfer to a human agent
+    if any(phrase in user_text for phrase in ("speak to human", "speak to a person", "transfer me", "talk to a manager")):
+        await call_control.transfer(HUMAN_AGENT_NUMBER)
+        return "Sure, let me transfer you to a team member right now."
+
+    # End the call gracefully
+    if any(phrase in user_text for phrase in ("goodbye", "bye", "that's all", "hang up")):
+        await call_control.hangup()
+        return "Thanks for calling! Have a great day."
+
+    # Fall back to the LLM for everything else
+    return None
+
+
+# ── Start the server ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000, on_message=on_message))

--- a/examples/startup/call_transfer.ts
+++ b/examples/startup/call_transfer.ts
@@ -1,0 +1,69 @@
+/**
+ * @file call_transfer.ts
+ * @description Call control with live transfer and hangup.
+ *
+ * Shows how to use the callControl parameter in onMessage to transfer
+ * callers to a human agent or gracefully end the call based on
+ * conversation context. The agent triages incoming calls and escalates
+ * when it cannot resolve the issue.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - A Twilio phone number pointed at your webhook URL
+ *
+ * Usage:
+ *   npx ts-node call_transfer.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const HUMAN_AGENT_NUMBER = process.env.TRANSFER_NUMBER ?? "+15551234567";
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a triage assistant for an insurance company. Help callers
+with simple questions about their policy. If the caller needs to file a claim
+or requests to speak with a human, let them know you are transferring them.
+If the caller says "goodbye" or the issue is resolved, end the call politely.`,
+  firstMessage: "Hello! Welcome to SafeGuard Insurance. How can I assist you today?",
+});
+
+agent.onMessage((message, callControl) => {
+  console.log(`[${message.role}] ${message.content}`);
+
+  if (callControl.ended) {
+    console.log("Call has already ended, skipping control logic.");
+    return;
+  }
+
+  const text = message.content.toLowerCase();
+
+  if (text.includes("transferring you") || text.includes("connect you to a human")) {
+    console.log(`Transferring call to ${HUMAN_AGENT_NUMBER}...`);
+    callControl.transfer(HUMAN_AGENT_NUMBER);
+    return;
+  }
+
+  if (text.includes("goodbye") || text.includes("have a great day")) {
+    console.log("Ending call gracefully.");
+    callControl.hangup();
+  }
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+  console.log("Call-transfer agent listening on port 8000");
+}
+
+main();

--- a/examples/startup/cost_tracking.py
+++ b/examples/startup/cost_tracking.py
@@ -1,0 +1,95 @@
+"""
+Cost Tracking
+=============
+Track per-call costs across STT, TTS, LLM, and telephony providers.
+Essential for startups monitoring unit economics and optimising their
+voice AI spend.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key
+    DEEPGRAM_API_KEY    - Deepgram API key
+    ELEVENLABS_API_KEY  - ElevenLabs API key
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise with custom pricing rates (USD per minute / per unit) ─
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    deepgram_key=os.getenv("DEEPGRAM_API_KEY"),
+    elevenlabs_key=os.getenv("ELEVENLABS_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+    pricing={
+        "deepgram": {"price": 0.005},
+        "elevenlabs": {"price": 0.018},
+        "openai": {"price": 0.012},
+        "twilio": {"price": 0.015},
+    },
+)
+
+# ── Agent ────────────────────────────────────────────────────────────
+agent = phone.agent(
+    provider="pipeline",
+    stt=Patter.deepgram(api_key=os.getenv("DEEPGRAM_API_KEY"), language="en"),
+    tts=Patter.elevenlabs(api_key=os.getenv("ELEVENLABS_API_KEY"), voice="rachel"),
+    system_prompt="You are a helpful billing assistant. Keep answers short.",
+    first_message="Hi! How can I help with your account today?",
+)
+
+
+# ── Real-time cost updates per turn ─────────────────────────────────
+async def on_metrics(metrics: dict) -> None:
+    """Fires after each conversation turn with updated metrics."""
+    cost = metrics.get("cost", {})
+    print(f"  [metrics] Turn cost — STT: ${cost.get('stt', 0):.4f}  "
+          f"TTS: ${cost.get('tts', 0):.4f}  LLM: ${cost.get('llm', 0):.4f}")
+
+
+# ── End-of-call cost report ──────────────────────────────────────────
+async def on_call_end(data: dict) -> None:
+    """Print a formatted cost breakdown when the call ends."""
+    metrics = data.get("metrics", {})
+    cost = metrics.get("cost", {})
+    duration = metrics.get("duration_seconds", 0)
+
+    print("\n╔══════════════════════════════════════╗")
+    print("║         CALL COST REPORT             ║")
+    print("╠══════════════════════════════════════╣")
+    print(f"║  Duration:    {duration:>6.1f}s               ║")
+    print(f"║  STT:         ${cost.get('stt', 0):>7.4f}              ║")
+    print(f"║  TTS:         ${cost.get('tts', 0):>7.4f}              ║")
+    print(f"║  LLM:         ${cost.get('llm', 0):>7.4f}              ║")
+    print(f"║  Telephony:   ${cost.get('telephony', 0):>7.4f}              ║")
+    print(f"║  ─────────────────────               ║")
+    print(f"║  TOTAL:       ${cost.get('total', 0):>7.4f}              ║")
+    print("╚══════════════════════════════════════╝\n")
+
+
+# ── Start the server ────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(
+        phone.serve(
+            agent,
+            port=8000,
+            on_metrics=on_metrics,
+            on_call_end=on_call_end,
+        )
+    )

--- a/examples/startup/cost_tracking.ts
+++ b/examples/startup/cost_tracking.ts
@@ -1,0 +1,69 @@
+/**
+ * @file cost_tracking.ts
+ * @description Real-time and per-call cost tracking for voice agents.
+ *
+ * Demonstrates how to configure per-provider pricing, monitor costs
+ * in real time via onMetrics, and generate a cost breakdown report
+ * when each call ends. Essential for startups watching unit economics.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - DEEPGRAM_API_KEY in .env
+ *   - A Twilio phone number pointed at your webhook URL
+ *
+ * Usage:
+ *   npx ts-node cost_tracking.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+  pricing: {
+    deepgram: { price: 0.005 },
+  },
+});
+
+const agent = phone.agent({
+  provider: "pipeline",
+  stt: Patter.deepgram({
+    apiKey: process.env.DEEPGRAM_API_KEY!,
+    language: "en",
+  }),
+  systemPrompt: `You are a helpful billing support agent. Answer questions about
+invoices, payment methods, and account balances. Be clear and accurate.`,
+  firstMessage: "Hello! I'm your billing assistant. What can I help you with?",
+});
+
+agent.onMetrics((metrics) => {
+  console.log(`[metrics] STT: $${metrics.cost.stt.toFixed(4)} | LLM: $${metrics.cost.llm.toFixed(4)} | TTS: $${metrics.cost.tts.toFixed(4)}`);
+});
+
+agent.onCallEnd((summary) => {
+  const { cost } = summary.metrics;
+  const total = cost.stt + cost.llm + cost.tts + cost.telephony;
+
+  console.log("\n--- Call Cost Report ---");
+  console.log(`Duration:   ${summary.metrics.durationSeconds}s`);
+  console.log(`STT:        $${cost.stt.toFixed(4)}`);
+  console.log(`LLM:        $${cost.llm.toFixed(4)}`);
+  console.log(`TTS:        $${cost.tts.toFixed(4)}`);
+  console.log(`Telephony:  $${cost.telephony.toFixed(4)}`);
+  console.log(`Total:      $${total.toFixed(4)}`);
+  console.log("------------------------\n");
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+  console.log("Cost-tracked agent listening on port 8000");
+}
+
+main();

--- a/examples/startup/dynamic_variables.py
+++ b/examples/startup/dynamic_variables.py
@@ -1,0 +1,86 @@
+"""
+Dynamic Variables
+=================
+Variable substitution in system prompts for personalised agent behaviour.
+Define placeholders like {customer_name} in the prompt and supply default
+values via the agent config. Override them dynamically at call start based
+on the caller's identity.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise ───────────────────────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Agent with placeholder variables in the system prompt ────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a scheduling assistant for Acme Health. "
+        "You are speaking with {customer_name} (account {account_number}). "
+        "Their next appointment is on {appointment_date}. "
+        "Help them reschedule, confirm, or cancel their appointment. "
+        "Always address them by name and reference their appointment date."
+    ),
+    voice="nova",
+    first_message="Hi {customer_name}! I see your appointment on {appointment_date}. How can I help?",
+    variables={
+        "customer_name": "Jane Doe",
+        "account_number": "AC-12345",
+        "appointment_date": "March 20th",
+    },
+)
+
+# ── Customer database (keyed by caller phone number) ────────────────
+CUSTOMER_DB: dict[str, dict[str, str]] = {
+    "+14155551234": {
+        "customer_name": "Alice Chen",
+        "account_number": "AC-78901",
+        "appointment_date": "April 3rd",
+    },
+    "+14155555678": {
+        "customer_name": "Bob Martinez",
+        "account_number": "AC-45678",
+        "appointment_date": "April 10th",
+    },
+}
+
+
+# ── Override variables at call start based on caller ID ──────────────
+async def on_call_start(data: dict) -> dict | None:
+    """Return dynamic variable overrides based on who is calling."""
+    caller = data.get("caller", "")
+    customer = CUSTOMER_DB.get(caller)
+    if customer:
+        print(f"[call_start] Known caller {caller} → {customer['customer_name']}")
+        return {"variables": customer}
+    print(f"[call_start] Unknown caller {caller} — using default variables")
+    return None
+
+
+# ── Start the server ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000, on_call_start=on_call_start))

--- a/examples/startup/dynamic_variables.ts
+++ b/examples/startup/dynamic_variables.ts
@@ -1,0 +1,73 @@
+/**
+ * @file dynamic_variables.ts
+ * @description Variable substitution in system prompts for personalized calls.
+ *
+ * Uses placeholder tokens like {customerName} and {accountNumber} in the
+ * system prompt, then resolves them at call time via the variables config
+ * and onCallStart overrides. This lets you reuse a single agent definition
+ * across many callers with personalized context.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *
+ * Usage:
+ *   npx tsx dynamic_variables.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+// Customer database keyed by phone number.
+// Replace with a real database lookup in production.
+const CUSTOMERS: Record<string, Record<string, string>> = {
+  "+14155551234": {
+    customerName: "Alice Chen",
+    accountNumber: "AC-78901",
+    planTier: "Enterprise",
+  },
+  "+14155555678": {
+    customerName: "Bob Martinez",
+    accountNumber: "AC-45678",
+    planTier: "Starter",
+  },
+};
+
+const agent = phone.agent({
+  systemPrompt: `You are a personal account manager for {customerName}.
+Their account number is {accountNumber} and their plan is {planTier}.
+Greet them by name, answer billing questions, and offer relevant upgrades
+based on their current plan. Be warm and concise.`,
+  firstMessage: "Hi {customerName}! Thanks for calling. How can I help you today?",
+  variables: {
+    customerName: "Valued Customer",
+    accountNumber: "unknown",
+    planTier: "Free",
+  },
+});
+
+async function onCallStart(data: Record<string, unknown>): Promise<Record<string, unknown> | void> {
+  const caller = data.caller as string;
+  const customer = CUSTOMERS[caller];
+  if (customer) {
+    console.log(`Known caller ${caller} → ${customer.customerName}`);
+    return { variables: customer };
+  }
+  console.log(`Unknown caller ${caller} — using default variables`);
+}
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000, onCallStart });
+}
+
+main();

--- a/examples/startup/pipeline_custom_voice.py
+++ b/examples/startup/pipeline_custom_voice.py
@@ -1,0 +1,72 @@
+"""
+Pipeline Custom Voice
+=====================
+Pipeline mode with Deepgram STT + ElevenLabs TTS for startups that want
+granular control over their speech providers. This is ideal for optimising
+cost and latency by choosing best-in-class providers independently.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key (used for the LLM turn)
+    DEEPGRAM_API_KEY    - Deepgram API key for speech-to-text
+    ELEVENLABS_API_KEY  - ElevenLabs API key for text-to-speech
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise the Patter client with all provider keys ──────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    deepgram_key=os.getenv("DEEPGRAM_API_KEY"),
+    elevenlabs_key=os.getenv("ELEVENLABS_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Define a pipeline agent with custom STT / TTS ───────────────────
+agent = phone.agent(
+    provider="pipeline",
+    stt=Patter.deepgram(api_key=os.getenv("DEEPGRAM_API_KEY"), language="en"),
+    tts=Patter.elevenlabs(api_key=os.getenv("ELEVENLABS_API_KEY"), voice="rachel"),
+    system_prompt=(
+        "You are a friendly startup onboarding assistant. Help new users "
+        "set up their account, choose a plan, and understand the product. "
+        "Be concise and enthusiastic."
+    ),
+    voice="rachel",
+    first_message="Hey there! Welcome aboard — let me help you get started.",
+)
+
+
+# ── Custom message handler ───────────────────────────────────────────
+async def on_message(data: dict) -> str:
+    """Process the user's transcribed text and return a response."""
+    user_text = data.get("text", "")
+    if "pricing" in user_text.lower():
+        return (
+            "We have three plans: Starter at $29/month, Growth at $99/month, "
+            "and Enterprise with custom pricing. Which sounds right for you?"
+        )
+    # Fall back to the LLM for everything else
+    return None
+
+
+# ── Start the server with recording enabled ──────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000, recording=True, on_message=on_message))

--- a/examples/startup/pipeline_custom_voice.ts
+++ b/examples/startup/pipeline_custom_voice.ts
@@ -1,0 +1,57 @@
+/**
+ * @file pipeline_custom_voice.ts
+ * @description Pipeline mode voice agent with custom STT/TTS providers.
+ *
+ * Combines Deepgram for speech-to-text and ElevenLabs for text-to-speech
+ * in pipeline mode, giving startups full control over the voice stack
+ * while keeping orchestration simple.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - DEEPGRAM_API_KEY, ELEVENLABS_API_KEY in .env
+ *   - A Twilio phone number pointed at your webhook URL
+ *
+ * Usage:
+ *   npx ts-node pipeline_custom_voice.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  provider: "pipeline",
+  stt: Patter.deepgram({
+    apiKey: process.env.DEEPGRAM_API_KEY!,
+    language: "en",
+  }),
+  tts: Patter.elevenlabs({
+    apiKey: process.env.ELEVENLABS_API_KEY!,
+    voice: "rachel",
+  }),
+  systemPrompt: `You are a friendly scheduling assistant for a dental clinic.
+Help callers book, reschedule, or cancel appointments. Confirm all details
+before finalizing. Keep responses concise and professional.`,
+  firstMessage: "Hi there! Thanks for calling Bright Smile Dental. How can I help you today?",
+});
+
+agent.onMessage((message) => {
+  console.log(`[${message.role}] ${message.content}`);
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000, recording: true });
+  console.log("Pipeline agent with Deepgram + ElevenLabs listening on port 8000");
+}
+
+main();

--- a/examples/startup/webhook_tools.py
+++ b/examples/startup/webhook_tools.py
@@ -1,0 +1,88 @@
+"""
+Webhook Tools
+=============
+Define tools that POST to external webhook URLs instead of running local
+handlers. Perfect for B2B startups that keep business logic in their own
+backend and only use Patter for the voice layer.
+
+Requirements:
+    pip install patter python-dotenv
+
+Environment variables (.env):
+    OPENAI_API_KEY      - OpenAI API key
+    TWILIO_ACCOUNT_SID  - Twilio account SID
+    TWILIO_AUTH_TOKEN   - Twilio auth token
+    TWILIO_PHONE_NUMBER - Your Twilio phone number (E.164 format)
+    WEBHOOK_URL         - Public URL where Twilio can reach this server
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from patter import Patter
+
+# ── Initialise ───────────────────────────────────────────────────────
+phone = Patter(
+    mode="local",
+    openai_key=os.getenv("OPENAI_API_KEY"),
+    twilio_sid=os.getenv("TWILIO_ACCOUNT_SID"),
+    twilio_token=os.getenv("TWILIO_AUTH_TOKEN"),
+    phone_number=os.getenv("TWILIO_PHONE_NUMBER"),
+    webhook_url=os.getenv("WEBHOOK_URL"),
+)
+
+# ── Tools backed by external webhooks ────────────────────────────────
+lookup_customer = Patter.tool(
+    name="lookup_customer",
+    description="Look up a customer by email or phone number.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "email": {"type": "string", "description": "Customer email address"},
+            "phone": {"type": "string", "description": "Customer phone number"},
+        },
+        "required": [],
+    },
+    webhook_url="https://api.example.com/customers/lookup",
+)
+
+create_ticket = Patter.tool(
+    name="create_ticket",
+    description="Create a support ticket for the customer.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "customer_id": {"type": "string", "description": "Customer ID"},
+            "subject": {"type": "string", "description": "Ticket subject"},
+            "priority": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Ticket priority level",
+            },
+        },
+        "required": ["customer_id", "subject"],
+    },
+    webhook_url="https://api.example.com/tickets/create",
+)
+
+# ── Agent with webhook-backed tools ──────────────────────────────────
+agent = phone.agent(
+    system_prompt=(
+        "You are a customer support agent for Acme Corp. "
+        "Use lookup_customer to find the caller's account, then help "
+        "resolve their issue. If the issue cannot be resolved on the call, "
+        "use create_ticket to open a support ticket. Always confirm the "
+        "ticket number with the customer before ending the call."
+    ),
+    voice="nova",
+    first_message="Thanks for calling Acme Corp support! How can I help you today?",
+    tools=[lookup_customer, create_ticket],
+)
+
+# ── Start the server ─────────────────────────────────────────────────
+if __name__ == "__main__":
+    asyncio.run(phone.serve(agent, port=8000))

--- a/examples/startup/webhook_tools.ts
+++ b/examples/startup/webhook_tools.ts
@@ -1,0 +1,74 @@
+/**
+ * @file webhook_tools.ts
+ * @description Webhook-based tool integration for voice agents.
+ *
+ * Instead of inline handler functions, each tool delegates execution to
+ * an external webhook URL. This lets you keep business logic in your own
+ * backend (CRM lookup, ticketing, etc.) while the agent handles the
+ * conversation flow.
+ *
+ * Prerequisites:
+ *   - OPENAI_API_KEY, TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN in .env
+ *   - Webhook endpoints deployed and reachable
+ *   - A Twilio phone number pointed at your webhook URL
+ *
+ * Usage:
+ *   npx ts-node webhook_tools.ts
+ */
+
+import { Patter } from "patter";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const phone = new Patter({
+  mode: "local",
+  openaiKey: process.env.OPENAI_API_KEY!,
+  twilioSid: process.env.TWILIO_ACCOUNT_SID!,
+  twilioToken: process.env.TWILIO_AUTH_TOKEN!,
+  phoneNumber: process.env.TWILIO_PHONE_NUMBER!,
+  webhookUrl: process.env.WEBHOOK_URL!,
+});
+
+const agent = phone.agent({
+  systemPrompt: `You are a customer support agent for TechCo. Look up the caller's
+account using their phone number or email, then help resolve their issue.
+If the issue cannot be resolved immediately, create a support ticket and
+give the caller the ticket number.`,
+  firstMessage: "Thank you for calling TechCo support. Can I have your name or email to pull up your account?",
+  tools: [
+    {
+      name: "lookupCustomer",
+      description: "Look up a customer by email or phone number and return their account details.",
+      parameters: {
+        type: "object",
+        properties: {
+          email: { type: "string", description: "Customer email address" },
+          phone: { type: "string", description: "Customer phone number" },
+        },
+      },
+      webhookUrl: "https://api.example.com/webhooks/patter/lookup-customer",
+    },
+    {
+      name: "createTicket",
+      description: "Create a support ticket for an unresolved issue and return the ticket ID.",
+      parameters: {
+        type: "object",
+        properties: {
+          customerId: { type: "string", description: "The customer's account ID" },
+          subject: { type: "string", description: "Brief summary of the issue" },
+          priority: { type: "string", enum: ["low", "medium", "high"], description: "Ticket priority" },
+        },
+        required: ["customerId", "subject"],
+      },
+      webhookUrl: "https://api.example.com/webhooks/patter/create-ticket",
+    },
+  ],
+});
+
+async function main(): Promise<void> {
+  await phone.serve({ agent, port: 8000 });
+  console.log("Webhook-tools agent listening on port 8000");
+}
+
+main();

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">Patter</h1>
-  <p align="center">Connect AI agents to phone numbers with ~10 lines of code</p>
+  <p align="center">Connect AI agents to phone numbers with 10 lines of code</p>
 </p>
 
 <p align="center">

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "patter",
   "version": "0.3.0",
-  "description": "Connect AI agents to phone numbers with ~10 lines of code",
+  "description": "Connect AI agents to phone numbers with 10 lines of code",
   "license": "MIT",
   "author": {
     "name": "Nicolò Tognoni",

--- a/sdk-ts/src/dashboard/routes.ts
+++ b/sdk-ts/src/dashboard/routes.ts
@@ -2,13 +2,13 @@
  * Dashboard and B2B API routes for the EmbeddedServer (Express).
  *
  * Mounts:
- *   GET /dashboard                      - HTML UI
- *   GET /dashboard/api/calls            - call list JSON
- *   GET /dashboard/api/calls/:callId    - single call JSON
- *   GET /dashboard/api/active           - active calls JSON
- *   GET /dashboard/api/aggregates       - aggregate stats JSON
- *   GET /dashboard/api/events           - SSE event stream
- *   GET /dashboard/api/export/calls     - CSV/JSON export
+ *   GET /                               - HTML UI
+ *   GET /api/dashboard/calls            - call list JSON
+ *   GET /api/dashboard/calls/:callId    - single call JSON
+ *   GET /api/dashboard/active           - active calls JSON
+ *   GET /api/dashboard/aggregates       - aggregate stats JSON
+ *   GET /api/dashboard/events           - SSE event stream
+ *   GET /api/dashboard/export/calls     - CSV/JSON export
  *
  *   GET /api/v1/calls                   - B2B paginated call history
  *   GET /api/v1/calls/active            - B2B active calls
@@ -28,19 +28,19 @@ export function mountDashboard(app: Express, store: MetricsStore, token = ''): v
 
   // --- Dashboard UI ---
 
-  app.get('/dashboard', auth, (_req, res) => {
+  app.get('/', auth, (_req, res) => {
     res.type('text/html').send(DASHBOARD_HTML);
   });
 
   // --- Dashboard API ---
 
-  app.get('/dashboard/api/calls', auth, (req, res) => {
+  app.get('/api/dashboard/calls', auth, (req, res) => {
     const limit = Math.min(parseInt((req.query.limit as string) || '50', 10) || 50, 1000);
     const offset = parseInt((req.query.offset as string) || '0', 10) || 0;
     res.json(store.getCalls(limit, offset));
   });
 
-  app.get('/dashboard/api/calls/:callId', auth, (req, res) => {
+  app.get('/api/dashboard/calls/:callId', auth, (req, res) => {
     const call = store.getCall(String(req.params.callId));
     if (!call) {
       res.status(404).json({ error: 'Not found' });
@@ -49,17 +49,17 @@ export function mountDashboard(app: Express, store: MetricsStore, token = ''): v
     res.json(call);
   });
 
-  app.get('/dashboard/api/active', auth, (_req, res) => {
+  app.get('/api/dashboard/active', auth, (_req, res) => {
     res.json(store.getActiveCalls());
   });
 
-  app.get('/dashboard/api/aggregates', auth, (_req, res) => {
+  app.get('/api/dashboard/aggregates', auth, (_req, res) => {
     res.json(store.getAggregates());
   });
 
   // --- SSE endpoint ---
 
-  app.get('/dashboard/api/events', auth, (req, res) => {
+  app.get('/api/dashboard/events', auth, (req, res) => {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
@@ -86,7 +86,7 @@ export function mountDashboard(app: Express, store: MetricsStore, token = ''): v
 
   // --- Export endpoint ---
 
-  app.get('/dashboard/api/export/calls', auth, (req, res) => {
+  app.get('/api/dashboard/export/calls', auth, (req, res) => {
     const fmt = (req.query.format as string) || 'json';
     const fromDate = (req.query.from as string) || '';
     const toDate = (req.query.to as string) || '';

--- a/sdk-ts/src/dashboard/ui.ts
+++ b/sdk-ts/src/dashboard/ui.ts
@@ -250,7 +250,7 @@ async function fetchJSON(url) {
 }
 
 async function refreshAggregates() {
-  const d = await fetchJSON('/dashboard/api/aggregates');
+  const d = await fetchJSON('/api/dashboard/aggregates');
   $('#stat-total').textContent = d.total_calls;
   $('#stat-active').textContent = d.active_calls;
   $('#stat-cost').textContent = fmt\\$(d.total_cost);
@@ -262,7 +262,7 @@ async function refreshAggregates() {
 }
 
 async function refreshCalls() {
-  const calls = await fetchJSON('/dashboard/api/calls?limit=50');
+  const calls = await fetchJSON('/api/dashboard/calls?limit=50');
   const body = $('#calls-body');
   if (!calls.length) {
     body.innerHTML = '<tr><td colspan="8" class="empty">No calls yet. Waiting for incoming calls...</td></tr>';
@@ -288,7 +288,7 @@ async function refreshCalls() {
 }
 
 async function refreshActive() {
-  const active = await fetchJSON('/dashboard/api/active');
+  const active = await fetchJSON('/api/dashboard/active');
   const body = $('#active-body');
   if (!active.length) {
     body.innerHTML = '<tr><td colspan="6" class="empty">No active calls</td></tr>';
@@ -309,7 +309,7 @@ async function refreshActive() {
 }
 
 async function showCall(callId) {
-  const c = await fetchJSON('/dashboard/api/calls/'+encodeURIComponent(callId));
+  const c = await fetchJSON('/api/dashboard/calls/'+encodeURIComponent(callId));
   if (c.error) return;
   const m = c.metrics || {};
   const cost = m.cost || {};
@@ -415,7 +415,7 @@ refresh();
 
 if (typeof EventSource !== 'undefined') {
   var tokenParam = new URLSearchParams(window.location.search).get('token');
-  var sseUrl = '/dashboard/api/events' + (tokenParam ? '?' + new URLSearchParams({ token: tokenParam }).toString() : '');
+  var sseUrl = '/api/dashboard/events' + (tokenParam ? '?' + new URLSearchParams({ token: tokenParam }).toString() : '');
   var sseBackoff = 1000;
   var sseFailures = 0;
   var SSE_MAX_BACKOFF = 30000;

--- a/sdk-ts/src/server.ts
+++ b/sdk-ts/src/server.ts
@@ -684,7 +684,7 @@ export class EmbeddedServer {
 ██║     ██║  ██║   ██║      ██║   ███████╗██║  ██║
 ╚═╝     ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
 
-Connect AI agents to phone numbers with ~10 lines of code
+Connect AI agents to phone numbers with 10 lines of code
 `);
         getLogger().info(`Server on port ${port}`);
         getLogger().info(`Webhook: https://${this.config.webhookUrl}`);

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">Patter</h1>
-  <p align="center">Connect AI agents to phone numbers with ~10 lines of code</p>
+  <p align="center">Connect AI agents to phone numbers with 10 lines of code</p>
 </p>
 
 <p align="center">

--- a/sdk/patter/banner.py
+++ b/sdk/patter/banner.py
@@ -8,7 +8,7 @@ BANNER = r"""
 ██║     ██║  ██║   ██║      ██║   ███████╗██║  ██║
 ╚═╝     ╚═╝  ╚═╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
 
-Connect AI agents to phone numbers with ~10 lines of code
+Connect AI agents to phone numbers with 10 lines of code
 """
 
 

--- a/sdk/patter/client.py
+++ b/sdk/patter/client.py
@@ -1,4 +1,4 @@
-"""Patter SDK — Connect AI agents to phone numbers with ~10 lines of code.
+"""Patter SDK — Connect AI agents to phone numbers with 10 lines of code.
 
 Three modes:
 

--- a/sdk/patter/dashboard/routes.py
+++ b/sdk/patter/dashboard/routes.py
@@ -12,13 +12,13 @@ def mount_dashboard(app, store: MetricsStore, token: str = "") -> None:
     """Add dashboard routes to an existing FastAPI app.
 
     Mounts:
-      - ``GET /dashboard`` — the web UI
-      - ``GET /dashboard/api/calls`` — call list JSON
-      - ``GET /dashboard/api/calls/{call_id}`` — single call JSON
-      - ``GET /dashboard/api/active`` — active calls JSON
-      - ``GET /dashboard/api/aggregates`` — aggregate stats JSON
-      - ``GET /dashboard/api/events`` — SSE event stream
-      - ``GET /dashboard/api/export/calls`` — CSV/JSON export
+      - ``GET /`` — the web UI
+      - ``GET /api/dashboard/calls`` — call list JSON
+      - ``GET /api/dashboard/calls/{call_id}`` — single call JSON
+      - ``GET /api/dashboard/active`` — active calls JSON
+      - ``GET /api/dashboard/aggregates`` — aggregate stats JSON
+      - ``GET /api/dashboard/events`` — SSE event stream
+      - ``GET /api/dashboard/export/calls`` — CSV/JSON export
 
     Args:
         app: The FastAPI application instance.
@@ -33,13 +33,13 @@ def mount_dashboard(app, store: MetricsStore, token: str = "") -> None:
 
     auth = make_auth_dependency(token=token)
 
-    @app.get("/dashboard", response_class=HTMLResponse)
+    @app.get("/", response_class=HTMLResponse)
     async def dashboard_ui(_=Depends(auth)):
         from patter.dashboard.ui import DASHBOARD_HTML
 
         return HTMLResponse(content=DASHBOARD_HTML)
 
-    @app.get("/dashboard/api/calls", dependencies=[Depends(auth)])
+    @app.get("/api/dashboard/calls", dependencies=[Depends(auth)])
     async def dashboard_calls(request: Request):
         try:
             limit = min(int(request.query_params.get("limit", "50")), 1000)
@@ -51,24 +51,24 @@ def mount_dashboard(app, store: MetricsStore, token: str = "") -> None:
             offset = 0
         return JSONResponse(content=store.get_calls(limit=limit, offset=offset))
 
-    @app.get("/dashboard/api/calls/{call_id}")
+    @app.get("/api/dashboard/calls/{call_id}")
     async def dashboard_call_detail(call_id: str, _=Depends(auth)):
         call = store.get_call(call_id)
         if call is None:
             return JSONResponse(content={"error": "Not found"}, status_code=404)
         return JSONResponse(content=call)
 
-    @app.get("/dashboard/api/active")
+    @app.get("/api/dashboard/active")
     async def dashboard_active(_=Depends(auth)):
         return JSONResponse(content=store.get_active_calls())
 
-    @app.get("/dashboard/api/aggregates")
+    @app.get("/api/dashboard/aggregates")
     async def dashboard_aggregates(_=Depends(auth)):
         return JSONResponse(content=store.get_aggregates())
 
     # --- SSE endpoint ---
 
-    @app.get("/dashboard/api/events")
+    @app.get("/api/dashboard/events")
     async def dashboard_sse(_=Depends(auth)):
         queue = store.subscribe()
 
@@ -94,7 +94,7 @@ def mount_dashboard(app, store: MetricsStore, token: str = "") -> None:
 
     # --- Export endpoint ---
 
-    @app.get("/dashboard/api/export/calls", dependencies=[Depends(auth)])
+    @app.get("/api/dashboard/export/calls", dependencies=[Depends(auth)])
     async def dashboard_export_calls(request: Request):
         fmt = request.query_params.get("format", "json")
         from_date = request.query_params.get("from", "")

--- a/sdk/patter/dashboard/ui.py
+++ b/sdk/patter/dashboard/ui.py
@@ -1,159 +1,248 @@
-"""Dashboard HTML template — single-page app with no external dependencies."""
+"""Dashboard HTML template — single-page app matching the Patter website style."""
 
 DASHBOARD_HTML = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Patter Dashboard</title>
+<title>Patter | Dashboard</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1188 1773' fill='none'%3E%3Cpath d='M25 561L245 694M25 561V818M245 694V951M25 961V1218M25 1357V1614M245 1489V1747M245 1093V1351M942 823V1080M1161 955V1213M1162 555V812M942 422V679M669 585V843L787 913M942 25V282M1162 158V415M25 818L245 951M244 1094L464 962M25 961L143 890M244 1352L464 1219M942 823L1162 956M942 679L1162 812M721 811L942 679M669 842L724 809M669 586L724 553M1041 883L1162 812M245 1747L1161 1213M244 1490L942 1080M25 1357L142 1289M518 1071L942 823M721 555L942 422M942 422L1162 556M942 282L1162 415M942 25L1162 158M942 1080L1161 1213M25 1218L245 1351M25 961L245 1094M464 962L519 929M464 1219L519 1186V928L403 859M25 1357L245 1490M25 1614L245 1747M25 561L942 25M244 694L941 282M1043 484L1162 415M245 951L668 704' stroke='%2309090b' stroke-width='50' stroke-linecap='round'/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {
-    --bg: #0a0a0f;
-    --surface: #12121a;
-    --surface2: #1a1a26;
-    --border: #2a2a3a;
-    --text: #e4e4ef;
-    --text2: #8888a0;
-    --accent: #6366f1;
-    --accent2: #818cf8;
+    --bg: #fdfcfc;
+    --fg: #09090b;
+    --card: #ffffff;
+    --primary: #18181b;
+    --primary-fg: #fafafa;
+    --secondary: #f4f4f5;
+    --muted: #71717b;
+    --border: #e4e4e7;
+    --border-d: #d4d4d8;
     --green: #22c55e;
     --red: #ef4444;
-    --yellow: #eab308;
     --blue: #3b82f6;
-    --radius: 8px;
+    --purple: #a78bfa;
+    --orange: #fb923c;
+    --yellow: #eab308;
+    --radius: 12px;
+    --font: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif;
+    --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   }
   * { margin:0; padding:0; box-sizing:border-box; }
+  html { -webkit-font-smoothing: antialiased; }
   body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
-    background: var(--bg); color: var(--text);
+    font-family: var(--font);
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--fg);
+    background: var(--bg);
     min-height: 100vh;
   }
+
+  /* Header */
   header {
+    position: sticky; top: 0; z-index: 100;
+    background: #fff;
     border-bottom: 1px solid var(--border);
-    padding: 16px 24px;
-    display: flex; align-items: center; gap: 16px;
+    padding: 0 24px;
+    height: 56px;
+    display: flex; align-items: center; gap: 14px;
   }
-  header h1 { font-size: 18px; font-weight: 600; }
-  header h1 span { color: var(--accent); }
-  header .status {
-    margin-left: auto; font-size: 13px; color: var(--text2);
+  .logo {
+    display: flex; align-items: center; gap: 10px;
+    font-weight: 700; font-size: 18px; letter-spacing: -0.02em;
+    text-decoration: none; color: var(--fg);
+  }
+  .logo svg { width: 22px; height: 22px; }
+  .header-sep {
+    width: 1px; height: 20px; background: var(--border-d); margin: 0 2px;
+  }
+  .header-title {
+    font-size: 14px; font-weight: 500; color: var(--muted);
+  }
+  .status {
+    margin-left: auto; font-size: 13px; color: var(--muted);
     display: flex; align-items: center; gap: 6px;
   }
-  header .dot {
-    width: 8px; height: 8px; border-radius: 50%;
+  .dot {
+    width: 7px; height: 7px; border-radius: 50%;
     background: var(--green); display: inline-block;
   }
+
+  /* Layout */
   .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+
+  /* Stat cards */
   .cards {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 16px; margin-bottom: 24px;
+    gap: 14px; margin-bottom: 28px;
   }
   .card {
-    background: var(--surface); border: 1px solid var(--border);
-    border-radius: var(--radius); padding: 16px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px 20px;
   }
-  .card .label { font-size: 12px; color: var(--text2); text-transform: uppercase; letter-spacing: 0.5px; }
-  .card .value { font-size: 28px; font-weight: 700; margin-top: 4px; }
-  .card .sub { font-size: 12px; color: var(--text2); margin-top: 2px; }
-  .section { margin-bottom: 24px; }
-  .section h2 { font-size: 15px; font-weight: 600; margin-bottom: 12px; color: var(--text2); }
+  .card .label {
+    font-size: 12px; color: var(--muted);
+    text-transform: uppercase; letter-spacing: 0.5px; font-weight: 500;
+  }
+  .card .value {
+    font-size: 28px; font-weight: 700; margin-top: 4px;
+    font-family: var(--mono); letter-spacing: -0.02em;
+  }
+  .card .sub { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+  /* Tabs */
+  .nav-tabs {
+    display: flex; gap: 0; margin-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-tab {
+    padding: 10px 20px; font-size: 13px; font-weight: 500;
+    color: var(--muted); cursor: pointer;
+    border: none; background: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px; font-family: var(--font);
+    transition: color .15s;
+  }
+  .nav-tab:hover { color: var(--fg); }
+  .nav-tab.active { color: var(--fg); border-bottom-color: var(--primary); }
+
+  .tab-content { display: none; }
+  .tab-content.active { display: block; }
+
+  /* Tables */
   table {
     width: 100%; border-collapse: collapse;
-    background: var(--surface); border: 1px solid var(--border);
-    border-radius: var(--radius); overflow: hidden;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
   }
-  th { text-align: left; font-size: 11px; text-transform: uppercase;
-    color: var(--text2); padding: 10px 14px; border-bottom: 1px solid var(--border);
-    letter-spacing: 0.5px;
+  th {
+    text-align: left; font-size: 11px; text-transform: uppercase;
+    color: var(--muted); padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    letter-spacing: 0.5px; font-weight: 600;
+    background: var(--secondary);
   }
-  td { padding: 10px 14px; border-bottom: 1px solid var(--border); font-size: 13px; }
+  td {
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    font-size: 13px;
+  }
   tr:last-child td { border-bottom: none; }
-  tr.clickable { cursor: pointer; }
-  tr.clickable:hover { background: var(--surface2); }
+  tr.clickable { cursor: pointer; transition: background .1s; }
+  tr.clickable:hover { background: var(--secondary); }
+
+  code {
+    font-family: var(--mono); font-size: 12px;
+    background: var(--secondary); padding: 2px 6px;
+    border-radius: 4px;
+  }
+
+  /* Badges */
   .badge {
-    display: inline-block; padding: 2px 8px; border-radius: 10px;
+    display: inline-block; padding: 3px 10px; border-radius: 100px;
     font-size: 11px; font-weight: 600;
   }
-  .badge-active { background: rgba(34,197,94,0.15); color: var(--green); }
-  .badge-ended { background: rgba(136,136,160,0.15); color: var(--text2); }
-  .badge-pipeline { background: rgba(99,102,241,0.15); color: var(--accent2); }
-  .badge-realtime { background: rgba(59,130,246,0.15); color: var(--blue); }
-  .cost { color: var(--green); }
-  .latency { color: var(--yellow); }
-  .empty { text-align: center; padding: 40px; color: var(--text2); font-size: 14px; }
+  .badge-active { background: rgba(34,197,94,0.1); color: #16a34a; }
+  .badge-ended { background: var(--secondary); color: var(--muted); }
+  .badge-pipeline { background: rgba(167,139,250,0.1); color: #7c3aed; }
+  .badge-realtime { background: rgba(59,130,246,0.1); color: #2563eb; }
 
-  /* Call detail modal */
+  .cost { color: #16a34a; font-family: var(--mono); font-size: 13px; }
+  .latency { color: #ca8a04; font-family: var(--mono); font-size: 13px; }
+  .empty {
+    text-align: center; padding: 48px; color: var(--muted);
+    font-size: 14px;
+  }
+
+  /* Modal */
   .modal-overlay {
     display: none; position: fixed; inset: 0;
-    background: rgba(0,0,0,0.7); z-index: 100;
+    background: rgba(0,0,0,0.3); backdrop-filter: blur(4px);
+    z-index: 200;
     justify-content: center; align-items: flex-start;
     padding: 60px 20px; overflow-y: auto;
   }
   .modal-overlay.open { display: flex; }
   .modal {
-    background: var(--surface); border: 1px solid var(--border);
-    border-radius: 12px; max-width: 800px; width: 100%;
-    padding: 24px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    max-width: 800px; width: 100%;
+    padding: 28px;
+    box-shadow: 0 24px 48px rgba(0,0,0,0.1);
   }
   .modal-header {
     display: flex; justify-content: space-between; align-items: center;
-    margin-bottom: 20px;
+    margin-bottom: 24px;
   }
-  .modal-header h2 { font-size: 16px; }
+  .modal-header h2 { font-size: 16px; font-weight: 600; }
   .modal-close {
-    background: none; border: none; color: var(--text2);
-    font-size: 24px; cursor: pointer;
+    background: none; border: 1px solid var(--border);
+    color: var(--muted); width: 32px; height: 32px;
+    border-radius: 8px; font-size: 18px; cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    transition: all .15s;
   }
-  .modal-close:hover { color: var(--text); }
+  .modal-close:hover { background: var(--secondary); color: var(--fg); }
+
   .detail-grid {
     display: grid; grid-template-columns: 1fr 1fr;
     gap: 16px; margin-bottom: 20px;
   }
   .detail-card {
-    background: var(--surface2); border-radius: var(--radius); padding: 14px;
+    background: var(--secondary);
+    border-radius: var(--radius); padding: 16px;
   }
-  .detail-card h3 { font-size: 12px; color: var(--text2); text-transform: uppercase; margin-bottom: 8px; }
-  .detail-row { display: flex; justify-content: space-between; font-size: 13px; padding: 3px 0; }
-  .detail-row .k { color: var(--text2); }
+  .detail-card h3 {
+    font-size: 11px; color: var(--muted);
+    text-transform: uppercase; letter-spacing: 0.5px;
+    margin-bottom: 10px; font-weight: 600;
+  }
+  .detail-row {
+    display: flex; justify-content: space-between;
+    font-size: 13px; padding: 4px 0;
+  }
+  .detail-row .k { color: var(--muted); }
+
   .transcript-box {
-    background: var(--surface2); border-radius: var(--radius);
-    padding: 14px; max-height: 300px; overflow-y: auto;
+    background: var(--secondary);
+    border-radius: var(--radius);
+    padding: 16px; max-height: 300px; overflow-y: auto;
   }
   .transcript-box .msg { padding: 4px 0; font-size: 13px; }
   .transcript-box .msg.user .role { color: var(--blue); }
-  .transcript-box .msg.assistant .role { color: var(--accent2); }
+  .transcript-box .msg.assistant .role { color: #7c3aed; }
   .transcript-box .role { font-weight: 600; margin-right: 8px; }
 
-  /* Turn table */
+  /* Turn bars */
   .turns-table { margin-top: 16px; }
-  .bar-container { display: flex; height: 14px; border-radius: 3px; overflow: hidden; min-width: 120px; }
+  .bar-container { display: flex; height: 14px; border-radius: 4px; overflow: hidden; min-width: 120px; }
   .bar-stt { background: var(--blue); }
-  .bar-llm { background: var(--accent); }
-  .bar-tts { background: var(--yellow); }
-
-  .nav-tabs {
-    display: flex; gap: 4px; margin-bottom: 16px;
-    border-bottom: 1px solid var(--border); padding-bottom: 0;
-  }
-  .nav-tab {
-    padding: 8px 16px; font-size: 13px; color: var(--text2);
-    cursor: pointer; border: none; background: none;
-    border-bottom: 2px solid transparent; margin-bottom: -1px;
-  }
-  .nav-tab:hover { color: var(--text); }
-  .nav-tab.active { color: var(--accent2); border-bottom-color: var(--accent); }
-  .tab-content { display: none; }
-  .tab-content.active { display: block; }
+  .bar-llm { background: var(--purple); }
+  .bar-tts { background: var(--orange); }
 </style>
 </head>
 <body>
 <header>
-  <h1><span>Patter</span> Dashboard</h1>
+  <a href="/" class="logo">
+    <svg viewBox="0 0 1188 1773" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M25 561L245 694M25 561V818M245 694V951M25 961V1218M25 1357V1614M245 1489V1747M245 1093V1351M942 823V1080M1161 955V1213M1162 555V812M942 422V679M669 585V843L787 913M942 25V282M1162 158V415M25 818L245 951M244 1094L464 962M25 961L143 890M244 1352L464 1219M942 823L1162 956M942 679L1162 812M721 811L942 679M669 842L724 809M669 586L724 553M1041 883L1162 812M245 1747L1161 1213M244 1490L942 1080M25 1357L142 1289M518 1071L942 823M721 555L942 422M942 422L1162 556M942 282L1162 415M942 25L1162 158M942 1080L1161 1213M25 1218L245 1351M25 961L245 1094M464 962L519 929M464 1219L519 1186V928L403 859M25 1357L245 1490M25 1614L245 1747M25 561L942 25M244 694L941 282M1043 484L1162 415M245 951L668 704" stroke="currentColor" stroke-width="50" stroke-linecap="round"/>
+    </svg>
+    Patter
+  </a>
+  <div class="header-sep"></div>
+  <span class="header-title">Dashboard</span>
   <div class="status"><span class="dot"></span> <span id="status-text">Listening</span></div>
 </header>
 
 <div class="container">
-  <!-- Aggregate cards -->
   <div class="cards">
     <div class="card">
       <div class="label">Total Calls</div>
@@ -176,26 +265,18 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
     </div>
   </div>
 
-  <!-- Nav tabs -->
   <div class="nav-tabs">
     <button class="nav-tab active" data-tab="calls">Calls</button>
     <button class="nav-tab" data-tab="active">Active</button>
   </div>
 
-  <!-- Calls table -->
   <div class="tab-content active" id="tab-calls">
     <div class="section">
       <table id="calls-table">
         <thead>
           <tr>
-            <th>Call ID</th>
-            <th>Direction</th>
-            <th>From / To</th>
-            <th>Duration</th>
-            <th>Mode</th>
-            <th>Cost</th>
-            <th>Avg Latency</th>
-            <th>Turns</th>
+            <th>Call ID</th><th>Direction</th><th>From / To</th>
+            <th>Duration</th><th>Mode</th><th>Cost</th><th>Avg Latency</th><th>Turns</th>
           </tr>
         </thead>
         <tbody id="calls-body">
@@ -205,7 +286,6 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
     </div>
   </div>
 
-  <!-- Active calls -->
   <div class="tab-content" id="tab-active">
     <div class="section">
       <table>
@@ -220,7 +300,6 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
   </div>
 </div>
 
-<!-- Call detail modal -->
 <div class="modal-overlay" id="modal">
   <div class="modal">
     <div class="modal-header">
@@ -235,7 +314,6 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
 const $ = (s) => document.querySelector(s);
 const $$ = (s) => document.querySelectorAll(s);
 
-// Tab switching
 $$('.nav-tab').forEach(tab => {
   tab.addEventListener('click', () => {
     $$('.nav-tab').forEach(t => t.classList.remove('active'));
@@ -264,7 +342,7 @@ async function fetchJSON(url) {
 }
 
 async function refreshAggregates() {
-  const d = await fetchJSON('/dashboard/api/aggregates');
+  const d = await fetchJSON('/api/dashboard/aggregates');
   $('#stat-total').textContent = d.total_calls;
   $('#stat-active').textContent = d.active_calls;
   $('#stat-cost').textContent = fmt$(d.total_cost);
@@ -276,7 +354,7 @@ async function refreshAggregates() {
 }
 
 async function refreshCalls() {
-  const calls = await fetchJSON('/dashboard/api/calls?limit=50');
+  const calls = await fetchJSON('/api/dashboard/calls?limit=50');
   const body = $('#calls-body');
   if (!calls.length) {
     body.innerHTML = '<tr><td colspan="8" class="empty">No calls yet. Waiting for incoming calls...</td></tr>';
@@ -303,7 +381,7 @@ async function refreshCalls() {
 }
 
 async function refreshActive() {
-  const active = await fetchJSON('/dashboard/api/active');
+  const active = await fetchJSON('/api/dashboard/active');
   const body = $('#active-body');
   if (!active.length) {
     body.innerHTML = '<tr><td colspan="6" class="empty">No active calls</td></tr>';
@@ -325,7 +403,7 @@ async function refreshActive() {
 }
 
 async function showCall(callId) {
-  const c = await fetchJSON(`/dashboard/api/calls/${encodeURIComponent(callId)}`);
+  const c = await fetchJSON(`/api/dashboard/calls/${encodeURIComponent(callId)}`);
   if (c.error) return;
   const m = c.metrics || {};
   const cost = m.cost || {};
@@ -355,10 +433,10 @@ async function showCall(callId) {
       <div class="detail-row"><span class="k">LLM</span><span class="cost">${fmt$(cost.llm || 0)}</span></div>
       <div class="detail-row"><span class="k">TTS</span><span class="cost">${fmt$(cost.tts || 0)}</span></div>
       <div class="detail-row"><span class="k">Telephony</span><span class="cost">${fmt$(cost.telephony || 0)}</span></div>
-      <div class="detail-row" style="border-top:1px solid var(--border);padding-top:6px;margin-top:4px">
+      <div class="detail-row" style="border-top:1px solid var(--border);padding-top:8px;margin-top:6px">
         <span class="k" style="font-weight:600">Total</span><span class="cost" style="font-weight:700">${fmt$(cost.total || 0)}</span>
       </div>
-      <h3 style="margin-top:14px">Latency (avg / p95)</h3>
+      <h3 style="margin-top:16px">Latency (avg / p95)</h3>
       <div class="detail-row"><span class="k">STT</span><span class="latency">${fmtMs(latAvg.stt_ms)} / ${fmtMs(latP95.stt_ms)}</span></div>
       <div class="detail-row"><span class="k">LLM</span><span class="latency">${fmtMs(latAvg.llm_ms)} / ${fmtMs(latP95.llm_ms)}</span></div>
       <div class="detail-row"><span class="k">TTS</span><span class="latency">${fmtMs(latAvg.tts_ms)} / ${fmtMs(latP95.tts_ms)}</span></div>
@@ -366,7 +444,6 @@ async function showCall(callId) {
     </div>
   </div>`;
 
-  // Turns table with latency bars
   if (turns.length) {
     const maxMs = Math.max(...turns.map(t => {
       const l = t.latency || {};
@@ -396,15 +473,14 @@ async function showCall(callId) {
       </tr>`;
     });
     html += `</tbody></table>
-      <div style="margin-top:8px;font-size:11px;color:var(--text2)">
+      <div style="margin-top:10px;font-size:11px;color:var(--muted)">
         <span style="color:var(--blue)">&#9632;</span> STT &nbsp;
-        <span style="color:var(--accent)">&#9632;</span> LLM &nbsp;
-        <span style="color:var(--yellow)">&#9632;</span> TTS
+        <span style="color:var(--purple)">&#9632;</span> LLM &nbsp;
+        <span style="color:var(--orange)">&#9632;</span> TTS
       </div>
     </div>`;
   }
 
-  // Transcript
   const transcript = c.transcript || [];
   if (transcript.length) {
     html += `<div class="detail-card" style="margin-top:16px"><h3>Transcript</h3>
@@ -424,7 +500,6 @@ function closeModal() { $('#modal').classList.remove('open'); }
 $('#modal').addEventListener('click', e => { if (e.target === $('#modal')) closeModal(); });
 document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
 
-// Polling
 async function refresh() {
   try {
     await Promise.all([refreshAggregates(), refreshCalls(), refreshActive()]);
@@ -436,22 +511,17 @@ async function refresh() {
 
 refresh();
 
-// SSE real-time updates with exponential backoff reconnection
 if (typeof EventSource !== 'undefined') {
   const tokenParam = new URLSearchParams(window.location.search).get('token');
-  const sseUrl = '/dashboard/api/events' + (tokenParam ? '?' + new URLSearchParams({ token: tokenParam }).toString() : '');
+  const sseUrl = '/api/dashboard/events' + (tokenParam ? '?' + new URLSearchParams({ token: tokenParam }).toString() : '');
   let sseBackoff = 1000;
   let sseFailures = 0;
   const SSE_MAX_BACKOFF = 30000;
   const SSE_MAX_FAILURES = 5;
-  let sseTimer = null;
 
   function connectSSE() {
     const es = new EventSource(sseUrl);
-    function onEvent() {
-      sseBackoff = 1000;
-      sseFailures = 0;
-    }
+    function onEvent() { sseBackoff = 1000; sseFailures = 0; }
     es.addEventListener('call_start', () => { onEvent(); refresh(); });
     es.addEventListener('turn_complete', () => { onEvent(); refreshAggregates(); });
     es.addEventListener('call_end', () => { onEvent(); refresh(); });
@@ -459,14 +529,12 @@ if (typeof EventSource !== 'undefined') {
       es.close();
       sseFailures++;
       if (sseFailures >= SSE_MAX_FAILURES) {
-        $('#status-text').textContent = 'Polling (SSE unavailable)';
+        $('#status-text').textContent = 'Polling';
         setInterval(refresh, 5000);
         return;
       }
       $('#status-text').textContent = 'Reconnecting...';
-      sseTimer = setTimeout(() => {
-        connectSSE();
-      }, sseBackoff);
+      setTimeout(connectSSE, sseBackoff);
       sseBackoff = Math.min(sseBackoff * 2, SSE_MAX_BACKOFF);
     };
   }

--- a/sdk/patter/server.py
+++ b/sdk/patter/server.py
@@ -325,7 +325,11 @@ class EmbeddedServer:
         logger.info("Phone: %s", self.config.phone_number)
         logger.info("Agent: %s / %s", self.agent.model, self.agent.voice)
         if self.dashboard:
-            logger.info("Dashboard: http://127.0.0.1:%s/dashboard", port)
+            logger.info("Dashboard: http://127.0.0.1:%s", port)
+
+        # Suppress Uvicorn's "Uvicorn running on..." startup message
+        # but keep request logs (INFO level) visible
+        logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
 
         config = uvicorn.Config(
             app, host="127.0.0.1", port=port, log_level="info"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "patter"
 version = "0.3.0"
-description = "Connect AI agents to phone numbers with ~10 lines of code"
+description = "Connect AI agents to phone numbers with 10 lines of code"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [

--- a/sdk/tests/test_dashboard.py
+++ b/sdk/tests/test_dashboard.py
@@ -164,11 +164,11 @@ class TestDashboardRoutes:
         mount_dashboard(app, store)
 
         route_paths = [r.path for r in app.routes if hasattr(r, "path")]
-        assert "/dashboard" in route_paths
-        assert "/dashboard/api/calls" in route_paths
-        assert "/dashboard/api/calls/{call_id}" in route_paths
-        assert "/dashboard/api/active" in route_paths
-        assert "/dashboard/api/aggregates" in route_paths
+        assert "/" in route_paths
+        assert "/api/dashboard/calls" in route_paths
+        assert "/api/dashboard/calls/{call_id}" in route_paths
+        assert "/api/dashboard/active" in route_paths
+        assert "/api/dashboard/aggregates" in route_paths
 
 
 class TestDashboardHTML:
@@ -179,8 +179,8 @@ class TestDashboardHTML:
 
         assert "Patter" in DASHBOARD_HTML
         assert "Dashboard" in DASHBOARD_HTML
-        assert "/dashboard/api/calls" in DASHBOARD_HTML
-        assert "/dashboard/api/aggregates" in DASHBOARD_HTML
+        assert "/api/dashboard/calls" in DASHBOARD_HTML
+        assert "/api/dashboard/aggregates" in DASHBOARD_HTML
         assert "Total Calls" in DASHBOARD_HTML
         assert "Total Cost" in DASHBOARD_HTML
         assert "Avg Latency" in DASHBOARD_HTML

--- a/sdk/tests/test_dashboard_auth.py
+++ b/sdk/tests/test_dashboard_auth.py
@@ -40,7 +40,7 @@ async def test_auth_valid_header(app_with_auth):
         transport=ASGITransport(app=app_with_auth), base_url="http://test"
     ) as client:
         r = await client.get(
-            "/dashboard/api/aggregates",
+            "/api/dashboard/aggregates",
             headers={"Authorization": "Bearer secret123"},
         )
         assert r.status_code == 200
@@ -54,7 +54,7 @@ async def test_auth_valid_query_param(app_with_auth):
     async with AsyncClient(
         transport=ASGITransport(app=app_with_auth), base_url="http://test"
     ) as client:
-        r = await client.get("/dashboard/api/aggregates?token=secret123")
+        r = await client.get("/api/dashboard/aggregates?token=secret123")
         assert r.status_code == 200
 
 
@@ -67,7 +67,7 @@ async def test_auth_invalid_token(app_with_auth):
         transport=ASGITransport(app=app_with_auth), base_url="http://test"
     ) as client:
         r = await client.get(
-            "/dashboard/api/aggregates",
+            "/api/dashboard/aggregates",
             headers={"Authorization": "Bearer wrong"},
         )
         assert r.status_code == 401
@@ -81,7 +81,7 @@ async def test_auth_missing_token(app_with_auth):
     async with AsyncClient(
         transport=ASGITransport(app=app_with_auth), base_url="http://test"
     ) as client:
-        r = await client.get("/dashboard/api/aggregates")
+        r = await client.get("/api/dashboard/aggregates")
         assert r.status_code == 401
 
 
@@ -93,5 +93,5 @@ async def test_no_auth_allows_all(app_no_auth):
     async with AsyncClient(
         transport=ASGITransport(app=app_no_auth), base_url="http://test"
     ) as client:
-        r = await client.get("/dashboard/api/aggregates")
+        r = await client.get("/api/dashboard/aggregates")
         assert r.status_code == 200

--- a/sdk/tests/test_dashboard_export.py
+++ b/sdk/tests/test_dashboard_export.py
@@ -91,7 +91,7 @@ async def test_export_endpoint_csv():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        r = await client.get("/dashboard/api/export/calls?format=csv")
+        r = await client.get("/api/dashboard/export/calls?format=csv")
         assert r.status_code == 200
         assert "text/csv" in r.headers["content-type"]
         assert "x1" in r.text
@@ -115,7 +115,7 @@ async def test_export_endpoint_json():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        r = await client.get("/dashboard/api/export/calls?format=json")
+        r = await client.get("/api/dashboard/export/calls?format=json")
         assert r.status_code == 200
         data = json.loads(r.text)
         assert len(data) == 1


### PR DESCRIPTION
## Summary
- 30 example scripts (Python + TypeScript) organized by use case: developer, startup, enterprise
- Dashboard redesigned to match website style (light theme, Instrument Sans, Patter logo/favicon)
- Dashboard served at root `/` instead of `/dashboard`
- Suppressed Uvicorn startup message while keeping request logs
- Fixed "~10 lines" → "10 lines" and "patter-sdk" → "patter" everywhere

## Test plan
- [x] Python SDK: 451 tests passing
- [x] TypeScript SDK: 311 tests passing
- [x] All 15 Python examples pass syntax check
- [x] Dashboard loads correctly at localhost:8000