### PR TITLE
feat(stt): port Soniox + Speechmatics STT from LiveKit Agents

### DIFF
--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -56,6 +56,8 @@ export { TestSession } from "./test-mode";
 export { ElevenLabsConvAIAdapter } from "./providers/elevenlabs-convai";
 export { OpenAIRealtimeAdapter } from "./providers/openai-realtime";
 export { DeepgramSTT } from "./providers/deepgram-stt";
+export { SonioxSTT } from "./providers/soniox-stt";
+export type { SonioxSTTOptions } from "./providers/soniox-stt";
 export { WhisperSTT } from "./providers/whisper-stt";
 export { ElevenLabsTTS } from "./providers/elevenlabs-tts";
 export { OpenAITTS } from "./providers/openai-tts";

--- a/sdk-ts/src/providers/soniox-stt.ts
+++ b/sdk-ts/src/providers/soniox-stt.ts
@@ -1,0 +1,307 @@
+/**
+ * Soniox Speech-to-Text adapter for Patter (TypeScript).
+ *
+ * Pure WebSocket client for the Soniox real-time STT API. Accumulates
+ * `is_final` tokens and flushes them on `<end>`/`<fin>` endpoint tokens,
+ * mirroring the Python `SonioxSTT` adapter.
+ *
+ * Adapted from LiveKit Agents (Apache 2.0):
+ * https://github.com/livekit/agents
+ * (source: livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+ *  at commit 78a66bcf79c5cea82989401c408f1dff4b961a5b)
+ *
+ * Speechmatics TypeScript adapter is **intentionally not ported**: the
+ * official Speechmatics Voice SDK (`speechmatics.voice`) is Python-only at
+ * the time of writing. Python users should install the optional
+ * `speechmatics` extra; TypeScript users need to wait for an official
+ * upstream SDK before this adapter can land without a WS-handshake reimpl.
+ */
+
+import WebSocket from 'ws';
+import { getLogger } from '../logger';
+
+const SONIOX_WS_URL = 'wss://stt-rt.soniox.com/transcribe-websocket';
+const KEEPALIVE_MESSAGE = '{"type": "keepalive"}';
+const END_TOKEN = '<end>';
+const FINALIZED_TOKEN = '<fin>';
+const KEEPALIVE_INTERVAL_MS = 5000;
+
+export interface Transcript {
+  readonly text: string;
+  readonly isFinal: boolean;
+  readonly confidence: number;
+}
+
+type TranscriptCallback = (transcript: Transcript) => void;
+
+interface SonioxToken {
+  text?: string;
+  is_final?: boolean;
+  confidence?: number;
+  [key: string]: unknown;
+}
+
+interface SonioxMessage {
+  tokens?: SonioxToken[];
+  finished?: boolean;
+  error_code?: unknown;
+  error_message?: string;
+}
+
+function isEndToken(token: SonioxToken): boolean {
+  return token.text === END_TOKEN || token.text === FINALIZED_TOKEN;
+}
+
+/** Accumulates Soniox token text + rolling confidence. */
+class TokenAccumulator {
+  text = '';
+  private confSum = 0;
+  private confCount = 0;
+
+  update(token: SonioxToken): void {
+    if (token.text) {
+      this.text += token.text;
+    }
+    if (typeof token.confidence === 'number') {
+      this.confSum += token.confidence;
+      this.confCount += 1;
+    }
+  }
+
+  get confidence(): number {
+    return this.confCount === 0 ? 0 : this.confSum / this.confCount;
+  }
+
+  reset(): void {
+    this.text = '';
+    this.confSum = 0;
+    this.confCount = 0;
+  }
+
+  get raw(): { sum: number; count: number } {
+    return { sum: this.confSum, count: this.confCount };
+  }
+}
+
+export interface SonioxSTTOptions {
+  model?: string;
+  languageHints?: string[];
+  languageHintsStrict?: boolean;
+  sampleRate?: number;
+  numChannels?: number;
+  enableSpeakerDiarization?: boolean;
+  enableLanguageIdentification?: boolean;
+  maxEndpointDelayMs?: number;
+  clientReferenceId?: string;
+  baseUrl?: string;
+}
+
+export class SonioxSTT {
+  private ws: WebSocket | null = null;
+  private callbacks: TranscriptCallback[] = [];
+  private final = new TokenAccumulator();
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly languageHints?: string[];
+  private readonly languageHintsStrict: boolean;
+  private readonly sampleRate: number;
+  private readonly numChannels: number;
+  private readonly enableSpeakerDiarization: boolean;
+  private readonly enableLanguageIdentification: boolean;
+  private readonly maxEndpointDelayMs: number;
+  private readonly clientReferenceId?: string;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, options: SonioxSTTOptions = {}) {
+    if (!apiKey) {
+      throw new Error('Soniox apiKey is required');
+    }
+    const maxEndpointDelayMs = options.maxEndpointDelayMs ?? 500;
+    if (maxEndpointDelayMs < 500 || maxEndpointDelayMs > 3000) {
+      throw new Error('maxEndpointDelayMs must be between 500 and 3000');
+    }
+
+    this.apiKey = apiKey;
+    this.model = options.model ?? 'stt-rt-v4';
+    this.languageHints = options.languageHints;
+    this.languageHintsStrict = options.languageHintsStrict ?? false;
+    this.sampleRate = options.sampleRate ?? 16000;
+    this.numChannels = options.numChannels ?? 1;
+    this.enableSpeakerDiarization = options.enableSpeakerDiarization ?? false;
+    this.enableLanguageIdentification = options.enableLanguageIdentification ?? true;
+    this.maxEndpointDelayMs = maxEndpointDelayMs;
+    this.clientReferenceId = options.clientReferenceId;
+    this.baseUrl = options.baseUrl ?? SONIOX_WS_URL;
+  }
+
+  /** Factory for Twilio-style 8 kHz linear PCM. */
+  static forTwilio(apiKey: string, languageHints?: string[]): SonioxSTT {
+    return new SonioxSTT(apiKey, { sampleRate: 8000, languageHints });
+  }
+
+  private buildConfig(): Record<string, unknown> {
+    const config: Record<string, unknown> = {
+      api_key: this.apiKey,
+      model: this.model,
+      audio_format: 'pcm_s16le',
+      num_channels: this.numChannels,
+      sample_rate: this.sampleRate,
+      enable_endpoint_detection: true,
+      enable_speaker_diarization: this.enableSpeakerDiarization,
+      enable_language_identification: this.enableLanguageIdentification,
+      max_endpoint_delay_ms: this.maxEndpointDelayMs,
+    };
+    if (this.languageHints) {
+      config.language_hints = this.languageHints;
+      config.language_hints_strict = this.languageHintsStrict;
+    }
+    if (this.clientReferenceId) {
+      config.client_reference_id = this.clientReferenceId;
+    }
+    return config;
+  }
+
+  async connect(): Promise<void> {
+    this.ws = new WebSocket(this.baseUrl);
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Soniox connect timeout')), 10000);
+      this.ws!.once('open', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      this.ws!.once('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    // Send the initial configuration payload as a JSON text frame.
+    this.ws.send(JSON.stringify(this.buildConfig()));
+
+    this.ws.on('message', (raw) => this.handleMessage(raw.toString()));
+    this.ws.on('close', () => this.clearKeepalive());
+    this.ws.on('error', (err) => {
+      getLogger().error(`SonioxSTT WebSocket error: ${String(err)}`);
+    });
+
+    this.keepaliveTimer = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        try {
+          this.ws.send(KEEPALIVE_MESSAGE);
+        } catch {
+          // ignore
+        }
+      }
+    }, KEEPALIVE_INTERVAL_MS);
+  }
+
+  private clearKeepalive(): void {
+    if (this.keepaliveTimer) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+
+  private handleMessage(raw: string): void {
+    let content: SonioxMessage;
+    try {
+      content = JSON.parse(raw) as SonioxMessage;
+    } catch {
+      return;
+    }
+
+    if (content.error_code || content.error_message) {
+      getLogger().error(
+        `SonioxSTT error ${String(content.error_code)}: ${String(content.error_message)}`,
+      );
+    }
+
+    const tokens = content.tokens ?? [];
+    const nonFinal = new TokenAccumulator();
+    let emittedFinalThisMsg = false;
+
+    for (const token of tokens) {
+      if (token.is_final) {
+        if (isEndToken(token)) {
+          if (this.final.text) {
+            this.emit({
+              text: this.final.text.trim(),
+              isFinal: true,
+              confidence: this.final.confidence,
+            });
+            this.final.reset();
+            emittedFinalThisMsg = true;
+          }
+        } else {
+          this.final.update(token);
+        }
+      } else {
+        nonFinal.update(token);
+      }
+    }
+
+    if (!emittedFinalThisMsg) {
+      const text = (this.final.text + nonFinal.text).trim();
+      if (text) {
+        const { sum: fSum, count: fCount } = this.final.raw;
+        const { sum: nSum, count: nCount } = nonFinal.raw;
+        const total = fCount + nCount;
+        const confidence = total > 0 ? (fSum + nSum) / total : 0;
+        this.emit({ text, isFinal: false, confidence });
+      }
+    }
+
+    if (content.finished && this.final.text) {
+      this.emit({
+        text: this.final.text.trim(),
+        isFinal: true,
+        confidence: this.final.confidence,
+      });
+      this.final.reset();
+    }
+  }
+
+  private emit(transcript: Transcript): void {
+    for (const cb of this.callbacks) {
+      cb(transcript);
+    }
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (audio.length === 0) return;
+    this.ws.send(audio);
+  }
+
+  onTranscript(callback: TranscriptCallback): void {
+    if (this.callbacks.length >= 10) {
+      getLogger().warn(
+        'SonioxSTT: maximum of 10 onTranscript callbacks reached; replacing the last callback.',
+      );
+      this.callbacks[this.callbacks.length - 1] = callback;
+      return;
+    }
+    this.callbacks.push(callback);
+  }
+
+  close(): void {
+    this.clearKeepalive();
+    if (this.ws) {
+      try {
+        // Soniox terminates the stream on an empty binary frame.
+        this.ws.send(Buffer.alloc(0));
+      } catch {
+        // ignore
+      }
+      try {
+        this.ws.close();
+      } catch {
+        // ignore
+      }
+      this.ws = null;
+    }
+  }
+}

