### PR TITLE
docs: add Patter SDK title below banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   </picture>
 </p>
 
+<h1 align="center">Patter SDK</h1>
+
 <p align="center">
   <a href="https://pypi.org/project/getpatter/"><img src="https://img.shields.io/pypi/v/getpatter?logo=pypi&logoColor=white&label=pip%20install%20getpatter" alt="PyPI" /></a>
   <a href="https://www.npmjs.com/package/getpatter"><img src="https://img.shields.io/npm/v/getpatter?logo=npm&logoColor=white&label=npm%20install%20getpatter" alt="npm" /></a>


### PR DESCRIPTION
Adds `<h1 align="center">Patter SDK</h1>` between the banner image and the badges row, matching the style of patter-mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)