### PR TITLE
fix: dashboard port not released on Ctrl+C

### DIFF
--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -86,14 +86,24 @@ async function main(): Promise<void> {
   });
 
   const server = createServer(app);
+
+  // Track open connections so we can destroy them on shutdown
+  const connections = new Set<import('node:net').Socket>();
+  server.on('connection', (conn) => {
+    connections.add(conn);
+    conn.on('close', () => connections.delete(conn));
+  });
+
   server.listen(port, '127.0.0.1', () => {
     getLogger().info(`Dashboard server listening on port ${port}`);
   });
 
   const shutdown = () => {
     console.log('\nShutting down dashboard...');
+    // Destroy all open connections (including SSE keep-alive)
+    for (const conn of connections) conn.destroy();
     server.close(() => process.exit(0));
-    setTimeout(() => process.exit(0), 3000);
+    setTimeout(() => process.exit(0), 1000);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- Track all open socket connections on the dashboard server
- Destroy them on SIGINT/SIGTERM before calling `server.close()`
- Fixes EADDRINUSE error when restarting the dashboard after Ctrl+C

The issue was that SSE keep-alive connections stayed open indefinitely, preventing the port from being freed.

## Test plan
- [x] Start dashboard, Ctrl+C, restart — no EADDRINUSE
- [x] 978 Python + 680 TypeScript tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)