### PR TITLE
feat: built-in cloudflared tunnel for local mode

### DIFF
--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -25,6 +25,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "cloudflared": "^1.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1510,6 +1513,9 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/cloudflared": {
+      "optional": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -54,6 +54,9 @@
     "express": "^5.2.1",
     "ws": "^8.18.0"
   },
+  "optionalDependencies": {
+    "cloudflared": "^1.0.0"
+  },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/express": "^5.0.6",

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -1,5 +1,6 @@
 import { PatterConnection } from "./connection";
 import { PatterConnectionError, ProvisionError } from "./errors";
+import type { TunnelHandle } from "./tunnel";
 import type {
   PatterOptions,
   LocalOptions,
@@ -31,6 +32,7 @@ export class Patter {
   private readonly mode: 'cloud' | 'local';
   private readonly localConfig: LocalOptions | null;
   private embeddedServer: EmbeddedServer | null = null;
+  private tunnelHandle: TunnelHandle | null = null;
 
   constructor(options: PatterOptions | LocalOptions) {
     if ('mode' in options && options.mode === 'local') {
@@ -38,9 +40,6 @@ export class Patter {
 
       if (!local.phoneNumber) {
         throw new Error('Local mode requires phoneNumber');
-      }
-      if (!local.webhookUrl) {
-        throw new Error('Local mode requires webhookUrl (e.g., your ngrok URL)');
       }
       if (!local.twilioSid && !local.telnyxKey) {
         throw new Error('Local mode requires twilioSid or telnyxKey');
@@ -121,13 +120,36 @@ export class Patter {
     if (opts.agent.provider && !validProviders.includes(opts.agent.provider)) {
       throw new Error(`agent.provider must be one of: ${validProviders.join(', ')}`);
     }
+
+    // Resolve webhookUrl: tunnel or explicit
+    let webhookUrl = this.localConfig.webhookUrl ?? '';
+    const port = opts.port ?? 8000;
+
+    if (opts.tunnel && webhookUrl) {
+      throw new Error('Cannot use both tunnel: true and webhookUrl. Pick one.');
+    }
+
+    if (opts.tunnel) {
+      const { startTunnel } = await import('./tunnel');
+      this.tunnelHandle = await startTunnel(port);
+      webhookUrl = this.tunnelHandle.hostname;
+    }
+
+    if (!webhookUrl) {
+      throw new Error(
+        'No webhookUrl configured. Either:\n' +
+        '  - Pass webhookUrl in the Patter constructor\n' +
+        '  - Use tunnel: true in serve() to auto-create a tunnel'
+      );
+    }
+
     this.embeddedServer = new EmbeddedServer(
       {
         twilioSid: this.localConfig.twilioSid,
         twilioToken: this.localConfig.twilioToken,
         openaiKey: this.localConfig.openaiKey,
         phoneNumber: this.localConfig.phoneNumber,
-        webhookUrl: this.localConfig.webhookUrl,
+        webhookUrl,
         telephonyProvider: this.localConfig.telephonyProvider,
         telnyxKey: this.localConfig.telnyxKey,
         telnyxConnectionId: this.localConfig.telnyxConnectionId,
@@ -145,7 +167,7 @@ export class Patter {
       opts.dashboard ?? true,
       opts.dashboardToken ?? '',
     );
-    await this.embeddedServer.start(opts.port ?? 8000);
+    await this.embeddedServer.start(port);
   }
 
   async test(opts: ServeOptions): Promise<void> {
@@ -282,6 +304,14 @@ export class Patter {
   }
 
   async disconnect(): Promise<void> {
+    if (this.tunnelHandle) {
+      this.tunnelHandle.stop();
+      this.tunnelHandle = null;
+    }
+    if (this.embeddedServer) {
+      await this.embeddedServer.stop();
+      this.embeddedServer = null;
+    }
     await this.connection.disconnect();
   }
 

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -56,3 +56,5 @@ export {
   resample16kTo8k,
   resample24kTo16k,
 } from "./transcoding";
+export { startTunnel } from "./tunnel";
+export type { TunnelHandle } from "./tunnel";

--- a/sdk-ts/src/tunnel.ts
+++ b/sdk-ts/src/tunnel.ts
@@ -1,0 +1,77 @@
+/**
+ * Built-in tunnel support via cloudflared.
+ *
+ * Spawns a Cloudflare Quick Tunnel that exposes a local port to the internet.
+ * Zero account required — uses Cloudflare's free trycloudflare.com service.
+ *
+ * Install: npm install cloudflared
+ */
+
+import { getLogger } from './logger';
+
+const log = getLogger();
+
+export interface TunnelHandle {
+  /** Public hostname (no protocol), e.g. "random-name.trycloudflare.com" */
+  hostname: string;
+  /** Stop the tunnel process */
+  stop: () => void;
+}
+
+/**
+ * Start a cloudflared quick tunnel pointing to the given local port.
+ *
+ * @param port - Local port to tunnel to
+ * @param timeoutMs - How long to wait for the tunnel URL (default 30s)
+ * @returns A handle with the public hostname and a stop function
+ */
+export async function startTunnel(port: number, timeoutMs = 30_000): Promise<TunnelHandle> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let tunnelMod: any;
+  try {
+    tunnelMod = await import('cloudflared' as string);
+  } catch {
+    throw new Error(
+      'Built-in tunnel requires the "cloudflared" package. Install it with:\n\n' +
+      '  npm install cloudflared\n\n' +
+      'Or provide your own webhookUrl instead of using tunnel: true.'
+    );
+  }
+
+  log.info('Starting tunnel to localhost:%d ...', port);
+
+  const result = tunnelMod.tunnel({
+    '--url': `http://localhost:${port}`,
+  }) as { url: Promise<string>; connections: Promise<unknown>; stop: () => void };
+
+  // Wait for the tunnel URL with a timeout
+  const tunnelUrl = await Promise.race([
+    result.url,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(
+        `Tunnel failed to start within ${timeoutMs / 1000}s. ` +
+        'Check your internet connection or provide webhookUrl manually.'
+      )), timeoutMs)
+    ),
+  ]);
+
+  // Extract hostname from URL (strip https://)
+  const hostname = tunnelUrl.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
+  log.info('Tunnel ready: https://%s', hostname);
+
+  // Wait for at least one connection to be established
+  result.connections.then(() => {
+    log.info('Tunnel connections established');
+  }).catch(() => {
+    // Connection info may not always resolve — non-critical
+  });
+
+  return {
+    hostname,
+    stop: () => {
+      log.info('Stopping tunnel...');
+      result.stop();
+    },
+  };
+}

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -111,7 +111,7 @@ export interface LocalOptions {
   twilioToken?: string;
   openaiKey?: string;
   phoneNumber: string;
-  webhookUrl: string;
+  webhookUrl?: string;
   telephonyProvider?: 'twilio' | 'telnyx';
   telnyxKey?: string;
   telnyxConnectionId?: string;
@@ -159,6 +159,8 @@ export type PipelineMessageHandler = (data: Record<string, unknown>) => Promise<
 export interface ServeOptions {
   agent: AgentOptions;
   port?: number;
+  /** When true, start a cloudflared tunnel automatically (requires `cloudflared` npm package). */
+  tunnel?: boolean;
   onCallStart?: (data: Record<string, unknown>) => Promise<void>;
   onCallEnd?: (data: Record<string, unknown>) => Promise<void>;
   onTranscript?: (data: Record<string, unknown>) => Promise<void>;

--- a/sdk-ts/tests/client.test.ts
+++ b/sdk-ts/tests/client.test.ts
@@ -149,8 +149,9 @@ describe('Parameter Validation', () => {
     expect(() => new Patter({ mode: 'local', twilioSid: 'AC', twilioToken: 'x', openaiKey: 'sk', webhookUrl: 'x' } as never)).toThrow('phoneNumber');
   });
 
-  it('constructor rejects local mode without webhookUrl', () => {
-    expect(() => new Patter({ mode: 'local', twilioSid: 'AC', twilioToken: 'x', openaiKey: 'sk', phoneNumber: '+1' } as never)).toThrow('webhookUrl');
+  it('constructor accepts local mode without webhookUrl (deferred to serve)', () => {
+    const phone = new Patter({ mode: 'local', twilioSid: 'AC', twilioToken: 'x', openaiKey: 'sk', phoneNumber: '+1' } as never);
+    expect(phone).toBeDefined();
   });
 
   it('constructor rejects local mode without twilioSid or telnyxKey', () => {

--- a/sdk-ts/tests/unit/client.test.ts
+++ b/sdk-ts/tests/unit/client.test.ts
@@ -384,17 +384,15 @@ describe('Patter (local mode)', () => {
     ).toThrow('Local mode requires phoneNumber');
   });
 
-  it('throws if webhookUrl missing in local mode', () => {
-    expect(
-      () =>
-        new Patter({
-          mode: 'local',
-          phoneNumber: '+15551234567',
-          webhookUrl: '',
-          twilioSid: 'AC123',
-          twilioToken: 'tok',
-        }),
-    ).toThrow('Local mode requires webhookUrl');
+  it('accepts missing webhookUrl in constructor (deferred to serve)', () => {
+    const phone = new Patter({
+      mode: 'local',
+      phoneNumber: '+15551234567',
+      webhookUrl: '',
+      twilioSid: 'AC123',
+      twilioToken: 'tok',
+    });
+    expect(phone).toBeDefined();
   });
 
   it('throws if neither twilioSid nor telnyxKey provided', () => {

--- a/sdk/patter/client.py
+++ b/sdk/patter/client.py
@@ -115,10 +115,6 @@ class Patter:
                     raise ValueError(
                         "Local mode requires phone_number (e.g., phone_number='+15550001234')."
                     )
-                if not webhook_url:
-                    raise ValueError(
-                        "Local mode requires webhook_url (e.g., webhook_url='abc.ngrok.io')."
-                    )
                 if twilio_sid and not twilio_token:
                     raise ValueError(
                         "twilio_token is required when using twilio_sid."
@@ -136,6 +132,7 @@ class Patter:
                 webhook_url=webhook_url,
             )
             self._server = None
+            self._tunnel_handle = None
             self._connection = None
             self._http = None
         else:
@@ -431,6 +428,7 @@ class Patter:
         on_metrics: Callable[[dict], Awaitable[None]] | None = None,
         dashboard: bool = True,
         dashboard_token: str = "",
+        tunnel: bool = False,
     ) -> None:
         """Start the embedded server for inbound calls (local mode only).
 
@@ -452,6 +450,9 @@ class Patter:
                 at ``http://localhost:{port}/dashboard``.
             dashboard_token: Optional bearer token for dashboard authentication.
                 When set, all dashboard routes require this token.
+            tunnel: When ``True``, start a cloudflared tunnel automatically.
+                Requires ``cloudflared`` binary on PATH. Mutually exclusive
+                with ``webhook_url``.
         """
         if self._mode != "local":
             raise PatterConnectionError(
@@ -473,10 +474,36 @@ class Patter:
                 f"recording must be a bool, got {type(recording).__name__}."
             )
 
+        # Resolve webhook_url: tunnel or explicit
+        config = self._local_config
+
+        if tunnel and config.webhook_url:
+            raise ValueError(
+                "Cannot use both tunnel=True and webhook_url. Pick one."
+            )
+
+        if tunnel:
+            from patter.tunnel import start_tunnel
+
+            handle = await start_tunnel(port)
+            self._tunnel_handle = handle
+            # Replace config with the tunnel hostname (frozen dataclass)
+            from dataclasses import replace
+
+            config = replace(config, webhook_url=handle.hostname)
+            self._local_config = config
+
+        if not config.webhook_url:
+            raise ValueError(
+                "No webhook_url configured. Either:\n"
+                "  - Pass webhook_url in the Patter constructor\n"
+                "  - Use tunnel=True in serve() to auto-create a tunnel"
+            )
+
         from patter.server import EmbeddedServer
 
         self._server = EmbeddedServer(
-            config=self._local_config,
+            config=config,
             agent=agent,
             recording=recording,
             voicemail_message=voicemail_message,
@@ -629,6 +656,9 @@ class Patter:
         if self._mode == "local":
             if self._server:
                 await self._server.stop()
+            if self._tunnel_handle:
+                self._tunnel_handle.stop()
+                self._tunnel_handle = None
             return
         await self._connection.disconnect()
         await self._http.aclose()

--- a/sdk/patter/tunnel.py
+++ b/sdk/patter/tunnel.py
@@ -1,0 +1,133 @@
+"""Built-in tunnel support via cloudflared.
+
+Spawns a Cloudflare Quick Tunnel that exposes a local port to the internet.
+Zero account required — uses Cloudflare's free trycloudflare.com service.
+
+Requires the ``cloudflared`` binary to be installed and on PATH.
+Install: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger("patter")
+
+_TUNNEL_URL_RE = re.compile(r"https://([a-zA-Z0-9._-]+\.trycloudflare\.com)")
+_STARTUP_TIMEOUT = 30  # seconds
+
+
+@dataclass(frozen=True)
+class TunnelHandle:
+    """Handle to a running cloudflared tunnel."""
+
+    hostname: str
+    """Public hostname (no protocol), e.g. 'random-name.trycloudflare.com'."""
+
+    stop: Callable[[], None]
+    """Stop the tunnel process."""
+
+
+async def start_tunnel(port: int, timeout: float = _STARTUP_TIMEOUT) -> TunnelHandle:
+    """Start a cloudflared quick tunnel pointing to the given local port.
+
+    Args:
+        port: Local port to tunnel to.
+        timeout: How long to wait for the tunnel URL (default 30s).
+
+    Returns:
+        A ``TunnelHandle`` with the public hostname and a stop function.
+
+    Raises:
+        FileNotFoundError: If cloudflared binary is not installed.
+        TimeoutError: If the tunnel doesn't produce a URL within ``timeout``.
+    """
+    binary = shutil.which("cloudflared")
+    if binary is None:
+        raise FileNotFoundError(
+            "Built-in tunnel requires the 'cloudflared' binary. Install it:\n\n"
+            "  brew install cloudflared          # macOS\n"
+            "  sudo apt install cloudflared      # Debian/Ubuntu\n"
+            "  https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/\n\n"
+            "Or provide your own webhook_url instead of using tunnel=True."
+        )
+
+    logger.info("Starting tunnel to localhost:%d ...", port)
+
+    proc = await asyncio.create_subprocess_exec(
+        binary,
+        "tunnel",
+        "--url",
+        f"http://localhost:{port}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    hostname: str | None = None
+
+    async def _read_stream(stream: asyncio.StreamReader) -> str | None:
+        """Read lines from a stream looking for the tunnel URL."""
+        while True:
+            line_bytes = await stream.readline()
+            if not line_bytes:
+                break
+            line = line_bytes.decode("utf-8", errors="replace")
+            match = _TUNNEL_URL_RE.search(line)
+            if match:
+                return match.group(1)
+        return None
+
+    try:
+        # cloudflared prints the URL to stderr
+        tasks = []
+        if proc.stderr:
+            tasks.append(asyncio.create_task(_read_stream(proc.stderr)))
+        if proc.stdout:
+            tasks.append(asyncio.create_task(_read_stream(proc.stdout)))
+
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in done:
+            result = task.result()
+            if result:
+                hostname = result
+                break
+
+        # Cancel remaining tasks
+        for task in pending:
+            task.cancel()
+
+    except Exception:
+        proc.terminate()
+        raise
+
+    if hostname is None:
+        proc.terminate()
+        raise TimeoutError(
+            f"Tunnel failed to start within {timeout}s. "
+            "Check your internet connection or provide webhook_url manually."
+        )
+
+    def _stop() -> None:
+        logger.info("Stopping tunnel...")
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            pass  # Already exited
+
+    # Safety net: kill tunnel if process exits without calling stop
+    atexit.register(_stop)
+
+    logger.info("Tunnel ready: https://%s", hostname)
+
+    return TunnelHandle(hostname=hostname, stop=_stop)

--- a/sdk/tests/test_validation_guardrails.py
+++ b/sdk/tests/test_validation_guardrails.py
@@ -45,10 +45,10 @@ def test_local_mode_requires_phone_number():
         Patter(twilio_sid="AC", twilio_token="tk", openai_key="sk", webhook_url="x")
 
 
-def test_local_mode_requires_webhook_url():
-    """Local mode without webhook_url raises ValueError."""
-    with pytest.raises(ValueError, match="webhook_url"):
-        Patter(twilio_sid="AC", twilio_token="tk", openai_key="sk", phone_number="+1")
+def test_local_mode_accepts_missing_webhook_url():
+    """Local mode without webhook_url is OK (deferred to serve)."""
+    phone = Patter(twilio_sid="AC", twilio_token="tk", openai_key="sk", phone_number="+1")
+    assert phone is not None
 
 
 def test_local_mode_twilio_requires_token():

--- a/sdk/tests/unit/test_client_unit.py
+++ b/sdk/tests/unit/test_client_unit.py
@@ -74,13 +74,13 @@ class TestPatterInit:
                 webhook_url="abc.ngrok.io",
             )
 
-    def test_local_mode_requires_webhook_url(self) -> None:
-        with pytest.raises(ValueError, match="webhook_url"):
-            Patter(
-                twilio_sid="ACtest000000000000000000000000000",
-                twilio_token="tok",
-                phone_number="+15550001234",
-            )
+    def test_local_mode_accepts_missing_webhook_url(self) -> None:
+        phone = Patter(
+            twilio_sid="ACtest000000000000000000000000000",
+            twilio_token="tok",
+            phone_number="+15550001234",
+        )
+        assert phone is not None
 
     def test_local_mode_requires_twilio_token(self) -> None:
         with pytest.raises(ValueError, match="twilio_token"):


### PR DESCRIPTION
## Summary

- Adds `tunnel: true` option to `serve()` in both TypeScript and Python SDKs
- Auto-spawns a Cloudflare Quick Tunnel (trycloudflare.com) — zero account, zero config
- Eliminates the manual ngrok step: no more "run ngrok, copy URL, paste it"
- `cloudflared` npm package as `optionalDependency` (TS), binary via subprocess (Python)
- Graceful cleanup on `disconnect()` + atexit safety net (Python)

### Usage

```typescript
// Before: manual ngrok
// 1. Run ngrok http 8000
// 2. Copy URL
// 3. Pass webhookUrl: "abc.ngrok.io"

// After: one flag
await phone.serve({ agent, tunnel: true })
```

```python
await phone.serve(agent, tunnel=True)
```

## Test plan

- [x] TypeScript SDK: 680 tests passed, lint clean, build clean
- [x] Python SDK: 978 tests passed
- [x] `webhookUrl` validation deferred from constructor to `serve()` time
- [x] Existing `webhookUrl` flow unchanged
- [ ] Manual test: `tunnel: true` spawns cloudflared and receives webhook calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)