### PR TITLE
docs: sync SDK documentation with code and reframe messaging

### DIFF
--- a/docs/dev-tools/mcp.mdx
+++ b/docs/dev-tools/mcp.mdx
@@ -38,14 +38,14 @@ claude mcp add --transport http patter-mcp http://localhost:3000/mcp
 
 | Tool | Description |
 |---|---|
-| `make_call` | Place an outbound call with an AI voice agent |
+| `make_call` | Place an outbound call through your AI agent |
 | `call_third_party` | Call a third party with an autonomous task |
 | `get_calls` | List all calls with status, duration, and cost |
 | `get_transcript` | Get the full transcript of a call |
 
 ## Claude Code Integration
 
-During a phone call, the voice agent has access to a full Claude Code session via the [Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview). The agent can:
+During a phone call, your agent has access to a full Claude Code session via the [Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview). It can:
 
 - Read, write, and edit files
 - Run shell commands and tests

--- a/docs/python-sdk/configuration.mdx
+++ b/docs/python-sdk/configuration.mdx
@@ -32,7 +32,7 @@ phone = Patter(telnyx_key="KEY...", telnyx_connection_id="...", openai_key="sk-.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `mode` | `str` | `"local"` | Operating mode. Can be omitted — auto-detected when provider keys are given. |
+| `mode` | `str` | `"cloud"` | Operating mode. Auto-detected to `"local"` when telephony provider keys (e.g. `twilio_sid`, `telnyx_key`) are supplied without `api_key`. |
 | `twilio_sid` | `str` | `""` | Twilio Account SID. |
 | `twilio_token` | `str` | `""` | Twilio Auth Token. Required when `twilio_sid` is provided. |
 | `telnyx_key` | `str` | `""` | Telnyx API key. |
@@ -42,6 +42,7 @@ phone = Patter(telnyx_key="KEY...", telnyx_connection_id="...", openai_key="sk-.
 | `deepgram_key` | `str` | `""` | Deepgram API key (optional, for pipeline mode). |
 | `phone_number` | `str` | `""` | Your phone number in E.164 format (e.g., `"+15550001234"`). Required when telephony keys are provided. |
 | `webhook_url` | `str` | `""` | Public hostname of this server, without scheme (e.g., `"abc.ngrok.io"`). Required when telephony keys are provided. |
+| `pricing` | `dict \| None` | `None` | Override default provider pricing estimates. See [Metrics & Cost Tracking](/python-sdk/metrics). |
 
 ```python
 # Twilio + OpenAI Realtime

--- a/docs/python-sdk/events.mdx
+++ b/docs/python-sdk/events.mdx
@@ -17,6 +17,7 @@ All callbacks are **async functions**. They are passed as parameters to `serve()
 | `on_call_end` | A call ends |
 | `on_transcript` | Each utterance is transcribed |
 | `on_message` | User message received (pipeline mode) |
+| `on_metrics` | After each conversation turn (real-time cost/latency) |
 
 ---
 
@@ -61,7 +62,11 @@ async def on_call_end(event):
 | Field | Type | Description |
 |-------|------|-------------|
 | `call_id` | `str` | Unique identifier for this call. |
+| `caller` | `str` | The caller's phone number (E.164). |
+| `callee` | `str` | The callee's phone number (E.164). |
+| `ended_at` | `float` | Unix timestamp when the call ended (e.g. `1710489601.234`). |
 | `transcript` | `list[dict]` | Full conversation transcript. Each entry has `role` (`"user"` or `"assistant"`) and `text`. |
+| `metrics` | `CallMetrics \| None` | Call metrics with cost and latency breakdowns. `None` if metrics collection failed. See [Metrics & Cost Tracking](/python-sdk/metrics). |
 
 ---
 
@@ -115,6 +120,7 @@ async def on_message(event) -> str:
 | `text` | `str` | The user's transcribed message. |
 | `call_id` | `str` | Unique identifier for this call. |
 | `caller` | `str` | The caller's phone number. |
+| `callee` | `str` | The callee's phone number. |
 | `history` | `list[dict]` | Conversation history. Each entry has `role`, `text`, and `timestamp`. |
 
 ### Return Value
@@ -129,11 +135,13 @@ All callbacks that include `history` receive it as a list of dictionaries:
 
 ```python
 [
-    {"role": "assistant", "text": "Hello! How can I help?", "timestamp": "2025-03-15T10:00:01Z"},
-    {"role": "user", "text": "I'd like to check my order status.", "timestamp": "2025-03-15T10:00:05Z"},
-    {"role": "assistant", "text": "Sure! What's your order ID?", "timestamp": "2025-03-15T10:00:06Z"},
+    {"role": "assistant", "text": "Hello! How can I help?", "timestamp": 1710489601.234},
+    {"role": "user", "text": "I'd like to check my order status.", "timestamp": 1710489605.891},
+    {"role": "assistant", "text": "Sure! What's your order ID?", "timestamp": 1710489606.712},
 ]
 ```
+
+Timestamps are Unix floats (from Python's `time.time()`), not ISO-8601 strings.
 
 ---
 

--- a/docs/python-sdk/features.mdx
+++ b/docs/python-sdk/features.mdx
@@ -134,12 +134,17 @@ No configuration is required. Barge-in is always enabled.
 
 ## AI Disclosure
 
-Patter automatically plays an AI disclosure message at the start of every call. This is a non-optional feature that ensures compliance with regulations requiring disclosure that the caller is speaking with an AI.
+Many jurisdictions require disclosure that the caller is speaking with an AI. Patter does not automatically inject a disclosure message. Instead, use the `first_message` field on your agent configuration to include an appropriate disclosure at the start of every call:
 
-The disclosure plays before the agent's `first_message` (if set) or before the agent begins listening.
+```python
+agent = phone.agent(
+    system_prompt="You are a helpful assistant.",
+    first_message="Hi, this is an AI-powered assistant calling on behalf of Acme Corp. How can I help you?",
+)
+```
 
 <Warning>
-  The AI disclosure message cannot be disabled. This is by design to ensure legal compliance across jurisdictions.
+  You are responsible for ensuring your AI disclosure complies with the regulations in your jurisdiction. Always consult legal counsel for compliance requirements.
 </Warning>
 
 ---
@@ -161,7 +166,7 @@ async def on_transcript(event):
 {
     "role": "user",       # or "assistant"
     "text": "Hello!",
-    "timestamp": "2025-03-15T10:00:01Z"
+    "timestamp": 1710489601.234  # Unix float from time.time()
 }
 ```
 

--- a/docs/python-sdk/local-mode.mdx
+++ b/docs/python-sdk/local-mode.mdx
@@ -70,6 +70,10 @@ await phone.serve(agent, port=8000)
 | `on_transcript` | `Callable \| None` | `None` | Async callback fired for each utterance. |
 | `on_message` | `Callable \| None` | `None` | Async callback for pipeline mode. Receives user text, returns agent response. |
 | `voicemail_message` | `str` | `""` | Message to speak when AMD detects a machine on outbound calls. |
+| `on_metrics` | `Callable \| None` | `None` | Async callback fired after each conversation turn with real-time cost and latency data. See [Metrics & Cost Tracking](/python-sdk/metrics). |
+| `dashboard` | `bool` | `True` | Serve a local metrics dashboard at `http://localhost:{port}/dashboard`. |
+| `dashboard_token` | `str` | `""` | Bearer token for dashboard authentication. When set, all dashboard routes require this token. |
+| `tunnel` | `bool` | `False` | Start a cloudflared tunnel automatically. Requires `cloudflared` on PATH. Mutually exclusive with `webhook_url`. |
 
 ---
 

--- a/docs/python-sdk/metrics.mdx
+++ b/docs/python-sdk/metrics.mdx
@@ -105,7 +105,7 @@ Use the `on_metrics` callback for live cost updates during a call:
 async def on_metrics(data):
     cost = data.get("cost_so_far")
     if cost:
-        print(f"Running cost: ${cost['total']:.4f}")
+        print(f"Running cost: ${cost.total:.4f}")
 
 await phone.serve(
     agent,
@@ -113,6 +113,8 @@ await phone.serve(
     on_metrics=on_metrics,
 )
 ```
+
+The `cost_so_far` value is a `CostBreakdown` dataclass, so access its fields as attributes (e.g. `cost.total`, `cost.stt`) rather than dictionary keys.
 
 ## Data Types
 
@@ -133,6 +135,7 @@ from patter import CallMetrics, CostBreakdown, LatencyBreakdown, TurnMetrics
 | `provider_mode` | `str` | Voice mode used. |
 | `stt_provider` | `str` | STT provider name. |
 | `tts_provider` | `str` | TTS provider name. |
+| `llm_provider` | `str` | LLM provider name. |
 | `telephony_provider` | `str` | Telephony provider name. |
 
 ### TurnMetrics

--- a/docs/python-sdk/overview.mdx
+++ b/docs/python-sdk/overview.mdx
@@ -5,7 +5,7 @@ description: "Connect AI agents to phone numbers with 4 lines of Python."
 
 # Python SDK
 
-The Patter Python SDK lets you connect AI voice agents to phone numbers in minutes. Build inbound call centers, outbound dialers, and conversational AI experiences with minimal code.
+The Patter Python SDK lets you connect AI voice agents to phone numbers in minutes. Power inbound call centers, outbound dialers, and conversational AI experiences with minimal code.
 
 ## Installation
 
@@ -52,7 +52,7 @@ Patter runs in local/self-hosted mode. You bring your own telephony and AI provi
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/python-sdk/quickstart">
-    Step-by-step guide to your first voice agent.
+    Connect your first agent to a phone number.
   </Card>
   <Card title="Configuration" icon="gear" href="/python-sdk/configuration">
     All constructor parameters and mode options.

--- a/docs/python-sdk/quickstart.mdx
+++ b/docs/python-sdk/quickstart.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quickstart"
-description: "Build your first voice AI agent in 5 minutes."
+description: "Give your AI agent a phone number in 5 minutes."
 ---
 
 # Python Quickstart
 
-This guide walks you through building a voice AI agent that answers phone calls using local/self-hosted mode.
+This guide walks you through connecting your AI agent to phone calls using local/self-hosted mode.
 
 ## Prerequisites
 

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -15,7 +15,7 @@ The main SDK client class.
 
 ```python
 Patter(
-    mode: str = "local",
+    mode: str = "cloud",
     twilio_sid: str = "",
     twilio_token: str = "",
     telnyx_key: str = "",
@@ -31,7 +31,7 @@ Patter(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `mode` | `str` | `"local"` | Operating mode. Can be omitted — auto-detected when provider keys are given. |
+| `mode` | `str` | `"cloud"` | Operating mode. Auto-detected to `"local"` when telephony provider keys (e.g. `twilio_sid`, `telnyx_key`) are supplied without `api_key`. |
 | `twilio_sid` | `str` | `""` | Twilio Account SID. |
 | `twilio_token` | `str` | `""` | Twilio Auth Token. |
 | `telnyx_key` | `str` | `""` | Telnyx API key. |
@@ -365,8 +365,8 @@ class TTSConfig:
 @dataclass(frozen=True)
 class Guardrail:
     name: str
-    check: object = None
-    blocked_terms: list | None = None
+    check: Callable[[str], bool] | None = None
+    blocked_terms: list[str] | None = None
     replacement: str = "I'm sorry, I can't respond to that."
 ```
 
@@ -481,7 +481,9 @@ All exceptions inherit from `PatterError`.
 
 ```
 PatterError
-└── PatterConnectionError
+├── PatterConnectionError
+├── AuthenticationError
+└── ProvisionError
 ```
 
 ### PatterError
@@ -510,6 +512,32 @@ except PatterConnectionError as e:
     print(f"Connection error: {e}")
 ```
 
+### AuthenticationError
+
+Raised when authentication fails (e.g., invalid API key).
+
+```python
+from patter import AuthenticationError
+
+try:
+    await phone.connect(on_message=handler)
+except AuthenticationError as e:
+    print(f"Authentication error: {e}")
+```
+
+### ProvisionError
+
+Raised when a provisioning operation fails (e.g., creating an agent, buying a number, registering a number).
+
+```python
+from patter import ProvisionError
+
+try:
+    await phone.create_agent(name="My Agent", system_prompt="Hello")
+except ProvisionError as e:
+    print(f"Provisioning error: {e}")
+```
+
 ---
 
 ## Exports
@@ -531,5 +559,7 @@ from patter import (
     TurnMetrics,
     PatterError,
     PatterConnectionError,
+    AuthenticationError,
+    ProvisionError,
 )
 ```

--- a/docs/python-sdk/test-mode.mdx
+++ b/docs/python-sdk/test-mode.mdx
@@ -29,7 +29,7 @@ This opens an interactive REPL:
 ============================================================
   PATTER TEST MODE
 ============================================================
-  Agent: gpt-4o-realtime / alloy
+  Agent: gpt-4o-mini-realtime-preview / alloy
   Provider: openai_realtime
   Call ID: test_a1b2c3d4e5f6
   Caller: +15550000001  →  Callee: +15550000002
@@ -90,7 +90,7 @@ agent = phone.agent(
                     "party_size": {"type": "integer"},
                 },
             },
-            "webhook": "https://api.example.com/availability",
+            "webhook_url": "https://api.example.com/availability",
         }
     ],
 )

--- a/docs/python-sdk/tools.mdx
+++ b/docs/python-sdk/tools.mdx
@@ -118,7 +118,7 @@ Your webhook must return valid JSON. The response is passed back to the AI as th
 |------------|-------|
 | Content type | `application/json` |
 | Max response size | 1 MB |
-| Timeout | Standard HTTP timeout |
+| Timeout | 10 seconds |
 
 ### Retry Behavior
 

--- a/docs/typescript-sdk/agents.mdx
+++ b/docs/typescript-sdk/agents.mdx
@@ -42,7 +42,7 @@ const agent = phone.agent({
 The `phone.agent()` method validates:
 
 - **Provider**: Must be one of `"openai_realtime"`, `"elevenlabs_convai"`, or `"pipeline"`. Throws if invalid.
-- **Tools**: Must be an array. Each tool requires `name` and `webhookUrl` fields.
+- **Tools**: Must be an array. Each tool requires a `name` field and either a `webhookUrl` or a `handler`.
 - **Variables**: Must be a plain object (not an array).
 
 ```typescript
@@ -52,7 +52,7 @@ phone.agent({
   provider: "invalid" as any,
 });
 
-// Throws: tools[0] missing required 'webhookUrl' field
+// Throws: tools[0] requires either 'webhookUrl' or 'handler'
 phone.agent({
   systemPrompt: "...",
   tools: [{ name: "lookup", description: "Look up data", parameters: {} }] as any,

--- a/docs/typescript-sdk/agents.mdx
+++ b/docs/typescript-sdk/agents.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Agents"
-description: "Configure AI voice agents with system prompts, voices, models, and tools."
+description: "Define your agent's voice, model, tools, and behavior for phone calls."
 ---
 
 # Agents
 
-An agent defines the personality, capabilities, and behavior of your AI voice assistant. Use `phone.agent()` to create and validate an agent configuration.
+An agent configuration defines the personality, capabilities, and behavior of your AI voice assistant. Use `phone.agent()` to validate your agent config before connecting it to a phone number.
 
 ## Basic Agent
 

--- a/docs/typescript-sdk/configuration.mdx
+++ b/docs/typescript-sdk/configuration.mdx
@@ -28,7 +28,7 @@ const phone = new Patter({
 |-----------|------|----------|---------|-------------|
 | `mode` | `"local"` | Yes | — | Must be `"local"` to enable local mode. |
 | `phoneNumber` | `string` | Yes | — | Your phone number in E.164 format. |
-| `webhookUrl` | `string` | Yes | — | Public hostname for webhooks (no protocol prefix, no path). |
+| `webhookUrl` | `string` | Conditional | — | Public hostname for webhooks (no protocol prefix, no path). Required unless using `tunnel: true` in `serve()`. |
 | `twilioSid` | `string` | Conditional | — | Twilio Account SID. Required if not using Telnyx. |
 | `twilioToken` | `string` | Conditional | — | Twilio Auth Token. Required when `twilioSid` is set. |
 | `openaiKey` | `string` | No | — | OpenAI API key for the realtime adapter. |

--- a/docs/typescript-sdk/dashboard.mdx
+++ b/docs/typescript-sdk/dashboard.mdx
@@ -5,7 +5,7 @@ description: "Embedded web dashboard for real-time call monitoring, analytics, a
 
 # Dashboard
 
-Patter includes a built-in web dashboard for monitoring calls in real time. It runs alongside your agent server and provides a visual interface for call analytics, live call tracking, and data export.
+Patter includes a built-in web dashboard for monitoring calls in real time. It runs alongside your server and provides a visual interface for call analytics, live call tracking, and data export.
 
 ## Enabling the Dashboard
 

--- a/docs/typescript-sdk/events.mdx
+++ b/docs/typescript-sdk/events.mdx
@@ -15,6 +15,7 @@ Patter emits events at key moments during a call. Register callbacks in `serve()
 | `onCallEnd` | When a call disconnects | `serve()` |
 | `onTranscript` | Each time a transcript segment arrives | `serve()` |
 | `onMessage` | User transcript ready for response (pipeline mode) | `serve()` |
+| `onMetrics` | After each conversational turn completes | `serve()` |
 
 ## onCallStart
 
@@ -38,12 +39,17 @@ await phone.serve({
 
 ```typescript
 {
-  call_id: string;    // Unique call identifier
-  caller: string;     // Caller phone number (E.164)
-  callee: string;     // Callee phone number (E.164)
-  direction: string;  // "inbound" or "outbound"
+  call_id: string;                        // Unique call identifier
+  caller: string;                         // Caller phone number (E.164)
+  callee: string;                         // Callee phone number (E.164)
+  direction: string;                      // "inbound" or "outbound"
+  custom_params?: Record<string, string>; // TwiML custom parameters (Twilio only, omitted when empty)
 }
 ```
+
+<Info>
+  `custom_params` contains key-value pairs passed via TwiML `<Parameter>` elements. This is only present for Twilio calls that include custom parameters. For Telnyx calls, this field is omitted.
+</Info>
 
 ## onCallEnd
 
@@ -72,12 +78,36 @@ await phone.serve({
 
 ```typescript
 {
-  call_id: string;
+  call_id: string;       // Unique call identifier
+  caller: string;        // Caller phone number (E.164)
+  callee: string;        // Callee phone number (E.164)
+  ended_at: number;      // Unix timestamp in seconds (fractional)
   transcript: Array<{
-    role: string;       // "user" or "assistant"
-    text: string;       // Transcript text
-    timestamp: number;  // Unix timestamp (ms)
+    role: string;        // "user" or "assistant"
+    text: string;        // Transcript text
+    timestamp: number;   // Unix timestamp (ms)
   }>;
+  metrics: {             // Aggregated call metrics
+    call_id: string;
+    duration_seconds: number;
+    turns: Array<{
+      turn_index: number;
+      user_text: string;
+      agent_text: string;
+      latency: { stt_ms: number; llm_ms: number; tts_ms: number; total_ms: number };
+      stt_audio_seconds: number;
+      tts_characters: number;
+      timestamp: number;
+    }>;
+    cost: { stt: number; tts: number; llm: number; telephony: number; total: number };
+    latency_avg: { stt_ms: number; llm_ms: number; tts_ms: number; total_ms: number };
+    latency_p95: { stt_ms: number; llm_ms: number; tts_ms: number; total_ms: number };
+    provider_mode: string;
+    stt_provider: string;
+    tts_provider: string;
+    llm_provider: string;
+    telephony_provider: string;
+  };
 }
 ```
 
@@ -109,6 +139,11 @@ await phone.serve({
   role: string;     // "user" or "assistant"
   text: string;     // Transcript segment
   call_id: string;  // Call identifier
+  history: Array<{  // Full conversation history up to this point (max 200 entries)
+    role: string;
+    text: string;
+    timestamp: number;
+  }>;
 }
 ```
 
@@ -154,6 +189,52 @@ await phone.serve({
 ### Return Value
 
 The function must return a `string` that will be converted to speech. If you return an empty string, nothing is spoken.
+
+## onMetrics
+
+Fires after each conversational turn completes. Use it for real-time latency monitoring, cost tracking, or per-turn analytics.
+
+```typescript
+await phone.serve({
+  agent,
+  onMetrics: async (data) => {
+    const callId = data.call_id as string;
+    const turn = data.turn as {
+      turn_index: number;
+      user_text: string;
+      agent_text: string;
+      latency: { stt_ms: number; llm_ms: number; tts_ms: number; total_ms: number };
+      stt_audio_seconds: number;
+      tts_characters: number;
+      timestamp: number;
+    };
+
+    console.log(`[${callId}] Turn ${turn.turn_index}: ${turn.latency.total_ms}ms total latency`);
+  },
+});
+```
+
+### Payload
+
+```typescript
+{
+  call_id: string;  // Call identifier
+  turn: {
+    turn_index: number;          // Zero-based turn counter
+    user_text: string;           // What the user said (empty for first message turns)
+    agent_text: string;          // What the agent responded
+    latency: {
+      stt_ms: number;            // Speech-to-text latency
+      llm_ms: number;            // LLM inference latency
+      tts_ms: number;            // Text-to-speech time-to-first-byte
+      total_ms: number;          // End-to-end turn latency
+    };
+    stt_audio_seconds: number;   // Duration of user audio processed by STT
+    tts_characters: number;      // Number of characters sent to TTS
+    timestamp: number;           // Unix timestamp (seconds) when the turn completed
+  };
+}
+```
 
 ## Type Signatures
 

--- a/docs/typescript-sdk/features.mdx
+++ b/docs/typescript-sdk/features.mdx
@@ -146,7 +146,26 @@ Each entry contains:
 
 ## AI Disclosure
 
-An AI disclosure message is automatically played at the start of every call. This is non-optional and ensures compliance with regulations requiring callers to be informed they are speaking with an AI.
+Patter does **not** automatically play an AI disclosure message. If your jurisdiction requires callers to be informed they are speaking with an AI, include a disclosure in your agent's `firstMessage`:
+
+```typescript
+const agent = phone.agent({
+  systemPrompt: "You are a helpful assistant.",
+  firstMessage: "Hi, this is an AI assistant from Acme Corp. How can I help you today?",
+});
+```
+
+The `firstMessage` is spoken as soon as the call connects, before the caller says anything. This is the recommended place for any legally required AI disclosure.
+
+## Max Call Duration
+
+As a safety measure, calls are automatically terminated after **1 hour** (60 minutes). This prevents runaway billing from calls that are accidentally left open.
+
+When the limit is reached:
+1. The SDK logs a warning: `Call {callId} hit max duration (60min), terminating`
+2. The call is hung up via the telephony provider API
+
+This limit is not configurable and applies to all calls.
 
 ## Outbound Calls
 

--- a/docs/typescript-sdk/local-mode.mdx
+++ b/docs/typescript-sdk/local-mode.mdx
@@ -37,12 +37,17 @@ await phone.serve({
 |-----------|------|----------|---------|-------------|
 | `agent` | `AgentOptions` | Yes | — | Agent configuration. |
 | `port` | `number` | No | `8000` | Port for the embedded server (1-65535). |
+| `tunnel` | `boolean` | No | `false` | When `true`, start a cloudflared tunnel automatically (requires `cloudflared` npm package). Cannot be used together with `webhookUrl`. |
 | `onCallStart` | `(data) => Promise<void>` | No | — | Called when a call connects. |
 | `onCallEnd` | `(data) => Promise<void>` | No | — | Called when a call disconnects. |
 | `onTranscript` | `(data) => Promise<void>` | No | — | Called for each transcript segment. |
-| `onMessage` | `(data) => Promise<string>` | No | — | Pipeline mode only. Receives user transcript, returns response text. |
+| `onMessage` | `(data) => Promise<string>` | No | — | Pipeline mode only. Receives user transcript, returns response text. Can also be a URL string for remote webhook/WebSocket integration. |
+| `onMetrics` | `(data) => Promise<void>` | No | — | Called after each conversational turn with per-turn latency and cost metrics. |
 | `recording` | `boolean` | No | `false` | Enable call recording (Twilio only). |
 | `voicemailMessage` | `string` | No | — | Default voicemail message for AMD. |
+| `pricing` | `Record<string, Record<string, unknown>>` | No | — | Custom pricing overrides for cost calculation. |
+| `dashboard` | `boolean` | No | `true` | When `true`, serve a dashboard UI at `/dashboard`. |
+| `dashboardToken` | `string` | No | — | Bearer token for dashboard/API authentication. |
 
 ## Webhook Endpoints
 
@@ -142,6 +147,36 @@ Phone Speaker
 | Telnyx | PCM 16kHz | No transcoding needed |
 | OpenAI TTS | PCM 24kHz | Resampled to 16kHz |
 
+## Graceful Shutdown
+
+Call `phone.disconnect()` to gracefully stop the embedded server. The shutdown sequence:
+
+1. **Stop accepting new connections** — the HTTP server stops listening.
+2. **Hang up active calls** — each active call is terminated via the telephony provider API (Twilio or Telnyx).
+3. **Close WebSocket connections** — a close frame (`1001 Server shutting down`) is sent to all active WebSocket connections.
+4. **Wait for drain** — the server waits up to **10 seconds** for active connections to close cleanly.
+5. **Force-terminate** — any connections still open after the drain timeout are forcibly terminated.
+6. **Close HTTP server** — the underlying HTTP server is fully closed.
+
+```typescript
+// Handle SIGINT/SIGTERM for clean shutdown
+process.on("SIGINT", async () => {
+  console.log("Shutting down...");
+  await phone.disconnect();
+  process.exit(0);
+});
+```
+
+<Info>
+  If a cloudflared tunnel was started with `tunnel: true`, it is also stopped when `disconnect()` is called.
+</Info>
+
 ## Binding Address
 
-The server binds to `127.0.0.1` by default. Use a tunnel (ngrok, Cloudflare Tunnel) to expose it to the internet for telephony provider webhooks.
+The server binds to `0.0.0.0` by default, which means it listens on all network interfaces. This is necessary for the server to accept connections from telephony providers and tunnels, but it also means the server is accessible from other machines on your network.
+
+<Warning>
+  Because the server binds to `0.0.0.0`, it is reachable from any network interface. In production, use a firewall or reverse proxy to restrict access. Always configure `twilioToken` (or `telnyxPublicKey` for Telnyx) to enable webhook signature verification.
+</Warning>
+
+Use a tunnel (ngrok, Cloudflare Tunnel) to expose the server to the internet for telephony provider webhooks.

--- a/docs/typescript-sdk/metrics.mdx
+++ b/docs/typescript-sdk/metrics.mdx
@@ -12,19 +12,20 @@ Patter automatically tracks cost and latency for every call, broken down by prov
 Metrics are collected automatically during calls. When a call ends, the `onCallEnd` callback receives a `CallMetrics` object with the full breakdown:
 
 ```typescript
-await phone.serve(agent, {
+await phone.serve({
+  agent,
   port: 8000,
   onCallEnd: async (event) => {
     const metrics = event.metrics;
     if (metrics) {
-      console.log(`Duration: ${metrics.durationSeconds}s`);
+      console.log(`Duration: ${metrics.duration_seconds}s`);
       console.log(`Total cost: $${metrics.cost.total.toFixed(4)}`);
       console.log(`  STT: $${metrics.cost.stt.toFixed(4)}`);
       console.log(`  TTS: $${metrics.cost.tts.toFixed(4)}`);
       console.log(`  LLM: $${metrics.cost.llm.toFixed(4)}`);
       console.log(`  Telephony: $${metrics.cost.telephony.toFixed(4)}`);
-      console.log(`Avg latency: ${metrics.latencyAvg.totalMs}ms`);
-      console.log(`P95 latency: ${metrics.latencyP95.totalMs}ms`);
+      console.log(`Avg latency: ${metrics.latency_avg.total_ms}ms`);
+      console.log(`P95 latency: ${metrics.latency_p95.total_ms}ms`);
     }
   },
 });
@@ -48,28 +49,29 @@ The `LatencyBreakdown` object provides per-component latency in milliseconds:
 
 | Field | Description |
 |-------|-------------|
-| `sttMs` | Time from user speech to transcript. |
-| `llmMs` | Time from transcript to LLM response. |
-| `ttsMs` | Time from LLM response to first audio byte. |
-| `totalMs` | End-to-end latency (user speech to first audio). |
+| `stt_ms` | Time from user speech to transcript. |
+| `llm_ms` | Time from transcript to LLM response. |
+| `tts_ms` | Time from LLM response to first audio byte. |
+| `total_ms` | End-to-end latency (user speech to first audio). |
 
-Both `latencyAvg` and `latencyP95` are available on `CallMetrics`.
+Both `latency_avg` and `latency_p95` are available on `CallMetrics`.
 
 ## Per-Turn Metrics
 
 Each conversation turn is tracked individually:
 
 ```typescript
-await phone.serve(agent, {
+await phone.serve({
+  agent,
   port: 8000,
   onCallEnd: async (event) => {
     const metrics = event.metrics;
     if (metrics) {
       for (const turn of metrics.turns) {
-        console.log(`Turn ${turn.turnIndex}:`);
-        console.log(`  User: ${turn.userText}`);
-        console.log(`  Agent: ${turn.agentText}`);
-        console.log(`  Latency: ${turn.latency.totalMs}ms`);
+        console.log(`Turn ${turn.turn_index}:`);
+        console.log(`  User: ${turn.user_text}`);
+        console.log(`  Agent: ${turn.agent_text}`);
+        console.log(`  Latency: ${turn.latency.total_ms}ms`);
       }
     }
   },
@@ -81,9 +83,9 @@ await phone.serve(agent, {
 Override default provider pricing estimates:
 
 ```typescript
-const phone = new Patter({
-  openaiKey: "sk-...",
-  mode: "local",
+await phone.serve({
+  agent,
+  port: 8000,
   pricing: {
     deepgram: { price: 0.005 },      // Override STT price per minute
     elevenlabs: { price: 0.15 },      // Override TTS price per 1k chars
@@ -113,13 +115,14 @@ const phone = new Patter({
 Use the `onMetrics` callback for live cost updates during a call:
 
 ```typescript
-await phone.serve(agent, {
+await phone.serve({
+  agent,
   port: 8000,
   onMetrics: async (data) => {
-    const cost = data.costSoFar;
-    if (cost) {
-      console.log(`Running cost: $${cost.total.toFixed(4)}`);
-    }
+    const turn = data.turn as Record<string, unknown>;
+    const latency = turn.latency as Record<string, number>;
+    console.log(`Call ${data.call_id} — turn ${turn.turn_index}`);
+    console.log(`  Latency: ${latency.total_ms}ms`);
   },
 });
 ```
@@ -139,25 +142,26 @@ import type {
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `callId` | `string` | Unique call identifier. |
-| `durationSeconds` | `number` | Total call duration. |
+| `call_id` | `string` | Unique call identifier. |
+| `duration_seconds` | `number` | Total call duration. |
 | `turns` | `TurnMetrics[]` | Per-turn metrics. |
 | `cost` | `CostBreakdown` | Cost breakdown. |
-| `latencyAvg` | `LatencyBreakdown` | Average latency. |
-| `latencyP95` | `LatencyBreakdown` | 95th percentile latency. |
-| `providerMode` | `string` | Voice mode used. |
-| `sttProvider` | `string` | STT provider name. |
-| `ttsProvider` | `string` | TTS provider name. |
-| `telephonyProvider` | `string` | Telephony provider name. |
+| `latency_avg` | `LatencyBreakdown` | Average latency. |
+| `latency_p95` | `LatencyBreakdown` | 95th percentile latency. |
+| `provider_mode` | `string` | Voice mode used. |
+| `stt_provider` | `string` | STT provider name. |
+| `tts_provider` | `string` | TTS provider name. |
+| `llm_provider` | `string` | LLM provider name. |
+| `telephony_provider` | `string` | Telephony provider name. |
 
 ### TurnMetrics
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `turnIndex` | `number` | Zero-based turn index. |
-| `userText` | `string` | What the user said. |
-| `agentText` | `string` | What the agent replied. |
+| `turn_index` | `number` | Zero-based turn index. |
+| `user_text` | `string` | What the user said. |
+| `agent_text` | `string` | What the agent replied. |
 | `latency` | `LatencyBreakdown` | Latency for this turn. |
-| `sttAudioSeconds` | `number` | Audio duration processed by STT. |
-| `ttsCharacters` | `number` | Characters synthesized by TTS. |
+| `stt_audio_seconds` | `number` | Audio duration processed by STT. |
+| `tts_characters` | `number` | Characters synthesized by TTS. |
 | `timestamp` | `number` | Unix timestamp. |

--- a/docs/typescript-sdk/overview.mdx
+++ b/docs/typescript-sdk/overview.mdx
@@ -57,7 +57,7 @@ Patter runs in **local mode**, embedding an Express server and all provider adap
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/typescript-sdk/quickstart">
-    Step-by-step guide to your first voice agent.
+    Connect your first agent to a phone call.
   </Card>
   <Card title="Configuration" icon="gear" href="/typescript-sdk/configuration">
     All constructor parameters and mode options.

--- a/docs/typescript-sdk/providers.mdx
+++ b/docs/typescript-sdk/providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Providers"
-description: "Voice AI providers: OpenAI Realtime, ElevenLabs ConvAI, and custom pipelines."
+description: "Voice providers: OpenAI Realtime, ElevenLabs ConvAI, and custom pipelines."
 ---
 
 # Providers

--- a/docs/typescript-sdk/quickstart.mdx
+++ b/docs/typescript-sdk/quickstart.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Quickstart"
-description: "Get a voice AI agent answering phone calls in under 5 minutes."
+description: "Give your AI agent a phone number in under 5 minutes."
 ---
 
 # Quickstart
 
-This guide walks you through setting up a voice AI agent in local mode using Twilio and OpenAI.
+This guide walks you through connecting your AI agent to a phone number in local mode using Twilio and OpenAI.
 
 ## Prerequisites
 
@@ -44,7 +44,7 @@ PHONE_NUMBER=+15550001234
 WEBHOOK_URL=abc123.ngrok.io
 ```
 
-## Step 4: Create Your Agent
+## Step 4: Define Your Agent
 
 Create `index.ts`:
 
@@ -89,13 +89,13 @@ https://abc123.ngrok.io/webhooks/twilio/voice
 
 Set the method to **POST**.
 
-## Step 6: Run Your Agent
+## Step 6: Start the Server
 
 ```bash
 npx tsx index.ts
 ```
 
-You should see the Patter banner and server status in your terminal. Call your Twilio number and start talking to your AI agent.
+You should see the Patter banner and server status in your terminal. Call your Twilio number — your agent is now live on the phone.
 
 ## Next Steps
 

--- a/docs/typescript-sdk/reference.mdx
+++ b/docs/typescript-sdk/reference.mdx
@@ -22,7 +22,8 @@ new Patter(options: LocalOptions)
 | `agent` | `(opts: AgentOptions) => AgentOptions` | Validates and returns an agent configuration. |
 | `serve` | `(opts: ServeOptions) => Promise<void>` | Starts the embedded server (local mode only). |
 | `call` | `(opts: LocalCallOptions) => Promise<void>` | Makes an outbound call. |
-| `test` | `(agent: AgentOptions, opts?: TestOptions) => Promise<void>` | Starts an interactive terminal test session (local mode only). See [Test Mode](/typescript-sdk/test-mode). |
+| `test` | `(opts: ServeOptions) => Promise<void>` | Starts an interactive terminal test session (local mode only). See [Test Mode](/typescript-sdk/test-mode). |
+| `disconnect` | `() => Promise<void>` | Stops the tunnel, embedded server, and WebSocket connection. |
 
 ### Static Methods
 
@@ -46,12 +47,11 @@ interface LocalOptions {
   twilioToken?: string;
   openaiKey?: string;
   phoneNumber: string;
-  webhookUrl: string;
+  webhookUrl?: string;
   telephonyProvider?: "twilio" | "telnyx";
   telnyxKey?: string;
   telnyxConnectionId?: string;
   telnyxPublicKey?: string;
-  pricing?: Record<string, Partial<ProviderPricing>>;
 }
 ```
 
@@ -82,6 +82,7 @@ interface AgentOptions {
 interface ServeOptions {
   agent: AgentOptions;
   port?: number;
+  tunnel?: boolean;
   onCallStart?: (data: Record<string, unknown>) => Promise<void>;
   onCallEnd?: (data: Record<string, unknown>) => Promise<void>;
   onTranscript?: (data: Record<string, unknown>) => Promise<void>;
@@ -89,8 +90,11 @@ interface ServeOptions {
   onMetrics?: (data: Record<string, unknown>) => Promise<void>;
   recording?: boolean;
   voicemailMessage?: string;
+  pricing?: Record<string, Record<string, unknown>>;
   dashboard?: boolean;
   dashboardToken?: string;
+  dashboardDb?: string;
+  dashboardPersist?: boolean;
 }
 ```
 
@@ -113,7 +117,8 @@ interface ToolDefinition {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
-  webhookUrl: string;
+  webhookUrl?: string;
+  handler?: (args: Record<string, unknown>, context: Record<string, unknown>) => Promise<string>;
 }
 ```
 
@@ -167,12 +172,8 @@ interface CallControl {
   readonly callId: string;
   readonly caller: string;
   readonly callee: string;
-  readonly telephonyProvider: string;
   transfer(number: string): Promise<void>;
   hangup(): Promise<void>;
-  readonly isTransferred: boolean;
-  readonly isHungUp: boolean;
-  readonly ended: boolean;
 }
 ```
 
@@ -182,16 +183,17 @@ Passed as the second argument to `onMessage` handlers. Allows dynamic call manag
 
 ```typescript
 interface CallMetrics {
-  callId: string;
-  durationSeconds: number;
+  call_id: string;
+  duration_seconds: number;
   turns: TurnMetrics[];
   cost: CostBreakdown;
-  latencyAvg: LatencyBreakdown;
-  latencyP95: LatencyBreakdown;
-  providerMode: string;
-  sttProvider: string;
-  ttsProvider: string;
-  telephonyProvider: string;
+  latency_avg: LatencyBreakdown;
+  latency_p95: LatencyBreakdown;
+  provider_mode: string;
+  stt_provider: string;
+  tts_provider: string;
+  llm_provider: string;
+  telephony_provider: string;
 }
 ```
 
@@ -211,10 +213,10 @@ interface CostBreakdown {
 
 ```typescript
 interface LatencyBreakdown {
-  sttMs: number;
-  llmMs: number;
-  ttsMs: number;
-  totalMs: number;
+  stt_ms: number;
+  llm_ms: number;
+  tts_ms: number;
+  total_ms: number;
 }
 ```
 
@@ -222,12 +224,12 @@ interface LatencyBreakdown {
 
 ```typescript
 interface TurnMetrics {
-  turnIndex: number;
-  userText: string;
-  agentText: string;
+  turn_index: number;
+  user_text: string;
+  agent_text: string;
   latency: LatencyBreakdown;
-  sttAudioSeconds: number;
-  ttsCharacters: number;
+  stt_audio_seconds: number;
+  tts_characters: number;
   timestamp: number;
 }
 ```
@@ -260,11 +262,15 @@ All errors extend `PatterError`, which extends the native `Error` class.
 |-------|-------------|
 | `PatterError` | Base error class for all SDK errors. |
 | `PatterConnectionError` | WebSocket connection failures or disconnection errors. |
+| `AuthenticationError` | Invalid or missing API key. |
+| `ProvisionError` | Failures when provisioning resources (numbers, agents, calls). |
 
 ```typescript
 import {
   PatterError,
   PatterConnectionError,
+  AuthenticationError,
+  ProvisionError,
 } from "getpatter";
 
 try {
@@ -296,6 +302,8 @@ export { OpenAITTS } from "getpatter";
 export {
   PatterError,
   PatterConnectionError,
+  AuthenticationError,
+  ProvisionError,
 } from "getpatter";
 ```
 

--- a/docs/typescript-sdk/test-mode.mdx
+++ b/docs/typescript-sdk/test-mode.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Test Mode"
-description: "Interactive terminal testing for voice agents without telephony, STT, or TTS."
+description: "Test your agent in the terminal without telephony, STT, or TTS."
 ---
 
 # Test Mode
 
-Test mode lets you interact with your voice agent in the terminal using pure text — no phone calls, no STT/TTS, no external services required. It simulates a phone conversation for rapid agent development.
+Test mode lets you interact with your agent in the terminal using pure text — no phone calls, no STT/TTS, no external services required. It simulates a phone conversation for rapid development.
 
 ## Quick Start
 

--- a/docs/typescript-sdk/test-mode.mdx
+++ b/docs/typescript-sdk/test-mode.mdx
@@ -19,7 +19,7 @@ const agent = phone.agent({
   firstMessage: "Hello! Welcome to Acme Corp. How can I help you today?",
 });
 
-await phone.test(agent);
+await phone.test({ agent });
 ```
 
 This opens an interactive REPL:
@@ -56,21 +56,20 @@ This opens an interactive REPL:
 Test mode works with custom message handlers, exactly as they would work in production:
 
 ```typescript
-async function onMessage(data: Record<string, unknown>, callControl: CallControl) {
+async function onMessage(data: Record<string, unknown>) {
   const userText = data.text as string;
 
   if (userText.toLowerCase().includes("cancel")) {
-    await callControl.transfer("+15550001111");
     return "Let me transfer you to our cancellation team.";
   }
 
   return `You said: ${userText}`;
 }
 
-await phone.test(agent, { onMessage });
+await phone.test({ agent, onMessage });
 ```
 
-The `callControl` parameter is automatically provided as the second argument.
+The `onMessage` handler receives a single data object with `text`, `call_id`, `caller`, and `history` fields.
 
 ## Using with Built-in LLM Loop
 
@@ -90,12 +89,12 @@ const agent = phone.agent({
           partySize: { type: "number" },
         },
       },
-      webhook: "https://api.example.com/availability",
+      webhookUrl: "https://api.example.com/availability",
     },
   ],
 });
 
-await phone.test(agent);
+await phone.test({ agent });
 ```
 
 The LLM loop supports tool calling — tools are executed via their configured webhooks just like in production.
@@ -105,14 +104,15 @@ The LLM loop supports tool calling — tools are executed via their configured w
 Test mode fires the same lifecycle callbacks as `serve()`:
 
 ```typescript
-await phone.test(agent, {
+await phone.test({
+  agent,
   onCallStart: async (event) => {
-    console.log(`Test call started: ${event.callId}`);
-    return { variables: { customerName: "Test User" } };
+    console.log(`Test call started: ${event.call_id}`);
   },
   onCallEnd: async (event) => {
-    console.log(`Test call ended: ${event.callId}`);
-    console.log(`Transcript: ${event.transcript.length} messages`);
+    console.log(`Test call ended: ${event.call_id}`);
+    const transcript = event.transcript as Array<unknown>;
+    console.log(`Transcript: ${transcript.length} messages`);
   },
 });
 ```

--- a/docs/typescript-sdk/tools.mdx
+++ b/docs/typescript-sdk/tools.mdx
@@ -56,7 +56,7 @@ interface ToolDefinition {
   description: string;
   parameters: Record<string, unknown>; // JSON Schema
   webhookUrl?: string;  // Required if handler is not provided
-  handler?: (args: Record<string, unknown>, context: Record<string, unknown>) => Promise<string | object>;
+  handler?: (args: Record<string, unknown>, context: Record<string, unknown>) => Promise<string>;
 }
 ```
 
@@ -70,15 +70,18 @@ When the AI model invokes a tool, the SDK sends a POST request to the `webhookUr
 
 ```json
 {
-  "tool_name": "check_availability",
+  "tool": "check_availability",
   "arguments": {
     "date": "2025-03-15"
   },
   "call_id": "call_abc123",
   "caller": "+15551234567",
-  "callee": "+15550001234"
+  "callee": "+15550001234",
+  "attempt": 1
 }
 ```
+
+The `attempt` field is a 1-based retry counter (1 on the first try, up to 3).
 
 Your webhook must return a JSON response. The response text is fed back to the AI model as the tool result.
 
@@ -89,10 +92,19 @@ Your webhook must return a JSON response. The response text is fed back to the A
 | HTTP method | POST |
 | Content type | `application/json` |
 | Timeout | 10 seconds |
-| Max response size | 64 KB |
+| Max response size | 1 MB |
 | Retries | 3 attempts with 500ms delay |
 
 If all retries fail, the SDK returns an error message to the AI model so it can inform the caller gracefully.
+
+## LLM Loop Limits
+
+When using the built-in LLM loop (pipeline mode without an `onMessage` handler), the following safety limits apply:
+
+| Setting | Value |
+|---------|-------|
+| Max iterations | 10 (tool-call round-trips before the loop stops) |
+| LLM request timeout | 30 seconds (`AbortSignal.timeout`) |
 
 ## SSRF Protection
 
@@ -167,7 +179,7 @@ const agent = phone.agent({
       },
       handler: async (args, context) => {
         const stock = await db.getStock(args.productId as string);
-        return { productId: args.productId, inStock: stock > 0, quantity: stock };
+        return JSON.stringify({ productId: args.productId, inStock: stock > 0, quantity: stock });
       },
     }),
   ],


### PR DESCRIPTION
## Summary

- **Reframe all messaging**: Patter gives your AI agent a phone number — it doesn't build voice agents. Updated all docs to position Patter as telephony infrastructure, not a voice AI platform.
- **Fix 38 documentation discrepancies** found via comprehensive code-vs-docs audit of both Python and TypeScript SDKs.

### Critical fixes (broke code written from docs)
- Fix snake_case field names throughout TS docs (metrics, events, reference)
- Fix `test()` and `serve()` method signatures in all examples
- Fix `ToolDefinition`: `webhookUrl` optional, add `handler` field
- Remove phantom `CallControl` fields that don't exist in code
- Fix `on_metrics` callback payload (dataclass access, not dict)
- Fix webhook payload field name (`tool`, not `tool_name`)
- Fix max response size (1 MB, not 64 KB)
- Fix `mode` default (`cloud` with auto-detection, not `local`)

### Incorrect info fixed
- Rewrite AI Disclosure section (not auto-implemented, use `firstMessage`)
- Fix server bind address (`0.0.0.0`, not `127.0.0.1`)
- Fix `webhookUrl` as conditional (optional with tunnel)
- Fix `Guardrail` types in reference (`Callable`, `list[str]`)
- Fix test mode model name and tool key
- Fix timestamp format (Unix float, not ISO-8601)

### New documentation added
- Max call duration (1h auto-hangup) safety feature
- Graceful shutdown behavior
- Missing `serve()` params (`tunnel`, `on_metrics`, `dashboard`, `pricing`)
- `AuthenticationError` and `ProvisionError` exceptions
- `disconnect()` method
- Missing event payload fields (`caller`, `callee`, `metrics`, `history`)
- LLM loop limits (10 iterations, 30s timeout)

## Test plan
- [ ] Verify docs site renders correctly (Mintlify preview)
- [ ] Spot-check code examples match actual SDK signatures
- [ ] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)