### PR TITLE
feat(noise-cancel): port Krisp + DeepFilterNet OSS fallback from LiveKit

### DIFF
--- a/sdk-ts/src/providers/deepfilternet-filter.ts
+++ b/sdk-ts/src/providers/deepfilternet-filter.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 PatterAI
+ *
+ * Licensed under the MIT License.  See LICENSE at the repository root.
+ *
+ * DeepFilterNet open-source AudioFilter for the Patter TypeScript SDK.
+ *
+ * NOTE: DeepFilterNet does not ship an official ONNX export for Node.js at
+ * time of writing.  This wrapper targets ``onnxruntime-node`` so it can load
+ * a user-supplied ``deepfilternet.onnx`` file when one is available.  When
+ * no ONNX model is provided, the filter falls back to a pass-through with a
+ * one-time warning — we deliberately do not fake enhancement, so tests or
+ * runtime audio quality metrics remain truthful.
+ *
+ * TODO: when DeepFilterNet3 has a stable community ONNX export, ship a
+ * default loader that downloads the model on first use.
+ */
+import { getLogger } from '../logger';
+import type { AudioFilter } from '../types';
+
+// Resolve the logger lazily so tests that swap it via ``setLogger`` after
+// import still capture our warnings/errors.
+function log() {
+  return getLogger();
+}
+
+// DeepFilterNet3 operates at 48 kHz natively.
+const DEEPFILTERNET_SR = 48000;
+
+/** Options accepted by {@link DeepFilterNetFilter}. */
+export interface DeepFilterNetOptions {
+  /** Absolute path to a DeepFilterNet ONNX model.  If omitted, the filter
+   *  logs a warning and becomes a pass-through. */
+  modelPath?: string;
+  /** When true, disable the pass-through warning (used by tests). */
+  silenceWarnings?: boolean;
+}
+
+// ``onnxruntime-node`` is declared as a peer/optional dependency; the module
+// is typed loosely to avoid a hard dependency in the default SDK install.
+type OnnxSession = {
+  readonly inputNames: readonly string[];
+  readonly outputNames: readonly string[];
+  run(feeds: Record<string, unknown>): Promise<Record<string, unknown>>;
+  release?(): Promise<void> | void;
+};
+
+type OnnxRuntimeModule = {
+  InferenceSession: {
+    create(path: string): Promise<OnnxSession>;
+  };
+  Tensor: new (type: string, data: Float32Array, dims: readonly number[]) => unknown;
+};
+
+async function loadOnnxRuntime(): Promise<OnnxRuntimeModule | null> {
+  // ``onnxruntime-node`` is an optional peer dependency; loaded via a
+  // dynamic expression so TypeScript does not require it at build time.
+  try {
+    const moduleName = 'onnxruntime-node';
+    const dynamicImport = new Function('m', 'return import(m)') as (m: string) => Promise<unknown>;
+    const mod = await dynamicImport(moduleName);
+    return mod as OnnxRuntimeModule;
+  } catch {
+    return null;
+  }
+}
+
+/** Linear-interpolation resampler (mono, Float32).  Good enough for the
+ *  narrow-band / wide-band conversions DeepFilterNet needs around telephony
+ *  audio. */
+function resample(samples: Float32Array, srcSr: number, dstSr: number): Float32Array {
+  if (srcSr === dstSr || samples.length === 0) {
+    return samples;
+  }
+  const dstLen = Math.max(1, Math.round((samples.length * dstSr) / srcSr));
+  const out = new Float32Array(dstLen);
+  const ratio = (samples.length - 1) / Math.max(1, dstLen - 1);
+  for (let i = 0; i < dstLen; i += 1) {
+    const srcIdx = i * ratio;
+    const lo = Math.floor(srcIdx);
+    const hi = Math.min(samples.length - 1, lo + 1);
+    const frac = srcIdx - lo;
+    out[i] = samples[lo] * (1 - frac) + samples[hi] * frac;
+  }
+  return out;
+}
+
+function pcm16ToFloat32(pcm: Buffer): Float32Array {
+  const view = new Int16Array(pcm.buffer, pcm.byteOffset, Math.floor(pcm.byteLength / 2));
+  const out = new Float32Array(view.length);
+  for (let i = 0; i < view.length; i += 1) {
+    out[i] = view[i] / 32768;
+  }
+  return out;
+}
+
+function float32ToPcm16(samples: Float32Array): Buffer {
+  const out = Buffer.alloc(samples.length * 2);
+  for (let i = 0; i < samples.length; i += 1) {
+    const clamped = Math.max(-1, Math.min(1, samples[i]));
+    out.writeInt16LE(Math.round(clamped * 32767), i * 2);
+  }
+  return out;
+}
+
+/** OSS noise-suppression filter backed by a DeepFilterNet ONNX model. */
+export class DeepFilterNetFilter implements AudioFilter {
+  private readonly modelPath: string | undefined;
+  private readonly silenceWarnings: boolean;
+  private session: OnnxSession | null = null;
+  private ort: OnnxRuntimeModule | null = null;
+  private warned = false;
+  private closed = false;
+
+  constructor(options: DeepFilterNetOptions = {}) {
+    this.modelPath = options.modelPath;
+    this.silenceWarnings = options.silenceWarnings === true;
+  }
+
+  private async ensureSession(): Promise<OnnxSession | null> {
+    if (this.session !== null) {
+      return this.session;
+    }
+    if (!this.modelPath) {
+      if (!this.warned && !this.silenceWarnings) {
+        log().warn(
+          'DeepFilterNetFilter: no modelPath provided; audio will pass ' +
+            'through unmodified. Provide a DeepFilterNet ONNX model to enable ' +
+            'noise suppression.',
+        );
+        this.warned = true;
+      }
+      return null;
+    }
+    if (this.ort === null) {
+      this.ort = await loadOnnxRuntime();
+    }
+    if (this.ort === null) {
+      if (!this.warned && !this.silenceWarnings) {
+        log().warn(
+          'DeepFilterNetFilter: onnxruntime-node is not installed; audio ' +
+            'will pass through unmodified. Run `npm install onnxruntime-node` ' +
+            'to enable noise suppression.',
+        );
+        this.warned = true;
+      }
+      return null;
+    }
+    try {
+      this.session = await this.ort.InferenceSession.create(this.modelPath);
+      return this.session;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      log().error(`DeepFilterNetFilter: failed to load model: ${message}`);
+      this.warned = true;
+      return null;
+    }
+  }
+
+  async process(pcmChunk: Buffer, sampleRate: number): Promise<Buffer> {
+    if (this.closed) {
+      throw new Error('DeepFilterNetFilter is closed');
+    }
+    if (pcmChunk.length === 0) {
+      return pcmChunk;
+    }
+    const session = await this.ensureSession();
+    if (session === null || this.ort === null) {
+      // No model/runtime available — pass-through. Never fabricate enhanced
+      // audio; tests rely on this being detectably a no-op.
+      return pcmChunk;
+    }
+
+    try {
+      const samples = pcm16ToFloat32(pcmChunk);
+      const upsampled = resample(samples, sampleRate, DEEPFILTERNET_SR);
+      const inputName = session.inputNames[0];
+      const outputName = session.outputNames[0];
+      const tensor = new this.ort.Tensor('float32', upsampled, [1, upsampled.length]);
+      const feeds: Record<string, unknown> = { [inputName]: tensor };
+      const results = await session.run(feeds);
+      const output = results[outputName] as { data?: Float32Array } | undefined;
+      if (!output || !output.data) {
+        return pcmChunk;
+      }
+      const enhanced = output.data instanceof Float32Array ? output.data : new Float32Array(output.data);
+      const restored = resample(enhanced, DEEPFILTERNET_SR, sampleRate);
+      return float32ToPcm16(restored);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      log().error(`DeepFilterNetFilter.process failed: ${message}`);
+      return pcmChunk;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.session !== null && typeof this.session.release === 'function') {
+      try {
+        await this.session.release();
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        log().warn(`DeepFilterNetFilter.close: release failed: ${message}`);
+      }
+    }
+    this.session = null;
+    this.closed = true;
+  }
+}

