### PR TITLE
feat(llm): port Anthropic + Groq + Cerebras + Google LLM from LiveKit Agents

### DIFF
--- a/sdk-ts/src/providers/anthropic-llm.ts
+++ b/sdk-ts/src/providers/anthropic-llm.ts
@@ -1,0 +1,300 @@
+/**
+ * Anthropic Claude LLM provider for Patter's pipeline mode.
+ *
+ * Implements the ``LLMProvider`` interface from ``../llm-loop`` on top
+ * of Anthropic's Messages API with streaming via Server-Sent Events.
+ * OpenAI-style ``messages`` / ``tools`` inputs are translated into the
+ * Anthropic shape and the vendor event stream is normalised back into
+ * Patter's ``{ type: 'text' | 'tool_call' | 'done' }`` chunk protocol.
+ *
+ * Portions adapted from LiveKit Agents
+ * (https://github.com/livekit/agents, commit
+ * 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+ * file livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py),
+ * licensed under Apache License 2.0. Copyright 2023 LiveKit, Inc.
+ *
+ * Adaptations from the LiveKit source:
+ *   * Ported the Python async class pair (``llm.LLM`` /
+ *     ``llm.LLMStream``) into a single TypeScript class that satisfies
+ *     Patter's ``LLMProvider`` interface.
+ *   * Uses native ``fetch`` + SSE parsing instead of the official
+ *     ``@anthropic-ai/sdk`` to keep Patter's runtime dependencies lean
+ *     (mirrors how ``OpenAILLMProvider`` is implemented in
+ *     ``llm-loop.ts``).
+ *   * Maps Anthropic event types (``content_block_start``,
+ *     ``content_block_delta``, ``content_block_stop``) to the Patter
+ *     chunk protocol.
+ */
+
+import type { LLMChunk, LLMProvider } from '../llm-loop';
+import { getLogger } from '../logger';
+
+const DEFAULT_ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MODEL = 'claude-3-5-sonnet-20241022';
+const DEFAULT_MAX_TOKENS = 1024;
+
+export interface AnthropicLLMOptions {
+  apiKey: string;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  baseUrl?: string;
+  anthropicVersion?: string;
+}
+
+interface OpenAIToolDef {
+  type?: string;
+  function?: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+  name?: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | Array<Record<string, unknown>>;
+}
+
+/** LLM provider backed by Anthropic's Messages API (streaming). */
+export class AnthropicLLMProvider implements LLMProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly temperature?: number;
+  private readonly url: string;
+  private readonly anthropicVersion: string;
+
+  constructor(options: AnthropicLLMOptions) {
+    if (!options.apiKey) {
+      throw new Error(
+        'Anthropic API key is required. Pass it via { apiKey } or set the ' +
+          'ANTHROPIC_API_KEY environment variable before constructing the provider.',
+      );
+    }
+    this.apiKey = options.apiKey;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.temperature = options.temperature;
+    this.url = options.baseUrl ?? DEFAULT_ANTHROPIC_URL;
+    this.anthropicVersion = options.anthropicVersion ?? DEFAULT_ANTHROPIC_VERSION;
+  }
+
+  async *stream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+  ): AsyncGenerator<LLMChunk, void, unknown> {
+    const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
+    const anthropicTools = tools ? toAnthropicTools(tools as OpenAIToolDef[]) : null;
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: anthropicMessages,
+      max_tokens: this.maxTokens,
+      stream: true,
+    };
+    if (system) body.system = system;
+    if (anthropicTools && anthropicTools.length > 0) body.tools = anthropicTools;
+    if (this.temperature !== undefined) body.temperature = this.temperature;
+
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': this.anthropicVersion,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      getLogger().error(`Anthropic API error: ${response.status} ${errText}`);
+      return;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return;
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const toolIndexByBlock = new Map<number, number>();
+    const toolIdByBlock = new Map<number, string>();
+    let nextIndex = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data: ')) continue;
+        const data = trimmed.slice(6);
+        if (!data || data === '[DONE]') continue;
+
+        let event: {
+          type?: string;
+          index?: number;
+          content_block?: { type?: string; id?: string; name?: string };
+          delta?: { type?: string; text?: string; partial_json?: string };
+        };
+        try {
+          event = JSON.parse(data);
+        } catch {
+          continue;
+        }
+
+        if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+          const blockIdx = event.index ?? 0;
+          const toolId = event.content_block.id ?? '';
+          const toolName = event.content_block.name ?? '';
+          const patterIndex = nextIndex++;
+          toolIndexByBlock.set(blockIdx, patterIndex);
+          toolIdByBlock.set(blockIdx, toolId);
+          yield {
+            type: 'tool_call',
+            index: patterIndex,
+            id: toolId,
+            name: toolName,
+            arguments: '',
+          };
+          continue;
+        }
+
+        if (event.type === 'content_block_delta') {
+          if (event.delta?.type === 'text_delta' && event.delta.text) {
+            yield { type: 'text', content: event.delta.text };
+            continue;
+          }
+          if (event.delta?.type === 'input_json_delta' && event.delta.partial_json) {
+            const blockIdx = event.index ?? 0;
+            const patterIndex = toolIndexByBlock.get(blockIdx);
+            if (patterIndex !== undefined) {
+              yield {
+                type: 'tool_call',
+                index: patterIndex,
+                id: toolIdByBlock.get(blockIdx),
+                arguments: event.delta.partial_json,
+              };
+            }
+          }
+        }
+      }
+    }
+
+    yield { type: 'done' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Translation helpers (OpenAI format -> Anthropic Messages API)
+// ---------------------------------------------------------------------------
+
+function toAnthropicTools(tools: OpenAIToolDef[]): AnthropicTool[] {
+  return tools.map((t) => {
+    const fn = t.function ?? t;
+    return {
+      name: String(fn.name ?? ''),
+      description: String(fn.description ?? ''),
+      input_schema:
+        (fn.parameters as Record<string, unknown>) ?? { type: 'object', properties: {} },
+    };
+  });
+}
+
+interface OpenAIStyleMessage {
+  role?: string;
+  content?: string | Array<Record<string, unknown>>;
+  tool_calls?: Array<{
+    id?: string;
+    function?: { name?: string; arguments?: string };
+  }>;
+  tool_call_id?: string;
+  name?: string;
+}
+
+export function toAnthropicMessages(
+  messages: Array<Record<string, unknown>>,
+): { system: string; messages: AnthropicMessage[] } {
+  const systemParts: string[] = [];
+  const out: AnthropicMessage[] = [];
+
+  for (const rawMsg of messages as OpenAIStyleMessage[]) {
+    const role = rawMsg.role;
+
+    if (role === 'system') {
+      if (typeof rawMsg.content === 'string' && rawMsg.content) {
+        systemParts.push(rawMsg.content);
+      }
+      continue;
+    }
+
+    if (role === 'user') {
+      if (typeof rawMsg.content === 'string') {
+        out.push({ role: 'user', content: rawMsg.content });
+      } else if (rawMsg.content) {
+        out.push({ role: 'user', content: rawMsg.content });
+      }
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const blocks: Array<Record<string, unknown>> = [];
+      if (typeof rawMsg.content === 'string' && rawMsg.content) {
+        blocks.push({ type: 'text', text: rawMsg.content });
+      }
+      for (const tc of rawMsg.tool_calls ?? []) {
+        let args: unknown = {};
+        try {
+          args = JSON.parse(tc.function?.arguments ?? '{}');
+        } catch {
+          args = {};
+        }
+        blocks.push({
+          type: 'tool_use',
+          id: tc.id ?? '',
+          name: tc.function?.name ?? '',
+          input: args,
+        });
+      }
+      if (blocks.length > 0) {
+        out.push({ role: 'assistant', content: blocks });
+      }
+      continue;
+    }
+
+    if (role === 'tool') {
+      const contentStr =
+        typeof rawMsg.content === 'string' ? rawMsg.content : JSON.stringify(rawMsg.content);
+      out.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: rawMsg.tool_call_id ?? '',
+            content: contentStr,
+          },
+        ],
+      });
+      continue;
+    }
+  }
+
+  return { system: systemParts.join('\n\n'), messages: out };
+}