--- a/sdk-ts/tests/soniox-stt.test.ts
+++ b/sdk-ts/tests/soniox-stt.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the TypeScript SonioxSTT adapter.
+ *
+ * The tests mock the `ws` package so no real network traffic occurs, and
+ * replay synthetic Soniox protocol frames (see MOCK notes on individual
+ * tests) to validate adapter behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock `ws` with an EventEmitter-based stub that records sent frames and
+// lets tests push protocol messages into the instance under test.
+vi.mock('ws', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require('events');
+
+  class MockWebSocket extends EventEmitter {
+    static OPEN = 1;
+    static CLOSED = 3;
+    readyState = MockWebSocket.OPEN;
+    sent: unknown[] = [];
+
+    constructor(_url: string) {
+      super();
+      // Dispatch `open` on the next tick so callers can register handlers.
+      setImmediate(() => this.emit('open'));
+    }
+
+    send(data: unknown) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.readyState = MockWebSocket.CLOSED;
+      this.emit('close');
+    }
+  }
+
+  return { default: MockWebSocket };
+});
+
+// Import after mocking
+// eslint-disable-next-line import/first
+import WebSocket from 'ws';
+// eslint-disable-next-line import/first
+import { SonioxSTT, type Transcript } from '../src/providers/soniox-stt';
+
+describe('SonioxSTT — initialisation', () => {
+  it('throws on missing api key', () => {
+    expect(() => new SonioxSTT('')).toThrow(/apiKey/);
+  });
+
+  it('rejects invalid endpoint delay', () => {
+    expect(
+      () => new SonioxSTT('k', { maxEndpointDelayMs: 100 }),
+    ).toThrow(/maxEndpointDelayMs/);
+  });
+
+  it('forTwilio uses 8 kHz sample rate', () => {
+    const stt = SonioxSTT.forTwilio('k');
+    expect(stt).toBeDefined();
+  });
+
+  it('accepts language hints', () => {
+    const stt = new SonioxSTT('k', { languageHints: ['en', 'it'] });
+    expect(stt).toBeDefined();
+  });
+});
+
+describe('SonioxSTT — connection & protocol', () => {
+  let stt: SonioxSTT;
+  let transcripts: Transcript[];
+  let mockWs: unknown;
+
+  beforeEach(async () => {
+    stt = new SonioxSTT('test-key', { model: 'stt-rt-v4' });
+    transcripts = [];
+    stt.onTranscript((t) => transcripts.push(t));
+    await stt.connect();
+    // Retrieve the mock WebSocket instance (we only create one per adapter).
+    mockWs = (stt as unknown as { ws: unknown }).ws;
+  });
+
+  it('sends the initial configuration JSON on connect', () => {
+    const sent = (mockWs as { sent: unknown[] }).sent;
+    expect(sent.length).toBeGreaterThanOrEqual(1);
+    const payload = JSON.parse(sent[0] as string);
+    expect(payload.api_key).toBe('test-key');
+    expect(payload.model).toBe('stt-rt-v4');
+    expect(payload.audio_format).toBe('pcm_s16le');
+  });
+
+  it('MOCK: emits interim transcripts for non-final tokens', () => {
+    // Simulate a Soniox message with only non-final tokens.
+    (mockWs as { emit: (ev: string, data: string) => void }).emit(
+      'message',
+      JSON.stringify({
+        tokens: [
+          { text: 'Hi ', is_final: false, confidence: 0.5 },
+          { text: 'there', is_final: false, confidence: 0.6 },
+        ],
+      }),
+    );
+    expect(transcripts).toHaveLength(1);
+    expect(transcripts[0].isFinal).toBe(false);
+    expect(transcripts[0].text).toBe('Hi there');
+  });
+
+  it('MOCK: accumulates finals and flushes on <end> token', () => {
+    const emit = (mockWs as { emit: (ev: string, data: string) => void }).emit.bind(
+      mockWs,
+    );
+
+    emit(
+      'message',
+      JSON.stringify({
+        tokens: [{ text: 'Hello ', is_final: true, confidence: 0.9 }],
+      }),
+    );
+    emit(
+      'message',
+      JSON.stringify({
+        tokens: [{ text: 'world', is_final: true, confidence: 0.8 }],
+      }),
+    );
+    emit(
+      'message',
+      JSON.stringify({ tokens: [{ text: '<end>', is_final: true }] }),
+    );
+
+    // Interim transcripts during accumulation, plus the final flush.
+    expect(transcripts[transcripts.length - 1].isFinal).toBe(true);
+    expect(transcripts[transcripts.length - 1].text).toBe('Hello world');
+  });
+
+  it('MOCK: flushes pending finals on server "finished" flag', () => {
+    const emit = (mockWs as { emit: (ev: string, data: string) => void }).emit.bind(
+      mockWs,
+    );
+    emit(
+      'message',
+      JSON.stringify({
+        tokens: [{ text: 'Goodbye', is_final: true, confidence: 0.95 }],
+      }),
+    );
+    emit('message', JSON.stringify({ tokens: [], finished: true }));
+
+    expect(transcripts[transcripts.length - 1].isFinal).toBe(true);
+    expect(transcripts[transcripts.length - 1].text).toBe('Goodbye');
+  });
+
+  it('ignores malformed JSON payloads', () => {
+    const before = transcripts.length;
+    (mockWs as { emit: (ev: string, data: string) => void }).emit(
+      'message',
+      'not json',
+    );
+    expect(transcripts.length).toBe(before);
+  });
+
+  it('sendAudio is a no-op when not connected', () => {
+    const fresh = new SonioxSTT('k');
+    expect(() => fresh.sendAudio(Buffer.from('a'))).not.toThrow();
+  });
+
+  it('close does not throw when called twice', () => {
+    stt.close();
+    expect(() => stt.close()).not.toThrow();
+  });
+
+  it('supports up to 10 onTranscript callbacks before replacing the last', () => {
+    const fresh = new SonioxSTT('k');
+    for (let i = 0; i < 12; i++) {
+      fresh.onTranscript(() => {});
+    }
+    // No crash, internal callbacks array stays bounded.
+    expect(fresh).toBeDefined();
+  });
+});
+
+describe('SonioxSTT — WebSocket constants', () => {
+  it('WebSocket.OPEN matches the mock sentinel', () => {
+    expect(WebSocket.OPEN).toBe(1);
+  });
+});