--- a/sdk-ts/tests/unit/deepfilternet-filter.test.ts
+++ b/sdk-ts/tests/unit/deepfilternet-filter.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Unit tests for the DeepFilterNet OSS AudioFilter (TypeScript port).
+ *
+ * MOCK: no real inference. These tests verify that without a model path (or
+ * without onnxruntime-node installed) the filter deliberately passes audio
+ * through unchanged rather than fabricating enhanced output. Real-model
+ * behaviour is out of scope for CI and must be validated manually.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DeepFilterNetFilter } from '../../src/providers/deepfilternet-filter';
+
+function pcm16Buffer(samples: number, fill: number = 0): Buffer {
+  const buf = Buffer.alloc(samples * 2);
+  for (let i = 0; i < samples; i += 1) {
+    buf.writeInt16LE(fill, i * 2);
+  }
+  return buf;
+}
+
+describe('DeepFilterNetFilter (TS)', () => {
+  it('passes audio through unchanged when no modelPath is provided', async () => {
+    const filter = new DeepFilterNetFilter({ silenceWarnings: true });
+    const input = pcm16Buffer(160, 1234);
+    const output = await filter.process(input, 16000);
+    expect(output.equals(input)).toBe(true);
+    await filter.close();
+  });
+
+  it('returns empty buffer for empty input', async () => {
+    const filter = new DeepFilterNetFilter({ silenceWarnings: true });
+    const output = await filter.process(Buffer.alloc(0), 16000);
+    expect(output.length).toBe(0);
+    await filter.close();
+  });
+
+  it('rejects process() after close()', async () => {
+    const filter = new DeepFilterNetFilter({ silenceWarnings: true });
+    await filter.close();
+    await expect(filter.process(pcm16Buffer(16, 0), 16000)).rejects.toThrow(/closed/);
+  });
+
+  it('warns exactly once when model is missing', async () => {
+    const warn = vi.fn();
+    const { setLogger } = await import('../../src/logger');
+    setLogger({
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      warn,
+    });
+    const filter = new DeepFilterNetFilter();
+    await filter.process(pcm16Buffer(16, 0), 16000);
+    await filter.process(pcm16Buffer(16, 0), 16000);
+    expect(warn).toHaveBeenCalledTimes(1);
+    await filter.close();
+  });
+});