--- a/sdk-ts/src/providers/cerebras-llm.ts
+++ b/sdk-ts/src/providers/cerebras-llm.ts
@@ -1,0 +1,131 @@
+/**
+ * Cerebras LLM provider for Patter's pipeline mode.
+ *
+ * Cerebras exposes an OpenAI-compatible Chat Completions API at
+ * ``https://api.cerebras.ai/v1``. This provider reuses the OpenAI SSE
+ * parser from ``groq-llm.ts`` and optionally enables gzip request-body
+ * compression to reduce TTFT for requests with large prompts
+ * (see https://inference-docs.cerebras.ai/payload-optimization).
+ *
+ * Portions adapted from LiveKit Agents
+ * (https://github.com/livekit/agents, commit
+ * 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+ * file livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py),
+ * licensed under Apache License 2.0. Copyright 2026 LiveKit, Inc.
+ *
+ * Adaptations from the LiveKit source:
+ *   * LiveKit's ``cerebras.LLM`` subclasses the LiveKit OpenAI plugin.
+ *     Patter's analogue is a tiny wrapper around ``fetch`` that swaps
+ *     the base URL and default model.
+ *   * The msgpack payload optimisation from LiveKit is Python-only
+ *     (msgpack in Node land isn't as standard); only gzip compression
+ *     is ported. Enable with ``gzipCompression: true``.
+ */
+
+import type { LLMChunk, LLMProvider } from '../llm-loop';
+import { getLogger } from '../logger';
+import { parseOpenAISseStream } from './groq-llm';
+
+const CEREBRAS_BASE_URL = 'https://api.cerebras.ai/v1';
+const DEFAULT_MODEL = 'llama3.1-8b';
+
+export interface CerebrasLLMOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  /** Gzip request payloads for faster TTFT on large prompts. */
+  gzipCompression?: boolean;
+}
+
+/** LLM provider backed by Cerebras's OpenAI-compatible Inference API. */
+export class CerebrasLLMProvider implements LLMProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly gzipCompression: boolean;
+
+  constructor(options: CerebrasLLMOptions) {
+    if (!options.apiKey) {
+      throw new Error(
+        'Cerebras API key is required. Pass it via { apiKey } or read CEREBRAS_API_KEY from the environment.',
+      );
+    }
+    this.apiKey = options.apiKey;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.baseUrl = options.baseUrl ?? CEREBRAS_BASE_URL;
+    this.gzipCompression = options.gzipCompression ?? false;
+  }
+
+  async *stream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+  ): AsyncGenerator<LLMChunk, void, unknown> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages,
+      stream: true,
+    };
+    if (tools) body.tools = tools;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    let payload: BodyInit = JSON.stringify(body);
+    if (this.gzipCompression) {
+      const compressed = await gzipEncode(payload as string);
+      if (compressed) {
+        // Cast via BlobPart — Uint8Array is a valid BodyInit at runtime
+        // even though the DOM typings omit it in some lib versions.
+        payload = compressed as unknown as BodyInit;
+        headers['Content-Encoding'] = 'gzip';
+      }
+    }
+
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: payload,
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      getLogger().error(`Cerebras API error: ${response.status} ${errText}`);
+      return;
+    }
+
+    yield* parseOpenAISseStream(response);
+  }
+}
+
+/** Gzip a UTF-8 string using the WHATWG ``CompressionStream`` API. */
+async function gzipEncode(data: string): Promise<Uint8Array | null> {
+  const CompressionCtor = (
+    globalThis as unknown as { CompressionStream?: new (format: string) => TransformStream }
+  ).CompressionStream;
+  if (!CompressionCtor) return null;
+
+  const stream = new CompressionCtor('gzip');
+  const writer = stream.writable.getWriter();
+  const encoder = new TextEncoder();
+  await writer.write(encoder.encode(data));
+  await writer.close();
+
+  const chunks: Uint8Array[] = [];
+  const reader = stream.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}

--- a/sdk-ts/src/providers/google-llm.ts
+++ b/sdk-ts/src/providers/google-llm.ts
@@ -1,0 +1,294 @@
+/**
+ * Google Gemini LLM provider for Patter's pipeline mode.
+ *
+ * Implements the ``LLMProvider`` interface against the Gemini Developer
+ * API's streaming endpoint (``:streamGenerateContent?alt=sse``).
+ * OpenAI-style messages/tools are translated into Gemini's ``contents``
+ * and ``tools`` shapes, and streamed response parts are normalised to
+ * Patter's ``{ type: 'text' | 'tool_call' | 'done' }`` chunks.
+ *
+ * Portions adapted from LiveKit Agents
+ * (https://github.com/livekit/agents, commit
+ * 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+ * file livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py),
+ * licensed under Apache License 2.0. Copyright 2023 LiveKit, Inc.
+ *
+ * Adaptations from the LiveKit source:
+ *   * LiveKit uses the ``google-genai`` Python SDK. The TypeScript port
+ *     uses native ``fetch`` against the REST SSE endpoint so we don't
+ *     pull in a large SDK dependency.
+ *   * Collapsed the Python ``llm.LLM`` / ``llm.LLMStream`` pair into a
+ *     single class that satisfies Patter's ``LLMProvider`` interface.
+ *   * Dropped Vertex AI support (which requires GCP auth) — only the
+ *     Developer API (API key) path is ported. Vertex can be added by a
+ *     follow-up PR once credential plumbing is in place.
+ */
+
+import type { LLMChunk, LLMProvider } from '../llm-loop';
+import { getLogger } from '../logger';
+
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+
+export interface GoogleLLMOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+}
+
+interface GeminiPart {
+  text?: string;
+  functionCall?: { name?: string; args?: Record<string, unknown>; id?: string };
+  functionResponse?: {
+    name?: string;
+    response?: Record<string, unknown>;
+    id?: string;
+  };
+}
+
+interface GeminiContent {
+  role: 'user' | 'model';
+  parts: GeminiPart[];
+}
+
+interface OpenAIToolDef {
+  type?: string;
+  function?: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+  name?: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+}
+
+/** LLM provider backed by Google Gemini (Developer API, streaming SSE). */
+export class GoogleLLMProvider implements LLMProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly temperature?: number;
+  private readonly maxOutputTokens?: number;
+
+  constructor(options: GoogleLLMOptions) {
+    if (!options.apiKey) {
+      throw new Error(
+        'Google API key is required. Pass it via { apiKey } or read GOOGLE_API_KEY from the environment.',
+      );
+    }
+    this.apiKey = options.apiKey;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.temperature = options.temperature;
+    this.maxOutputTokens = options.maxOutputTokens;
+  }
+
+  async *stream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+  ): AsyncGenerator<LLMChunk, void, unknown> {
+    const { systemInstruction, contents } = toGeminiContents(messages);
+    const geminiTools = tools ? toGeminiTools(tools as OpenAIToolDef[]) : null;
+
+    const body: Record<string, unknown> = { contents };
+    if (systemInstruction) {
+      body.systemInstruction = { role: 'system', parts: [{ text: systemInstruction }] };
+    }
+    if (geminiTools) body.tools = geminiTools;
+
+    const generationConfig: Record<string, unknown> = {};
+    if (this.temperature !== undefined) generationConfig.temperature = this.temperature;
+    if (this.maxOutputTokens !== undefined)
+      generationConfig.maxOutputTokens = this.maxOutputTokens;
+    if (Object.keys(generationConfig).length > 0) body.generationConfig = generationConfig;
+
+    const url =
+      `${this.baseUrl}/models/${encodeURIComponent(this.model)}:streamGenerateContent?alt=sse` +
+      `&key=${encodeURIComponent(this.apiKey)}`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      getLogger().error(`Gemini API error: ${response.status} ${errText}`);
+      return;
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) return;
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let nextIndex = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data: ')) continue;
+        const data = trimmed.slice(6);
+        if (!data) continue;
+
+        let payload: {
+          candidates?: Array<{
+            content?: { parts?: GeminiPart[] };
+          }>;
+        };
+        try {
+          payload = JSON.parse(data);
+        } catch {
+          continue;
+        }
+
+        const candidate = payload.candidates?.[0];
+        const parts = candidate?.content?.parts ?? [];
+        for (const part of parts) {
+          if (part.functionCall) {
+            const args = part.functionCall.args ?? {};
+            const callId =
+              part.functionCall.id ?? `gemini_call_${nextIndex}`;
+            yield {
+              type: 'tool_call',
+              index: nextIndex,
+              id: callId,
+              name: part.functionCall.name ?? '',
+              arguments: JSON.stringify(args),
+            };
+            nextIndex++;
+            continue;
+          }
+          if (part.text) {
+            yield { type: 'text', content: part.text };
+          }
+        }
+      }
+    }
+
+    yield { type: 'done' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Translation helpers (OpenAI format -> Gemini REST contents)
+// ---------------------------------------------------------------------------
+
+function toGeminiTools(tools: OpenAIToolDef[]): Array<Record<string, unknown>> {
+  const functionDeclarations = tools.map((t) => {
+    const fn = t.function ?? t;
+    return {
+      name: String(fn.name ?? ''),
+      description: String(fn.description ?? ''),
+      parameters: fn.parameters ?? { type: 'object', properties: {} },
+    };
+  });
+  if (functionDeclarations.length === 0) return [];
+  return [{ functionDeclarations }];
+}
+
+interface OpenAIStyleMessage {
+  role?: string;
+  content?: string | Array<Record<string, unknown>>;
+  tool_calls?: Array<{
+    id?: string;
+    function?: { name?: string; arguments?: string };
+  }>;
+  tool_call_id?: string;
+  name?: string;
+}
+
+export function toGeminiContents(
+  messages: Array<Record<string, unknown>>,
+): { systemInstruction: string; contents: GeminiContent[] } {
+  const systemParts: string[] = [];
+  const contents: GeminiContent[] = [];
+
+  for (const rawMsg of messages as OpenAIStyleMessage[]) {
+    const role = rawMsg.role;
+
+    if (role === 'system') {
+      if (typeof rawMsg.content === 'string' && rawMsg.content) {
+        systemParts.push(rawMsg.content);
+      }
+      continue;
+    }
+
+    if (role === 'user') {
+      if (typeof rawMsg.content === 'string' && rawMsg.content) {
+        contents.push({ role: 'user', parts: [{ text: rawMsg.content }] });
+      }
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const parts: GeminiPart[] = [];
+      if (typeof rawMsg.content === 'string' && rawMsg.content) {
+        parts.push({ text: rawMsg.content });
+      }
+      for (const tc of rawMsg.tool_calls ?? []) {
+        let args: Record<string, unknown> = {};
+        try {
+          const parsed = JSON.parse(tc.function?.arguments ?? '{}');
+          if (parsed && typeof parsed === 'object') args = parsed as Record<string, unknown>;
+        } catch {
+          args = {};
+        }
+        parts.push({
+          functionCall: {
+            name: tc.function?.name ?? '',
+            args,
+            id: tc.id,
+          },
+        });
+      }
+      if (parts.length > 0) contents.push({ role: 'model', parts });
+      continue;
+    }
+
+    if (role === 'tool') {
+      const raw = rawMsg.content;
+      let response: Record<string, unknown>;
+      if (typeof raw === 'string') {
+        try {
+          const parsed = JSON.parse(raw);
+          response =
+            parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+              ? (parsed as Record<string, unknown>)
+              : { result: parsed };
+        } catch {
+          response = { result: raw };
+        }
+      } else {
+        response = (raw as unknown as Record<string, unknown>) ?? {};
+      }
+      contents.push({
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: rawMsg.name ?? rawMsg.tool_call_id ?? '',
+              response,
+              id: rawMsg.tool_call_id,
+            },
+          },
+        ],
+      });
+      continue;
+    }
+  }
+
+  return { systemInstruction: systemParts.join('\n\n'), contents };
+}