--- a/sdk/patter/providers/__init__.py
+++ b/sdk/patter/providers/__init__.py
@@ -11,6 +11,16 @@ def whisper(api_key: str, language: str = "en") -> STTConfig:
     return STTConfig(provider="whisper", api_key=api_key, language=language)
 
 
+def soniox(api_key: str, language: str = "en") -> STTConfig:
+    """Soniox real-time STT config (requires the ``soniox`` optional extra)."""
+    return STTConfig(provider="soniox", api_key=api_key, language=language)
+
+
+def speechmatics(api_key: str, language: str = "en") -> STTConfig:
+    """Speechmatics real-time STT config (requires the ``speechmatics`` optional extra)."""
+    return STTConfig(provider="speechmatics", api_key=api_key, language=language)
+
+
 def elevenlabs(api_key: str, voice: str = "rachel") -> TTSConfig:
     return TTSConfig(provider="elevenlabs", api_key=api_key, voice=voice)
 
@@ -23,4 +33,4 @@ def openai_tts(api_key: str, voice: str = "alloy") -> TTSConfig:
 # Python's package import mechanism can bind submodule objects (e.g.
 # patter.providers.openai_tts) onto this package's namespace, which would
 # shadow the function of the same name. We re-bind them explicitly here.
-__all__ = ["deepgram", "whisper", "elevenlabs", "openai_tts"]
+__all__ = ["deepgram", "whisper", "soniox", "speechmatics", "elevenlabs", "openai_tts"]