--- a/sdk/patter/providers/deepfilternet_filter.py
+++ b/sdk/patter/providers/deepfilternet_filter.py
@@ -1,0 +1,184 @@
+# Copyright 2025 PatterAI
+#
+# Licensed under the MIT License.  See the repository root ``LICENSE`` file for
+# the full license text.
+
+"""DeepFilterNet open-source :class:`AudioFilter` implementation.
+
+Wraps the ``deep-filter`` (MIT) PyPI package, which exposes the pre-trained
+DeepFilterNet3 deep-learning noise suppressor.  DeepFilterNet works natively at
+48 kHz; PCM at common telephony rates (8 kHz/16 kHz) is up-sampled for
+inference and down-sampled back before being returned, so callers see a filter
+that preserves the input sample rate.
+
+The heavy imports (``deepfilternet``, ``torch``, ``numpy``) are deferred until
+the filter is actually instantiated so merely importing this module has no
+cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from patter.providers.base import AudioFilter
+
+logger = logging.getLogger(__name__)
+
+# DeepFilterNet operates at 48 kHz.  Any other rate is resampled around
+# inference.
+_DEEPFILTERNET_SR: int = 48000
+
+_INSTALL_MESSAGE = (
+    "DeepFilterNet not installed: pip install 'getpatter[deepfilternet]' "
+    "(requires torch and the deep-filter package)"
+)
+
+
+class DeepFilterNetFilter(AudioFilter):
+    """OSS noise-suppression filter powered by DeepFilterNet3.
+
+    Parameters
+    ----------
+    model_base_dir:
+        Optional path passed to :func:`df.enhance.init_df`.  When ``None`` the
+        bundled default DeepFilterNet3 model is downloaded / loaded from the
+        package's cache directory on first use.
+    atten_lim_db:
+        Optional attenuation limit in dB forwarded to ``df.enhance.enhance``.
+        When ``None`` the model default is used.
+    """
+
+    def __init__(
+        self,
+        model_base_dir: str | None = None,
+        atten_lim_db: float | None = None,
+    ) -> None:
+        try:
+            import numpy as np  # noqa: F401 - imported here to fail fast
+            import torch  # noqa: F401
+            from df.enhance import enhance, init_df
+        except ImportError as e:
+            raise RuntimeError(_INSTALL_MESSAGE) from e
+
+        self._model_base_dir = model_base_dir
+        self._atten_lim_db = atten_lim_db
+        self._enhance = enhance
+
+        try:
+            # ``init_df`` returns ``(model, df_state, suffix)`` in
+            # DeepFilterNet >= 0.5.  We only need the first two.
+            result = init_df(model_base_dir) if model_base_dir else init_df()
+        except Exception as e:
+            logger.error("DeepFilterNet init_df failed: %s", e)
+            raise RuntimeError(f"DeepFilterNet init failed: {e}") from e
+
+        if not isinstance(result, tuple) or len(result) < 2:
+            raise RuntimeError(
+                "Unexpected DeepFilterNet init_df() return shape: "
+                f"{type(result).__name__}"
+            )
+
+        self._model: Any = result[0]
+        self._df_state: Any = result[1]
+        self._closed: bool = False
+
+        # DeepFilterNet expects 48 kHz audio; expose the native rate for
+        # callers/tests that want to skip resampling.
+        self._native_sr: int = _DEEPFILTERNET_SR
+        logger.info(
+            "DeepFilterNet filter initialised (native_sr=%s Hz, model_dir=%s)",
+            self._native_sr,
+            model_base_dir,
+        )
+
+    @staticmethod
+    def _pcm16_to_float32(pcm: bytes) -> Any:
+        import numpy as np
+
+        samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
+        # Normalise into [-1, 1] as expected by torch/DeepFilterNet.
+        return samples / 32768.0
+
+    @staticmethod
+    def _float32_to_pcm16(samples: Any) -> bytes:
+        import numpy as np
+
+        clipped = np.clip(samples, -1.0, 1.0)
+        pcm = (clipped * 32767.0).astype(np.int16)
+        return pcm.tobytes()
+
+    @staticmethod
+    def _resample(samples: Any, src_sr: int, dst_sr: int) -> Any:
+        """Linear-interpolation resampler.
+
+        DeepFilterNet inference dominates runtime; a simple numpy resampler is
+        sufficient here and avoids a hard dependency on ``scipy``/``librosa``.
+        """
+        import numpy as np
+
+        if src_sr == dst_sr:
+            return samples
+        src_len = samples.shape[0]
+        if src_len == 0:
+            return samples
+        dst_len = int(round(src_len * dst_sr / src_sr))
+        if dst_len <= 0:
+            return np.zeros(0, dtype=samples.dtype)
+        x_src = np.linspace(0.0, 1.0, num=src_len, endpoint=False)
+        x_dst = np.linspace(0.0, 1.0, num=dst_len, endpoint=False)
+        return np.interp(x_dst, x_src, samples).astype(samples.dtype)
+
+    async def process(self, pcm_chunk: bytes, sample_rate: int) -> bytes:
+        """Run DeepFilterNet enhancement on the given PCM chunk."""
+        if self._closed:
+            raise RuntimeError("DeepFilterNetFilter is closed")
+        if not pcm_chunk:
+            return pcm_chunk
+
+        import numpy as np
+        import torch
+
+        samples = self._pcm16_to_float32(pcm_chunk)
+        if samples.size == 0:
+            return pcm_chunk
+
+        # Up-sample to 48 kHz for inference when required.
+        inference_samples = self._resample(samples, sample_rate, self._native_sr)
+
+        audio_tensor = torch.from_numpy(inference_samples).unsqueeze(0)
+        try:
+            if self._atten_lim_db is not None:
+                enhanced = self._enhance(
+                    self._model,
+                    self._df_state,
+                    audio_tensor,
+                    atten_lim_db=self._atten_lim_db,
+                )
+            else:
+                enhanced = self._enhance(
+                    self._model, self._df_state, audio_tensor
+                )
+        except Exception as e:
+            logger.error("DeepFilterNet enhance failed: %s", e)
+            return pcm_chunk
+
+        if hasattr(enhanced, "detach"):
+            enhanced_np = enhanced.detach().cpu().numpy()
+        else:
+            enhanced_np = np.asarray(enhanced)
+
+        # ``enhance`` returns shape (1, N) or (N,).  Normalise to 1-D.
+        if enhanced_np.ndim == 2:
+            enhanced_np = enhanced_np[0]
+
+        # Down-sample back to the caller's rate.
+        restored = self._resample(enhanced_np, self._native_sr, sample_rate)
+        return self._float32_to_pcm16(restored)
+
+    async def close(self) -> None:
+        """Release model references (GC handles actual teardown)."""
+        self._model = None
+        self._df_state = None
+        self._closed = True
+        logger.debug("DeepFilterNet filter closed")

--- a/sdk/patter/providers/krisp_filter.py
+++ b/sdk/patter/providers/krisp_filter.py
@@ -1,0 +1,265 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Krisp VIVA noise-reduction :class:`AudioFilter` for Patter.
+
+Adapted from LiveKit Agents (Apache 2.0):
+https://github.com/livekit/agents/blob/main/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/viva_filter.py
+
+The original LiveKit implementation subclasses ``rtc.FrameProcessor`` and
+operates on :class:`livekit.rtc.AudioFrame`.  Patter does not depend on
+livekit-rtc, so this port implements :class:`patter.providers.base.AudioFilter`
+directly, exposing an ``async process(pcm_chunk, sample_rate) -> bytes`` API
+that integrates with ``PipelineStreamHandler``.
+
+Requires the proprietary Krisp Audio SDK; see
+:mod:`patter.providers.krisp_instance` for setup instructions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from patter.providers.base import AudioFilter
+from patter.providers.krisp_instance import (
+    KRISP_AUDIO_AVAILABLE,
+    KRISP_FRAME_DURATIONS,
+    KRISP_NOT_INSTALLED_MESSAGE,
+    KrispSDKManager,
+    int_to_krisp_frame_duration,
+    int_to_krisp_sample_rate,
+    krisp_audio,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KrispVivaFilter(AudioFilter):
+    """:class:`AudioFilter` backed by the Krisp VIVA noise-reduction SDK.
+
+    Parameters
+    ----------
+    model_path:
+        Path to the Krisp ``.kef`` model file.  If ``None`` the value of
+        ``KRISP_VIVA_FILTER_MODEL_PATH`` is used.
+    noise_suppression_level:
+        Suppression strength in ``[0, 100]``.  Defaults to ``100``.
+    frame_duration_ms:
+        Frame duration in milliseconds — one of ``10``, ``15``, ``20``, ``30``
+        or ``32``.  Defaults to ``10`` ms.
+    sample_rate:
+        Initial sample rate in Hz.  Defaults to ``16000``.  The internal Krisp
+        session is lazily recreated if the runtime sample rate differs.
+
+    Raises
+    ------
+    RuntimeError
+        If ``krisp-audio`` is not installed.
+    ValueError
+        If ``model_path`` is missing or ``frame_duration_ms`` is unsupported.
+    FileNotFoundError
+        If ``model_path`` does not point to an existing file.
+    """
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        noise_suppression_level: int = 100,
+        frame_duration_ms: int = 10,
+        sample_rate: int | None = None,
+    ) -> None:
+        if not KRISP_AUDIO_AVAILABLE or krisp_audio is None:
+            raise RuntimeError(KRISP_NOT_INSTALLED_MESSAGE)
+
+        self._sdk_acquired: bool = False
+        self._filtering_enabled: bool = True
+        self._session: Any | None = None
+        self._noise_suppression_level: int = noise_suppression_level
+        self._sample_rate: int | None = None
+        self._frame_duration_ms: int = frame_duration_ms
+
+        try:
+            KrispSDKManager.acquire()
+            self._sdk_acquired = True
+        except Exception as e:
+            logger.error("Failed to acquire Krisp SDK: %s", e)
+            raise RuntimeError(f"Failed to acquire Krisp SDK: {e}") from e
+
+        try:
+            self._model_path = model_path or os.getenv(
+                "KRISP_VIVA_FILTER_MODEL_PATH"
+            )
+            if not self._model_path:
+                logger.error(
+                    "Model path is not provided and "
+                    "KRISP_VIVA_FILTER_MODEL_PATH is not set."
+                )
+                raise ValueError(
+                    "Model path for KrispVivaFilter must be provided."
+                )
+
+            if not self._model_path.endswith(".kef"):
+                raise ValueError("Model is expected with .kef extension")
+
+            if not os.path.isfile(self._model_path):
+                raise FileNotFoundError(
+                    f"Model file not found: {self._model_path}"
+                )
+
+            if frame_duration_ms not in KRISP_FRAME_DURATIONS:
+                raise ValueError(
+                    f"Unsupported frame duration: {frame_duration_ms}ms. "
+                    f"Supported durations: "
+                    f"{sorted(KRISP_FRAME_DURATIONS.keys())}"
+                )
+
+            init_sample_rate = sample_rate if sample_rate is not None else 16000
+            self._create_session(init_sample_rate)
+            logger.info(
+                "Krisp filter initialised (model=%s, sr=%s Hz)",
+                self._model_path,
+                init_sample_rate,
+            )
+        except Exception:
+            if self._sdk_acquired:
+                KrispSDKManager.release()
+                self._sdk_acquired = False
+            raise
+
+    def _create_session(self, sample_rate: int) -> None:
+        """Create or recreate a Krisp session for the given sample rate."""
+        if self._session is not None and self._sample_rate == sample_rate:
+            return
+
+        logger.info("Creating Krisp session for sample rate: %sHz", sample_rate)
+
+        assert krisp_audio is not None  # narrowed by constructor check
+
+        model_info = krisp_audio.ModelInfo()
+        model_info.path = self._model_path
+
+        nc_cfg = krisp_audio.NcSessionConfig()
+        nc_cfg.inputSampleRate = int_to_krisp_sample_rate(sample_rate)
+        nc_cfg.inputFrameDuration = int_to_krisp_frame_duration(
+            self._frame_duration_ms
+        )
+        nc_cfg.outputSampleRate = nc_cfg.inputSampleRate
+        nc_cfg.modelInfo = model_info
+
+        try:
+            self._session = krisp_audio.NcInt16.create(nc_cfg)
+            self._sample_rate = sample_rate
+            logger.info("Krisp session created successfully")
+        except Exception as e:
+            logger.error("Failed to create Krisp session: %s", e)
+            raise
+
+    async def process(self, pcm_chunk: bytes, sample_rate: int) -> bytes:
+        """Run the PCM chunk through Krisp and return the filtered bytes.
+
+        When filtering is disabled the input is returned unchanged.  Errors in
+        the underlying SDK are logged and the original PCM is returned to
+        avoid breaking the call audio path.
+        """
+        if not self._filtering_enabled:
+            return pcm_chunk
+
+        try:
+            import numpy as np  # local import keeps numpy optional
+        except ImportError as e:  # pragma: no cover - numpy ships with krisp
+            raise RuntimeError(
+                "numpy is required for KrispVivaFilter: pip install numpy"
+            ) from e
+
+        # Lazy session re-creation if sample rate changed mid-call.
+        if self._session is None or self._sample_rate != sample_rate:
+            self._create_session(sample_rate)
+
+        expected_samples = int(
+            (sample_rate * self._frame_duration_ms) / 1000
+        )
+        audio_samples = np.frombuffer(pcm_chunk, dtype=np.int16)
+        if len(audio_samples) != expected_samples:
+            raise ValueError(
+                f"Frame size mismatch: expected {expected_samples} samples "
+                f"({self._frame_duration_ms}ms @ {sample_rate}Hz), "
+                f"got {len(audio_samples)} samples"
+            )
+
+        try:
+            filtered_samples = self._session.process(
+                audio_samples, self._noise_suppression_level
+            )
+
+            if filtered_samples is None or len(filtered_samples) == 0:
+                logger.warning("Krisp returned empty output, using original audio")
+                return pcm_chunk
+            if len(filtered_samples) != len(audio_samples):
+                logger.warning(
+                    "Krisp output size mismatch: expected %s, got %s, using original",
+                    len(audio_samples),
+                    len(filtered_samples),
+                )
+                return pcm_chunk
+
+            return bytes(filtered_samples.tobytes())
+        except Exception as e:
+            logger.error("Error processing Krisp frame: %s", e)
+            return pcm_chunk
+
+    def enable(self) -> None:
+        """Enable noise filtering."""
+        self._filtering_enabled = True
+
+    def disable(self) -> None:
+        """Disable noise filtering (audio passes through unmodified)."""
+        self._filtering_enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when filtering is active."""
+        return self._filtering_enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self._filtering_enabled = value
+
+    async def close(self) -> None:
+        """Release the Krisp session and decrement the SDK refcount."""
+        if self._session is not None:
+            self._session = None
+        if self._sdk_acquired:
+            try:
+                KrispSDKManager.release()
+            except Exception as e:
+                logger.error("Error releasing Krisp SDK: %s", e)
+            finally:
+                self._sdk_acquired = False
+        logger.debug("Krisp filter closed")
+
+    def __del__(self) -> None:  # pragma: no cover - interpreter shutdown path
+        # Avoid calling C extensions during Python shutdown to prevent GIL
+        # errors.  Callers should invoke ``await close()`` explicitly.
+        if KrispSDKManager is None:
+            return
+        if getattr(self, "_sdk_acquired", False):
+            try:
+                if getattr(self, "_session", None) is not None:
+                    self._session = None
+                KrispSDKManager.release()
+                self._sdk_acquired = False
+            except Exception:
+                pass

