### PR TITLE
docs: mark Telnyx as Beta before launch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your-twilio-auth-token
 TWILIO_PHONE_NUMBER=+1xxxxxxxxxx
 
-# Telnyx (alternative to Twilio)
+# Telnyx (Beta — alternative to Twilio, not yet validated in production)
 # TELNYX_API_KEY=KEY...
 # TELNYX_CONNECTION_ID=...
 # TELNYX_PHONE_NUMBER=+1xxxxxxxxxx

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ await phone.serve({ agent, port: 8000 });
 <td align="center">→</td>
 <td align="center">
   <strong>Twilio</strong><br><sub>Telephony</sub><br><br>
-  <strong>Telnyx</strong><br><sub>Telephony</sub>
+  <strong>Telnyx</strong> <sup>Beta</sup><br><sub>Telephony</sub>
 </td>
 </tr>
 </table>
@@ -181,6 +181,8 @@ cd python && pip install -r requirements.txt && python main.py
 cp .env.example .env
 # Edit .env with your API keys
 ```
+
+> **Telnyx (Beta):** Telnyx is supported as an alternative telephony provider but is currently in beta — tested locally, not yet validated in production.
 
 ### Docker
 

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -62,7 +62,7 @@ In pipeline mode, your `on_message` callback receives transcribed text and retur
 | Provider | Audio Format | Features |
 |----------|-------------|----------|
 | **Twilio** | mulaw 8kHz (auto-transcoded) | Recording, AMD, DTMF, call transfer |
-| **Telnyx** | PCM 16kHz native | Low latency, Ed25519 webhook validation |
+| **Telnyx** (Beta) | PCM 16kHz native | Low latency, Ed25519 webhook validation |
 
 ## Audio Pipeline
 

--- a/docs/examples/custom-voice.py
+++ b/docs/examples/custom-voice.py
@@ -1,3 +1,7 @@
+# ⚠️  BETA: This example uses Telnyx for telephony. Telnyx support is in beta —
+# tested locally but not yet validated in production. For a production-ready
+# setup, use Twilio instead. See the quickstart guide for Twilio examples.
+
 """
 Self-hosted mode with custom STT and TTS providers.
 

--- a/docs/examples/custom-voice.ts
+++ b/docs/examples/custom-voice.ts
@@ -1,3 +1,7 @@
+// ⚠️  BETA: This example uses Telnyx for telephony. Telnyx support is in beta —
+// tested locally but not yet validated in production. For a production-ready
+// setup, use Twilio instead. See the quickstart guide for Twilio examples.
+
 /**
  * Self-hosted mode with custom STT and TTS providers.
  *

--- a/docs/home/index.mdx
+++ b/docs/home/index.mdx
@@ -37,7 +37,7 @@ Your agent receives transcribed speech as text and returns a text response. Patt
 - **4 lines of code** — Write an async handler. Patter does the rest.
 - **Python & TypeScript** — Same API surface in both languages. Pick your stack.
 - **Multiple voice modes** — OpenAI Realtime, ElevenLabs ConvAI, or custom Pipeline (STT + TTS).
-- **Twilio & Telnyx** — Both telephony providers supported. Bring your own credentials.
+- **Twilio & Telnyx (Beta)** — Twilio is fully supported. Telnyx is in beta — tested locally, not yet validated in production.
 - **Call transfer & recording** — Built-in system tools for transferring calls and enabling recording.
 - **Guardrails** — Block terms, run custom checks, or replace responses before they reach the caller.
 - **Built-in tunnel** — Cloudflare tunnel support, no ngrok required.

--- a/docs/python-sdk/configuration.mdx
+++ b/docs/python-sdk/configuration.mdx
@@ -21,7 +21,7 @@ Patter runs in local mode. It is auto-detected when telephony provider keys are 
 phone = Patter(twilio_sid="AC...", twilio_token="...", openai_key="sk-...",
                phone_number="+15550001234", webhook_url="abc.ngrok.io")
 
-# Local mode (auto-detected — telnyx_key)
+# Local mode (auto-detected — telnyx_key) [Beta]
 phone = Patter(telnyx_key="KEY...", telnyx_connection_id="...", openai_key="sk-...",
                phone_number="+15550001234", webhook_url="abc.ngrok.io")
 ```