--- a/sdk-ts/src/providers/groq-llm.ts
+++ b/sdk-ts/src/providers/groq-llm.ts
@@ -1,0 +1,151 @@
+/**
+ * Groq LLM provider for Patter's pipeline mode.
+ *
+ * Groq exposes an OpenAI-compatible Chat Completions API. We reuse the
+ * streaming code path by implementing the same SSE parser as
+ * ``OpenAILLMProvider`` but pointed at ``api.groq.com``.
+ *
+ * Portions adapted from LiveKit Agents
+ * (https://github.com/livekit/agents, commit
+ * 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+ * file livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py),
+ * licensed under Apache License 2.0. Copyright LiveKit, Inc.
+ *
+ * Adaptations from the LiveKit source:
+ *   * Ported the Python ``groq.LLM`` subclass (which subclasses the
+ *     LiveKit OpenAI plugin) into a tiny TypeScript wrapper that swaps
+ *     the base URL and defaults to ``llama-3.3-70b-versatile``.
+ */
+
+import type { LLMChunk, LLMProvider } from '../llm-loop';
+import { getLogger } from '../logger';
+
+const GROQ_BASE_URL = 'https://api.groq.com/openai/v1';
+const DEFAULT_MODEL = 'llama-3.3-70b-versatile';
+
+export interface GroqLLMOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}
+
+/** LLM provider backed by Groq's OpenAI-compatible Chat Completions API. */
+export class GroqLLMProvider implements LLMProvider {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+
+  constructor(options: GroqLLMOptions) {
+    if (!options.apiKey) {
+      throw new Error(
+        'Groq API key is required. Pass it via { apiKey } or read GROQ_API_KEY from the environment.',
+      );
+    }
+    this.apiKey = options.apiKey;
+    this.model = options.model ?? DEFAULT_MODEL;
+    this.baseUrl = options.baseUrl ?? GROQ_BASE_URL;
+  }
+
+  async *stream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+  ): AsyncGenerator<LLMChunk, void, unknown> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages,
+      stream: true,
+    };
+    if (tools) body.tools = tools;
+
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      getLogger().error(`Groq API error: ${response.status} ${errText}`);
+      return;
+    }
+
+    yield* parseOpenAISseStream(response);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared OpenAI-format SSE stream parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a streaming OpenAI-format Chat Completions response and yield
+ * Patter ``LLMChunk`` objects.
+ *
+ * Exported so ``cerebras-llm.ts`` can reuse the same parser.
+ */
+export async function* parseOpenAISseStream(
+  response: Response,
+): AsyncGenerator<LLMChunk, void, unknown> {
+  const reader = response.body?.getReader();
+  if (!reader) return;
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.startsWith('data: ')) continue;
+      const data = trimmed.slice(6);
+      if (data === '[DONE]') continue;
+
+      let chunk: {
+        choices?: Array<{
+          delta?: {
+            content?: string;
+            tool_calls?: Array<{
+              index: number;
+              id?: string;
+              function?: { name?: string; arguments?: string };
+            }>;
+          };
+        }>;
+      };
+      try {
+        chunk = JSON.parse(data);
+      } catch {
+        continue;
+      }
+
+      const delta = chunk.choices?.[0]?.delta;
+      if (!delta) continue;
+
+      if (delta.content) {
+        yield { type: 'text', content: delta.content };
+      }
+
+      if (delta.tool_calls) {
+        for (const tc of delta.tool_calls) {
+          yield {
+            type: 'tool_call',
+            index: tc.index,
+            id: tc.id,
+            name: tc.function?.name,
+            arguments: tc.function?.arguments,
+          };
+        }
+      }
+    }
+  }
+}