--- a/sdk/patter/providers/krisp_instance.py
+++ b/sdk/patter/providers/krisp_instance.py
@@ -1,0 +1,215 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Krisp VIVA SDK singleton manager with reference counting.
+
+Adapted from LiveKit Agents (Apache 2.0):
+https://github.com/livekit/agents/blob/main/livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/krisp_instance.py
+
+This module provides a singleton manager for the Krisp VIVA SDK with reference
+counting, ensuring proper initialization and cleanup when multiple components
+(filters) use the SDK.
+
+The Krisp SDK is a proprietary component that must be installed separately via
+``pip install krisp-audio`` and requires a valid license key provided through
+the ``KRISP_VIVA_SDK_LICENSE_KEY`` environment variable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Lazy/optional import of the proprietary Krisp Audio SDK.  We deliberately do
+# not raise at import time; the error surface is deferred to ``acquire`` so
+# callers can decide whether to fall back to a different filter.
+try:
+    import krisp_audio  # type: ignore[import-not-found]
+
+    KRISP_AUDIO_AVAILABLE = True
+
+    # Mapping of sample rates (Hz) to Krisp SDK SamplingRate enums
+    KRISP_SAMPLE_RATES: dict[int, Any] = {
+        8000: krisp_audio.SamplingRate.Sr8000Hz,
+        16000: krisp_audio.SamplingRate.Sr16000Hz,
+        24000: krisp_audio.SamplingRate.Sr24000Hz,
+        32000: krisp_audio.SamplingRate.Sr32000Hz,
+        44100: krisp_audio.SamplingRate.Sr44100Hz,
+        48000: krisp_audio.SamplingRate.Sr48000Hz,
+    }
+
+    KRISP_FRAME_DURATIONS: dict[int, Any] = {
+        10: krisp_audio.FrameDuration.Fd10ms,
+        15: krisp_audio.FrameDuration.Fd15ms,
+        20: krisp_audio.FrameDuration.Fd20ms,
+        30: krisp_audio.FrameDuration.Fd30ms,
+        32: krisp_audio.FrameDuration.Fd32ms,
+    }
+except ModuleNotFoundError:
+    krisp_audio = None  # type: ignore[assignment]
+    KRISP_AUDIO_AVAILABLE = False
+    KRISP_SAMPLE_RATES = {}
+    KRISP_FRAME_DURATIONS = {}
+
+
+KRISP_NOT_INSTALLED_MESSAGE = (
+    "Krisp SDK not installed: pip install krisp-audio "
+    "and set KRISP_VIVA_SDK_LICENSE_KEY"
+)
+
+
+def int_to_krisp_frame_duration(frame_duration_ms: int) -> Any:
+    """Translate an integer frame duration (ms) into the Krisp enum value."""
+    if frame_duration_ms not in KRISP_FRAME_DURATIONS:
+        supported_durations = ", ".join(
+            str(duration) for duration in sorted(KRISP_FRAME_DURATIONS.keys())
+        )
+        raise ValueError(
+            f"Unsupported frame duration: {frame_duration_ms} ms. "
+            f"Supported durations: {supported_durations} ms"
+        )
+    return KRISP_FRAME_DURATIONS[frame_duration_ms]
+
+
+def int_to_krisp_sample_rate(sample_rate: int) -> Any:
+    """Translate an integer sample rate (Hz) into the Krisp enum value."""
+    if sample_rate not in KRISP_SAMPLE_RATES:
+        supported_rates = ", ".join(
+            str(rate) for rate in sorted(KRISP_SAMPLE_RATES.keys())
+        )
+        raise ValueError(
+            f"Unsupported sample rate: {sample_rate} Hz. "
+            f"Supported rates: {supported_rates} Hz"
+        )
+    return KRISP_SAMPLE_RATES[sample_rate]
+
+
+class KrispSDKManager:
+    """Singleton manager for Krisp VIVA SDK with reference counting.
+
+    This manager ensures the Krisp SDK is initialized only once and properly
+    cleaned up when all components are done using it. It uses reference counting
+    to track active users (filters).
+
+    Thread-safe implementation using a lock for all operations.
+
+    The license key must be provided via the ``KRISP_VIVA_SDK_LICENSE_KEY``
+    environment variable.
+    """
+
+    _initialized: bool = False
+    _lock: Lock = Lock()
+    _reference_count: int = 0
+
+    @staticmethod
+    def _log_callback(log_message: str, log_level: Any) -> None:
+        """Thread-safe callback for Krisp SDK logging."""
+        logger.debug("[Krisp %s] %s", log_level, log_message)
+
+    @staticmethod
+    def licensing_error_callback(error: Any, error_message: str) -> None:
+        """Callback invoked by the Krisp SDK on licensing errors."""
+        logger.error("[Krisp Licensing Error: %s] %s", error, error_message)
+
+    @classmethod
+    def _get_license_key(cls) -> str:
+        """Return the license key from ``KRISP_VIVA_SDK_LICENSE_KEY``."""
+        return os.getenv("KRISP_VIVA_SDK_LICENSE_KEY", "")
+
+    @classmethod
+    def acquire(cls) -> None:
+        """Acquire a reference to the SDK (initializes if needed).
+
+        Call this when creating a filter instance. The SDK will be initialized
+        on the first call.
+
+        Raises:
+            RuntimeError: If the ``krisp-audio`` package is not installed.
+            Exception: If SDK initialization fails (propagated from krisp_audio).
+        """
+        if not KRISP_AUDIO_AVAILABLE or krisp_audio is None:
+            raise RuntimeError(KRISP_NOT_INSTALLED_MESSAGE)
+
+        with cls._lock:
+            # Initialize SDK on first acquire
+            if cls._reference_count == 0:
+                try:
+                    license_key = cls._get_license_key()
+                    krisp_audio.globalInit(
+                        "",
+                        license_key,
+                        cls.licensing_error_callback,
+                        cls._log_callback,
+                        krisp_audio.LogLevel.Off,
+                    )
+                    cls._initialized = True
+
+                    version = krisp_audio.getVersion()
+                    logger.debug(
+                        "Krisp Audio SDK initialized - Version: %s.%s.%s",
+                        version.major,
+                        version.minor,
+                        version.patch,
+                    )
+
+                except Exception as e:
+                    cls._initialized = False
+                    logger.error("Krisp SDK initialization failed: %s", e)
+                    raise
+
+            cls._reference_count += 1
+            logger.debug("Krisp SDK reference count: %s", cls._reference_count)
+
+    @classmethod
+    def release(cls) -> None:
+        """Release a reference to the SDK (destroys if last reference).
+
+        Call this when destroying a filter instance. The SDK will be cleaned up
+        when the last reference is released.
+        """
+        with cls._lock:
+            if cls._reference_count > 0:
+                cls._reference_count -= 1
+                logger.debug(
+                    "Krisp SDK reference count: %s", cls._reference_count
+                )
+
+                # Destroy SDK when last reference is released
+                if cls._reference_count == 0 and cls._initialized:
+                    try:
+                        if krisp_audio is not None:
+                            krisp_audio.globalDestroy()
+                        cls._initialized = False
+                        logger.debug(
+                            "Krisp Audio SDK destroyed (all references released)"
+                        )
+                    except Exception as e:
+                        logger.error("Error during Krisp SDK cleanup: %s", e)
+                        cls._initialized = False
+
+    @classmethod
+    def is_initialized(cls) -> bool:
+        """Return True when the SDK is currently initialized."""
+        with cls._lock:
+            return cls._initialized
+
+    @classmethod
+    def get_reference_count(cls) -> int:
+        """Return the current reference count."""
+        with cls._lock:
+            return cls._reference_count

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -57,6 +57,19 @@ silero = [
     "onnxruntime>=1.18",
     "numpy>=1.26",
 ]