@@ -35,13 +35,17 @@ phone = Patter(telnyx_key="KEY...", telnyx_connection_id="...", openai_key="sk-.
 | `mode` | `str` | `"local"` | Operating mode. Can be omitted — auto-detected when provider keys are given. |
 | `twilio_sid` | `str` | `""` | Twilio Account SID. |
 | `twilio_token` | `str` | `""` | Twilio Auth Token. Required when `twilio_sid` is provided. |
-| `telnyx_key` | `str` | `""` | Telnyx API key. |
-| `telnyx_connection_id` | `str` | `""` | Telnyx Call Control Application ID. |
+| `telnyx_key` | `str` | `""` | Telnyx API key (Beta). |
+| `telnyx_connection_id` | `str` | `""` | Telnyx Call Control Application ID (Beta). |
 | `openai_key` | `str` | `""` | OpenAI API key for the Realtime API. |
 | `elevenlabs_key` | `str` | `""` | ElevenLabs API key (optional, for pipeline mode). |
 | `deepgram_key` | `str` | `""` | Deepgram API key (optional, for pipeline mode). |
 | `phone_number` | `str` | `""` | Your phone number in E.164 format (e.g., `"+15550001234"`). Required when telephony keys are provided. |
 | `webhook_url` | `str` | `""` | Public hostname of this server, without scheme (e.g., `"abc.ngrok.io"`). Required when telephony keys are provided. |
+
+<Warning>
+  **Telnyx (Beta):** Telnyx support is in beta — tested locally but not yet validated in production. We recommend Twilio for production deployments until Telnyx exits beta.
+</Warning>
 
 ```python
 # Twilio + OpenAI Realtime
@@ -53,7 +57,7 @@ phone = Patter(
     webhook_url="abc.ngrok.io",
 )
 
-# Telnyx + OpenAI Realtime
+# Telnyx + OpenAI Realtime (Beta)
 phone = Patter(
     telnyx_key="KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     telnyx_connection_id="your_connection_id",

--- a/docs/python-sdk/local-mode.mdx
+++ b/docs/python-sdk/local-mode.mdx
@@ -142,8 +142,8 @@ The `LocalConfig` dataclass holds all provider credentials for local mode. It is
 | `telephony_provider` | `str` | `"twilio"` or `"telnyx"` (auto-detected). |
 | `twilio_sid` | `str` | Twilio Account SID. |
 | `twilio_token` | `str` | Twilio Auth Token. |
-| `telnyx_key` | `str` | Telnyx API key. |
-| `telnyx_connection_id` | `str` | Telnyx Call Control Application ID. |
+| `telnyx_key` | `str` | Telnyx API key (Beta). |
+| `telnyx_connection_id` | `str` | Telnyx Call Control Application ID (Beta). |
 | `openai_key` | `str` | OpenAI API key. |
 | `elevenlabs_key` | `str` | ElevenLabs API key. |
 | `deepgram_key` | `str` | Deepgram API key. |

--- a/docs/python-sdk/metrics.mdx
+++ b/docs/python-sdk/metrics.mdx
@@ -91,7 +91,7 @@ phone = Patter(
 | OpenAI TTS | per 1k chars | $0.015 |
 | OpenAI Realtime | per token | varies by type |
 | Twilio | per minute | $0.013 |
-| Telnyx | per minute | $0.007 |
+| Telnyx (Beta) | per minute | $0.007 |
 
 <Note>
   Default pricing is based on publicly listed provider rates and may become stale. Pass your own overrides for accurate cost tracking, or check the provider's pricing page.

--- a/docs/python-sdk/overview.mdx
+++ b/docs/python-sdk/overview.mdx
@@ -16,7 +16,7 @@ pip install patter[local]
 ## Requirements
 
 - Python 3.11 or higher
-- An account with at least one telephony provider (Twilio or Telnyx)
+- A telephony account — Twilio (recommended) or Telnyx (Beta)
 - An AI provider key (OpenAI, ElevenLabs, or Deepgram)
 
 ## Minimal Example

--- a/docs/python-sdk/providers.mdx
+++ b/docs/python-sdk/providers.mdx
@@ -27,7 +27,7 @@ OpenAI Realtime handles audio encoding automatically based on your telephony pro
 | Telephony Provider | Audio Format | Sample Rate |
 |-------------------|--------------|-------------|
 | Twilio | G.711 mu-law | 8 kHz |
-| Telnyx | PCM 16-bit | 16 kHz |
+| Telnyx (Beta) | PCM 16-bit | 16 kHz |
 
 ### Available Voices
 

--- a/docs/python-sdk/quickstart.mdx
+++ b/docs/python-sdk/quickstart.mdx
@@ -10,7 +10,7 @@ This guide walks you through building a voice AI agent that answers phone calls 
 ## Prerequisites
 
 - Python 3.11+
-- A telephony account (Twilio or Telnyx)
+- A Twilio account (Telnyx is available as a beta alternative)
 - An AI provider key (OpenAI, ElevenLabs, or Deepgram)
 
 ## Step 1: Install the SDK
@@ -33,7 +33,11 @@ WEBHOOK_URL=abc.ngrok.io
 
 ## Step 3: Expose Your Server
 
-Patter needs a public URL so Twilio/Telnyx can reach your local server. Use [ngrok](https://ngrok.com):
+Patter needs a public URL so your telephony provider can reach your local server. Use [ngrok](https://ngrok.com):
+
+<Warning>
+  **Telnyx (Beta):** Telnyx support is in beta — tested locally but not yet validated in production. We recommend Twilio for production deployments until Telnyx exits beta.
+</Warning>
 
 ```bash
 ngrok http 8000

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -34,8 +34,8 @@ Patter(
 | `mode` | `str` | `"local"` | Operating mode. Can be omitted — auto-detected when provider keys are given. |
 | `twilio_sid` | `str` | `""` | Twilio Account SID. |
 | `twilio_token` | `str` | `""` | Twilio Auth Token. |
-| `telnyx_key` | `str` | `""` | Telnyx API key. |
-| `telnyx_connection_id` | `str` | `""` | Telnyx Call Control App ID. |
+| `telnyx_key` | `str` | `""` | Telnyx API key (Beta). |
+| `telnyx_connection_id` | `str` | `""` | Telnyx Call Control App ID (Beta). |
 | `openai_key` | `str` | `""` | OpenAI API key. |
 | `elevenlabs_key` | `str` | `""` | ElevenLabs API key. |
 | `deepgram_key` | `str` | `""` | Deepgram API key. |

--- a/docs/typescript-sdk/configuration.mdx
+++ b/docs/typescript-sdk/configuration.mdx
@@ -33,9 +33,9 @@ const phone = new Patter({
 | `twilioToken` | `string` | Conditional | — | Twilio Auth Token. Required when `twilioSid` is set. |
 | `openaiKey` | `string` | No | — | OpenAI API key for the realtime adapter. |
 | `telephonyProvider` | `"twilio" \| "telnyx"` | No | `"twilio"` | Which telephony provider to use. |
-| `telnyxKey` | `string` | Conditional | — | Telnyx API key. Required if `telephonyProvider` is `"telnyx"`. |
-| `telnyxConnectionId` | `string` | No | — | Telnyx SIP Connection ID for outbound calls. |
-| `telnyxPublicKey` | `string` | No | — | Telnyx Ed25519 public key (base64 DER/SPKI) for webhook signature verification. |
+| `telnyxKey` | `string` | Conditional | — | (Beta) Telnyx API key. Required if `telephonyProvider` is `"telnyx"`. |
+| `telnyxConnectionId` | `string` | No | — | (Beta) Telnyx SIP Connection ID for outbound calls. |
+| `telnyxPublicKey` | `string` | No | — | (Beta) Telnyx Ed25519 public key (base64 DER/SPKI) for webhook signature verification. |
 
 <Warning>
   You must provide either `twilioSid` or `telnyxKey`. The constructor throws if neither is set.
@@ -55,6 +55,10 @@ webhookUrl: "abc123.ngrok.io/webhooks"
 ```
 
 The SDK constructs full URLs internally (e.g., `https://{webhookUrl}/webhooks/twilio/voice`).
+
+<Warning>
+  **Telnyx (Beta):** Telnyx support is in beta — tested locally but not yet validated in production. We recommend Twilio for production deployments until Telnyx exits beta.
+</Warning>
 
 ## Using Telnyx
 

--- a/docs/typescript-sdk/local-mode.mdx
+++ b/docs/typescript-sdk/local-mode.mdx
@@ -65,6 +65,8 @@ Returns `{ "status": "ok", "mode": "local" }`.
 | `/webhooks/twilio/amd` | POST | Receives AMD (answering machine detection) results. |
 | `/webhooks/twilio/status` | POST | Receives call status callbacks for outbound calls. |
 
+<Info>Telnyx endpoints are in beta — tested locally, not yet validated in production.</Info>
+
 ### Telnyx Endpoints
 
 | Endpoint | Method | Purpose |
@@ -139,7 +141,7 @@ Phone Speaker
 | Provider | Input Format | Transcoding |
 |----------|-------------|-------------|
 | Twilio | mulaw 8kHz | Decoded to PCM 16kHz |
-| Telnyx | PCM 16kHz | No transcoding needed |
+| Telnyx (Beta) | PCM 16kHz | No transcoding needed |
 | OpenAI TTS | PCM 24kHz | Resampled to 16kHz |
 
 ## Binding Address

--- a/docs/typescript-sdk/metrics.mdx
+++ b/docs/typescript-sdk/metrics.mdx
@@ -102,7 +102,7 @@ const phone = new Patter({
 | OpenAI TTS | per 1k chars | $0.015 |
 | OpenAI Realtime | per token | varies by type |
 | Twilio | per minute | $0.013 |
-| Telnyx | per minute | $0.007 |
+| Telnyx (Beta) | per minute | $0.007 |
 
 <Note>
   Default pricing is based on publicly listed provider rates and may become stale. Pass your own overrides for accurate cost tracking, or check the provider's pricing page.

--- a/docs/typescript-sdk/overview.mdx
+++ b/docs/typescript-sdk/overview.mdx
@@ -16,7 +16,7 @@ npm install getpatter
 ## Requirements
 
 - Node.js 18 or higher
-- An account with at least one telephony provider (Twilio or Telnyx)
+- A telephony account — Twilio (recommended) or Telnyx (Beta)
 - An AI provider key (OpenAI, ElevenLabs, or Deepgram)
 
 ## Minimal Example

--- a/docs/typescript-sdk/reference.mdx
+++ b/docs/typescript-sdk/reference.mdx
@@ -48,9 +48,9 @@ interface LocalOptions {
   phoneNumber: string;
   webhookUrl: string;
   telephonyProvider?: "twilio" | "telnyx";
-  telnyxKey?: string;
-  telnyxConnectionId?: string;
-  telnyxPublicKey?: string;
+  telnyxKey?: string; // Beta
+  telnyxConnectionId?: string; // Beta
+  telnyxPublicKey?: string; // Beta
   pricing?: Record<string, Partial<ProviderPricing>>;
 }
 ```

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -125,7 +125,7 @@ await phone.serve({ agent, port: 8000 });
 
 | | Cloud Mode | Local Mode |
 |---|---|---|
-| **Setup** | Patter API key only | Twilio/Telnyx + OpenAI keys |
+| **Setup** | Patter API key only | Twilio/Telnyx (Beta) + OpenAI keys |
 | **Infrastructure** | Managed by Patter | Runs in your process |
 | **Backend** | `wss://api.getpatter.com` | Built-in (FastAPI / Express) |
 | **Webhook** | Configured automatically | Requires public URL (e.g. ngrok) |
@@ -149,7 +149,7 @@ await phone.serve({ agent, port: 8000 });
 - Built-in tools: `transfer_call`, `end_call` (auto-injected)
 
 ### Telephony
-- Twilio and Telnyx carriers
+- Twilio and Telnyx (Beta) carriers
 - Inbound and outbound calls
 - Call transfer to humans (`transfer_call` system tool)
 - Call recording (`recording: true` in `serve()`)
@@ -226,7 +226,7 @@ Your Code (on_message handler)
                               ┌───────┴────────┐                              │
                               ▼                ▼                              ▼
                           STT Engine       TTS Engine          Telephony Provider
-                       (Deepgram /      (ElevenLabs /          (Twilio / Telnyx)
+                       (Deepgram /      (ElevenLabs /          (Twilio / Telnyx [Beta])
                         Whisper /        OpenAI TTS)                  │
                        OpenAI RT)              │                       │
                               │               └───────────────────────►│

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -50,6 +50,13 @@ export class Patter {
 
       this.mode = 'local';
       this.localConfig = options;
+      // TODO: Remove beta warning when Telnyx is validated in production
+      if (local.telnyxKey) {
+        console.warn(
+          '[patter] Telnyx support is in beta — tested locally but not yet validated in production. ' +
+          'If you encounter issues, please report them at https://github.com/PatterAI/Patter/issues'
+        );
+      }
       this.apiKey = '';
       this.backendUrl = DEFAULT_BACKEND_URL;
       this.restUrl = DEFAULT_REST_URL;

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -125,7 +125,7 @@ await phone.serve({ agent, port: 8000 });
 
 | | Cloud Mode | Local Mode |
 |---|---|---|
-| **Setup** | Patter API key only | Twilio/Telnyx + OpenAI keys |
+| **Setup** | Patter API key only | Twilio/Telnyx (Beta) + OpenAI keys |
 | **Infrastructure** | Managed by Patter | Runs in your process |
 | **Backend** | `wss://api.getpatter.com` | Built-in (FastAPI / Express) |
 | **Webhook** | Configured automatically | Requires public URL (e.g. ngrok) |
@@ -149,7 +149,7 @@ await phone.serve({ agent, port: 8000 });
 - Built-in tools: `transfer_call`, `end_call` (auto-injected)
 
 ### Telephony
-- Twilio and Telnyx carriers
+- Twilio and Telnyx (Beta) carriers
 - Inbound and outbound calls
 - Call transfer to humans (`transfer_call` system tool)
 - Call recording (`recording: true` in `serve()`)
@@ -226,7 +226,7 @@ Your Code (on_message handler)
                               ┌───────┴────────┐                              │
                               ▼                ▼                              ▼
                           STT Engine       TTS Engine          Telephony Provider
-                       (Deepgram /      (ElevenLabs /          (Twilio / Telnyx)
+                       (Deepgram /      (ElevenLabs /          (Twilio / Telnyx [Beta])
                         Whisper /        OpenAI TTS)                  │
                        OpenAI RT)              │                       │
                               │               └───────────────────────►│

--- a/sdk/patter/client.py
+++ b/sdk/patter/client.py
@@ -131,6 +131,13 @@ class Patter:
                 phone_number=phone_number,
                 webhook_url=webhook_url,
             )
+            # TODO: Remove beta warning when Telnyx is validated in production
+            if telnyx_key:
+                logger.warning(
+                    "Telnyx support is in beta — tested locally but not yet "
+                    "validated in production. If you encounter issues, please "
+                    "report them at https://github.com/PatterAI/Patter/issues"
+                )
             self._server = None
             self._tunnel_handle = None
             self._connection = None


### PR DESCRIPTION
## Summary

- **Runtime warnings**: Added `logger.warning` (Python) and `console.warn` (TypeScript) when Telnyx keys are provided — non-blocking, fires once at init
- **Documentation**: Added Beta badges/callouts (`<Warning>`, `<Info>`) in all 18 doc pages that reference Telnyx (overview, quickstart, configuration, local-mode, providers, reference, metrics for both SDKs + home, concepts)
- **READMEs**: Marked Telnyx as "(Beta)" in root, Python SDK, and TypeScript SDK READMEs
- **Examples**: Added beta disclaimer comments at top of `custom-voice.py` and `custom-voice.ts`
- **Config**: Updated `.env.example` with beta note

### Context

Telnyx has been tested locally but not yet validated end-to-end with real accounts and live calls in production. Twilio is the only fully e2e-tested provider for tonight's launch.

## Test plan

- [x] Python SDK: 978 tests passed
- [x] TypeScript SDK: 680 tests passed
- [x] Grep verification: all user-facing Telnyx mentions have Beta labels
- [ ] Visual check of docs site after merge