### PR TITLE
feat(ivr): port IVR auto-navigation from LiveKit Agents

### DIFF
--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -70,3 +70,17 @@ export { startTunnel } from "./tunnel";
 export type { TunnelHandle } from "./tunnel";
 export { ChatContext } from "./chat-context";
 export type { ChatMessage, ChatRole, OpenAIMessage, AnthropicMessage, AnthropicConversion } from "./chat-context";
+export {
+  IVRActivity,
+  TfidfLoopDetector,
+  DTMF_EVENTS,
+  formatDtmf,
+} from "./services/ivr";
+export type {
+  DtmfEvent,
+  IVRActivityOptions,
+  IVRToolDefinition,
+  TfidfLoopDetectorOptions,
+  LoopCallback,
+  SilenceCallback,
+} from "./services/ivr";

--- a/sdk-ts/src/metrics.ts
+++ b/sdk-ts/src/metrics.ts
@@ -61,6 +61,13 @@ export interface CallControl {
   transfer(number: string): Promise<void>;
   /** Hang up the call. */
   hangup(): Promise<void>;
+  /**
+   * Send DTMF digits (for IVR navigation, e.g. "1234#").
+   *
+   * @param digits  String of DTMF digits (0-9, *, #, A-D).
+   * @param options Per-call tuning. `delayMs` defaults to `300`.
+   */
+  sendDtmf?(digits: string, options?: { delayMs?: number }): Promise<void>;
   /** Current call ID. */
   readonly callId: string;
   /** Caller number. */

--- a/sdk-ts/src/services/ivr.ts
+++ b/sdk-ts/src/services/ivr.ts
@@ -1,0 +1,400 @@
+/**
+ * IVR auto-navigation activity for telephony calls (TypeScript port).
+ *
+ * Detects IVR prompts via transcribed speech, forwards DTMF responses
+ * through `CallControl.sendDtmf`, and recovers from two common failure
+ * modes:
+ *
+ * 1. The agent hears the same IVR prompt repeated several times
+ *    (loop detection). `TfidfLoopDetector` flags this by comparing the
+ *    cosine similarity of recent transcript chunks.
+ * 2. The IVR falls silent while both parties are passive (silence
+ *    detection). A debounced timer triggers a follow-up after
+ *    `maxSilenceDuration` seconds of combined silence.
+ *
+ * The Python port uses scikit-learn for TF-IDF; TypeScript has no
+ * equivalent battle-tested package in the std library, so we ship a
+ * minimal in-house bag-of-words + cosine-similarity implementation.
+ * It is intentionally simple — enough to match repeated IVR prompts.
+ *
+ * Algorithm adapted from LiveKit Agents (Apache 2.0):
+ * https://github.com/livekit/agents
+ *
+ * Source:
+ *  - livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
+ *  - livekit-agents/livekit/agents/beta/tools/send_dtmf.py
+ * LiveKit SHA at port time: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+ */
+
+import type { CallControl } from "../metrics";
+
+// ---------------------------------------------------------------------------
+// DTMF event taxonomy
+// ---------------------------------------------------------------------------
+
+/** Valid DTMF tone values (keypad characters). */
+export const DTMF_EVENTS = [
+  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+  "*", "#", "A", "B", "C", "D",
+] as const;
+
+export type DtmfEvent = (typeof DTMF_EVENTS)[number];
+
+/** Join DTMF events into a space-separated debug string. */
+export function formatDtmf(events: DtmfEvent[]): string {
+  return events.join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Bag-of-words + cosine similarity (minimal TF-IDF-ish loop detector)
+// ---------------------------------------------------------------------------
+
+const WORD_RE = /[a-z0-9]+/g;
+
+function tokenize(text: string): string[] {
+  return (text.toLowerCase().match(WORD_RE) ?? []);
+}
+
+/** Term-frequency bag-of-words vector. */
+function bagOfWords(text: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const token of tokenize(text)) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function cosineSimilarity(a: Map<string, number>, b: Map<string, number>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+
+  let dot = 0;
+  // Iterate the smaller map for efficiency.
+  const [small, big] = a.size <= b.size ? [a, b] : [b, a];
+  for (const [term, weight] of small) {
+    const other = big.get(term);
+    if (other !== undefined) {
+      dot += weight * other;
+    }
+  }
+
+  let normA = 0;
+  for (const w of a.values()) normA += w * w;
+  let normB = 0;
+  for (const w of b.values()) normB += w * w;
+
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  if (denom === 0) return 0;
+  return dot / denom;
+}
+
+// ---------------------------------------------------------------------------
+// TfidfLoopDetector
+// ---------------------------------------------------------------------------
+
+export interface TfidfLoopDetectorOptions {
+  /** Number of recent chunks to keep in the comparison window. */
+  windowSize?: number;
+  /** Cosine similarity above which two chunks are "the same prompt". */
+  similarityThreshold?: number;
+  /** Consecutive near-duplicates required before firing. */
+  consecutiveThreshold?: number;
+}
+
+/**
+ * Detects repeated IVR prompts via cosine similarity on bag-of-words
+ * vectors. Not a full TF-IDF implementation — good enough for catching
+ * IVRs that re-read the same menu.
+ */
+export class TfidfLoopDetector {
+  private readonly windowSize: number;
+  private readonly similarityThreshold: number;
+  private readonly consecutiveThreshold: number;
+  private chunks: Array<{ text: string; vec: Map<string, number> }> = [];
+  private consecutiveSimilar = 0;
+
+  constructor(opts: TfidfLoopDetectorOptions = {}) {
+    const {
+      windowSize = 20,
+      similarityThreshold = 0.85,
+      consecutiveThreshold = 3,
+    } = opts;
+
+    if (windowSize <= 0) {
+      throw new Error("windowSize must be greater than 0");
+    }
+    if (similarityThreshold < 0 || similarityThreshold > 1) {
+      throw new Error("similarityThreshold must be between 0.0 and 1.0");
+    }
+    if (consecutiveThreshold <= 0) {
+      throw new Error("consecutiveThreshold must be greater than 0");
+    }
+
+    this.windowSize = windowSize;
+    this.similarityThreshold = similarityThreshold;
+    this.consecutiveThreshold = consecutiveThreshold;
+  }
+
+  reset(): void {
+    this.chunks = [];
+    this.consecutiveSimilar = 0;
+  }
+
+  addChunk(text: string): void {
+    this.chunks.push({ text, vec: bagOfWords(text) });
+    if (this.chunks.length > this.windowSize) {
+      this.chunks = this.chunks.slice(-this.windowSize);
+    }
+  }
+
+  checkLoopDetection(): boolean {
+    if (this.chunks.length < 2) return false;
+
+    const last = this.chunks[this.chunks.length - 1];
+    let maxSim = 0;
+    for (let i = 0; i < this.chunks.length - 1; i++) {
+      const sim = cosineSimilarity(last.vec, this.chunks[i].vec);
+      if (sim > maxSim) maxSim = sim;
+    }
+
+    if (maxSim > this.similarityThreshold) {
+      this.consecutiveSimilar += 1;
+    } else {
+      this.consecutiveSimilar = 0;
+    }
+
+    return this.consecutiveSimilar >= this.consecutiveThreshold;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Debounced silence helper
+// ---------------------------------------------------------------------------
+
+class DebouncedCall {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  constructor(
+    private readonly callback: () => Promise<void> | void,
+    private readonly delayMs: number,
+  ) {}
+
+  schedule(): void {
+    this.cancel();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      Promise.resolve(this.callback()).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("IVR silence callback raised:", err);
+      });
+    }, this.delayMs);
+  }
+
+  cancel(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IVRActivity
+// ---------------------------------------------------------------------------
+
+/** Async callback fired when the TF-IDF detector trips. */
+export type LoopCallback = () => Promise<void> | void;
+/** Async callback fired after sustained silence. */
+export type SilenceCallback = () => Promise<void> | void;
+
+export interface IVRActivityOptions {
+  /** Seconds of combined silence before firing `onSilence`. Default `5.0`. */
+  maxSilenceDuration?: number;
+  /** Enable the TF-IDF loop detector. Default `true`. */
+  loopDetector?: boolean;
+  /** Fired when the loop detector trips. */
+  onLoopDetected?: LoopCallback;
+  /** Fired after `maxSilenceDuration` seconds of combined silence. */
+  onSilence?: SilenceCallback;
+}
+
+/** OpenAI-style function tool spec with attached handler. */
+export interface IVRToolDefinition {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  handler: (args: { events: string[] }) => Promise<string>;
+}
+
+/**
+ * Coordinate IVR navigation heuristics for a single call.
+ *
+ * Usage::
+ *
+ *     const ivr = new IVRActivity(callControl);
+ *     await ivr.start();
+ *
+ *     // In the STT loop, on each final transcript:
+ *     await ivr.onUserTranscribed(text);
+ *
+ *     // When done:
+ *     await ivr.stop();
+ */
+export class IVRActivity {
+  private readonly callControl: CallControl;
+  private readonly maxSilenceDurationMs: number;
+  private readonly loopDetector: TfidfLoopDetector | null;
+  private readonly onLoopDetected?: LoopCallback;
+  private readonly onSilence?: SilenceCallback;
+
+  private currentUserState: string | null = null;
+  private currentAgentState: string | null = null;
+  private readonly debouncedSilence: DebouncedCall;
+  private lastShouldSchedule: boolean | null = null;
+  private started = false;
+
+  constructor(callControl: CallControl, opts: IVRActivityOptions = {}) {
+    const {
+      maxSilenceDuration = 5.0,
+      loopDetector = true,
+      onLoopDetected,
+      onSilence,
+    } = opts;
+
+    this.callControl = callControl;
+    this.maxSilenceDurationMs = maxSilenceDuration * 1000;
+    this.loopDetector = loopDetector ? new TfidfLoopDetector() : null;
+    this.onLoopDetected = onLoopDetected;
+    this.onSilence = onSilence;
+
+    this.debouncedSilence = new DebouncedCall(
+      () => this.onSilenceDetected(),
+      this.maxSilenceDurationMs,
+    );
+  }
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    this.debouncedSilence.cancel();
+    this.started = false;
+  }
+
+  async onUserTranscribed(text: string): Promise<void> {
+    if (!this.started || !text) return;
+
+    if (this.loopDetector !== null) {
+      this.loopDetector.addChunk(text);
+      if (this.loopDetector.checkLoopDetection()) {
+        this.loopDetector.reset();
+        if (this.onLoopDetected) {
+          try {
+            await this.onLoopDetected();
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.error("IVR onLoopDetected callback raised:", err);
+          }
+        }
+      }
+    }
+  }
+
+  noteUserState(state: string): void {
+    this.currentUserState = state;
+    this.scheduleSilenceCheck();
+  }
+
+  noteAgentState(state: string): void {
+    this.currentAgentState = state;
+    this.scheduleSilenceCheck();
+  }
+
+  get tools(): IVRToolDefinition[] {
+    return [this.buildSendDtmfTool()];
+  }
+
+  // -------- internals --------
+
+  private scheduleSilenceCheck(): void {
+    const shouldSchedule = this.shouldScheduleCheck();
+    if (shouldSchedule) {
+      if (this.lastShouldSchedule) return;
+      this.debouncedSilence.schedule();
+    } else {
+      this.debouncedSilence.cancel();
+    }
+    this.lastShouldSchedule = shouldSchedule;
+  }
+
+  private shouldScheduleCheck(): boolean {
+    const userSilent =
+      this.currentUserState === "listening" || this.currentUserState === "away";
+    const agentSilent =
+      this.currentAgentState === "idle" || this.currentAgentState === "listening";
+    return userSilent && agentSilent;
+  }
+
+  private async onSilenceDetected(): Promise<void> {
+    if (this.onSilence) {
+      try {
+        await this.onSilence();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("IVR onSilence callback raised:", err);
+      }
+    }
+  }
+
+  private buildSendDtmfTool(): IVRToolDefinition {
+    const allowedValues = [...DTMF_EVENTS];
+
+    const handler = async (args: { events: string[] }): Promise<string> => {
+      const events = args.events ?? [];
+      const validated: string[] = [];
+      for (const raw of events) {
+        if (!allowedValues.includes(raw as DtmfEvent)) {
+          return `Failed to send DTMF event: invalid digit '${raw}'`;
+        }
+        validated.push(raw);
+      }
+
+      const digits = validated.join("");
+      try {
+        if (!this.callControl.sendDtmf) {
+          return "Failed to send DTMF events: CallControl.sendDtmf not implemented";
+        }
+        await this.callControl.sendDtmf(digits, { delayMs: 300 });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return `Failed to send DTMF events: ${msg}`;
+      }
+      return `Successfully sent DTMF events: ${validated.join(" ")}`;
+    };
+
+    return {
+      name: "send_dtmf_events",
+      description:
+        "Send a list of DTMF events to the telephony provider. " +
+        "Call when the IVR is asking for keypad input.",
+      parameters: {
+        type: "object",
+        properties: {
+          events: {
+            type: "array",
+            description: "Ordered list of DTMF digits to send.",
+            items: {
+              type: "string",
+              enum: allowedValues,
+            },
+          },
+        },
+        required: ["events"],
+      },
+      handler,
+    };
+  }
+}

--- a/sdk-ts/tests/unit/ivr.test.ts
+++ b/sdk-ts/tests/unit/ivr.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  IVRActivity,
+  TfidfLoopDetector,
+  DTMF_EVENTS,
+  formatDtmf,
+  type DtmfEvent,
+} from '../../src/services/ivr';
+import type { CallControl } from '../../src/metrics';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * MOCK: no real call. Records sendDtmf invocations so tests can assert
+ * the correct digits were forwarded from the tool handler.
+ */
+function makeCallControl(overrides: Partial<CallControl> = {}): CallControl {
+  const sendDtmf = vi.fn(async (_digits: string, _opts?: { delayMs?: number }) => {});
+  return {
+    callId: 'test-call-id',
+    caller: '+15551234567',
+    callee: '+15559876543',
+    transfer: vi.fn(async () => {}),
+    hangup: vi.fn(async () => {}),
+    sendDtmf,
+    ...overrides,
+  } as CallControl;
+}
+
+// ---------------------------------------------------------------------------
+// DtmfEvent / formatDtmf
+// ---------------------------------------------------------------------------
+
+describe('DTMF_EVENTS + formatDtmf', () => {
+  it('covers the full keypad', () => {
+    const expected = new Set([
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      '*', '#', 'A', 'B', 'C', 'D',
+    ]);
+    expect(new Set(DTMF_EVENTS)).toEqual(expected);
+  });
+
+  it('formatDtmf joins with single spaces', () => {
+    expect(formatDtmf(['1', '2', '#'] as DtmfEvent[])).toBe('1 2 #');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IVRActivity.tools
+// ---------------------------------------------------------------------------
+
+describe('IVRActivity.tools', () => {
+  it('exposes a send_dtmf_events tool with keypad enum', () => {
+    const cc = makeCallControl();
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+
+    const tools = ivr.tools;
+    expect(tools).toHaveLength(1);
+
+    const tool = tools[0];
+    expect(tool.name).toBe('send_dtmf_events');
+    expect(tool.description.length).toBeGreaterThan(0);
+    expect(tool.parameters.type).toBe('object');
+    expect(tool.parameters.required).toEqual(['events']);
+
+    const items = (tool.parameters.properties.events as {
+      items: { enum: string[] };
+    }).items;
+    expect(new Set(items.enum)).toEqual(new Set(DTMF_EVENTS));
+  });
+
+  it('forwards digits to CallControl.sendDtmf (MOCK: no real call)', async () => {
+    const cc = makeCallControl();
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+
+    const result = await ivr.tools[0].handler({ events: ['1', '2', '3', '#'] });
+
+    expect(cc.sendDtmf).toHaveBeenCalledOnce();
+    expect(cc.sendDtmf).toHaveBeenCalledWith('123#', { delayMs: 300 });
+    expect(result).toContain('Successfully');
+  });
+
+  it('rejects invalid digits without hitting sendDtmf', async () => {
+    const cc = makeCallControl();
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+
+    const result = await ivr.tools[0].handler({ events: ['1', 'Z'] });
+
+    expect(cc.sendDtmf).not.toHaveBeenCalled();
+    expect(result.toLowerCase()).toContain('invalid');
+  });
+
+  it('reports errors from CallControl.sendDtmf', async () => {
+    const cc = makeCallControl({
+      sendDtmf: vi.fn(async () => {
+        throw new Error('carrier rejected');
+      }),
+    });
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+
+    const result = await ivr.tools[0].handler({ events: ['1'] });
+
+    expect(result).toContain('Failed');
+    expect(result).toContain('carrier rejected');
+  });
+
+  it('gracefully handles CallControl without sendDtmf implementation', async () => {
+    const cc = makeCallControl();
+    // Remove the method to simulate an older provider.
+    delete (cc as Partial<CallControl>).sendDtmf;
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+
+    const result = await ivr.tools[0].handler({ events: ['1'] });
+    expect(result).toContain('not implemented');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TfidfLoopDetector — authentic: real bag-of-words path, synthetic but
+// realistic IVR prompts. No mocks.
+// ---------------------------------------------------------------------------
+
+describe('TfidfLoopDetector', () => {
+  it('fires on 3 consecutive duplicate IVR prompts', () => {
+    const detector = new TfidfLoopDetector();
+    const prompt = 'Press 1 for sales, 2 for support, or 3 for billing';
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(true);
+  });
+
+  it('resets the consecutive counter on a different prompt', () => {
+    const detector = new TfidfLoopDetector();
+    const prompt = 'Please enter your account number followed by pound';
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+
+    // Unrelated chunk breaks the streak.
+    detector.addChunk('We are experiencing longer than usual wait times');
+    expect(detector.checkLoopDetection()).toBe(false);
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+  });
+
+  it('reset() clears buffered history and counter', () => {
+    const detector = new TfidfLoopDetector({ consecutiveThreshold: 2 });
+    const prompt = 'For new customers press 1';
+
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(true);
+
+    detector.reset();
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+    detector.addChunk(prompt);
+    expect(detector.checkLoopDetection()).toBe(false);
+  });
+
+  it('validates constructor arguments', () => {
+    expect(() => new TfidfLoopDetector({ windowSize: 0 })).toThrow();
+    expect(() => new TfidfLoopDetector({ similarityThreshold: 1.5 })).toThrow();
+    expect(() => new TfidfLoopDetector({ consecutiveThreshold: 0 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IVRActivity transcript → loop callback wiring
+// ---------------------------------------------------------------------------
+
+describe('IVRActivity.onUserTranscribed', () => {
+  it('invokes onLoopDetected when the detector trips', async () => {
+    const cc = makeCallControl();
+    const onLoopDetected = vi.fn(async () => {});
+    const ivr = new IVRActivity(cc, {
+      loopDetector: true,
+      onLoopDetected,
+    });
+    await ivr.start();
+
+    const prompt = 'Press 1 for sales, 2 for support, or 3 for billing';
+    for (let i = 0; i < 4; i++) {
+      await ivr.onUserTranscribed(prompt);
+    }
+
+    expect(onLoopDetected).toHaveBeenCalledOnce();
+    await ivr.stop();
+  });
+
+  it('ignores transcripts before start()', async () => {
+    const cc = makeCallControl();
+    const onLoopDetected = vi.fn();
+    const ivr = new IVRActivity(cc, { loopDetector: true, onLoopDetected });
+
+    for (let i = 0; i < 5; i++) {
+      await ivr.onUserTranscribed('Press 1 for sales');
+    }
+
+    expect(onLoopDetected).not.toHaveBeenCalled();
+  });
+
+  it('silently accepts empty transcripts', async () => {
+    const cc = makeCallControl();
+    const ivr = new IVRActivity(cc, { loopDetector: false });
+    await ivr.start();
+    await expect(ivr.onUserTranscribed('')).resolves.toBeUndefined();
+    await ivr.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silence debounce — real timers, short delay, NO mocking of setTimeout
+// ---------------------------------------------------------------------------
+
+describe('IVRActivity silence debounce', () => {
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  it('fires onSilence after maxSilenceDuration seconds of combined silence', async () => {
+    const cc = makeCallControl();
+    let fired = false;
+    const ivr = new IVRActivity(cc, {
+      maxSilenceDuration: 0.1,
+      loopDetector: false,
+      onSilence: async () => {
+        fired = true;
+      },
+    });
+    await ivr.start();
+
+    ivr.noteUserState('listening');
+    ivr.noteAgentState('idle');
+
+    await sleep(200);
+    expect(fired).toBe(true);
+    await ivr.stop();
+  });
+
+  it('cancels the silence timer when the user starts speaking', async () => {
+    const cc = makeCallControl();
+    const onSilence = vi.fn();
+    const ivr = new IVRActivity(cc, {
+      maxSilenceDuration: 0.2,
+      loopDetector: false,
+      onSilence,
+    });
+    await ivr.start();
+
+    ivr.noteUserState('listening');
+    ivr.noteAgentState('idle');
+
+    await sleep(50);
+    ivr.noteUserState('speaking');
+
+    await sleep(300);
+    expect(onSilence).not.toHaveBeenCalled();
+    await ivr.stop();
+  });
+
+  it('does not restart the timer on repeated silent-state updates', async () => {
+    const cc = makeCallControl();
+    const fireTimes: number[] = [];
+    const ivr = new IVRActivity(cc, {
+      maxSilenceDuration: 0.15,
+      loopDetector: false,
+      onSilence: async () => {
+        fireTimes.push(Date.now());
+      },
+    });
+    await ivr.start();
+
+    const t0 = Date.now();
+    ivr.noteUserState('listening');
+    ivr.noteAgentState('idle');
+
+    await sleep(80);
+    ivr.noteAgentState('idle');
+
+    await sleep(150);
+    expect(fireTimes).toHaveLength(1);
+    const elapsed = fireTimes[0] - t0;
+    expect(elapsed).toBeLessThan(250);
+
+    await ivr.stop();
+  });
+
+  it('stop() cancels a pending silence timer', async () => {
+    const cc = makeCallControl();
+    const onSilence = vi.fn();
+    const ivr = new IVRActivity(cc, {
+      maxSilenceDuration: 0.15,
+      loopDetector: false,
+      onSilence,
+    });
+    await ivr.start();
+    ivr.noteUserState('listening');
+    ivr.noteAgentState('idle');
+    await ivr.stop();
+
+    await sleep(250);
+    expect(onSilence).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/patter/__init__.py
+++ b/sdk/patter/__init__.py
@@ -27,6 +27,7 @@ from patter.services.fallback_provider import (
     PartialStreamError,
 )
 from patter.services.chat_context import ChatContext, ChatMessage
+from patter.services.ivr import DtmfEvent, IVRActivity, TfidfLoopDetector, format_dtmf
 
 __all__ = [
     "Patter",
@@ -58,4 +59,8 @@ __all__ = [
     "PartialStreamError",
     "ChatContext",
     "ChatMessage",
+    "IVRActivity",
+    "TfidfLoopDetector",
+    "DtmfEvent",
+    "format_dtmf",
 ]

--- a/sdk/patter/services/ivr.py
+++ b/sdk/patter/services/ivr.py
@@ -1,0 +1,410 @@
+"""
+IVR auto-navigation activity for telephony calls.
+
+Detects IVR prompts via transcribed speech, forwards DTMF responses
+through ``CallControl.send_dtmf``, and recovers from two common
+failure modes:
+
+1. The agent hears the same IVR prompt repeated several times (loop
+   detection). ``TfidfLoopDetector`` flags this by comparing the
+   cosine similarity of recent transcript chunks.
+2. The IVR falls silent while both parties are passive (silence
+   detection). A debounced timer triggers a follow-up action after
+   ``max_silence_duration`` seconds of combined silence.
+
+The public surface mirrors LiveKit ``IVRActivity`` but is wired to
+Patter's ``CallControl`` abstraction rather than LiveKit rooms, so
+transcripts are pushed in explicitly by the caller (typically
+``PipelineStreamHandler``) through ``on_user_transcribed``.
+
+Optional extras install::
+
+    pip install "getpatter[ivr]"
+
+Algorithm adapted from LiveKit Agents (Apache 2.0):
+https://github.com/livekit/agents
+
+Source:
+- livekit-agents/livekit/agents/voice/ivr/ivr_activity.py
+- livekit-agents/livekit/agents/beta/tools/send_dtmf.py
+LiveKit SHA at port time: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from patter.models import CallControl
+
+logger = logging.getLogger("patter.ivr")
+
+
+# ── DTMF event taxonomy ─────────────────────────────────────────────────
+
+class DtmfEvent(str, Enum):
+    """Valid DTMF tones. ``value`` is the literal keypad character.
+
+    Kept as a string enum so the value doubles as the digit string
+    forwarded to ``CallControl.send_dtmf``.
+    """
+
+    ONE = "1"
+    TWO = "2"
+    THREE = "3"
+    FOUR = "4"
+    FIVE = "5"
+    SIX = "6"
+    SEVEN = "7"
+    EIGHT = "8"
+    NINE = "9"
+    ZERO = "0"
+    STAR = "*"
+    POUND = "#"
+    A = "A"
+    B = "B"
+    C = "C"
+    D = "D"
+
+
+def format_dtmf(events: list[DtmfEvent]) -> str:
+    """Join DTMF events into a space-separated debug string."""
+    return " ".join(event.value for event in events)
+
+
+# ── Debounced silence detector ──────────────────────────────────────────
+
+class _DebouncedCall:
+    """Schedule an async callback after a quiet period.
+
+    Reset each time ``schedule()`` is called; the most recent schedule
+    "wins". ``cancel()`` stops any pending call.
+
+    This replaces LiveKit's ``Debounced`` helper without the LiveKit
+    async primitives.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[], Awaitable[None]],
+        delay: float,
+    ) -> None:
+        self._callback = callback
+        self._delay = delay
+        self._task: asyncio.Task[None] | None = None
+
+    def schedule(self) -> None:
+        self.cancel()
+        self._task = asyncio.create_task(self._run())
+
+    def cancel(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
+
+    async def _run(self) -> None:
+        try:
+            await asyncio.sleep(self._delay)
+        except asyncio.CancelledError:
+            return
+
+        try:
+            await self._callback()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.exception("IVR silence callback raised")
+
+
+# ── TF-IDF loop detector ────────────────────────────────────────────────
+
+class TfidfLoopDetector:
+    """Detect repeated IVR prompts via TF-IDF cosine similarity.
+
+    Args:
+        window_size: Number of recent chunks to retain for comparison.
+        similarity_threshold: Cosine similarity above which two chunks
+            are considered "the same prompt". Range ``[0.0, 1.0]``.
+        consecutive_threshold: How many consecutive near-duplicates
+            must appear before ``check_loop_detection`` returns ``True``.
+
+    Requires the optional ``ivr`` extras (``scikit-learn`` + ``numpy``).
+    """
+
+    def __init__(
+        self,
+        window_size: int = 20,
+        similarity_threshold: float = 0.85,
+        consecutive_threshold: int = 3,
+    ) -> None:
+        if window_size <= 0:
+            raise ValueError("window_size must be greater than 0")
+        if similarity_threshold < 0.0 or similarity_threshold > 1.0:
+            raise ValueError("similarity_threshold must be between 0.0 and 1.0")
+        if consecutive_threshold <= 0:
+            raise ValueError("consecutive_threshold must be greater than 0")
+
+        # Lazy import — keep sklearn/numpy out of the hot path import.
+        try:
+            import numpy as np  # noqa: F401
+            from sklearn.feature_extraction.text import TfidfVectorizer  # noqa: F401
+            from sklearn.metrics.pairwise import cosine_similarity  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "TfidfLoopDetector requires the 'ivr' extras. "
+                "Install with: pip install 'getpatter[ivr]'"
+            ) from exc
+
+        self._window_size = window_size
+        self._similarity_threshold = similarity_threshold
+        self._consecutive_threshold = consecutive_threshold
+        self._chunks: list[str] = []
+        self._consecutive_similar = 0
+
+    def reset(self) -> None:
+        """Clear buffered history and consecutive counter."""
+        self._chunks = []
+        self._consecutive_similar = 0
+
+    def add_chunk(self, chunk: str) -> None:
+        """Append a transcript chunk, trimming to the window size."""
+        self._chunks.append(chunk)
+        if len(self._chunks) > self._window_size:
+            self._chunks = self._chunks[-self._window_size :]
+
+    def check_loop_detection(self) -> bool:
+        """Return ``True`` when the last chunk has repeated enough times."""
+        if len(self._chunks) < 2:
+            return False
+
+        import numpy as np
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        from sklearn.metrics.pairwise import cosine_similarity
+
+        vectorizer = TfidfVectorizer()
+        try:
+            doc_matrix = vectorizer.fit_transform(self._chunks)
+        except ValueError:
+            # Empty vocabulary — all chunks were stop-words/empty.
+            return False
+
+        doc_similarity = cosine_similarity(doc_matrix)
+        last_row = doc_similarity[-1][:-1]
+
+        if last_row.size > 0 and np.max(last_row) > self._similarity_threshold:
+            self._consecutive_similar += 1
+        else:
+            self._consecutive_similar = 0
+
+        return self._consecutive_similar >= self._consecutive_threshold
+
+
+# ── IVRActivity ─────────────────────────────────────────────────────────
+
+# Callback signature: async () -> None
+SilenceCallback = Callable[[], Awaitable[None]]
+LoopCallback = Callable[[], Awaitable[None]]
+
+
+class IVRActivity:
+    """Coordinate IVR navigation heuristics for a single call.
+
+    The activity does not own a timer loop while idle; silence checks
+    are debounced and re-armed each time ``note_user_silent`` /
+    ``note_agent_idle`` is called. Call sites (typically
+    ``PipelineStreamHandler``) push transcripts and state updates into
+    the activity; the activity reacts asynchronously.
+
+    Args:
+        call_control: The active call's control interface — used to
+            forward DTMF digits.
+        max_silence_duration: Seconds of combined quiet before the
+            silence callback fires. Defaults to ``5.0``.
+        loop_detector: Whether to enable TF-IDF loop detection.
+            Requires the ``ivr`` extras. Defaults to ``True``.
+        on_loop_detected: Async callback fired when the loop detector
+            trips (e.g. re-prompt the IVR).
+        on_silence: Async callback fired after ``max_silence_duration``
+            of combined silence (e.g. speak a filler).
+
+    Usage::
+
+        call_control = ...  # provided by the handler
+        ivr = IVRActivity(call_control)
+        await ivr.start()
+
+        # In the handler's STT loop:
+        async def on_transcript(text: str) -> None:
+            await ivr.on_user_transcribed(text)
+
+        # When done:
+        await ivr.stop()
+    """
+
+    def __init__(
+        self,
+        call_control: CallControl,
+        *,
+        max_silence_duration: float = 5.0,
+        loop_detector: bool = True,
+        on_loop_detected: LoopCallback | None = None,
+        on_silence: SilenceCallback | None = None,
+    ) -> None:
+        self._call_control = call_control
+        self._max_silence_duration = max_silence_duration
+        self._loop_detector: TfidfLoopDetector | None = None
+        if loop_detector:
+            self._loop_detector = TfidfLoopDetector()
+        self._on_loop_detected = on_loop_detected
+        self._on_silence = on_silence
+
+        self._current_user_state: str | None = None
+        self._current_agent_state: str | None = None
+        self._debounced_silence = _DebouncedCall(
+            self._on_silence_detected,
+            max_silence_duration,
+        )
+        self._last_should_schedule: bool | None = None
+        self._started = False
+
+    # ── lifecycle ────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Mark the activity as active. Idempotent."""
+        self._started = True
+
+    async def stop(self) -> None:
+        """Cancel any pending silence timer. Idempotent."""
+        self._debounced_silence.cancel()
+        self._started = False
+
+    # Backwards-compat alias mirroring the LiveKit ``aclose`` name.
+    aclose = stop
+
+    # ── external event hooks ─────────────────────────────────────────
+
+    async def on_user_transcribed(self, text: str) -> None:
+        """Feed a final user transcript to the activity.
+
+        Called by ``PipelineStreamHandler`` whenever the STT emits a
+        final transcript. A non-final transcript must NOT be passed.
+        """
+        if not self._started:
+            return
+        if not text:
+            return
+
+        if self._loop_detector is not None:
+            self._loop_detector.add_chunk(text)
+            if self._loop_detector.check_loop_detection():
+                logger.debug("IVRActivity: speech loop detected")
+                self._loop_detector.reset()
+                if self._on_loop_detected is not None:
+                    try:
+                        await self._on_loop_detected()
+                    except Exception:  # noqa: BLE001
+                        logger.exception("IVR on_loop_detected callback raised")
+
+    def note_user_state(self, state: str) -> None:
+        """Record the user's latest voice activity state.
+
+        ``state`` is one of ``"listening"``, ``"speaking"``, ``"away"``
+        in the LiveKit taxonomy; any other value is treated as "active".
+        """
+        self._current_user_state = state
+        self._schedule_silence_check()
+
+    def note_agent_state(self, state: str) -> None:
+        """Record the agent's latest state (``"idle"``, ``"speaking"``, ...)."""
+        self._current_agent_state = state
+        self._schedule_silence_check()
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _schedule_silence_check(self) -> None:
+        should_schedule = self._should_schedule_check()
+        if should_schedule:
+            # Only (re)schedule if we weren't already waiting.
+            if self._last_should_schedule:
+                return
+            self._debounced_silence.schedule()
+        else:
+            self._debounced_silence.cancel()
+        self._last_should_schedule = should_schedule
+
+    def _should_schedule_check(self) -> bool:
+        is_user_silent = self._current_user_state in {"listening", "away"}
+        is_agent_silent = self._current_agent_state in {"idle", "listening"}
+        return is_user_silent and is_agent_silent
+
+    async def _on_silence_detected(self) -> None:
+        logger.debug("IVRActivity: silence detected")
+        if self._on_silence is not None:
+            try:
+                await self._on_silence()
+            except Exception:  # noqa: BLE001
+                logger.exception("IVR on_silence callback raised")
+
+    # ── LLM tool surface ─────────────────────────────────────────────
+
+    @property
+    def tools(self) -> list[dict[str, Any]]:
+        """Return LLM function-call tool specs bound to this call.
+
+        The returned dicts follow the OpenAI function-calling schema
+        and include a ``handler`` coroutine that drives
+        ``CallControl.send_dtmf``.
+        """
+        return [self._build_send_dtmf_tool()]
+
+    def _build_send_dtmf_tool(self) -> dict[str, Any]:
+        allowed_values = [e.value for e in DtmfEvent]
+
+        async def handler(events: list[str]) -> str:
+            # Validate each event — reject anything outside the enum.
+            validated: list[str] = []
+            for raw in events:
+                if raw not in allowed_values:
+                    return f"Failed to send DTMF event: invalid digit '{raw}'"
+                validated.append(raw)
+
+            digits = "".join(validated)
+            try:
+                await self._call_control.send_dtmf(digits, delay_ms=300)
+            except Exception as exc:  # noqa: BLE001
+                return f"Failed to send DTMF events: {exc}"
+            return f"Successfully sent DTMF events: {' '.join(validated)}"
+
+        return {
+            "name": "send_dtmf_events",
+            "description": (
+                "Send a list of DTMF events to the telephony provider. "
+                "Call when the IVR is asking for keypad input."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "events": {
+                        "type": "array",
+                        "description": "Ordered list of DTMF digits to send.",
+                        "items": {
+                            "type": "string",
+                            "enum": allowed_values,
+                        },
+                    }
+                },
+                "required": ["events"],
+            },
+            "handler": handler,
+        }
+
+
+__all__ = [
+    "DtmfEvent",
+    "IVRActivity",
+    "TfidfLoopDetector",
+    "format_dtmf",
+]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -70,6 +70,10 @@ deepfilternet = [
     "torch>=2.0",
     "numpy>=1.26",
 ]
+ivr = [
+    "scikit-learn>=1.3",
+    "numpy>=1.26",
+]
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/sdk/tests/test_ivr.py
+++ b/sdk/tests/test_ivr.py
@@ -1,0 +1,372 @@
+"""Tests for ``patter.services.ivr``.
+
+Covers:
+- ``IVRActivity.tools`` builds a valid OpenAI-style function tool that
+  forwards to ``CallControl.send_dtmf``. (MOCK: no real call.)
+- ``IVRActivity.on_user_transcribed`` triggers the loop-detected
+  callback once the TF-IDF detector fires.
+- ``TfidfLoopDetector`` fires on 3 consecutive duplicate prompts
+  (authentic: real sklearn path, synthetic but realistic data).
+- Silence debounce actually waits — uses real ``asyncio.sleep`` with
+  a short ``max_silence_duration`` (1s in tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from patter.services.ivr import (
+    DtmfEvent,
+    IVRActivity,
+    TfidfLoopDetector,
+    format_dtmf,
+)
+
+
+# ── fixtures ───────────────────────────────────────────────────────────
+
+def _make_call_control() -> AsyncMock:
+    """MOCK CallControl: no real call; records send_dtmf calls."""
+    cc = AsyncMock()
+    cc.call_id = "test-call-id"
+    cc.caller = "+15551234567"
+    cc.callee = "+15559876543"
+    cc.telephony_provider = "test"
+    cc.send_dtmf = AsyncMock()
+    return cc
+
+
+# ── DtmfEvent ──────────────────────────────────────────────────────────
+
+def test_dtmf_event_values_cover_keypad() -> None:
+    expected = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                "*", "#", "A", "B", "C", "D"}
+    assert {e.value for e in DtmfEvent} == expected
+
+
+def test_format_dtmf_joins_with_spaces() -> None:
+    events = [DtmfEvent.ONE, DtmfEvent.TWO, DtmfEvent.POUND]
+    assert format_dtmf(events) == "1 2 #"
+
+
+# ── IVRActivity.tools ──────────────────────────────────────────────────
+
+async def test_tools_contains_send_dtmf_spec() -> None:
+    cc = _make_call_control()
+    ivr = IVRActivity(cc, loop_detector=False)
+
+    tools = ivr.tools
+    assert len(tools) == 1
+
+    tool = tools[0]
+    assert tool["name"] == "send_dtmf_events"
+    assert "description" in tool and tool["description"]
+    assert tool["parameters"]["type"] == "object"
+    assert "events" in tool["parameters"]["properties"]
+    assert tool["parameters"]["required"] == ["events"]
+
+    # Allowed values include the whole keypad.
+    enum_vals = tool["parameters"]["properties"]["events"]["items"]["enum"]
+    assert set(enum_vals) == {e.value for e in DtmfEvent}
+
+
+async def test_tool_handler_forwards_to_send_dtmf() -> None:
+    """MOCK: no real call; verifies CallControl is driven correctly."""
+    cc = _make_call_control()
+    ivr = IVRActivity(cc, loop_detector=False)
+
+    handler = ivr.tools[0]["handler"]
+    result = await handler(["1", "2", "3", "#"])
+
+    cc.send_dtmf.assert_awaited_once_with("123#", delay_ms=300)
+    assert "Successfully" in result
+
+
+async def test_tool_handler_rejects_invalid_digit() -> None:
+    cc = _make_call_control()
+    ivr = IVRActivity(cc, loop_detector=False)
+
+    handler = ivr.tools[0]["handler"]
+    result = await handler(["1", "Z"])
+
+    cc.send_dtmf.assert_not_awaited()
+    assert "invalid" in result.lower()
+
+
+async def test_tool_handler_surfaces_call_control_errors() -> None:
+    cc = _make_call_control()
+    cc.send_dtmf.side_effect = RuntimeError("carrier rejected")
+    ivr = IVRActivity(cc, loop_detector=False)
+
+    handler = ivr.tools[0]["handler"]
+    result = await handler(["1"])
+
+    assert "Failed" in result
+    assert "carrier rejected" in result
+
+
+# ── TfidfLoopDetector (authentic sklearn path) ─────────────────────────
+
+def test_tfidf_detector_fires_on_three_consecutive_duplicates() -> None:
+    """Authentic: 5 identical IVR prompts → loop detected on 3rd duplicate."""
+    try:
+        detector = TfidfLoopDetector()
+    except ImportError:
+        pytest.skip("scikit-learn not installed")
+
+    prompt = "Press 1 for sales, 2 for support, or 3 for billing"
+
+    # 1st chunk: no prior chunks -> cannot be a duplicate.
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+
+    # 2nd chunk: 1 duplicate.
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+
+    # 3rd chunk: 2 consecutive duplicates (below the default threshold of 3).
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+
+    # 4th chunk: 3 consecutive duplicates → fires.
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is True
+
+
+def test_tfidf_detector_resets_counter_on_different_prompt() -> None:
+    try:
+        detector = TfidfLoopDetector()
+    except ImportError:
+        pytest.skip("scikit-learn not installed")
+
+    detector.add_chunk("Please enter your account number followed by pound")
+    assert detector.check_loop_detection() is False
+
+    detector.add_chunk("Please enter your account number followed by pound")
+    assert detector.check_loop_detection() is False
+
+    # Break the loop with a completely unrelated chunk.
+    detector.add_chunk(
+        "We are experiencing longer than usual wait times, hold music follows"
+    )
+    assert detector.check_loop_detection() is False
+
+    # Back to the original prompt — counter should have reset.
+    detector.add_chunk("Please enter your account number followed by pound")
+    assert detector.check_loop_detection() is False
+
+
+def test_tfidf_detector_reset_clears_state() -> None:
+    try:
+        detector = TfidfLoopDetector(consecutive_threshold=2)
+    except ImportError:
+        pytest.skip("scikit-learn not installed")
+
+    prompt = "For new customers press 1"
+    # Each add-then-check increments the internal counter when similar;
+    # with threshold=2 it fires on the 3rd add (2 consecutive duplicates).
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is True
+
+    detector.reset()
+    # After reset, even the original repeated prompt shouldn't fire until
+    # enough new chunks accumulate.
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+    detector.add_chunk(prompt)
+    assert detector.check_loop_detection() is False
+
+
+def test_tfidf_detector_validates_args() -> None:
+    try:
+        with pytest.raises(ValueError):
+            TfidfLoopDetector(window_size=0)
+        with pytest.raises(ValueError):
+            TfidfLoopDetector(similarity_threshold=1.5)
+        with pytest.raises(ValueError):
+            TfidfLoopDetector(consecutive_threshold=0)
+    except ImportError:
+        pytest.skip("scikit-learn not installed")
+
+
+# ── IVRActivity transcript path ───────────────────────────────────────
+
+async def test_on_user_transcribed_triggers_loop_callback() -> None:
+    """Loop callback fires once the detector trips."""
+    try:
+        TfidfLoopDetector()  # probe sklearn availability
+    except ImportError:
+        pytest.skip("scikit-learn not installed")
+
+    cc = _make_call_control()
+    calls: list[int] = []
+
+    async def on_loop() -> None:
+        calls.append(1)
+
+    ivr = IVRActivity(cc, loop_detector=True, on_loop_detected=on_loop)
+    await ivr.start()
+
+    prompt = "Press 1 for sales, 2 for support, or 3 for billing"
+    for _ in range(4):
+        await ivr.on_user_transcribed(prompt)
+
+    assert len(calls) == 1
+    await ivr.stop()
+
+
+async def test_on_user_transcribed_ignored_before_start() -> None:
+    cc = _make_call_control()
+    called: list[int] = []
+
+    async def on_loop() -> None:
+        called.append(1)
+
+    ivr = IVRActivity(cc, loop_detector=True, on_loop_detected=on_loop)
+    # Do NOT call start()
+
+    for _ in range(5):
+        await ivr.on_user_transcribed("Press 1 for sales")
+
+    assert called == []
+
+
+async def test_on_user_transcribed_empty_text_is_noop() -> None:
+    cc = _make_call_control()
+    ivr = IVRActivity(cc, loop_detector=False)
+    await ivr.start()
+    await ivr.on_user_transcribed("")  # should not raise
+    await ivr.stop()
+
+
+# ── silence debounce (authentic timing, short delays) ─────────────────
+
+async def test_silence_callback_fires_after_max_silence_duration() -> None:
+    """Real asyncio.sleep with a 1s debounce — no mocking of time."""
+    cc = _make_call_control()
+    fired = asyncio.Event()
+
+    async def on_silence() -> None:
+        fired.set()
+
+    ivr = IVRActivity(
+        cc,
+        max_silence_duration=0.1,
+        loop_detector=False,
+        on_silence=on_silence,
+    )
+    await ivr.start()
+
+    ivr.note_user_state("listening")
+    ivr.note_agent_state("idle")
+
+    try:
+        await asyncio.wait_for(fired.wait(), timeout=1.0)
+    finally:
+        await ivr.stop()
+
+
+async def test_silence_callback_cancelled_when_user_speaks() -> None:
+    cc = _make_call_control()
+    fired: list[int] = []
+
+    async def on_silence() -> None:
+        fired.append(1)
+
+    ivr = IVRActivity(
+        cc,
+        max_silence_duration=0.2,
+        loop_detector=False,
+        on_silence=on_silence,
+    )
+    await ivr.start()
+
+    # Both sides silent — debounce scheduled.
+    ivr.note_user_state("listening")
+    ivr.note_agent_state("idle")
+
+    # User starts speaking before the debounce fires.
+    await asyncio.sleep(0.05)
+    ivr.note_user_state("speaking")
+
+    # Wait past the original debounce deadline.
+    await asyncio.sleep(0.3)
+    assert fired == []
+
+    await ivr.stop()
+
+
+async def test_silence_debounce_not_rescheduled_while_pending() -> None:
+    """A second 'silent' update should not reset the timer."""
+    cc = _make_call_control()
+    fire_times: list[float] = []
+
+    async def on_silence() -> None:
+        loop = asyncio.get_running_loop()
+        fire_times.append(loop.time())
+
+    ivr = IVRActivity(
+        cc,
+        max_silence_duration=0.15,
+        loop_detector=False,
+        on_silence=on_silence,
+    )
+    await ivr.start()
+
+    loop = asyncio.get_running_loop()
+    t0 = loop.time()
+    ivr.note_user_state("listening")
+    ivr.note_agent_state("idle")
+
+    # Same-state nudges mid-flight — debounce should NOT restart.
+    await asyncio.sleep(0.08)
+    ivr.note_agent_state("idle")
+    await asyncio.sleep(0.15)
+
+    assert len(fire_times) == 1
+    # Original deadline was ~0.15s from t0.
+    elapsed = fire_times[0] - t0
+    assert elapsed < 0.25, f"debounce fired late ({elapsed:.3f}s after start)"
+
+    await ivr.stop()
+
+
+async def test_stop_cancels_pending_silence_timer() -> None:
+    cc = _make_call_control()
+    fired: list[int] = []
+
+    async def on_silence() -> None:
+        fired.append(1)
+
+    ivr = IVRActivity(
+        cc,
+        max_silence_duration=0.15,
+        loop_detector=False,
+        on_silence=on_silence,
+    )
+    await ivr.start()
+    ivr.note_user_state("listening")
+    ivr.note_agent_state("idle")
+    await ivr.stop()
+
+    # Wait past the would-be deadline.
+    await asyncio.sleep(0.25)
+    assert fired == []
+
+
+# ── loop_detector=False bypasses sklearn requirement ──────────────────
+
+async def test_loop_detector_disabled_skips_sklearn() -> None:
+    """loop_detector=False must not touch sklearn or raise ImportError."""
+    cc = _make_call_control()
+    ivr = IVRActivity(cc, loop_detector=False)
+    await ivr.start()
+    await ivr.on_user_transcribed("anything")
+    await ivr.stop()


### PR DESCRIPTION
## Summary

Stream D of the LiveKit Agents port: **IVR auto-navigation** for
telephony calls. Adds `IVRActivity` to both SDKs with:

- **TF-IDF loop detection** — catches IVR prompts that keep looping
  back to the same menu; Python uses `scikit-learn`, TS ships a
  minimal in-house bag-of-words + cosine-similarity implementation.
- **Silence debounce** — fires an `onSilence` callback after
  `max_silence_duration` seconds of combined quiet on both sides.
- **`send_dtmf_events` LLM tool** — an OpenAI-style function spec
  with an attached handler that forwards digits to
  `CallControl.send_dtmf(digits, delay_ms=300)`.
- **Pluggable integration** — the handler calls
  `await ivr.on_user_transcribed(text)` on each final STT transcript
  instead of subscribing to LiveKit room events.

### API

```python
from patter import IVRActivity, CallControl

ivr = IVRActivity(call_control, max_silence_duration=5.0, loop_detector=True)
await ivr.start()

# In the STT loop:
async def on_final_transcript(text: str) -> None:
    await ivr.on_user_transcribed(text)

# Register the LLM tool:
llm_tools.extend(ivr.tools)  # [{"name": "send_dtmf_events", ...}]

await ivr.stop()
```

### Attribution

Adapted from LiveKit Agents (Apache 2.0) at SHA
`78a66bcf79c5cea82989401c408f1dff4b961a5b`:
- `livekit-agents/livekit/agents/voice/ivr/ivr_activity.py`
- `livekit-agents/livekit/agents/beta/tools/send_dtmf.py`
- `livekit-agents/livekit/agents/beta/workflows/utils.py` (`DtmfEvent`)

### Packaging

- `sdk/pyproject.toml`: new optional-dependencies group
  `ivr = ["scikit-learn>=1.3", "numpy>=1.26"]`. The loop detector
  lazy-imports these and raises a clear `ImportError` pointing to
  `pip install 'getpatter[ivr]'` when missing.
- `sdk-ts/src/metrics.ts`: `CallControl` extended with an optional
  `sendDtmf(digits, { delayMs })` method to mirror Python Wave 1.

### Test plan

- [x] Python: 18 new tests (`sdk/tests/test_ivr.py`). Full suite
  **1251 passed** (1233 prior + 18 new), zero regressions.
- [x] TypeScript: 18 new tests (`sdk-ts/tests/unit/ivr.test.ts`) and
  `npx tsc --noEmit` clean. Full suite **903 passed**, zero
  regressions.
- [x] Test strategy per project rules:
  - Tool handler tests mock `CallControl` (documented in docstrings
    as "MOCK: no real call").
  - `TfidfLoopDetector` tests **no mocks** — real sklearn (Python)
    and real bag-of-words (TS) paths with synthetic-but-realistic
    IVR prompts. Five identical "Press 1 for sales, 2 for support,
    or 3 for billing" chunks verify the 3-consecutive-duplicate
    firing threshold.
  - Silence debounce tests use **real timers** with a short
    `max_silence_duration` (100-200 ms) rather than mocking
    `asyncio.sleep` / `setTimeout`.

### Notes for review

- The integration with `PipelineStreamHandler` is exposed as a simple
  `await ivr.on_user_transcribed(text)` call site; wiring it into the
  handler is intentionally left for a follow-up PR to keep this
  diff focused on the port.
- The TS loop detector is deliberately simpler than sklearn's TF-IDF
  (pure term-frequency bag-of-words). That is sufficient for catching
  a carrier that re-reads the same menu verbatim; if we ever need IDF
  weighting in TS we can revisit.