### PR TITLE
chore: set version to 0.4.0

### DIFF
--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.4.1",
+  "version": "0.4.0",
   "description": "Connect AI agents to phone numbers with 10 lines of code",
   "license": "MIT",
   "author": {

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.4.1"
+version = "0.4.0"
 description = "Connect AI agents to phone numbers with 10 lines of code"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Revert version from 0.4.1 back to 0.4.0 in both SDKs
- v0.4.1 tag was premature — npm is still at 0.3.0, PyPI not yet published

After merge, publish manually with `cd sdk-ts && npm publish`.