--- a/sdk-ts/tests/llm-providers-vendor.test.ts
+++ b/sdk-ts/tests/llm-providers-vendor.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for the Anthropic / Groq / Cerebras / Google LLM providers.
+ *
+ * All tests in this file are MOCK unit tests: ``globalThis.fetch`` is
+ * stubbed to return a synthetic SSE stream shaped like the vendor API.
+ * They verify that each provider correctly translates vendor-specific
+ * events into Patter's ``{ type: 'text' | 'tool_call' | 'done' }``
+ * chunk protocol without making network calls.
+ *
+ * Integration tests that hit real APIs should live in
+ * ``tests/integration/`` and skip when the matching env var is absent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LLMChunk } from '../src/llm-loop';
+import { AnthropicLLMProvider } from '../src/providers/anthropic-llm';
+import { GroqLLMProvider } from '../src/providers/groq-llm';
+import { CerebrasLLMProvider } from '../src/providers/cerebras-llm';
+import { GoogleLLMProvider } from '../src/providers/google-llm';
+
+function buildSSEBody(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line));
+      }
+      controller.close();
+    },
+  });
+}
+
+function mockFetchResponse(body: ReadableStream<Uint8Array>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    body,
+    text: async () => '',
+  } as unknown as Response;
+}
+
+async function collect<T>(iter: AsyncGenerator<T, void, unknown>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const v of iter) out.push(v);
+  return out;
+}
+
+describe('AnthropicLLMProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('emits text chunks then done (MOCK Anthropic SSE)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({ type: 'message_start' })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'Hello ' },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'world!' },
+      })}\n\n`,
+      `data: ${JSON.stringify({ type: 'content_block_stop', index: 0 })}\n\n`,
+      `data: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
+    ]);
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse(body));
+
+    const provider = new AnthropicLLMProvider({ apiKey: 'sk-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream([
+        { role: 'system', content: 'Be concise.' },
+        { role: 'user', content: 'Hi' },
+      ]),
+    );
+
+    expect(chunks).toEqual([
+      { type: 'text', content: 'Hello ' },
+      { type: 'text', content: 'world!' },
+      { type: 'done' },
+    ]);
+  });
+
+  it('emits tool_call chunks for tool_use blocks (MOCK Anthropic SSE)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({ type: 'message_start' })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu_01', name: 'get_weather' },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"city":' },
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '"Paris"}' },
+      })}\n\n`,
+      `data: ${JSON.stringify({ type: 'content_block_stop', index: 0 })}\n\n`,
+      `data: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
+    ]);
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse(body));
+
+    const provider = new AnthropicLLMProvider({ apiKey: 'sk-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream(
+        [{ role: 'user', content: 'Weather in Paris?' }],
+        [
+          {
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              description: 'Get weather',
+              parameters: { type: 'object', properties: { city: { type: 'string' } } },
+            },
+          },
+        ],
+      ),
+    );
+
+    expect(chunks[0]).toEqual({
+      type: 'tool_call',
+      index: 0,
+      id: 'toolu_01',
+      name: 'get_weather',
+      arguments: '',
+    });
+    expect(chunks[1]).toMatchObject({
+      type: 'tool_call',
+      index: 0,
+      arguments: '{"city":',
+    });
+    expect(chunks[2]).toMatchObject({
+      type: 'tool_call',
+      index: 0,
+      arguments: '"Paris"}',
+    });
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('throws on missing API key', () => {
+    expect(() => new AnthropicLLMProvider({ apiKey: '' })).toThrow(/Anthropic API key/);
+  });
+});
+
+describe('GroqLLMProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('emits text chunks (MOCK OpenAI-compatible SSE)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'Hi ' } }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'there!' } }] })}\n\n`,
+      `data: [DONE]\n\n`,
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse(body));
+    globalThis.fetch = fetchMock;
+
+    const provider = new GroqLLMProvider({ apiKey: 'gsk-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream([{ role: 'user', content: 'hi' }]),
+    );
+    expect(chunks).toEqual([
+      { type: 'text', content: 'Hi ' },
+      { type: 'text', content: 'there!' },
+    ]);
+    // URL points at Groq
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.groq.com/openai/v1/chat/completions',
+    );
+    // Uses bearer auth
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer gsk-test',
+    );
+  });
+
+  it('throws on missing API key', () => {
+    expect(() => new GroqLLMProvider({ apiKey: '' })).toThrow(/Groq API key/);
+  });
+});
+
+describe('CerebrasLLMProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('emits text chunks with Cerebras base URL (MOCK)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'Fast.' } }] })}\n\n`,
+      `data: [DONE]\n\n`,
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse(body));
+    globalThis.fetch = fetchMock;
+
+    const provider = new CerebrasLLMProvider({ apiKey: 'cb-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream([{ role: 'user', content: 'hi' }]),
+    );
+    expect(chunks).toEqual([{ type: 'text', content: 'Fast.' }]);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.cerebras.ai/v1/chat/completions',
+    );
+  });
+
+  it('throws on missing API key', () => {
+    expect(() => new CerebrasLLMProvider({ apiKey: '' })).toThrow(/Cerebras API key/);
+  });
+});
+
+describe('GoogleLLMProvider', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('emits text chunks then done (MOCK Gemini SSE)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'Hello ' }] } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'Gemini!' }] } }],
+      })}\n\n`,
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse(body));
+    globalThis.fetch = fetchMock;
+
+    const provider = new GoogleLLMProvider({ apiKey: 'AIza-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream([
+        { role: 'system', content: 'Be nice.' },
+        { role: 'user', content: 'Hi' },
+      ]),
+    );
+    expect(chunks).toEqual([
+      { type: 'text', content: 'Hello ' },
+      { type: 'text', content: 'Gemini!' },
+      { type: 'done' },
+    ]);
+    // URL includes SSE alt=sse and model
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('gemini-2.5-flash:streamGenerateContent');
+    expect(url).toContain('alt=sse');
+  });
+
+  it('emits tool_call chunks for functionCall parts (MOCK Gemini SSE)', async () => {
+    const body = buildSSEBody([
+      `data: ${JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'get_weather',
+                    args: { city: 'Paris' },
+                    id: 'gc1',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })}\n\n`,
+    ]);
+    globalThis.fetch = vi.fn().mockResolvedValue(mockFetchResponse(body));
+
+    const provider = new GoogleLLMProvider({ apiKey: 'AIza-test' });
+    const chunks = await collect<LLMChunk>(
+      provider.stream(
+        [{ role: 'user', content: 'weather?' }],
+        [
+          {
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              description: 'x',
+              parameters: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+              },
+            },
+          },
+        ],
+      ),
+    );
+    expect(chunks[0]).toMatchObject({
+      type: 'tool_call',
+      name: 'get_weather',
+      id: 'gc1',
+    });
+    expect(JSON.parse(chunks[0].arguments!)).toEqual({ city: 'Paris' });
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('throws on missing API key', () => {
+    expect(() => new GoogleLLMProvider({ apiKey: '' })).toThrow(/Google API key/);
+  });
+});

--- a/sdk/patter/providers/__init__.py
+++ b/sdk/patter/providers/__init__.py
@@ -44,6 +44,39 @@ def lmnt(api_key: str, voice: str = "leah") -> TTSConfig:
     return TTSConfig(provider="lmnt", api_key=api_key, voice=voice)
 
 
+def _load_anthropic_llm():
+    from patter.providers.anthropic_llm import AnthropicLLMProvider
+    return AnthropicLLMProvider
+
+
+def _load_groq_llm():
+    from patter.providers.groq_llm import GroqLLMProvider
+    return GroqLLMProvider
+
+
+def _load_cerebras_llm():
+    from patter.providers.cerebras_llm import CerebrasLLMProvider
+    return CerebrasLLMProvider
+
+
+def _load_google_llm():
+    from patter.providers.google_llm import GoogleLLMProvider
+    return GoogleLLMProvider
+
+
+def __getattr__(name: str):
+    """Lazy-load optional LLM providers to avoid importing heavy vendor SDKs."""
+    loaders = {
+        "AnthropicLLMProvider": _load_anthropic_llm,
+        "GroqLLMProvider": _load_groq_llm,
+        "CerebrasLLMProvider": _load_cerebras_llm,
+        "GoogleLLMProvider": _load_google_llm,
+    }
+    if name in loaders:
+        return loaders[name]()
+    raise AttributeError(f"module 'patter.providers' has no attribute {name!r}")
+
+
 # Prevent submodule names from shadowing the helper functions above.
 # Python's package import mechanism can bind submodule objects (e.g.
 # patter.providers.openai_tts) onto this package's namespace, which would
@@ -58,4 +91,8 @@ __all__ = [
     "cartesia",
     "rime",
     "lmnt",
+    "AnthropicLLMProvider",
+    "GroqLLMProvider",
+    "CerebrasLLMProvider",
+    "GoogleLLMProvider",
 ]

--- a/sdk/patter/providers/anthropic_llm.py
+++ b/sdk/patter/providers/anthropic_llm.py
@@ -1,0 +1,268 @@
+"""Anthropic Claude LLM provider for Patter's pipeline mode.
+
+This provider implements the :class:`patter.services.llm_loop.LLMProvider`
+protocol on top of Anthropic's Messages API with streaming.  Tool calls
+are translated from Anthropic's ``tool_use`` content blocks into the
+OpenAI-compatible ``{"type": "tool_call", ...}`` chunk format that the
+:class:`~patter.services.llm_loop.LLMLoop` expects.
+
+Portions adapted from LiveKit Agents
+(https://github.com/livekit/agents, commit 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+file livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py),
+licensed under Apache License 2.0. Copyright 2023 LiveKit, Inc.
+
+Adaptations from the LiveKit source:
+  * Reshaped the ``llm.LLM`` / ``llm.LLMStream`` class pair into a single
+    :class:`AnthropicLLMProvider` that conforms to Patter's duck-typed
+    ``LLMProvider`` Protocol (``async def stream(messages, tools)``).
+  * Translates OpenAI-formatted messages (``role``/``content``/
+    ``tool_calls``/``tool_call_id``) into Anthropic's Messages API shape
+    (single ``system`` string, ``user``/``assistant`` turns with
+    ``tool_use``/``tool_result`` content blocks) so callers don't need
+    two message formats.
+  * Maps Anthropic stream events (``content_block_start``,
+    ``content_block_delta``, ``content_block_stop``) to the Patter chunk
+    protocol ``{"type": "text"|"tool_call"|"done", ...}``.
+  * Dropped LiveKit-specific concerns (``APIConnectOptions``,
+    ``chat_ctx.to_provider_format``, metrics events, retry wrapping)
+    that don't apply to Patter's thinner runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import AsyncIterator
+
+logger = logging.getLogger("patter")
+
+__all__ = ["AnthropicLLMProvider"]
+
+
+# Default model. Anthropic requires an explicit max_tokens for every request;
+# we use LiveKit's default of 1024 when the caller doesn't provide one.
+_DEFAULT_MODEL = "claude-3-5-sonnet-20241022"
+_DEFAULT_MAX_TOKENS = 1024
+
+
+class AnthropicLLMProvider:
+    """LLM provider backed by Anthropic's Messages API (streaming).
+
+    Implements Patter's :class:`LLMProvider` protocol: ``stream`` yields
+    ``{"type": "text" | "tool_call" | "done", ...}`` chunks.
+
+    Args:
+        api_key: Anthropic API key. If omitted, ``ANTHROPIC_API_KEY`` is
+            read from the environment.
+        model: Model identifier (e.g. ``"claude-3-5-sonnet-20241022"``).
+        max_tokens: Maximum tokens to generate per response.  Required
+            by the Messages API; defaults to 1024.
+        temperature: Optional sampling temperature.
+        base_url: Optional Anthropic API base URL override.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+        temperature: float | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        try:
+            import anthropic
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'anthropic' package is required for AnthropicLLMProvider. "
+                "Install it with: pip install 'getpatter[anthropic]'"
+            ) from e
+
+        resolved_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Anthropic API key is required, either as the 'api_key' "
+                "argument or via the ANTHROPIC_API_KEY environment variable."
+            )
+
+        self._client = anthropic.AsyncAnthropic(
+            api_key=resolved_key,
+            base_url=base_url,
+        )
+        self._model = model
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+
+    async def stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[dict]:
+        """Stream chunks from Anthropic's Messages API.
+
+        Translates OpenAI-style ``messages``/``tools`` to Anthropic's
+        shape, then normalises the event stream back into the Patter
+        chunk protocol.
+        """
+        system_prompt, anthropic_messages = _to_anthropic_messages(messages)
+        anthropic_tools = _to_anthropic_tools(tools) if tools else None
+
+        kwargs: dict = {
+            "model": self._model,
+            "messages": anthropic_messages,
+            "max_tokens": self._max_tokens,
+        }
+        if system_prompt:
+            kwargs["system"] = system_prompt
+        if anthropic_tools:
+            kwargs["tools"] = anthropic_tools
+        if self._temperature is not None:
+            kwargs["temperature"] = self._temperature
+
+        # tool_call_id -> stable "index" for the Patter chunk protocol.
+        tool_indices: dict[str, int] = {}
+        current_tool_id: str | None = None
+        current_tool_index: int | None = None
+
+        async with self._client.messages.stream(**kwargs) as stream:
+            async for event in stream:
+                event_type = getattr(event, "type", None)
+
+                if event_type == "content_block_start":
+                    block = getattr(event, "content_block", None)
+                    if block is not None and getattr(block, "type", None) == "tool_use":
+                        tool_id = getattr(block, "id", "") or ""
+                        tool_name = getattr(block, "name", "") or ""
+                        if tool_id not in tool_indices:
+                            tool_indices[tool_id] = len(tool_indices)
+                        current_tool_id = tool_id
+                        current_tool_index = tool_indices[tool_id]
+                        yield {
+                            "type": "tool_call",
+                            "index": current_tool_index,
+                            "id": tool_id,
+                            "name": tool_name,
+                            "arguments": "",
+                        }
+
+                elif event_type == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    delta_type = getattr(delta, "type", None) if delta else None
+
+                    if delta_type == "text_delta":
+                        text = getattr(delta, "text", "") or ""
+                        if text:
+                            yield {"type": "text", "content": text}
+
+                    elif delta_type == "input_json_delta":
+                        partial = getattr(delta, "partial_json", "") or ""
+                        if partial and current_tool_index is not None:
+                            yield {
+                                "type": "tool_call",
+                                "index": current_tool_index,
+                                "id": current_tool_id,
+                                "name": None,
+                                "arguments": partial,
+                            }
+
+                elif event_type == "content_block_stop":
+                    current_tool_id = None
+                    current_tool_index = None
+
+        yield {"type": "done"}
+
+
+# ---------------------------------------------------------------------------
+# Message / tool translation (OpenAI format -> Anthropic Messages API)
+# ---------------------------------------------------------------------------
+
+
+def _to_anthropic_tools(tools: list[dict]) -> list[dict]:
+    """Convert OpenAI-style tool definitions to Anthropic tool schema."""
+    out: list[dict] = []
+    for tool in tools:
+        # OpenAI format: {"type": "function", "function": {...}}
+        fn = tool.get("function", tool)
+        out.append(
+            {
+                "name": fn["name"],
+                "description": fn.get("description", ""),
+                "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+            }
+        )
+    return out
+
+
+def _to_anthropic_messages(messages: list[dict]) -> tuple[str, list[dict]]:
+    """Convert OpenAI-style messages to Anthropic (system_str, messages).
+
+    Anthropic expects:
+      * A single ``system`` string (sent as a top-level kwarg).
+      * ``user`` / ``assistant`` turns only.
+      * Assistant tool calls become ``tool_use`` content blocks.
+      * Tool results become ``user`` messages with ``tool_result`` blocks.
+    """
+    system_parts: list[str] = []
+    out: list[dict] = []
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "system":
+            content = msg.get("content")
+            if isinstance(content, str) and content:
+                system_parts.append(content)
+            continue
+
+        if role == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                out.append({"role": "user", "content": content})
+            else:
+                out.append({"role": "user", "content": content})
+            continue
+
+        if role == "assistant":
+            blocks: list[dict] = []
+            text = msg.get("content")
+            if isinstance(text, str) and text:
+                blocks.append({"type": "text", "text": text})
+
+            for tc in msg.get("tool_calls", []) or []:
+                fn = tc.get("function", {})
+                try:
+                    args = json.loads(fn.get("arguments", "") or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "input": args,
+                    }
+                )
+
+            if not blocks:
+                # Skip empty assistant turns to keep Anthropic happy.
+                continue
+            out.append({"role": "assistant", "content": blocks})
+            continue
+
+        if role == "tool":
+            tool_call_id = msg.get("tool_call_id", "")
+            content = msg.get("content", "")
+            out.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_call_id,
+                            "content": content if isinstance(content, str) else json.dumps(content),
+                        }
+                    ],
+                }
+            )
+            continue
+
+    return "\n\n".join(system_parts), out

--- a/sdk/patter/providers/cerebras_llm.py
+++ b/sdk/patter/providers/cerebras_llm.py
@@ -1,0 +1,178 @@
+"""Cerebras LLM provider for Patter's pipeline mode.
+
+Cerebras exposes an OpenAI-compatible Chat Completions API at
+``https://api.cerebras.ai/v1``, so this provider is a thin wrapper
+around :class:`patter.services.llm_loop.OpenAILLMProvider` with a
+Cerebras-specific base URL.  Payload compression (msgpack + gzip) is
+supported and enabled by default to reduce TTFT for large prompts —
+see https://inference-docs.cerebras.ai/payload-optimization.
+
+Portions adapted from LiveKit Agents
+(https://github.com/livekit/agents, commit 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+file livekit-plugins/livekit-plugins-cerebras/livekit/plugins/cerebras/llm.py),
+licensed under Apache License 2.0. Copyright 2026 LiveKit, Inc.
+
+Adaptations from the LiveKit source:
+  * LiveKit's ``cerebras.LLM`` subclasses the LiveKit OpenAI LLM; Patter's
+    analogue subclasses :class:`OpenAILLMProvider`.
+  * Ported the ``_CerebrasClient`` helper that overrides ``_build_request``
+    to compress payloads with msgpack/gzip.  When either compression
+    option is enabled we construct this custom client; otherwise we fall
+    back to the stock ``openai.AsyncOpenAI`` client.
+  * Dropped LiveKit's ``NotGivenOr`` sentinel plumbing in favour of plain
+    ``Optional`` kwargs that match Patter's Python idioms.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from typing import Any, AsyncIterator
+
+from patter.services.llm_loop import OpenAILLMProvider
+
+__all__ = ["CerebrasLLMProvider"]
+
+
+_CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1"
+_DEFAULT_MODEL = "llama3.1-8b"
+
+
+def _build_cerebras_client(
+    api_key: str,
+    base_url: str,
+    use_msgpack: bool,
+    use_gzip: bool,
+):
+    """Return an ``openai.AsyncOpenAI`` subclass that compresses requests."""
+    try:
+        import openai
+        from openai._models import FinalRequestOptions
+        from openai._utils import is_mapping
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'openai' package is required for CerebrasLLMProvider. "
+            "Install it with: pip install 'getpatter[cerebras]'"
+        ) from e
+
+    if use_msgpack:
+        try:
+            import msgpack  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'msgpack' package is required for Cerebras msgpack "
+                "encoding. Install it with: pip install 'getpatter[cerebras]'"
+            ) from e
+    else:
+        msgpack = None  # type: ignore
+
+    class _CerebrasClient(openai.AsyncOpenAI):
+        """AsyncOpenAI subclass that compresses requests via msgpack/gzip.
+
+        Adapted from LiveKit's ``cerebras._CerebrasClient``.  Overrides
+        ``_build_request`` to serialise ``json_data`` directly into the
+        target binary format and sets the appropriate ``Content-Type``
+        and ``Content-Encoding`` headers.
+        """
+
+        def _build_request(
+            self,
+            options: FinalRequestOptions,
+            *,
+            retries_taken: int = 0,
+        ):
+            if not (use_msgpack or use_gzip):
+                return super()._build_request(options, retries_taken=retries_taken)
+
+            json_data = options.json_data
+            if json_data is not None:
+                if options.extra_json is not None and is_mapping(json_data):
+                    json_data = {**json_data, **options.extra_json}
+
+                if use_msgpack and msgpack is not None:
+                    body = msgpack.packb(json_data)
+                    content_type = "application/vnd.msgpack"
+                else:
+                    body = json.dumps(
+                        json_data, separators=(",", ":"), ensure_ascii=False
+                    ).encode()
+                    content_type = "application/json"
+
+                if use_gzip:
+                    body = gzip.compress(body, compresslevel=5)
+
+                options.json_data = None
+                options.extra_json = None
+                options.content = body
+
+                existing = dict(options.headers) if options.headers else {}
+                overrides: dict[str, str] = {"Content-Type": content_type}
+                if use_gzip:
+                    overrides["Content-Encoding"] = "gzip"
+                options.headers = existing | overrides
+
+            return super()._build_request(options, retries_taken=retries_taken)
+
+    return _CerebrasClient(api_key=api_key, base_url=base_url)
+
+
+class CerebrasLLMProvider(OpenAILLMProvider):
+    """LLM provider backed by Cerebras's OpenAI-compatible Inference API.
+
+    Streams in the same ``{"type": "text" | "tool_call" | "done"}`` chunk
+    format as :class:`OpenAILLMProvider`.
+
+    Args:
+        api_key: Cerebras API key. Reads ``CEREBRAS_API_KEY`` if omitted.
+        model: Cerebras chat model ID. Defaults to ``llama3.1-8b``.
+        base_url: Optional Cerebras base URL override.
+        gzip_compression: Gzip request payloads for faster TTFT.
+        msgpack_encoding: Encode request payloads with msgpack for smaller
+            wire size.  Requires ``msgpack>=1.0``.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        base_url: str = _CEREBRAS_BASE_URL,
+        gzip_compression: bool = True,
+        msgpack_encoding: bool = True,
+    ) -> None:
+        try:
+            from openai import AsyncOpenAI  # noqa: F401
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'openai' package is required for CerebrasLLMProvider. "
+                "Install it with: pip install 'getpatter[cerebras]'"
+            ) from e
+
+        resolved_key = api_key or os.environ.get("CEREBRAS_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Cerebras API key is required, either as the 'api_key' argument "
+                "or via the CEREBRAS_API_KEY environment variable."
+            )
+
+        if gzip_compression or msgpack_encoding:
+            self._client: Any = _build_cerebras_client(
+                api_key=resolved_key,
+                base_url=base_url,
+                use_msgpack=msgpack_encoding,
+                use_gzip=gzip_compression,
+            )
+        else:
+            from openai import AsyncOpenAI
+
+            self._client = AsyncOpenAI(api_key=resolved_key, base_url=base_url)
+
+        self._model = model
+
+    async def stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[dict]:
+        async for chunk in super().stream(messages, tools):
+            yield chunk

--- a/sdk/patter/providers/google_llm.py
+++ b/sdk/patter/providers/google_llm.py
@@ -1,0 +1,291 @@
+"""Google Gemini LLM provider for Patter's pipeline mode.
+
+Backed by the ``google-genai`` SDK (``google.genai.Client``) which
+supports both the Gemini Developer API and Vertex AI.  This provider
+bridges Patter's OpenAI-style chunk protocol with Gemini's
+``generate_content_stream`` event format.
+
+Portions adapted from LiveKit Agents
+(https://github.com/livekit/agents, commit 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+file livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py),
+licensed under Apache License 2.0. Copyright 2023 LiveKit, Inc.
+
+Adaptations from the LiveKit source:
+  * Collapsed the ``llm.LLM`` / ``llm.LLMStream`` pair into a single
+    :class:`GoogleLLMProvider` that satisfies Patter's ``LLMProvider``
+    Protocol (``async def stream(messages, tools)``).
+  * Translates OpenAI-formatted messages into Gemini ``Content`` turns
+    (including ``function_call`` / ``function_response`` parts) so
+    callers don't need a second message format.
+  * Maps Gemini stream events (``text`` parts, ``function_call`` parts)
+    to the Patter chunk protocol ``{"type": "text"|"tool_call"|"done"}``.
+  * Dropped LiveKit-specific machinery (``thought_signatures``,
+    ``APIConnectOptions``, metrics/usage events, retry wrapping) that
+    don't apply to Patter's thinner runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, AsyncIterator
+
+logger = logging.getLogger("patter")
+
+__all__ = ["GoogleLLMProvider"]
+
+
+_DEFAULT_MODEL = "gemini-2.5-flash"
+
+
+class GoogleLLMProvider:
+    """LLM provider backed by Google Gemini (``google-genai`` SDK).
+
+    Supports both the Gemini Developer API (with an API key) and
+    Vertex AI (with Google Cloud credentials).  Streams chunks in
+    Patter's ``{"type": "text" | "tool_call" | "done", ...}`` protocol.
+
+    Args:
+        api_key: Google API key for the Gemini Developer API. If
+            omitted, ``GOOGLE_API_KEY`` is read from the environment.
+            Ignored when ``vertexai=True``.
+        model: Gemini model ID. Defaults to ``gemini-2.5-flash``.
+        vertexai: If True, use Vertex AI instead of the Developer API.
+        project: GCP project (Vertex AI only).
+        location: GCP location (Vertex AI only). Defaults to
+            ``us-central1``.
+        temperature: Optional sampling temperature.
+        max_output_tokens: Optional output token cap.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        vertexai: bool = False,
+        project: str | None = None,
+        location: str | None = None,
+        temperature: float | None = None,
+        max_output_tokens: int | None = None,
+    ) -> None:
+        try:
+            from google.genai import Client
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'google-genai' package is required for GoogleLLMProvider. "
+                "Install it with: pip install 'getpatter[google]'"
+            ) from e
+
+        use_vertexai = (
+            vertexai
+            if vertexai
+            else os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "0").lower() in ["true", "1"]
+        )
+
+        resolved_key: str | None = None
+        gcp_project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        gcp_location = location or os.environ.get("GOOGLE_CLOUD_LOCATION") or "us-central1"
+
+        if use_vertexai:
+            if not gcp_project:
+                raise ValueError(
+                    "Project is required for Vertex AI, either via the 'project' "
+                    "argument or the GOOGLE_CLOUD_PROJECT environment variable."
+                )
+        else:
+            resolved_key = api_key or os.environ.get("GOOGLE_API_KEY")
+            if not resolved_key:
+                raise ValueError(
+                    "Google API key is required, either as the 'api_key' argument "
+                    "or via the GOOGLE_API_KEY environment variable."
+                )
+            gcp_project = None
+            gcp_location = None
+
+        self._client = Client(
+            api_key=resolved_key,
+            vertexai=use_vertexai,
+            project=gcp_project,
+            location=gcp_location,
+        )
+        self._model = model
+        self._temperature = temperature
+        self._max_output_tokens = max_output_tokens
+
+    async def stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[dict]:
+        """Stream chunks from Gemini's ``generate_content_stream``."""
+        from google.genai import types
+
+        system_instruction, contents = _to_gemini_contents(messages)
+        gemini_tools = _to_gemini_tools(tools) if tools else None
+
+        config_kwargs: dict[str, Any] = {}
+        if system_instruction:
+            config_kwargs["system_instruction"] = [types.Part(text=system_instruction)]
+        if gemini_tools is not None:
+            config_kwargs["tools"] = gemini_tools
+        if self._temperature is not None:
+            config_kwargs["temperature"] = self._temperature
+        if self._max_output_tokens is not None:
+            config_kwargs["max_output_tokens"] = self._max_output_tokens
+
+        config = types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
+
+        stream = await self._client.aio.models.generate_content_stream(
+            model=self._model,
+            contents=contents,
+            config=config,
+        )
+
+        # Gemini does not provide a stable per-function-call index across
+        # chunks, so we assign a monotonically increasing index per
+        # function_call part that we see.
+        next_index = 0
+
+        async for response in stream:
+            if not getattr(response, "candidates", None):
+                continue
+            candidate = response.candidates[0]
+            content = getattr(candidate, "content", None)
+            if not content or not getattr(content, "parts", None):
+                continue
+
+            for part in content.parts:
+                function_call = getattr(part, "function_call", None)
+                if function_call:
+                    args = getattr(function_call, "args", {}) or {}
+                    call_id = (
+                        getattr(function_call, "id", None)
+                        or f"gemini_call_{next_index}"
+                    )
+                    yield {
+                        "type": "tool_call",
+                        "index": next_index,
+                        "id": call_id,
+                        "name": getattr(function_call, "name", "") or "",
+                        "arguments": json.dumps(args),
+                    }
+                    next_index += 1
+                    continue
+
+                text = getattr(part, "text", None)
+                if text:
+                    yield {"type": "text", "content": text}
+
+        yield {"type": "done"}
+
+
+# ---------------------------------------------------------------------------
+# Message / tool translation (OpenAI format -> google.genai types)
+# ---------------------------------------------------------------------------
+
+
+def _to_gemini_tools(tools: list[dict]) -> list[Any]:
+    """Convert OpenAI-style tool definitions to Gemini ``Tool`` objects."""
+    from google.genai import types
+
+    function_decls: list[types.FunctionDeclaration] = []
+    for tool in tools:
+        fn = tool.get("function", tool)
+        function_decls.append(
+            types.FunctionDeclaration(
+                name=fn["name"],
+                description=fn.get("description", ""),
+                parameters=fn.get("parameters", {"type": "object", "properties": {}}),
+            )
+        )
+    if not function_decls:
+        return []
+    return [types.Tool(function_declarations=function_decls)]
+
+
+def _to_gemini_contents(messages: list[dict]) -> tuple[str, list[Any]]:
+    """Convert OpenAI-style messages to (system_instruction, Gemini Contents).
+
+    Gemini expects:
+      * ``system`` as a top-level ``GenerateContentConfig.system_instruction``.
+      * ``user`` / ``model`` turns with ``Part`` lists.
+      * Tool calls are ``Part(function_call=...)`` on ``model`` turns.
+      * Tool results are ``Part(function_response=...)`` on ``user`` turns.
+    """
+    from google.genai import types
+
+    system_parts: list[str] = []
+    contents: list[types.Content] = []
+
+    for msg in messages:
+        role = msg.get("role")
+
+        if role == "system":
+            content = msg.get("content")
+            if isinstance(content, str) and content:
+                system_parts.append(content)
+            continue
+
+        if role == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str) and content:
+                contents.append(
+                    types.Content(role="user", parts=[types.Part(text=content)])
+                )
+            continue
+
+        if role == "assistant":
+            parts: list[types.Part] = []
+            text = msg.get("content")
+            if isinstance(text, str) and text:
+                parts.append(types.Part(text=text))
+
+            for tc in msg.get("tool_calls", []) or []:
+                fn = tc.get("function", {})
+                try:
+                    args = json.loads(fn.get("arguments", "") or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                parts.append(
+                    types.Part(
+                        function_call=types.FunctionCall(
+                            name=fn.get("name", ""),
+                            args=args,
+                            id=tc.get("id"),
+                        )
+                    )
+                )
+
+            if parts:
+                contents.append(types.Content(role="model", parts=parts))
+            continue
+
+        if role == "tool":
+            tool_call_id = msg.get("tool_call_id", "")
+            raw = msg.get("content", "")
+            try:
+                response_dict = (
+                    json.loads(raw) if isinstance(raw, str) else dict(raw)
+                )
+                if not isinstance(response_dict, dict):
+                    response_dict = {"result": response_dict}
+            except (json.JSONDecodeError, TypeError):
+                response_dict = {"result": raw}
+            contents.append(
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part(
+                            function_response=types.FunctionResponse(
+                                name=msg.get("name", "") or tool_call_id,
+                                response=response_dict,
+                                id=tool_call_id or None,
+                            )
+                        )
+                    ],
+                )
+            )
+            continue
+
+    return "\n\n".join(system_parts), contents

--- a/sdk/patter/providers/groq_llm.py
+++ b/sdk/patter/providers/groq_llm.py
@@ -1,0 +1,81 @@
+"""Groq LLM provider for Patter's pipeline mode.
+
+Groq's Chat Completions API is OpenAI-compatible, so this provider is a
+thin wrapper around :class:`patter.services.llm_loop.OpenAILLMProvider`
+that points at ``https://api.groq.com/openai/v1``.
+
+Portions adapted from LiveKit Agents
+(https://github.com/livekit/agents, commit 78a66bcf79c5cea82989401c408f1dff4b961a5b,
+file livekit-plugins/livekit-plugins-groq/livekit/plugins/groq/services.py),
+licensed under Apache License 2.0. Copyright LiveKit, Inc.
+
+Adaptations from the LiveKit source:
+  * LiveKit's ``groq.LLM`` subclasses the LiveKit OpenAI LLM (which
+    depends on the ``livekit.agents`` runtime). Patter's analogue
+    subclasses :class:`OpenAILLMProvider`, which talks to the Chat
+    Completions API directly via the official ``openai`` SDK.
+  * Kept Groq-specific defaults (``llama-3.3-70b-versatile`` model,
+    ``GROQ_API_KEY`` env var, Groq base URL).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import AsyncIterator
+
+from patter.services.llm_loop import OpenAILLMProvider
+
+__all__ = ["GroqLLMProvider"]
+
+
+_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+_DEFAULT_MODEL = "llama-3.3-70b-versatile"
+
+
+class GroqLLMProvider(OpenAILLMProvider):
+    """LLM provider backed by Groq's OpenAI-compatible Chat Completions API.
+
+    Streams in the same ``{"type": "text" | "tool_call" | "done"}`` chunk
+    format as :class:`OpenAILLMProvider`.
+
+    Args:
+        api_key: Groq API key. If omitted, ``GROQ_API_KEY`` is read from
+            the environment.
+        model: Groq chat model ID. Defaults to ``llama-3.3-70b-versatile``.
+        base_url: Optional Groq base URL override.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = _DEFAULT_MODEL,
+        base_url: str = _GROQ_BASE_URL,
+    ) -> None:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'openai' package is required for GroqLLMProvider. "
+                "Install it with: pip install 'getpatter[groq]'"
+            ) from e
+
+        resolved_key = api_key or os.environ.get("GROQ_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Groq API key is required, either as the 'api_key' argument "
+                "or via the GROQ_API_KEY environment variable."
+            )
+
+        # We don't call super().__init__() because it instantiates a
+        # vanilla OpenAI client pointed at api.openai.com. We bind the
+        # same underlying attributes with Groq's base URL.
+        self._client = AsyncOpenAI(api_key=resolved_key, base_url=base_url)
+        self._model = model
+
+    async def stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[dict]:
+        async for chunk in super().stream(messages, tools):
+            yield chunk

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -89,6 +89,30 @@ ivr = [
     "scikit-learn>=1.3",
     "numpy>=1.26",
 ]
+# Telnyx STT and TTS WebSocket providers. Note: the `telnyx` telephony
+# package (Call Control REST API) is unrelated and does not require this
+# extra — only the in-call STT/TTS providers do.
+telnyx-ai = [
+    "aiohttp>=3.10",
+]
+# Anthropic Claude LLM provider (pipeline mode).
+anthropic = [
+    "anthropic>=0.41",
+    "httpx>=0.27",
+]
+# Groq LLM provider (OpenAI-compatible).
+groq = [
+    "openai>=1.0",
+]
+# Cerebras LLM provider (OpenAI-compatible with optional msgpack/gzip payload compression).
+cerebras = [
+    "openai>=1.0",
+    "msgpack>=1.0",
+]
+# Google Gemini LLM provider.
+google = [
+    "google-genai>=1.55",
+]
 # Background audio player (hold music + ambient cues). Ports LiveKit Agents'
 # BackgroundAudioPlayer and mixes bundled .ogg clips with the outbound PCM
 # stream. Requires numpy for PCM math and soundfile for .ogg decoding.

--- a/sdk/tests/test_llm_providers_vendor.py
+++ b/sdk/tests/test_llm_providers_vendor.py
@@ -1,0 +1,626 @@
+"""Tests for the Anthropic / Groq / Cerebras / Google LLM providers.
+
+All tests in this module are MOCK unit tests: the vendor SDK clients
+(``anthropic.AsyncAnthropic``, ``openai.AsyncOpenAI``,
+``google.genai.Client``) are replaced with fakes that yield synthetic
+event streams with the same shape the real APIs return.  This lets us
+verify that each Patter provider correctly translates vendor-specific
+events into Patter's ``{"type": "text" | "tool_call" | "done"}`` chunk
+protocol without making network calls.
+
+Integration tests that hit real APIs should live in
+``tests/integration/`` and skip when the matching env var is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect(async_iter):
+    out = []
+    async for item in async_iter:
+        out.append(item)
+    return out
+
+
+def _install_fake_module(name: str, module: types.ModuleType) -> None:
+    """Install a module into ``sys.modules`` for vendor-SDK stubbing."""
+    sys.modules[name] = module
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class _FakeAnthropicStreamContext:
+    """Async context manager that yields pre-defined stream events.
+
+    Matches the shape of ``anthropic.AsyncAnthropic.messages.stream()``.
+    """
+
+    def __init__(self, events: list):
+        self._events = events
+
+    async def __aenter__(self):
+        events = self._events
+
+        class _Iter:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not events:
+                    raise StopAsyncIteration
+                return events.pop(0)
+
+        return _Iter()
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _FakeAnthropicMessages:
+    def __init__(self, events: list):
+        self._events = events
+
+    def stream(self, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeAnthropicStreamContext(list(self._events))
+
+
+class _FakeAnthropicClient:
+    def __init__(self, *args, **kwargs):
+        self.messages = _FakeAnthropicMessages(_FakeAnthropicClient.events)
+
+
+@pytest.fixture
+def patch_anthropic(monkeypatch):
+    """Install a fake ``anthropic`` module so ``import anthropic`` works."""
+    fake = types.ModuleType("anthropic")
+
+    def _factory(events):
+        _FakeAnthropicClient.events = events
+        return _FakeAnthropicClient
+
+    fake.AsyncAnthropic = _FakeAnthropicClient  # type: ignore[attr-defined]
+    _install_fake_module("anthropic", fake)
+
+    # Also drop the cached import of our provider module so it picks up
+    # the fake module on next import.
+    sys.modules.pop("patter.providers.anthropic_llm", None)
+
+    yield _factory
+
+    sys.modules.pop("anthropic", None)
+    sys.modules.pop("patter.providers.anthropic_llm", None)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_text_stream(patch_anthropic):
+    """AnthropicLLMProvider emits text chunks and a final done chunk.
+
+    MOCK: the anthropic SDK is stubbed to yield a realistic sequence of
+    ``message_start`` / ``content_block_start`` / ``content_block_delta``
+    (``text_delta``) / ``content_block_stop`` / ``message_stop`` events.
+    """
+    events = [
+        SimpleNamespace(type="message_start"),
+        SimpleNamespace(
+            type="content_block_start",
+            content_block=SimpleNamespace(type="text"),
+        ),
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="text_delta", text="Hello "),
+        ),
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="text_delta", text="world!"),
+        ),
+        SimpleNamespace(type="content_block_stop"),
+        SimpleNamespace(type="message_stop"),
+    ]
+    patch_anthropic(events)
+
+    from patter.providers.anthropic_llm import AnthropicLLMProvider
+
+    provider = AnthropicLLMProvider(api_key="sk-test", model="claude-3-5-sonnet-20241022")
+    chunks = await _collect(
+        provider.stream(
+            [
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+    )
+
+    assert chunks == [
+        {"type": "text", "content": "Hello "},
+        {"type": "text", "content": "world!"},
+        {"type": "done"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_call_stream(patch_anthropic):
+    """AnthropicLLMProvider emits tool_call chunks for ``tool_use`` blocks.
+
+    MOCK: the anthropic SDK is stubbed to yield a ``tool_use``
+    ``content_block_start`` followed by streamed ``input_json_delta``
+    events, matching the real Anthropic streaming format.
+    """
+    events = [
+        SimpleNamespace(type="message_start"),
+        SimpleNamespace(
+            type="content_block_start",
+            content_block=SimpleNamespace(
+                type="tool_use", id="toolu_01", name="get_weather"
+            ),
+        ),
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="input_json_delta", partial_json='{"city":'),
+        ),
+        SimpleNamespace(
+            type="content_block_delta",
+            delta=SimpleNamespace(type="input_json_delta", partial_json='"Paris"}'),
+        ),
+        SimpleNamespace(type="content_block_stop"),
+        SimpleNamespace(type="message_stop"),
+    ]
+    patch_anthropic(events)
+
+    from patter.providers.anthropic_llm import AnthropicLLMProvider
+
+    provider = AnthropicLLMProvider(api_key="sk-test")
+    chunks = await _collect(
+        provider.stream(
+            [
+                {"role": "system", "content": "You call tools."},
+                {"role": "user", "content": "Weather in Paris?"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+    )
+
+    # Expected: initial tool_call with empty args, then two argument
+    # delta chunks, then done.
+    assert chunks[0] == {
+        "type": "tool_call",
+        "index": 0,
+        "id": "toolu_01",
+        "name": "get_weather",
+        "arguments": "",
+    }
+    assert chunks[1] == {
+        "type": "tool_call",
+        "index": 0,
+        "id": "toolu_01",
+        "name": None,
+        "arguments": '{"city":',
+    }
+    assert chunks[2] == {
+        "type": "tool_call",
+        "index": 0,
+        "id": "toolu_01",
+        "name": None,
+        "arguments": '"Paris"}',
+    }
+    assert chunks[-1] == {"type": "done"}
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible providers (Groq + Cerebras) share a streaming path
+# via OpenAILLMProvider, so we build one fake AsyncOpenAI client.
+# ---------------------------------------------------------------------------
+
+
+class _FakeChoicesDelta:
+    def __init__(self, content=None, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _FakeChoice:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class _FakeChatChunk:
+    def __init__(self, choices):
+        self.choices = choices
+
+
+class _FakeAsyncStream:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+class _FakeCompletions:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return _FakeAsyncStream(self._chunks)
+
+
+class _FakeChat:
+    def __init__(self, chunks):
+        self.completions = _FakeCompletions(chunks)
+
+
+class _FakeAsyncOpenAI:
+    last_kwargs = None
+    instances: list = []
+
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+        self.chat = _FakeChat(_FakeAsyncOpenAI.chunks)
+        _FakeAsyncOpenAI.instances.append(self)
+
+
+@pytest.fixture
+def patch_openai(monkeypatch):
+    """Install a fake ``openai`` module."""
+    fake = types.ModuleType("openai")
+    fake.AsyncOpenAI = _FakeAsyncOpenAI  # type: ignore[attr-defined]
+
+    # Cerebras imports submodules from openai; stub them too.
+    models_mod = types.ModuleType("openai._models")
+    class FinalRequestOptions:  # noqa: D401
+        pass
+    models_mod.FinalRequestOptions = FinalRequestOptions  # type: ignore[attr-defined]
+
+    utils_mod = types.ModuleType("openai._utils")
+    utils_mod.is_mapping = lambda x: isinstance(x, dict)  # type: ignore[attr-defined]
+
+    _install_fake_module("openai", fake)
+    _install_fake_module("openai._models", models_mod)
+    _install_fake_module("openai._utils", utils_mod)
+
+    sys.modules.pop("patter.providers.groq_llm", None)
+    sys.modules.pop("patter.providers.cerebras_llm", None)
+
+    def _setup(chunks):
+        _FakeAsyncOpenAI.chunks = chunks
+        _FakeAsyncOpenAI.instances = []
+        return _FakeAsyncOpenAI
+
+    yield _setup
+
+    sys.modules.pop("openai", None)
+    sys.modules.pop("openai._models", None)
+    sys.modules.pop("openai._utils", None)
+    sys.modules.pop("patter.providers.groq_llm", None)
+    sys.modules.pop("patter.providers.cerebras_llm", None)
+
+
+@pytest.mark.asyncio
+async def test_groq_text_stream(patch_openai):
+    """GroqLLMProvider forwards OpenAI-style chunks unchanged.
+
+    MOCK: ``openai.AsyncOpenAI`` is stubbed with a chat.completions.create
+    that returns a synthetic stream of chunks shaped like Groq's (and
+    OpenAI's) Chat Completions streaming format.
+    """
+    chunks = [
+        _FakeChatChunk(
+            [_FakeChoice(_FakeChoicesDelta(content="Hi "))]
+        ),
+        _FakeChatChunk(
+            [_FakeChoice(_FakeChoicesDelta(content="there!"))]
+        ),
+    ]
+    patch_openai(chunks)
+
+    from patter.providers.groq_llm import GroqLLMProvider
+
+    provider = GroqLLMProvider(api_key="gsk-test", model="llama-3.3-70b-versatile")
+    out = await _collect(
+        provider.stream(
+            [
+                {"role": "system", "content": "x"},
+                {"role": "user", "content": "hi"},
+            ]
+        )
+    )
+    assert out == [
+        {"type": "text", "content": "Hi "},
+        {"type": "text", "content": "there!"},
+    ]
+
+    # Client was built with Groq base URL
+    assert _FakeAsyncOpenAI.instances[0].init_kwargs["base_url"] == (
+        "https://api.groq.com/openai/v1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_groq_requires_api_key(patch_openai, monkeypatch):
+    """Groq raises ValueError when no key is provided and env var is unset."""
+    patch_openai([])
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    from patter.providers.groq_llm import GroqLLMProvider
+
+    with pytest.raises(ValueError, match="Groq API key"):
+        GroqLLMProvider()
+
+
+@pytest.mark.asyncio
+async def test_cerebras_falls_back_without_compression(patch_openai):
+    """CerebrasLLMProvider uses the stock AsyncOpenAI when compression off.
+
+    MOCK: reuses the same OpenAI fake as Groq — Cerebras is
+    OpenAI-compatible.
+    """
+    chunks = [
+        _FakeChatChunk(
+            [_FakeChoice(_FakeChoicesDelta(content="Cerebras fast."))]
+        ),
+    ]
+    patch_openai(chunks)
+
+    from patter.providers.cerebras_llm import CerebrasLLMProvider
+
+    provider = CerebrasLLMProvider(
+        api_key="cb-test",
+        model="llama3.1-8b",
+        gzip_compression=False,
+        msgpack_encoding=False,
+    )
+    out = await _collect(
+        provider.stream([{"role": "user", "content": "hi"}])
+    )
+    assert out == [{"type": "text", "content": "Cerebras fast."}]
+    assert _FakeAsyncOpenAI.instances[0].init_kwargs["base_url"] == (
+        "https://api.cerebras.ai/v1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google Gemini
+# ---------------------------------------------------------------------------
+
+
+class _FakePart:
+    def __init__(self, text=None, function_call=None):
+        self.text = text
+        self.function_call = function_call
+
+
+class _FakeContent:
+    def __init__(self, parts):
+        self.parts = parts
+
+
+class _FakeCandidate:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeGenResponse:
+    def __init__(self, candidates):
+        self.candidates = candidates
+
+
+class _FakeFunctionCall:
+    def __init__(self, name, args, id=None):
+        self.name = name
+        self.args = args
+        self.id = id
+
+
+class _FakeModels:
+    def __init__(self, responses):
+        self._responses = responses
+        self.last_call: dict | None = None
+
+    async def generate_content_stream(self, *, model, contents, config=None):
+        self.last_call = {"model": model, "contents": contents, "config": config}
+
+        async def _gen():
+            for r in self._responses:
+                yield r
+
+        return _gen()
+
+
+class _FakeAio:
+    def __init__(self, responses):
+        self.models = _FakeModels(responses)
+
+
+class _FakeGeminiClient:
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+        self.aio = _FakeAio(_FakeGeminiClient.responses)
+
+
+@pytest.fixture
+def patch_google(monkeypatch):
+    """Install fake google.genai modules."""
+    genai_mod = types.ModuleType("google.genai")
+    genai_mod.Client = _FakeGeminiClient  # type: ignore[attr-defined]
+
+    types_mod = types.ModuleType("google.genai.types")
+
+    class _StubDataclass:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class Part(_StubDataclass):
+        pass
+
+    class Content(_StubDataclass):
+        pass
+
+    class Tool(_StubDataclass):
+        pass
+
+    class FunctionDeclaration(_StubDataclass):
+        pass
+
+    class FunctionCall(_StubDataclass):
+        pass
+
+    class FunctionResponse(_StubDataclass):
+        pass
+
+    class GenerateContentConfig(_StubDataclass):
+        pass
+
+    types_mod.Part = Part  # type: ignore[attr-defined]
+    types_mod.Content = Content  # type: ignore[attr-defined]
+    types_mod.Tool = Tool  # type: ignore[attr-defined]
+    types_mod.FunctionDeclaration = FunctionDeclaration  # type: ignore[attr-defined]
+    types_mod.FunctionCall = FunctionCall  # type: ignore[attr-defined]
+    types_mod.FunctionResponse = FunctionResponse  # type: ignore[attr-defined]
+    types_mod.GenerateContentConfig = GenerateContentConfig  # type: ignore[attr-defined]
+
+    google_mod = types.ModuleType("google")
+    google_mod.genai = genai_mod  # type: ignore[attr-defined]
+
+    _install_fake_module("google", google_mod)
+    _install_fake_module("google.genai", genai_mod)
+    _install_fake_module("google.genai.types", types_mod)
+
+    sys.modules.pop("patter.providers.google_llm", None)
+
+    def _setup(responses):
+        _FakeGeminiClient.responses = responses
+        return _FakeGeminiClient
+
+    yield _setup
+
+    for name in (
+        "google",
+        "google.genai",
+        "google.genai.types",
+        "patter.providers.google_llm",
+    ):
+        sys.modules.pop(name, None)
+
+
+@pytest.mark.asyncio
+async def test_google_text_stream(patch_google):
+    """GoogleLLMProvider emits text chunks + done.
+
+    MOCK: ``google.genai.Client`` is stubbed with a fake
+    ``generate_content_stream`` that yields shaped responses mirroring
+    the real Gemini streaming format.
+    """
+    responses = [
+        _FakeGenResponse([_FakeCandidate(_FakeContent([_FakePart(text="Hello ")]))]),
+        _FakeGenResponse([_FakeCandidate(_FakeContent([_FakePart(text="Gemini!")]))]),
+    ]
+    patch_google(responses)
+
+    from patter.providers.google_llm import GoogleLLMProvider
+
+    provider = GoogleLLMProvider(api_key="AIza-test", model="gemini-2.5-flash")
+    chunks = await _collect(
+        provider.stream(
+            [
+                {"role": "system", "content": "Be kind."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+    )
+    assert chunks == [
+        {"type": "text", "content": "Hello "},
+        {"type": "text", "content": "Gemini!"},
+        {"type": "done"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_google_tool_call_stream(patch_google):
+    """GoogleLLMProvider emits tool_call chunks for function_call parts.
+
+    MOCK: Gemini returns a ``function_call`` part; the provider should
+    translate it into a ``tool_call`` chunk with JSON-encoded arguments.
+    """
+    fn_call = _FakeFunctionCall(name="get_weather", args={"city": "Paris"}, id="gc1")
+    responses = [
+        _FakeGenResponse([_FakeCandidate(_FakeContent([_FakePart(function_call=fn_call)]))]),
+    ]
+    patch_google(responses)
+
+    from patter.providers.google_llm import GoogleLLMProvider
+
+    provider = GoogleLLMProvider(api_key="AIza-test")
+    chunks = await _collect(
+        provider.stream(
+            [
+                {"role": "user", "content": "weather?"},
+            ],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+    )
+
+    assert chunks[0]["type"] == "tool_call"
+    assert chunks[0]["name"] == "get_weather"
+    assert chunks[0]["id"] == "gc1"
+    assert json.loads(chunks[0]["arguments"]) == {"city": "Paris"}
+    assert chunks[-1] == {"type": "done"}
+
+
+@pytest.mark.asyncio
+async def test_google_requires_api_key(patch_google, monkeypatch):
+    """Google raises ValueError when no key is provided and env is unset."""
+    patch_google([])
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+
+    from patter.providers.google_llm import GoogleLLMProvider
+
+    with pytest.raises(ValueError, match="Google API key"):
+        GoogleLLMProvider(vertexai=False)


### PR DESCRIPTION
## Summary

Stream G2 of the LiveKit Agents port. Adds four new LLM providers for Patter's pipeline mode, each implementing the `LLMProvider` protocol (`async stream(messages, tools) -> AsyncIterator<{type, ...}>`):

- **AnthropicLLMProvider** — Claude via Anthropic Messages API with streaming, tool use, and system prompts. Python uses the `anthropic` SDK; TS uses native `fetch` + SSE parsing to keep deps lean.
- **GroqLLMProvider** — OpenAI-compatible wrapper targeting `api.groq.com/openai/v1` with `llama-3.3-70b-versatile` default.
- **CerebrasLLMProvider** — OpenAI-compatible wrapper targeting `api.cerebras.ai/v1`, with msgpack+gzip payload optimisation (Python) or gzip-only (TS) for reduced TTFT on large prompts.
- **GoogleLLMProvider** — Gemini via `google-genai` SDK (Python) or the REST SSE endpoint (TS). Python supports both Developer API and Vertex AI; TS supports Developer API.

All four providers translate OpenAI-style `messages`/`tools` inputs into each vendor's native shape, and normalise the vendor event stream back into Patter's `{ type: 'text' | 'tool_call' | 'done' }` chunk protocol so they drop into `LLMLoop` unchanged.

**LiveKit source commit**: `78a66bcf79c5cea82989401c408f1dff4b961a5b`. Each ported file carries an attribution header with the upstream path, commit SHA, and a bullet list of adaptations (Apache 2.0 licensed).

**New optional extras** in `sdk/pyproject.toml`:
```toml
anthropic = ["anthropic>=0.41", "httpx>=0.27"]
groq      = ["openai>=1.0"]
cerebras  = ["openai>=1.0", "msgpack>=1.0"]
google    = ["google-genai>=1.55"]
```

Base branch: `develop`. This PR is a sibling of #39 (Wave 1 core protocols); it can merge after Wave 1.

## Test plan

- [x] Python: `cd sdk && pytest tests/test_llm_providers_vendor.py` — 8 passed
- [x] Python: full suite — 1241 passed (pre-existing `krisp_filter` failure is unrelated to this stream)
- [x] TypeScript: `cd sdk-ts && npx vitest run tests/llm-providers-vendor.test.ts` — 10 passed
- [x] TypeScript: full suite — 895 passed
- [x] TypeScript: `npx tsc --noEmit` — clean for new files (pre-existing `deepfilternet-filter.ts` warning is unrelated)
- [ ] Optional: integration tests against real vendor APIs (require `ANTHROPIC_API_KEY` / `GROQ_API_KEY` / `CEREBRAS_API_KEY` / `GOOGLE_API_KEY`) — not included in this PR; can follow up under `tests/integration/`