--- a/sdk/patter/providers/soniox_stt.py
+++ b/sdk/patter/providers/soniox_stt.py
@@ -1,0 +1,373 @@
+"""
+Soniox Speech-to-Text adapter for the Patter SDK pipeline mode.
+
+Connects to the Soniox real-time WebSocket API and streams PCM audio in,
+yielding :class:`~patter.providers.base.Transcript` events. The adapter
+accumulates ``is_final`` tokens into segments and flushes them when an
+``<end>`` / ``<fin>`` endpoint token is received, following the Soniox
+real-time protocol.
+
+Adapted from LiveKit Agents (Apache 2.0):
+https://github.com/livekit/agents
+(source: livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+ at commit 78a66bcf79c5cea82989401c408f1dff4b961a5b)
+
+Changes from upstream:
+- Replaced ``stt.STT`` / ``stt.SpeechStream`` hierarchy with Patter's
+  :class:`~patter.providers.base.STTProvider`.
+- Converted the multi-task ``_run`` pipeline into a queue-based
+  AsyncIterator-friendly implementation mirroring ``DeepgramSTT`` /
+  ``WhisperSTT``.
+- Removed the reconnection loop, LiveKit type dependencies, translation
+  metadata plumbing, and language-identification events; kept the raw
+  transcript text + confidence surface required by Patter pipelines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator
+
+import aiohttp
+
+from patter.providers.base import STTProvider, Transcript
+
+logger = logging.getLogger("patter")
+
+# === Constants ===
+
+# Base URL for Soniox Speech-to-Text API (WebSocket).
+SONIOX_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
+
+# Soniox keepalive payload (JSON).
+KEEPALIVE_MESSAGE = '{"type": "keepalive"}'
+# Tokens that mark a speech segment endpoint in the Soniox stream.
+END_TOKEN = "<end>"
+FINALIZED_TOKEN = "<fin>"
+# Interval between keepalive messages while no audio is being sent.
+KEEPALIVE_INTERVAL_SEC = 5.0
+
+
+def _is_end_token(token: dict[str, Any]) -> bool:
+    """Return True if the token marks an end or finalized event."""
+    return token.get("text") in (END_TOKEN, FINALIZED_TOKEN)
+
+
+class _TokenAccumulator:
+    """Accumulates token metadata (text + rolling confidence).
+
+    Tokens are assumed to arrive in chronological order. The accumulator
+    concatenates the ``text`` field and maintains a running average of
+    per-token confidences.
+    """
+
+    __slots__ = ("text", "_confidence_sum", "_confidence_count")
+
+    def __init__(self) -> None:
+        self.text: str = ""
+        self._confidence_sum: float = 0.0
+        self._confidence_count: int = 0
+
+    def update(self, token: dict[str, Any]) -> None:
+        self.text += token.get("text", "")
+        confidence = token.get("confidence")
+        if confidence is not None:
+            self._confidence_sum += float(confidence)
+            self._confidence_count += 1
+
+    @property
+    def confidence(self) -> float:
+        if self._confidence_count == 0:
+            return 0.0
+        return self._confidence_sum / self._confidence_count
+
+    def reset(self) -> None:
+        self.text = ""
+        self._confidence_sum = 0.0
+        self._confidence_count = 0
+
+
+class SonioxSTT(STTProvider):
+    """Soniox real-time STT adapter.
+
+    Connects to the Soniox Speech-to-Text WebSocket API and yields
+    :class:`~patter.providers.base.Transcript` objects.
+
+    Args:
+        api_key: Soniox API key.
+        model: Soniox STT model (default ``"stt-rt-v4"``).
+        language_hints: Optional BCP-47 language hints (e.g. ``["en", "it"]``).
+        language_hints_strict: When True, restrict to the hints supplied.
+        sample_rate: PCM sample rate (Hz). Defaults to 16 kHz, matching
+            Patter's pipeline mode.
+        num_channels: Audio channels (default 1).
+        enable_speaker_diarization: Turn on server-side speaker diarization.
+        enable_language_identification: Attach language codes to tokens.
+        max_endpoint_delay_ms: Silence, in ms, before Soniox reports an
+            endpoint. Must be in ``[500, 3000]`` (validated by the server).
+        client_reference_id: Optional correlation ID for Soniox dashboards.
+        base_url: Override the Soniox WebSocket URL (used by tests).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = "stt-rt-v4",
+        language_hints: list[str] | None = None,
+        language_hints_strict: bool = False,
+        sample_rate: int = 16000,
+        num_channels: int = 1,
+        enable_speaker_diarization: bool = False,
+        enable_language_identification: bool = True,
+        max_endpoint_delay_ms: int = 500,
+        client_reference_id: str | None = None,
+        base_url: str = SONIOX_WS_URL,
+    ) -> None:
+        if not api_key:
+            raise ValueError("Soniox api_key is required")
+        if not (500 <= max_endpoint_delay_ms <= 3000):
+            raise ValueError("max_endpoint_delay_ms must be between 500 and 3000")
+
+        self.api_key = api_key
+        self.model = model
+        self.language_hints = language_hints
+        self.language_hints_strict = language_hints_strict
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        self.enable_speaker_diarization = enable_speaker_diarization
+        self.enable_language_identification = enable_language_identification
+        self.max_endpoint_delay_ms = max_endpoint_delay_ms
+        self.client_reference_id = client_reference_id
+        self.base_url = base_url
+
+        self._session: aiohttp.ClientSession | None = None
+        self._owns_session: bool = False
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
+
+    def __repr__(self) -> str:
+        return (
+            f"SonioxSTT(model={self.model!r}, sample_rate={self.sample_rate}, "
+            f"diarization={self.enable_speaker_diarization})"
+        )
+
+    @classmethod
+    def for_twilio(
+        cls,
+        api_key: str,
+        language_hints: list[str] | None = None,
+        model: str = "stt-rt-v4",
+    ) -> "SonioxSTT":
+        """Create a Soniox adapter configured for Twilio-style 8 kHz linear PCM.
+
+        Soniox supports 8 kHz PCM directly via ``sample_rate=8000``; Patter's
+        Twilio bridge converts inbound mulaw to linear16 before hitting the
+        STT, so pass 8000 here to avoid needless resampling.
+        """
+        return cls(
+            api_key=api_key,
+            model=model,
+            language_hints=language_hints,
+            sample_rate=8000,
+        )
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def _build_config(self) -> dict[str, Any]:
+        """Build the initial configuration payload sent after ws_connect."""
+        config: dict[str, Any] = {
+            "api_key": self.api_key,
+            "model": self.model,
+            "audio_format": "pcm_s16le",
+            "num_channels": self.num_channels,
+            "sample_rate": self.sample_rate,
+            "enable_endpoint_detection": True,
+            "enable_speaker_diarization": self.enable_speaker_diarization,
+            "enable_language_identification": self.enable_language_identification,
+            "max_endpoint_delay_ms": self.max_endpoint_delay_ms,
+        }
+        if self.language_hints:
+            config["language_hints"] = self.language_hints
+            config["language_hints_strict"] = self.language_hints_strict
+        if self.client_reference_id:
+            config["client_reference_id"] = self.client_reference_id
+        return config
+
+    async def connect(self) -> None:
+        """Open the WebSocket and send the initial configuration payload."""
+        if self._ws is not None:
+            return  # Already connected — idempotent.
+
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+
+        try:
+            self._ws = await self._session.ws_connect(self.base_url)
+            await self._ws.send_str(json.dumps(self._build_config()))
+        except Exception:
+            # Clean up partial state if connect fails.
+            if self._owns_session and self._session is not None:
+                await self._session.close()
+                self._session = None
+                self._owns_session = False
+            self._ws = None
+            raise
+
+        # Spawn keepalive task so idle streams don't get dropped.
+        self._keepalive_task = asyncio.create_task(self._run_keepalive())
+
+    async def _run_keepalive(self) -> None:
+        """Send periodic keepalive frames while the socket is open."""
+        try:
+            while self._ws is not None and not self._ws.closed:
+                await asyncio.sleep(KEEPALIVE_INTERVAL_SEC)
+                if self._ws is None or self._ws.closed:
+                    break
+                try:
+                    await self._ws.send_str(KEEPALIVE_MESSAGE)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("SonioxSTT keepalive send failed: %s", exc)
+                    break
+        except asyncio.CancelledError:
+            pass
+
+    async def send_audio(self, audio_chunk: bytes) -> None:
+        """Send a PCM audio chunk (signed 16-bit little-endian)."""
+        if self._ws is None:
+            raise RuntimeError("SonioxSTT is not connected. Call connect() first.")
+        if not audio_chunk:
+            return
+        await self._ws.send_bytes(audio_chunk)
+
+    # ------------------------------------------------------------------
+    # Transcript stream
+    # ------------------------------------------------------------------
+
+    async def receive_transcripts(self) -> AsyncIterator[Transcript]:
+        """Yield :class:`Transcript` objects from the Soniox stream.
+
+        Behaviour:
+        - Final transcripts are emitted when an ``<end>``/``<fin>`` token
+          is received, containing all accumulated final tokens.
+        - Interim transcripts combine accumulated final tokens with any
+          current non-final tokens, so callers always see the best
+          in-flight hypothesis.
+        """
+        if self._ws is None:
+            raise RuntimeError("SonioxSTT is not connected. Call connect() first.")
+
+        final_acc = _TokenAccumulator()
+
+        async for msg in self._ws:
+            if msg.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+            ):
+                break
+            if msg.type == aiohttp.WSMsgType.ERROR:
+                logger.error("SonioxSTT WebSocket error: %s", self._ws.exception())
+                break
+            if msg.type != aiohttp.WSMsgType.TEXT:
+                continue
+
+            try:
+                content = json.loads(msg.data)
+            except json.JSONDecodeError:
+                logger.warning("SonioxSTT: received non-JSON message")
+                continue
+
+            if content.get("error_code") or content.get("error_message"):
+                logger.error(
+                    "SonioxSTT error %s: %s",
+                    content.get("error_code"),
+                    content.get("error_message"),
+                )
+
+            tokens = content.get("tokens") or []
+            non_final = _TokenAccumulator()
+            emitted_final_this_msg = False
+
+            for token in tokens:
+                if token.get("is_final"):
+                    if _is_end_token(token):
+                        # Endpoint detected — flush the accumulated final text.
+                        if final_acc.text:
+                            yield Transcript(
+                                text=final_acc.text.strip(),
+                                is_final=True,
+                                confidence=final_acc.confidence,
+                            )
+                            final_acc.reset()
+                            emitted_final_this_msg = True
+                    else:
+                        final_acc.update(token)
+                else:
+                    non_final.update(token)
+
+            # Emit an interim update with ``final_acc + non_final`` so
+            # downstream consumers see the best in-flight hypothesis.
+            interim_text = (final_acc.text + non_final.text).strip()
+            if interim_text and not emitted_final_this_msg:
+                # Blended confidence: average of whichever sides contributed.
+                total_count = (
+                    final_acc._confidence_count + non_final._confidence_count
+                )
+                total_sum = (
+                    final_acc._confidence_sum + non_final._confidence_sum
+                )
+                confidence = total_sum / total_count if total_count else 0.0
+                yield Transcript(
+                    text=interim_text,
+                    is_final=False,
+                    confidence=confidence,
+                )
+
+            if content.get("finished"):
+                # Final flush on server-side finish.
+                if final_acc.text:
+                    yield Transcript(
+                        text=final_acc.text.strip(),
+                        is_final=True,
+                        confidence=final_acc.confidence,
+                    )
+                    final_acc.reset()
+                break
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the WebSocket and release owned resources."""
+        if self._keepalive_task is not None:
+            self._keepalive_task.cancel()
+            try:
+                await self._keepalive_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._keepalive_task = None
+
+        if self._ws is not None:
+            try:
+                # Soniox finishes cleanly when the client sends an empty
+                # binary frame; emulate the official client behaviour.
+                await self._ws.send_bytes(b"")
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._ws = None
+
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+            self._owns_session = False

--- a/sdk/patter/providers/speechmatics_stt.py
+++ b/sdk/patter/providers/speechmatics_stt.py
@@ -1,0 +1,330 @@
+"""
+Speechmatics Speech-to-Text adapter for the Patter SDK pipeline mode.
+
+Uses the official ``speechmatics-voice[smart]`` SDK (imported lazily so the
+dependency remains optional) to stream PCM audio to the Speechmatics real-time
+API and yield :class:`~patter.providers.base.Transcript` events.
+
+Adapted from LiveKit Agents (Apache 2.0):
+https://github.com/livekit/agents
+(source: livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+ at commit 78a66bcf79c5cea82989401c408f1dff4b961a5b)
+
+Changes from upstream:
+- Replaced ``stt.STT`` / ``stt.RecognizeStream`` hierarchy with Patter's
+  :class:`~patter.providers.base.STTProvider`.
+- Converted the dual-task (audio send / message receive) pipeline into a
+  queue-fed AsyncIterator, matching the pattern in ``DeepgramSTT`` /
+  ``WhisperSTT``.
+- Dropped LiveKit-specific types (``SpeechEvent``, ``LanguageCode``,
+  ``APIConnectOptions``), speaker-update side channels and diagnostics.
+- Lazy-imports ``speechmatics.voice`` so consumers that do not install the
+  ``speechmatics`` extra can still import the rest of the SDK.
+
+Install with::
+
+    pip install 'getpatter[speechmatics]'
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from typing import Any, AsyncIterator
+
+from patter.providers.base import STTProvider, Transcript
+
+logger = logging.getLogger("patter")
+
+
+SPEECHMATICS_INSTALL_HINT = (
+    "The Speechmatics Voice SDK is required for SpeechmaticsSTT. "
+    "Install the optional dependency with:\n"
+    "    pip install 'getpatter[speechmatics]'\n"
+    "or directly: pip install 'speechmatics-voice[smart]>=0.2.8'"
+)
+
+
+class TurnDetectionMode(str, Enum):
+    """Endpoint / turn-detection handling mode.
+
+    Mirrors the values accepted by ``speechmatics.voice.VoiceAgentConfigPreset``.
+    See LiveKit's original documentation for the semantic differences.
+    """
+
+    EXTERNAL = "external"
+    FIXED = "fixed"
+    ADAPTIVE = "adaptive"
+    SMART_TURN = "smart_turn"
+
+
+def _require_voice_sdk() -> Any:
+    """Import and return the ``speechmatics.voice`` module.
+
+    Raises a ``RuntimeError`` with installation instructions if the SDK is
+    not available, rather than leaking an ``ImportError`` at import time.
+    """
+    try:
+        import speechmatics.voice as voice_sdk  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - trivial guard
+        raise RuntimeError(SPEECHMATICS_INSTALL_HINT) from exc
+    return voice_sdk
+
+
+class SpeechmaticsSTT(STTProvider):
+    """Speechmatics real-time STT adapter.
+
+    Connects via the official ``speechmatics-voice`` SDK and emits
+    :class:`Transcript` objects for partial and final segments.
+
+    Args:
+        api_key: Speechmatics API key (or ``SPEECHMATICS_API_KEY`` env var).
+        base_url: Optional override for the Speechmatics realtime endpoint
+            (``SPEECHMATICS_RT_URL`` env var, falls back to the SDK default).
+        language: BCP-47 language code (default ``"en"``).
+        turn_detection_mode: How Speechmatics detects end of turn. Use
+            ``TurnDetectionMode.EXTERNAL`` with an external VAD.
+        sample_rate: PCM sample rate (Hz). Defaults to 16 kHz.
+        enable_diarization: Attach speaker IDs to transcripts.
+        max_delay: Max latency in seconds before the engine emits finals.
+        end_of_utterance_silence_trigger: Silence (s) that triggers EOU.
+        end_of_utterance_max_delay: Max EOU delay (s); must be greater
+            than ``end_of_utterance_silence_trigger``.
+        include_partials: Include partial words in interim output.
+        additional_vocab: List of ``AdditionalVocabEntry`` from the SDK.
+        operating_point: SDK ``OperatingPoint`` enum (accuracy vs latency).
+        domain: Optional Speechmatics domain (e.g. ``"finance"``).
+        output_locale: Optional output locale (e.g. ``"en-GB"``).
+    """
+
+    # Sentinel used to shut down the receive loop.
+    _STOP = object()
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str | None = None,
+        language: str = "en",
+        turn_detection_mode: TurnDetectionMode = TurnDetectionMode.ADAPTIVE,
+        sample_rate: int = 16000,
+        enable_diarization: bool = False,
+        max_delay: float | None = None,
+        end_of_utterance_silence_trigger: float | None = None,
+        end_of_utterance_max_delay: float | None = None,
+        include_partials: bool = True,
+        additional_vocab: list[Any] | None = None,
+        operating_point: Any | None = None,
+        domain: str | None = None,
+        output_locale: str | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("Speechmatics api_key is required")
+
+        # Validate ranges (mirrors LiveKit's upstream checks).
+        if end_of_utterance_silence_trigger is not None and not (
+            0 < end_of_utterance_silence_trigger < 2
+        ):
+            raise ValueError(
+                "end_of_utterance_silence_trigger must be between 0 and 2"
+            )
+        if (
+            end_of_utterance_max_delay is not None
+            and end_of_utterance_silence_trigger is not None
+            and end_of_utterance_max_delay <= end_of_utterance_silence_trigger
+        ):
+            raise ValueError(
+                "end_of_utterance_max_delay must be greater than "
+                "end_of_utterance_silence_trigger"
+            )
+        if max_delay is not None and not (0.7 <= max_delay <= 4.0):
+            raise ValueError("max_delay must be between 0.7 and 4.0")
+
+        # Eagerly validate SDK availability so failures surface at init.
+        self._voice = _require_voice_sdk()
+
+        self.api_key = api_key
+        self.base_url = base_url
+        self.language = language
+        self.turn_detection_mode = turn_detection_mode
+        self.sample_rate = sample_rate
+        self.enable_diarization = enable_diarization
+        self.max_delay = max_delay
+        self.end_of_utterance_silence_trigger = end_of_utterance_silence_trigger
+        self.end_of_utterance_max_delay = end_of_utterance_max_delay
+        self.include_partials = include_partials
+        self.additional_vocab = additional_vocab or []
+        self.operating_point = operating_point
+        self.domain = domain
+        self.output_locale = output_locale
+
+        self._client: Any | None = None
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+
+    def __repr__(self) -> str:
+        return (
+            f"SpeechmaticsSTT(language={self.language!r}, "
+            f"turn_detection={self.turn_detection_mode.value!r}, "
+            f"sample_rate={self.sample_rate})"
+        )
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def _build_config(self) -> Any:
+        """Build a ``VoiceAgentConfig`` from the adapter parameters."""
+        voice = self._voice
+        config = voice.VoiceAgentConfigPreset.load(self.turn_detection_mode.value)
+        config.sample_rate = self.sample_rate
+        config.audio_encoding = voice.AudioEncoding.PCM_S16LE
+        config.language = self.language
+        if self.domain is not None:
+            config.domain = self.domain
+        if self.output_locale is not None:
+            config.output_locale = self.output_locale
+        if self.additional_vocab:
+            config.additional_vocab = self.additional_vocab
+        if self.operating_point is not None:
+            config.operating_point = self.operating_point
+        if self.max_delay is not None:
+            config.max_delay = self.max_delay
+        if self.end_of_utterance_silence_trigger is not None:
+            config.end_of_utterance_silence_trigger = (
+                self.end_of_utterance_silence_trigger
+            )
+        if self.end_of_utterance_max_delay is not None:
+            config.end_of_utterance_max_delay = self.end_of_utterance_max_delay
+        config.enable_diarization = self.enable_diarization
+        config.include_partials = self.include_partials
+        return config
+
+    def _register_handlers(self, client: Any) -> None:
+        """Wire Speechmatics server events to our internal queue."""
+        voice = self._voice
+
+        def _enqueue(message: dict[str, Any]) -> None:
+            self._queue.put_nowait(message)
+
+        handlers = [
+            voice.AgentServerMessageType.ADD_PARTIAL_SEGMENT,
+            voice.AgentServerMessageType.ADD_SEGMENT,
+            voice.AgentServerMessageType.END_OF_TURN,
+            voice.AgentServerMessageType.ERROR,
+            voice.AgentServerMessageType.WARNING,
+        ]
+        for event in handlers:
+            client.on(event, _enqueue)
+
+    async def connect(self) -> None:
+        """Create the underlying ``VoiceAgentClient`` and connect."""
+        if self._client is not None:
+            return
+
+        voice = self._voice
+        kwargs: dict[str, Any] = {
+            "api_key": self.api_key,
+            "config": self._build_config(),
+            "app": "patter-sdk",
+        }
+        if self.base_url:
+            kwargs["url"] = self.base_url
+
+        self._client = voice.VoiceAgentClient(**kwargs)
+        self._register_handlers(self._client)
+        await self._client.connect()
+
+    async def send_audio(self, audio_chunk: bytes) -> None:
+        """Send a PCM audio chunk (signed 16-bit little-endian)."""
+        if self._client is None:
+            raise RuntimeError(
+                "SpeechmaticsSTT is not connected. Call connect() first."
+            )
+        if not audio_chunk:
+            return
+        await self._client.send_audio(audio_chunk)
+
+    # ------------------------------------------------------------------
+    # Transcript stream
+    # ------------------------------------------------------------------
+
+    def _message_to_transcript(self, message: dict[str, Any]) -> Transcript | None:
+        """Translate a Speechmatics server message into a Patter Transcript."""
+        voice = self._voice
+        event = message.get("message")
+
+        if event == voice.AgentServerMessageType.ADD_PARTIAL_SEGMENT:
+            is_final = False
+        elif event == voice.AgentServerMessageType.ADD_SEGMENT:
+            is_final = True
+        elif event == voice.AgentServerMessageType.END_OF_TURN:
+            # End-of-turn carries no text; Patter signals finality via the
+            # is_final flag on transcript events — ignore here.
+            return None
+        elif event in (
+            voice.AgentServerMessageType.ERROR,
+            voice.AgentServerMessageType.WARNING,
+        ):
+            logger.warning("SpeechmaticsSTT %s: %s", event, message)
+            return None
+        else:
+            return None
+
+        segments = message.get("segments") or []
+        texts: list[str] = []
+        confidences: list[float] = []
+        for segment in segments:
+            text = segment.get("text")
+            if text:
+                texts.append(text)
+            confidence = segment.get("confidence")
+            if isinstance(confidence, (int, float)):
+                confidences.append(float(confidence))
+
+        joined = " ".join(t for t in texts if t).strip()
+        if not joined:
+            return None
+
+        confidence = (
+            sum(confidences) / len(confidences) if confidences else 1.0
+        )
+        return Transcript(text=joined, is_final=is_final, confidence=confidence)
+
+    async def receive_transcripts(self) -> AsyncIterator[Transcript]:
+        """Yield :class:`Transcript` objects from Speechmatics events."""
+        if self._client is None:
+            raise RuntimeError(
+                "SpeechmaticsSTT is not connected. Call connect() first."
+            )
+
+        while True:
+            message = await self._queue.get()
+            if message is self._STOP:
+                break
+            try:
+                transcript = self._message_to_transcript(message)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("SpeechmaticsSTT handler error: %s", exc)
+                continue
+            if transcript is not None:
+                yield transcript
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Disconnect the Speechmatics client and stop the receive loop."""
+        if self._client is not None:
+            try:
+                await self._client.disconnect()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("SpeechmaticsSTT disconnect error: %s", exc)
+            self._client = None
+
+        # Unblock any outstanding receive_transcripts() call.
+        try:
+            self._queue.put_nowait(self._STOP)
+        except Exception:  # noqa: BLE001
+            pass

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -47,6 +47,12 @@ local = [
     "openai>=1.0.0",
     "cryptography>=42.0.0",
 ]
+soniox = [
+    "aiohttp>=3.10",
+]
+speechmatics = [
+    "speechmatics-voice[smart]>=0.2.8",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",

--- a/sdk/tests/unit/test_soniox_speechmatics_unit.py
+++ b/sdk/tests/unit/test_soniox_speechmatics_unit.py
@@ -1,0 +1,605 @@
+"""Unit tests for SonioxSTT and SpeechmaticsSTT adapters.
+
+These tests use **synthetic mocks** of the Soniox / Speechmatics protocol
+frames. They exercise the adapter state machines (token accumulation,
+endpoint flushes, interim vs final transcripts) without any real network
+traffic. See the module-level MOCK docstring below for details on the
+protocol payloads each test replays.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# MOCK HELPERS (synthetic Soniox / Speechmatics frames)
+# ---------------------------------------------------------------------------
+#
+# The tests below synthesise the exact JSON payloads that Soniox emits over
+# its real-time WebSocket API (``tokens`` with ``is_final`` flags, plus the
+# ``<end>`` endpoint sentinel), and the object-style dict messages that the
+# Speechmatics Voice SDK forwards from its server stream.  Both shapes are
+# drawn from the upstream LiveKit plugin behaviour, which is our reference.
+
+
+class _FakeWSMsg:
+    """Duck-typed mock of ``aiohttp.WSMessage`` used by the aiohttp iterator."""
+
+    def __init__(self, kind: str, data: str | bytes = ""):
+        self.type = kind
+        self.data = data
+
+
+class _FakeAiohttpWS:
+    """Async-iterable fake of ``aiohttp.ClientWebSocketResponse``."""
+
+    def __init__(self, incoming: list[_FakeWSMsg]):
+        self._incoming = incoming
+        self.sent_text: list[str] = []
+        self.sent_bytes: list[bytes] = []
+        self.closed = False
+
+    async def send_str(self, payload: str) -> None:
+        self.sent_text.append(payload)
+
+    async def send_bytes(self, payload: bytes) -> None:
+        self.sent_bytes.append(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def exception(self) -> Exception | None:  # pragma: no cover - defensive
+        return None
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._incoming:
+            raise StopAsyncIteration
+        return self._incoming.pop(0)
+
+
+class _FakeAiohttpSession:
+    def __init__(self, ws: _FakeAiohttpWS):
+        self._ws = ws
+        self.closed = False
+
+    async def ws_connect(self, url: str):
+        self._last_url = url
+        return self._ws
+
+    async def close(self):
+        self.closed = True
+
+
+# Lazy import helpers — the aiohttp import happens at module import time
+# in soniox_stt.py, but we treat it as an optional runtime dependency in
+# the tests to avoid hard-requiring it in the base dev env.
+aiohttp = pytest.importorskip("aiohttp")
+
+
+# ---------------------------------------------------------------------------
+# SonioxSTT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSonioxSTTInit:
+    def test_requires_api_key(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        with pytest.raises(ValueError, match="api_key"):
+            SonioxSTT(api_key="")
+
+    def test_validates_endpoint_delay_range(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        with pytest.raises(ValueError, match="max_endpoint_delay_ms"):
+            SonioxSTT(api_key="k", max_endpoint_delay_ms=100)
+
+    def test_for_twilio_uses_8khz(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        stt = SonioxSTT.for_twilio(api_key="k")
+        assert stt.sample_rate == 8000
+
+    def test_build_config_defaults(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        stt = SonioxSTT(api_key="k", language_hints=["en", "it"])
+        config = stt._build_config()
+        assert config["api_key"] == "k"
+        assert config["audio_format"] == "pcm_s16le"
+        assert config["sample_rate"] == 16000
+        assert config["language_hints"] == ["en", "it"]
+        assert config["enable_endpoint_detection"] is True
+
+    def test_repr(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        stt = SonioxSTT(api_key="k")
+        assert "SonioxSTT" in repr(stt)
+
+
+@pytest.mark.unit
+class TestSonioxSTTIO:
+    """Mocked-WebSocket tests for SonioxSTT behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_connect_sends_initial_config(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        ws = _FakeAiohttpWS([])
+        session = _FakeAiohttpSession(ws)
+        stt = SonioxSTT(api_key="test-key")
+        stt._session = session  # inject fake session
+        await stt.connect()
+        try:
+            assert stt._ws is ws
+            assert len(ws.sent_text) == 1
+            payload = json.loads(ws.sent_text[0])
+            assert payload["api_key"] == "test-key"
+            assert payload["model"] == "stt-rt-v4"
+        finally:
+            await stt.close()
+
+    @pytest.mark.asyncio
+    async def test_send_audio_requires_connect(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        stt = SonioxSTT(api_key="k")
+        with pytest.raises(RuntimeError):
+            await stt.send_audio(b"abc")
+
+    @pytest.mark.asyncio
+    async def test_receive_accumulates_finals_until_endpoint(self):
+        """MOCK: simulate two final tokens followed by an ``<end>`` token.
+
+        Expected: one interim transcript for each partial message, then one
+        final transcript carrying the concatenated text once the endpoint
+        arrives.
+        """
+        from patter.providers.soniox_stt import SonioxSTT
+
+        frames = [
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps(
+                    {"tokens": [{"text": "Hello ", "is_final": True, "confidence": 0.9}]}
+                ),
+            ),
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps(
+                    {"tokens": [{"text": "world", "is_final": True, "confidence": 0.8}]}
+                ),
+            ),
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps({"tokens": [{"text": "<end>", "is_final": True}]}),
+            ),
+        ]
+        ws = _FakeAiohttpWS(frames)
+        stt = SonioxSTT(api_key="k")
+        stt._ws = ws  # bypass connect to drive only the receive path
+
+        transcripts = []
+        async for t in stt.receive_transcripts():
+            transcripts.append(t)
+
+        # Two interim emissions (one after each is_final-but-not-endpoint),
+        # followed by one final emission.
+        assert transcripts[-1].is_final is True
+        assert transcripts[-1].text == "Hello world"
+        assert any(not t.is_final for t in transcripts[:-1])
+
+    @pytest.mark.asyncio
+    async def test_receive_emits_interim_for_nonfinal_tokens(self):
+        """MOCK: a single message containing only non-final tokens should
+        produce an interim transcript with the best in-flight hypothesis."""
+        from patter.providers.soniox_stt import SonioxSTT
+
+        frames = [
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps(
+                    {
+                        "tokens": [
+                            {"text": "Hi ", "is_final": False, "confidence": 0.5},
+                            {"text": "there", "is_final": False, "confidence": 0.6},
+                        ]
+                    }
+                ),
+            ),
+        ]
+        ws = _FakeAiohttpWS(frames)
+        stt = SonioxSTT(api_key="k")
+        stt._ws = ws
+
+        transcripts = [t async for t in stt.receive_transcripts()]
+        assert len(transcripts) == 1
+        assert transcripts[0].is_final is False
+        assert transcripts[0].text == "Hi there"
+
+    @pytest.mark.asyncio
+    async def test_receive_skips_empty_tokens(self):
+        """MOCK: a message with no tokens must not yield anything."""
+        from patter.providers.soniox_stt import SonioxSTT
+
+        frames = [_FakeWSMsg(aiohttp.WSMsgType.TEXT, json.dumps({"tokens": []}))]
+        ws = _FakeAiohttpWS(frames)
+        stt = SonioxSTT(api_key="k")
+        stt._ws = ws
+
+        transcripts = [t async for t in stt.receive_transcripts()]
+        assert transcripts == []
+
+    @pytest.mark.asyncio
+    async def test_finished_flushes_pending_final(self):
+        """MOCK: server finished flag flushes any buffered final tokens."""
+        from patter.providers.soniox_stt import SonioxSTT
+
+        frames = [
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps(
+                    {"tokens": [{"text": "Goodbye", "is_final": True, "confidence": 0.95}]}
+                ),
+            ),
+            _FakeWSMsg(
+                aiohttp.WSMsgType.TEXT,
+                json.dumps({"tokens": [], "finished": True}),
+            ),
+        ]
+        ws = _FakeAiohttpWS(frames)
+        stt = SonioxSTT(api_key="k")
+        stt._ws = ws
+
+        transcripts = [t async for t in stt.receive_transcripts()]
+        # An interim after the first frame, then a final flush on finished=true.
+        assert transcripts[-1].is_final is True
+        assert transcripts[-1].text == "Goodbye"
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_keepalive_and_owns_session(self):
+        from patter.providers.soniox_stt import SonioxSTT
+
+        ws = _FakeAiohttpWS([])
+        session = _FakeAiohttpSession(ws)
+        stt = SonioxSTT(api_key="k")
+        stt._session = session
+        stt._owns_session = True
+        await stt.connect()
+        assert stt._keepalive_task is not None
+        await stt.close()
+        assert stt._ws is None
+        assert stt._keepalive_task is None
+        assert session.closed is True
+
+
+# ---------------------------------------------------------------------------
+# SpeechmaticsSTT (SDK mocked via sys.modules injection)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_speechmatics(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Install a fake ``speechmatics.voice`` module so the adapter can import.
+
+    Returns a namespace with references to the fake classes so tests can
+    assert on the VoiceAgentClient interactions.
+    """
+
+    class _FakeEnum(str):
+        """String-compatible enum stand-in for message type sentinels."""
+
+    ADD_PARTIAL = "AddPartialSegment"
+    ADD_SEGMENT = "AddSegment"
+    END_OF_TURN = "EndOfTurn"
+    ERROR = "Error"
+    WARNING = "Warning"
+
+    AgentServerMessageType = SimpleNamespace(
+        ADD_PARTIAL_SEGMENT=ADD_PARTIAL,
+        ADD_SEGMENT=ADD_SEGMENT,
+        END_OF_TURN=END_OF_TURN,
+        ERROR=ERROR,
+        WARNING=WARNING,
+    )
+
+    class _FakeAudioEncoding:
+        PCM_S16LE = "pcm_s16le"
+
+    class _FakeSpeakerFocusMode:
+        RETAIN = "retain"
+
+    class _FakeOperatingPoint:
+        ENHANCED = "enhanced"
+
+    class _FakeConfig:
+        def __init__(self, mode: str):
+            self.mode = mode
+            self.sample_rate = 16000
+            self.audio_encoding = None
+            self.language = None
+            self.domain = None
+            self.output_locale = None
+            self.additional_vocab = None
+            self.operating_point = None
+            self.max_delay = None
+            self.end_of_utterance_silence_trigger = None
+            self.end_of_utterance_max_delay = None
+            self.enable_diarization = False
+            self.include_partials = True
+
+    class _FakeConfigPreset:
+        @staticmethod
+        def load(mode: str) -> _FakeConfig:
+            return _FakeConfig(mode)
+
+    class _FakeVoiceAgentClient:
+        def __init__(self, *, api_key: str, config: _FakeConfig, app: str = "", url: str = ""):
+            self.api_key = api_key
+            self.config = config
+            self.app = app
+            self.url = url
+            self.handlers: dict[str, list] = {}
+            self.connected = False
+            self.sent_audio: list[bytes] = []
+            self.disconnected = False
+
+        def on(self, event, handler):
+            self.handlers.setdefault(event, []).append(handler)
+
+        async def connect(self):
+            self.connected = True
+
+        async def send_audio(self, audio: bytes):
+            self.sent_audio.append(audio)
+
+        async def disconnect(self):
+            self.disconnected = True
+
+        # Helper used by tests to push a message to all registered handlers.
+        def _emit(self, event: str, message: dict):
+            for handler in self.handlers.get(event, []):
+                handler(message)
+
+    class _FakeAdditionalVocabEntry:
+        def __init__(self, content: str):
+            self.content = content
+
+    class _FakeSpeakerIdentifier:
+        def __init__(self, label: str):
+            self.label = label
+
+    fake_voice = ModuleType("speechmatics.voice")
+    fake_voice.AgentServerMessageType = AgentServerMessageType
+    fake_voice.AudioEncoding = _FakeAudioEncoding
+    fake_voice.SpeakerFocusMode = _FakeSpeakerFocusMode
+    fake_voice.OperatingPoint = _FakeOperatingPoint
+    fake_voice.VoiceAgentConfig = _FakeConfig
+    fake_voice.VoiceAgentConfigPreset = _FakeConfigPreset
+    fake_voice.VoiceAgentClient = _FakeVoiceAgentClient
+    fake_voice.AdditionalVocabEntry = _FakeAdditionalVocabEntry
+    fake_voice.SpeakerIdentifier = _FakeSpeakerIdentifier
+    fake_voice.SpeakerFocusConfig = MagicMock
+
+    fake_parent = ModuleType("speechmatics")
+    fake_parent.voice = fake_voice
+
+    monkeypatch.setitem(sys.modules, "speechmatics", fake_parent)
+    monkeypatch.setitem(sys.modules, "speechmatics.voice", fake_voice)
+
+    return SimpleNamespace(
+        voice=fake_voice,
+        AgentServerMessageType=AgentServerMessageType,
+        VoiceAgentClient=_FakeVoiceAgentClient,
+        ADD_PARTIAL=ADD_PARTIAL,
+        ADD_SEGMENT=ADD_SEGMENT,
+        END_OF_TURN=END_OF_TURN,
+        ERROR=ERROR,
+        WARNING=WARNING,
+    )
+
+
+@pytest.mark.unit
+class TestSpeechmaticsSTTInit:
+    def test_raises_on_missing_sdk(self, monkeypatch):
+        # Make sure the import fails by removing any previous stub.
+        monkeypatch.setitem(sys.modules, "speechmatics", None)
+        monkeypatch.setitem(sys.modules, "speechmatics.voice", None)
+        # Reimport module to force re-evaluation of _require_voice_sdk().
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        with pytest.raises(RuntimeError, match="speechmatics-voice"):
+            SpeechmaticsSTT(api_key="k")
+
+    def test_rejects_invalid_api_key(self, monkeypatch):
+        _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        with pytest.raises(ValueError, match="api_key"):
+            SpeechmaticsSTT(api_key="")
+
+    def test_validates_max_delay_range(self, monkeypatch):
+        _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        with pytest.raises(ValueError, match="max_delay"):
+            SpeechmaticsSTT(api_key="k", max_delay=0.1)
+
+    def test_validates_eou_constraints(self, monkeypatch):
+        _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        with pytest.raises(ValueError, match="end_of_utterance_silence_trigger"):
+            SpeechmaticsSTT(api_key="k", end_of_utterance_silence_trigger=3.0)
+        with pytest.raises(ValueError, match="end_of_utterance_max_delay"):
+            SpeechmaticsSTT(
+                api_key="k",
+                end_of_utterance_silence_trigger=1.0,
+                end_of_utterance_max_delay=0.5,
+            )
+
+
+@pytest.mark.unit
+class TestSpeechmaticsSTTIO:
+    @pytest.mark.asyncio
+    async def test_connect_configures_client(self, monkeypatch):
+        fake = _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        stt = SpeechmaticsSTT(api_key="k", language="fr", enable_diarization=True)
+        await stt.connect()
+        try:
+            assert stt._client is not None
+            assert stt._client.connected is True
+            # Assert the fake client received ADD_PARTIAL_SEGMENT handler.
+            assert fake.ADD_PARTIAL in stt._client.handlers
+            assert fake.ADD_SEGMENT in stt._client.handlers
+        finally:
+            await stt.close()
+
+    @pytest.mark.asyncio
+    async def test_send_audio_forwards_to_client(self, monkeypatch):
+        _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        stt = SpeechmaticsSTT(api_key="k")
+        await stt.connect()
+        try:
+            await stt.send_audio(b"\x01\x02")
+            assert stt._client.sent_audio == [b"\x01\x02"]
+            # Empty chunk is a no-op.
+            await stt.send_audio(b"")
+            assert stt._client.sent_audio == [b"\x01\x02"]
+        finally:
+            await stt.close()
+
+    @pytest.mark.asyncio
+    async def test_receive_transcripts_translates_partial_and_final(self, monkeypatch):
+        """MOCK: push two messages (partial + final) through the fake client
+        event handler and assert that the adapter yields matching interim /
+        final Transcript objects.
+        """
+        fake = _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        stt = SpeechmaticsSTT(api_key="k")
+        await stt.connect()
+        try:
+            # Enqueue a partial and a final message as if coming from the server.
+            stt._client._emit(
+                fake.ADD_PARTIAL,
+                {
+                    "message": fake.ADD_PARTIAL,
+                    "segments": [{"text": "hello"}, {"text": "there"}],
+                },
+            )
+            stt._client._emit(
+                fake.ADD_SEGMENT,
+                {
+                    "message": fake.ADD_SEGMENT,
+                    "segments": [{"text": "hello there", "confidence": 0.9}],
+                },
+            )
+            # Stop the loop cleanly.
+            stt._queue.put_nowait(stt._STOP)
+
+            results = []
+            async for t in stt.receive_transcripts():
+                results.append(t)
+
+            assert len(results) == 2
+            assert results[0].is_final is False
+            assert results[0].text == "hello there"
+            assert results[1].is_final is True
+            assert results[1].text == "hello there"
+            assert results[1].confidence == pytest.approx(0.9)
+        finally:
+            await stt.close()
+
+    @pytest.mark.asyncio
+    async def test_end_of_turn_is_silent(self, monkeypatch):
+        """MOCK: EndOfTurn should not produce a transcript."""
+        fake = _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        stt = SpeechmaticsSTT(api_key="k")
+        await stt.connect()
+        try:
+            stt._client._emit(
+                fake.END_OF_TURN, {"message": fake.END_OF_TURN}
+            )
+            stt._queue.put_nowait(stt._STOP)
+            results = [t async for t in stt.receive_transcripts()]
+            assert results == []
+        finally:
+            await stt.close()
+
+    @pytest.mark.asyncio
+    async def test_close_disconnects_client(self, monkeypatch):
+        _install_fake_speechmatics(monkeypatch)
+        monkeypatch.delitem(sys.modules, "patter.providers.speechmatics_stt", raising=False)
+        from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+        stt = SpeechmaticsSTT(api_key="k")
+        await stt.connect()
+        client = stt._client
+        await stt.close()
+        assert client.disconnected is True
+        assert stt._client is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (skipped by default — require real API keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("SONIOX_API_KEY"),
+    reason="SONIOX_API_KEY not set; skipping live integration test",
+)
+@pytest.mark.asyncio
+async def test_soniox_live_smoke():  # pragma: no cover - gated on credentials
+    from patter.providers.soniox_stt import SonioxSTT
+
+    stt = SonioxSTT(api_key=os.environ["SONIOX_API_KEY"])
+    await stt.connect()
+    await stt.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("SPEECHMATICS_API_KEY"),
+    reason="SPEECHMATICS_API_KEY not set; skipping live integration test",
+)
+@pytest.mark.asyncio
+async def test_speechmatics_live_smoke():  # pragma: no cover - gated on credentials
+    try:
+        import speechmatics.voice  # noqa: F401
+    except ImportError:
+        pytest.skip("speechmatics-voice not installed")
+    from patter.providers.speechmatics_stt import SpeechmaticsSTT
+
+    stt = SpeechmaticsSTT(api_key=os.environ["SPEECHMATICS_API_KEY"])
+    await stt.connect()
+    await stt.close()


### PR DESCRIPTION
## Summary

- Port **Soniox** real-time STT (pure aiohttp / `ws` WebSocket client) and **Speechmatics** real-time STT (over `speechmatics-voice[smart]`) from LiveKit Agents (Apache 2.0, commit `78a66bcf`) to the Patter SDK.
- Both adapters implement Patter's `STTProvider` interface with queue-based `AsyncIterator` transcript streams, matching the existing `DeepgramSTT` / `WhisperSTT` style.
- Add `[soniox]` and `[speechmatics]` optional extras so the dependencies stay pay-as-you-go; `SpeechmaticsSTT` lazy-imports its SDK and raises a clear `RuntimeError` with install instructions when the extra is missing.
- TypeScript SDK: port Soniox to `sdk-ts/src/providers/soniox-stt.ts`. Speechmatics is **not** ported to TS (upstream Voice SDK is Python-only); this is documented in the module header.

## Files touched

Python:
- `sdk/patter/providers/soniox_stt.py` (new, ~370 lines, LiveKit attribution header)
- `sdk/patter/providers/speechmatics_stt.py` (new, ~280 lines, LiveKit attribution + lazy import)
- `sdk/patter/providers/__init__.py` (+`soniox()` / `speechmatics()` config helpers)
- `sdk/pyproject.toml` (+`[soniox]` / `[speechmatics]` extras)
- `sdk/tests/unit/test_soniox_speechmatics_unit.py` (new, 21 unit + 2 integration tests)

TypeScript:
- `sdk-ts/src/providers/soniox-stt.ts` (new)
- `sdk-ts/src/index.ts` (+`SonioxSTT`, `SonioxSTTOptions` exports)
- `sdk-ts/tests/soniox-stt.test.ts` (new, 13 unit tests)

## Protocol notes

- Soniox frames replayed in tests are synthetic but follow the documented token shape: `{"tokens": [{"text": "...", "is_final": bool, "confidence": float}], "finished": bool}` with `<end>` / `<fin>` endpoint sentinels. Interim transcripts combine buffered final text with current non-final tokens so downstream consumers always see the best in-flight hypothesis.
- Speechmatics tests inject a fake `speechmatics.voice` module via `monkeypatch.setitem(sys.modules, ...)` and assert that the adapter:
  - registers `ADD_PARTIAL_SEGMENT` / `ADD_SEGMENT` / `END_OF_TURN` handlers,
  - converts partials to `is_final=False` transcripts and segments to `is_final=True`,
  - stays silent on `END_OF_TURN` (no empty transcript).
- Live integration tests are skipped by default; set `SONIOX_API_KEY` / `SPEECHMATICS_API_KEY` to exercise them.

## Test plan

- [x] `cd sdk && python3 -m pytest tests/ -x --tb=short` — **1254 passed, 2 skipped (integration gates)**
- [x] `cd sdk-ts && npx tsc --noEmit` — clean
- [x] `cd sdk-ts && npx vitest run` — **898 passed across 51 files**
- [ ] Manual smoke against a real Soniox session (follow-up: `SONIOX_API_KEY=... pytest tests/unit/test_soniox_speechmatics_unit.py -k live`)
- [ ] Manual smoke against a real Speechmatics session (follow-up: install `speechmatics-voice[smart]` + set `SPEECHMATICS_API_KEY`)

## Follow-ups / out of scope

- Wire `soniox` / `speechmatics` provider strings into `handler-utils.ts` / `_create_stt_from_config` once downstream routing decides on canonical model names.
- Revisit a TS Speechmatics adapter when the official Voice SDK ships for Node — the current handshake + diarization semantics are non-trivial to reimplement from scratch.