+# Krisp VIVA is a proprietary SDK (krisp-audio). Users must install it
+# separately and provide KRISP_VIVA_SDK_LICENSE_KEY + KRISP_VIVA_FILTER_MODEL_PATH.
+krisp = [
+    "krisp-audio>=2.0",
+    "numpy>=1.26",
+]
+# DeepFilterNet OSS fallback (MIT). Heavy deps (torch ~2 GB, model ~60 MB)
+# are opt-in.
+deepfilternet = [
+    "deep-filter>=0.5",
+    "torch>=2.0",
+    "numpy>=1.26",
+]
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/sdk/tests/unit/test_deepfilternet_filter.py
+++ b/sdk/tests/unit/test_deepfilternet_filter.py
@@ -1,0 +1,197 @@
+"""Unit tests for :mod:`patter.providers.deepfilternet_filter`.
+
+These tests inject fake ``deep-filter`` / ``torch`` / ``numpy`` modules via
+``sys.modules`` so the wrapper can be exercised without downloading the real
+DeepFilterNet weights (~60 MB) or installing the ~2 GB torch runtime.
+
+MOCK: no real inference.  Real RMS-before/after assertions require the
+pre-trained model and are skipped by default.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake deep-filter + torch
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Install fake ``df.enhance`` and ``torch`` modules.
+
+    Returns the underlying MagicMocks so individual tests can assert on calls.
+    """
+    # torch
+    torch_mod = types.ModuleType("torch")
+
+    class _FakeTensor:
+        def __init__(self, data):
+            self._data = np.asarray(data)
+
+        def unsqueeze(self, _dim):  # noqa: D401 - mimics torch API
+            return _FakeTensor(self._data[np.newaxis, :])
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self._data
+
+    def _from_numpy(arr):
+        return _FakeTensor(arr)
+
+    torch_mod.from_numpy = _from_numpy  # type: ignore[attr-defined]
+    torch_mod.Tensor = _FakeTensor  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    # df + df.enhance
+    df_mod = types.ModuleType("df")
+    df_enhance_mod = types.ModuleType("df.enhance")
+
+    fake_model = MagicMock(name="deepfilternet_model")
+    fake_state = MagicMock(name="df_state")
+    init_df = MagicMock(return_value=(fake_model, fake_state, ""))
+
+    # The fake enhancer flips the sign of the audio so tests can detect it ran.
+    def enhance(_model, _state, tensor, **_kwargs):  # noqa: ARG001
+        return _FakeTensor(-tensor._data)  # type: ignore[attr-defined]
+
+    enhance_mock = MagicMock(side_effect=enhance)
+
+    df_enhance_mod.enhance = enhance_mock  # type: ignore[attr-defined]
+    df_enhance_mod.init_df = init_df  # type: ignore[attr-defined]
+    df_mod.enhance = df_enhance_mod  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "df", df_mod)
+    monkeypatch.setitem(sys.modules, "df.enhance", df_enhance_mod)
+
+    # Reload patter module.
+    sys.modules.pop("patter.providers.deepfilternet_filter", None)
+
+    return {"init_df": init_df, "enhance": enhance_mock}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_init_raises_when_deps_missing(monkeypatch):
+    """Without ``df.enhance`` or torch, instantiation must raise RuntimeError."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {"df.enhance", "torch"}:
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("df.enhance", None)
+    sys.modules.pop("torch", None)
+    sys.modules.pop("patter.providers.deepfilternet_filter", None)
+
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    with pytest.raises(RuntimeError, match="DeepFilterNet not installed"):
+        DeepFilterNetFilter()
+
+
+@pytest.mark.unit
+async def test_process_calls_enhance_and_returns_bytes(monkeypatch):
+    """MOCK: no real inference.  Verifies bytes<->float round-trip + call chain."""
+    mocks = _install_fake_modules(monkeypatch)
+
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    flt = DeepFilterNetFilter()
+    assert mocks["init_df"].call_count == 1
+
+    # 20 ms @ 16 kHz = 320 samples.
+    pcm = (np.ones(320, dtype=np.int16) * 1000).tobytes()
+    out = await flt.process(pcm, 16000)
+
+    assert isinstance(out, bytes)
+    # Length matches the input duration (same sample rate in/out).
+    assert len(out) == len(pcm)
+    assert mocks["enhance"].called
+    await flt.close()
+
+
+@pytest.mark.unit
+async def test_process_empty_chunk(monkeypatch):
+    _install_fake_modules(monkeypatch)
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    flt = DeepFilterNetFilter()
+    assert await flt.process(b"", 16000) == b""
+    await flt.close()
+
+
+@pytest.mark.unit
+async def test_process_after_close_raises(monkeypatch):
+    _install_fake_modules(monkeypatch)
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    flt = DeepFilterNetFilter()
+    await flt.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        await flt.process(b"\x00\x00", 16000)
+
+
+@pytest.mark.unit
+async def test_native_sample_rate_skips_resampling(monkeypatch):
+    """At 48 kHz input, up/down-sampling is a no-op."""
+    _install_fake_modules(monkeypatch)
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    flt = DeepFilterNetFilter()
+    # 10 ms @ 48 kHz = 480 samples.
+    pcm = np.zeros(480, dtype=np.int16).tobytes()
+    out = await flt.process(pcm, 48000)
+    assert len(out) == len(pcm)
+    await flt.close()
+
+
+# ---------------------------------------------------------------------------
+# Real-model tests (skipped by default)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    os.getenv("PATTER_DEEPFILTERNET_REAL") != "1",
+    reason="Requires real DeepFilterNet3 model (~60 MB) + torch (~2 GB).",
+)
+async def test_real_rms_before_after():
+    """RMS of white noise should decrease after DeepFilterNet enhancement.
+
+    Enable with ``PATTER_DEEPFILTERNET_REAL=1`` once torch + deep-filter are
+    installed.
+    """
+    from patter.providers.deepfilternet_filter import DeepFilterNetFilter
+
+    flt = DeepFilterNetFilter()
+    rng = np.random.default_rng(0)
+    noise = (rng.normal(0, 0.1, 48000) * 32767).astype(np.int16).tobytes()
+
+    def rms(b: bytes) -> float:
+        arr = np.frombuffer(b, dtype=np.int16).astype(np.float32) / 32768
+        return float(np.sqrt(np.mean(arr**2)))
+
+    enhanced = await flt.process(noise, 48000)
+    assert rms(enhanced) <= rms(noise)
+    await flt.close()

--- a/sdk/tests/unit/test_krisp_filter.py
+++ b/sdk/tests/unit/test_krisp_filter.py
@@ -1,0 +1,286 @@
+"""Unit tests for the Krisp VIVA filter port.
+
+These tests exercise the Patter wrapper in isolation from the proprietary
+``krisp-audio`` SDK by injecting a fake ``krisp_audio`` module before
+importing :mod:`patter.providers.krisp_filter` / :mod:`patter.providers.krisp_instance`.
+
+MOCK: no real inference.  Tests that require the real SDK + license key are
+documented in the module docstring and must be run manually.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake krisp_audio module fixture
+# ---------------------------------------------------------------------------
+
+
+class _FakeSamplingRate:
+    Sr8000Hz = object()
+    Sr16000Hz = object()
+    Sr24000Hz = object()
+    Sr32000Hz = object()
+    Sr44100Hz = object()
+    Sr48000Hz = object()
+
+
+class _FakeFrameDuration:
+    Fd10ms = object()
+    Fd15ms = object()
+    Fd20ms = object()
+    Fd30ms = object()
+    Fd32ms = object()
+
+
+class _FakeLogLevel:
+    Off = 0
+
+
+class _FakeVersion:
+    major = 1
+    minor = 0
+    patch = 0
+
+
+class _FakeNcSession:
+    def __init__(self) -> None:
+        self.process = MagicMock(side_effect=lambda samples, level: samples)
+
+
+class _FakeNcInt16:
+    @staticmethod
+    def create(_cfg):
+        return _FakeNcSession()
+
+
+class _FakeModelInfo:
+    def __init__(self) -> None:
+        self.path: str | None = None
+
+
+class _FakeNcSessionConfig:
+    def __init__(self) -> None:
+        self.inputSampleRate = None
+        self.outputSampleRate = None
+        self.inputFrameDuration = None
+        self.modelInfo = None
+
+
+def _build_fake_module() -> types.ModuleType:
+    mod = types.ModuleType("krisp_audio")
+    mod.SamplingRate = _FakeSamplingRate
+    mod.FrameDuration = _FakeFrameDuration
+    mod.LogLevel = _FakeLogLevel
+    mod.ModelInfo = _FakeModelInfo
+    mod.NcSessionConfig = _FakeNcSessionConfig
+    mod.NcInt16 = _FakeNcInt16
+    mod.globalInit = MagicMock()
+    mod.globalDestroy = MagicMock()
+    mod.getVersion = MagicMock(return_value=_FakeVersion)
+    return mod
+
+
+@pytest.fixture
+def fake_krisp(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake ``krisp_audio`` module and reload Patter modules."""
+    fake = _build_fake_module()
+    monkeypatch.setitem(sys.modules, "krisp_audio", fake)
+    # Drop any cached imports so the providers pick up the fake module.
+    for mod in (
+        "patter.providers.krisp_instance",
+        "patter.providers.krisp_filter",
+    ):
+        sys.modules.pop(mod, None)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# KrispSDKManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sdk_manager_acquire_initialises_once(fake_krisp):
+    from patter.providers.krisp_instance import KrispSDKManager
+
+    # Reset counters between tests because the manager is a classmethod-based
+    # singleton.
+    KrispSDKManager._reference_count = 0
+    KrispSDKManager._initialized = False
+
+    KrispSDKManager.acquire()
+    KrispSDKManager.acquire()
+
+    assert fake_krisp.globalInit.call_count == 1
+    assert KrispSDKManager.get_reference_count() == 2
+
+    KrispSDKManager.release()
+    KrispSDKManager.release()
+    assert fake_krisp.globalDestroy.call_count == 1
+    assert KrispSDKManager.get_reference_count() == 0
+
+
+@pytest.mark.unit
+def test_sdk_manager_acquire_raises_when_sdk_missing(monkeypatch: pytest.MonkeyPatch):
+    """When krisp_audio is absent, acquire must raise RuntimeError."""
+    import importlib
+
+    monkeypatch.setitem(sys.modules, "krisp_audio", None)
+    sys.modules.pop("patter.providers.krisp_instance", None)
+
+    # Force ImportError during the lazy import.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "krisp_audio":
+            raise ModuleNotFoundError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module("patter.providers.krisp_instance")
+    assert module.KRISP_AUDIO_AVAILABLE is False
+    with pytest.raises(RuntimeError, match="Krisp SDK not installed"):
+        module.KrispSDKManager.acquire()
+
+
+# ---------------------------------------------------------------------------
+# KrispVivaFilter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_filter_requires_model_path(fake_krisp, monkeypatch: pytest.MonkeyPatch):
+    from patter.providers.krisp_filter import KrispVivaFilter
+    from patter.providers.krisp_instance import KrispSDKManager
+
+    KrispSDKManager._reference_count = 0
+    KrispSDKManager._initialized = False
+    monkeypatch.delenv("KRISP_VIVA_FILTER_MODEL_PATH", raising=False)
+
+    with pytest.raises(ValueError, match="Model path"):
+        KrispVivaFilter()
+
+
+@pytest.mark.unit
+def test_filter_rejects_non_kef_extension(fake_krisp, tmp_path, monkeypatch):
+    from patter.providers.krisp_filter import KrispVivaFilter
+    from patter.providers.krisp_instance import KrispSDKManager
+
+    KrispSDKManager._reference_count = 0
+    KrispSDKManager._initialized = False
+
+    bad = tmp_path / "model.bin"
+    bad.write_bytes(b"x")
+    with pytest.raises(ValueError, match="kef"):
+        KrispVivaFilter(model_path=str(bad))
+
+
+@pytest.mark.unit
+async def test_filter_process_delegates_to_krisp(fake_krisp, tmp_path, monkeypatch):
+    """MOCK: no real inference.  Verifies bytes<->numpy round-trip and call chain."""
+    import numpy as np
+
+    from patter.providers.krisp_filter import KrispVivaFilter
+    from patter.providers.krisp_instance import KrispSDKManager
+
+    KrispSDKManager._reference_count = 0
+    KrispSDKManager._initialized = False
+
+    model = tmp_path / "noisenet.kef"
+    model.write_bytes(b"fake-model")
+
+    flt = KrispVivaFilter(
+        model_path=str(model),
+        frame_duration_ms=10,
+        sample_rate=16000,
+    )
+    assert flt.enabled is True
+
+    # 10 ms @ 16 kHz = 160 samples × int16
+    pcm_in = np.arange(160, dtype=np.int16).tobytes()
+    pcm_out = await flt.process(pcm_in, 16000)
+
+    assert isinstance(pcm_out, bytes)
+    assert len(pcm_out) == len(pcm_in)
+    assert flt._session.process.call_count == 1  # type: ignore[attr-defined]
+
+    await flt.close()
+    assert flt._sdk_acquired is False
+
+
+@pytest.mark.unit
+async def test_filter_disable_passthrough(fake_krisp, tmp_path):
+    import numpy as np
+
+    from patter.providers.krisp_filter import KrispVivaFilter
+    from patter.providers.krisp_instance import KrispSDKManager
+
+    KrispSDKManager._reference_count = 0
+    KrispSDKManager._initialized = False
+
+    model = tmp_path / "m.kef"
+    model.write_bytes(b"x")
+    flt = KrispVivaFilter(model_path=str(model), frame_duration_ms=10, sample_rate=16000)
+    flt.disable()
+    pcm = np.zeros(160, dtype=np.int16).tobytes()
+    assert await flt.process(pcm, 16000) == pcm
+    await flt.close()
+
+
+@pytest.mark.unit
+def test_filter_raises_when_sdk_unavailable(monkeypatch):
+    """Without krisp-audio, direct instantiation must fail with a clear message."""
+    import importlib
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "krisp_audio":
+            raise ModuleNotFoundError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("patter.providers.krisp_instance", None)
+    sys.modules.pop("patter.providers.krisp_filter", None)
+
+    module = importlib.import_module("patter.providers.krisp_filter")
+    with pytest.raises(RuntimeError, match="Krisp SDK not installed"):
+        module.KrispVivaFilter(model_path="whatever.kef")
+
+
+# ---------------------------------------------------------------------------
+# Real SDK integration (skipped by default)
+# ---------------------------------------------------------------------------
+
+
+import os  # noqa: E402
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("KRISP_VIVA_SDK_LICENSE_KEY")
+    or not os.getenv("KRISP_VIVA_FILTER_MODEL_PATH"),
+    reason="Krisp SDK / license / model not available",
+)
+async def test_filter_real_sdk_smoke():
+    """Smoke test against the real Krisp SDK (requires license + model file)."""
+    from patter.providers.krisp_filter import KrispVivaFilter
+
+    flt = KrispVivaFilter(frame_duration_ms=10, sample_rate=16000)
+    import numpy as np
+
+    pcm = np.zeros(160, dtype=np.int16).tobytes()
+    out = await flt.process(pcm, 16000)
+    assert len(out) == len(pcm)
+    await flt.close()


### PR DESCRIPTION
## Summary

Stream B of the LiveKit port brings noise cancellation to Patter:

- **Krisp VIVA** (proprietary): ported from LiveKit's `livekit-plugins-krisp` (Apache 2.0) — `KrispSDKManager` singleton/refcount in `sdk/patter/providers/krisp_instance.py` and `KrispVivaFilter` reshaped to Patter's `AudioFilter` ABC in `sdk/patter/providers/krisp_filter.py`.
- **DeepFilterNet** (OSS fallback, MIT): new `DeepFilterNetFilter` in Python (wrapping the `deep-filter` PyPI package + torch) and TypeScript (wrapping `onnxruntime-node`, declared optional). Written from scratch, PatterAI copyright.
- `AudioFilter` ABC was introduced in Wave 1 (`sdk/patter/providers/base.py`) so integration with `PipelineStreamHandler` is a drop-in.

## Attribution

- **Source**: [livekit/agents](https://github.com/livekit/agents), `livekit-plugins/livekit-plugins-krisp/livekit/plugins/krisp/krisp_instance.py` and `viva_filter.py`.
- **License**: Apache 2.0 — headers preserved at the top of `krisp_instance.py` and `krisp_filter.py` (same format as `sdk/patter/services/sentence_chunker.py`).
- **Commit SHA**: `78a66bcf79c5cea82989401c408f1dff4b961a5b` (LiveKit main at port time).
- `deepfilternet_filter.py` / `deepfilternet-filter.ts` are PatterAI-copyright MIT.

## Licensing notes

- **Krisp VIVA** is a proprietary SDK. The extra `pip install getpatter[krisp]` pulls `krisp-audio>=2.0`, but the native library download + `KRISP_VIVA_SDK_LICENSE_KEY` + `.kef` model file (`KRISP_VIVA_FILTER_MODEL_PATH`) are the user's responsibility. Without these, `KrispVivaFilter.__init__` raises `RuntimeError("Krisp SDK not installed: pip install krisp-audio and set KRISP_VIVA_SDK_LICENSE_KEY")`.
- **DeepFilterNet** (MIT) is shipped as `pip install getpatter[deepfilternet]` (pulls `deep-filter>=0.5`, `torch>=2.0`, `numpy>=1.26`; torch is ~2 GB + the DeepFilterNet3 model ~60 MB). TS SDK: `onnxruntime-node` is declared as an optional peer — without it the filter passes audio through and warns once. No official DeepFilterNet ONNX export exists yet, so the TS path is marked as a TODO placeholder.

## Dependency footprint

| Extra | Size | Required for CI | Notes |
|---|---|---|---|
| `krisp` | ~10 MB wheel (native lib separate) | No | License + model user-supplied |
| `deepfilternet` | ~2 GB (torch) + ~60 MB (model) | No | Skipped in unit tests via mocks |
| TS `onnxruntime-node` | ~50 MB | No | Pass-through fallback w/ warning |

## Test plan

- [x] `cd sdk && python3 -m pytest tests/ --tb=short` — 1245 passed, 2 skipped (baseline 1233; 12 new unit tests + 2 integration-skipped)
- [x] `cd sdk-ts && npx tsc --noEmit` — clean
- [x] `cd sdk-ts && npx vitest run` — 889 passed, 0 failing (baseline 885; 4 new unit tests)
- [x] Unit tests mock `krisp_audio` / `df.enhance` / `torch` so no proprietary SDK or ~2 GB download is required in CI (docstring tag: "MOCK: no real inference")
- [ ] Manual: real Krisp with valid license key + `.kef` model (run `pytest tests/unit/test_krisp_filter.py -m integration` with `KRISP_VIVA_SDK_LICENSE_KEY` and `KRISP_VIVA_FILTER_MODEL_PATH` set)
- [ ] Manual: real DeepFilterNet3 RMS-before/after (set `PATTER_DEEPFILTERNET_REAL=1` after installing torch + deep-filter)

## Adaptations from LiveKit

- `rtc.FrameProcessor[rtc.AudioFrame]` → `AudioFilter` ABC with `async process(pcm_chunk: bytes, sample_rate: int) -> bytes` + `async close()`.
- numpy-based bytes ⇄ `np.int16` array conversion replaces `rtc.AudioFrame` plumbing.
- Session is lazily recreated on sample-rate change to keep the drop-in behaviour for pipeline mode.
- Krisp env vars (`KRISP_VIVA_SDK_LICENSE_KEY`, `KRISP_VIVA_FILTER_MODEL_PATH`) are preserved verbatim.

Do not merge — leaving in review per Wave 1 plan.