### PR TITLE
docs: fix navbar logo size and Home icon

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,8 @@
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg",
-    "href": "https://www.getpatter.com"
+    "href": "https://www.getpatter.com",
+    "height": 30
   },
   "navbar": {
     "links": [
@@ -38,7 +39,7 @@
     "products": [
       {
         "product": "Home",
-        "icon": "/patter-logo-banner.svg",
+        "icon": "house",
         "groups": [
           {
             "group": "Welcome",


### PR DESCRIPTION
## Summary
- Increased navbar logo height from default to 30px for better visibility
- Changed Home section icon from custom SVG to Font Awesome `house` icon

## Test plan
- [ ] Verify logo appears larger in the Mintlify navbar
- [ ] Verify Home section shows a house icon instead of the Patter logo