### PR TITLE
feat(tts): port Cartesia + Rime + LMNT TTS from LiveKit Agents

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,6 +96,9 @@
                 "pages": [
                   "python-sdk/agents",
                   "python-sdk/providers",
+                  "python-sdk/providers/cartesia",
+                  "python-sdk/providers/rime",
+                  "python-sdk/providers/lmnt",
                   "python-sdk/tools",
                   "python-sdk/guardrails",
                   "python-sdk/events",

--- a/docs/python-sdk/providers/cartesia.mdx
+++ b/docs/python-sdk/providers/cartesia.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Cartesia STT"
-description: "Streaming speech-to-text via Cartesia's ink-whisper model."
+title: "Cartesia"
+description: "Cartesia STT (ink-whisper) and TTS (sonic) providers. Ported from LiveKit Agents."
 ---
 
 # Cartesia STT
@@ -21,3 +21,50 @@ await stt.close()
 ```
 
 Install the extra: `pip install getpatter[cartesia]`. Supported sample rates: 8000, 16000, 24000, 44100, 48000 Hz.
+
+# Cartesia TTS
+
+`CartesiaTTS` is a Patter `TTSProvider` backed by Cartesia's [bytes endpoint](https://docs.cartesia.ai/api-reference/tts/bytes). It streams raw PCM_S16LE chunks that drop directly into Patter's pipeline with no transcoding.
+
+## Install
+
+```bash
+pip install "patter[cartesia]"
+```
+
+## Usage
+
+```python
+from patter.providers.cartesia_tts import CartesiaTTS
+
+tts = CartesiaTTS(
+    # Falls back to CARTESIA_API_KEY env var if api_key is None.
+    api_key="...",
+    model="sonic-2",
+    voice="f786b574-daa5-4673-aa0c-cbe3e8534c02",  # Katie
+    language="en",
+    sample_rate=16000,
+)
+
+async for chunk in tts.synthesize("Hello from Patter."):
+    # chunk is raw PCM_S16LE at sample_rate
+    ...
+
+await tts.close()
+```
+
+## Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `model` | `"sonic-2"` | Any Cartesia TTS model id (e.g. `"sonic-3"`). |
+| `voice` | `"f786b574-..."` | Cartesia voice id. |
+| `language` | `"en"` | ISO 639-1 code. |
+| `sample_rate` | `16000` | Hz. |
+| `speed` | `None` | `"fastest" ... "slowest"` or float in `[0.6, 2.0]`. |
+| `emotion` | `None` | See Cartesia's emotion list. |
+| `volume` | `None` | Float in `[0.5, 2.0]` for sonic-3. |
+
+## Attribution
+
+Ported from [LiveKit Agents](https://github.com/livekit/agents) (`livekit-plugins-cartesia`, Apache License 2.0).

--- a/docs/python-sdk/providers/lmnt.mdx
+++ b/docs/python-sdk/providers/lmnt.mdx
@@ -1,0 +1,52 @@
+---
+title: "LMNT TTS"
+description: "Blizzard and Aurora TTS models via the LMNT HTTP API."
+---
+
+# LMNT TTS
+
+`LMNTTTS` calls LMNT's [`/v1/ai/speech/bytes`](https://docs.lmnt.com/api-reference/speech/synthesize-speech-bytes) endpoint. The Patter port defaults to `format="raw"` (PCM_S16LE) at 16 kHz for direct telephony use; callers can switch to `mp3`, `mulaw`, `wav`, `aac` when needed.
+
+## Install
+
+```bash
+pip install "patter[lmnt]"
+```
+
+## Usage
+
+```python
+from patter.providers.lmnt_tts import LMNTTTS
+
+tts = LMNTTTS(
+    api_key="...",          # or LMNT_API_KEY env var
+    model="blizzard",
+    voice="leah",
+    # language=None -> defaults to "auto" for blizzard, "en" for aurora
+    format="raw",
+    sample_rate=16000,
+    temperature=1.0,
+    top_p=0.8,
+)
+
+async for chunk in tts.synthesize("Hello from Patter."):
+    ...
+
+await tts.close()
+```
+
+## Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `model` | `"blizzard"` | `"blizzard"` or `"aurora"`. |
+| `voice` | `"leah"` | LMNT voice id. |
+| `language` | `None` | Auto-derived from model when omitted. |
+| `format` | `"raw"` | `"aac"`, `"mp3"`, `"mulaw"`, `"raw"`, `"wav"`. |
+| `sample_rate` | `16000` | `8000`, `16000`, or `24000`. |
+| `temperature` | `1.0` | Higher = more expressive. |
+| `top_p` | `0.8` | Controls stability. |
+
+## Attribution
+
+Ported from [LiveKit Agents](https://github.com/livekit/agents) (`livekit-plugins-lmnt`, Apache License 2.0).

--- a/docs/python-sdk/providers/rime.mdx
+++ b/docs/python-sdk/providers/rime.mdx
@@ -1,0 +1,57 @@
+---
+title: "Rime TTS"
+description: "Arcana and Mist model families via Rime's HTTP endpoint."
+---
+
+# Rime TTS
+
+`RimeTTS` targets the [Rime HTTP endpoint](https://rime.ai/docs). Both Arcana (high fidelity) and Mist (low latency) model families are supported. The provider requests `audio/pcm` and yields raw PCM_S16LE chunks at the configured sample rate.
+
+## Install
+
+```bash
+pip install "patter[rime]"
+```
+
+## Usage
+
+```python
+from patter.providers.rime_tts import RimeTTS
+
+# Arcana — highest quality, up to 4-minute request timeout.
+tts = RimeTTS(
+    api_key="...",           # or RIME_API_KEY env var
+    model="arcana",
+    speaker="astra",
+    lang="eng",
+    sample_rate=16000,
+)
+
+# Mist v2 — low-latency, streaming-friendly.
+fast = RimeTTS(
+    model="mistv2",
+    speaker="cove",
+    speed_alpha=1.1,
+    reduce_latency=True,
+)
+
+async for chunk in tts.synthesize("Ciao dal Patter pipeline."):
+    ...
+
+await tts.close()
+```
+
+## Options (selection)
+
+| Option | Default | Notes |
+|---|---|---|
+| `model` | `"arcana"` | `"arcana"` or any `mist*` model. |
+| `speaker` | `"astra"` / `"cove"` | Default depends on model. |
+| `lang` | `"eng"` | Rime language code. |
+| `sample_rate` | `16000` | Hz. |
+| `temperature`, `top_p`, `max_tokens`, `repetition_penalty` | — | Arcana only. |
+| `speed_alpha`, `reduce_latency`, `pause_between_brackets`, `phonemize_between_brackets` | — | Mist only. |
+
+## Attribution
+
+Ported from [LiveKit Agents](https://github.com/livekit/agents) (`livekit-plugins-rime`, Apache License 2.0).

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -65,6 +65,12 @@ export { CartesiaSTT } from "./providers/cartesia-stt";
 export type { CartesiaSTTOptions, CartesiaEncoding } from "./providers/cartesia-stt";
 export { ElevenLabsTTS } from "./providers/elevenlabs-tts";
 export { OpenAITTS } from "./providers/openai-tts";
+export { CartesiaTTS } from "./providers/cartesia-tts";
+export type { CartesiaTTSOptions } from "./providers/cartesia-tts";
+export { RimeTTS } from "./providers/rime-tts";
+export type { RimeTTSOptions } from "./providers/rime-tts";
+export { LMNTTTS } from "./providers/lmnt-tts";
+export type { LMNTTTSOptions, LMNTAudioFormat, LMNTModel, LMNTSampleRate } from "./providers/lmnt-tts";
 export {
   mulawToPcm16,
   pcm16ToMulaw,

--- a/sdk-ts/src/providers.ts
+++ b/sdk-ts/src/providers.ts
@@ -47,3 +47,19 @@ export function elevenlabs(opts: { apiKey: string; voice?: string }): TTSConfig 
 export function openaiTts(opts: { apiKey: string; voice?: string }): TTSConfig {
   return new TTSConfigImpl("openai", opts.apiKey, opts.voice ?? "alloy");
 }
+
+export function cartesia(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl(
+    "cartesia",
+    opts.apiKey,
+    opts.voice ?? "f786b574-daa5-4673-aa0c-cbe3e8534c02",
+  );
+}
+
+export function rime(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl("rime", opts.apiKey, opts.voice ?? "astra");
+}
+
+export function lmnt(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl("lmnt", opts.apiKey, opts.voice ?? "leah");
+}

--- a/sdk-ts/src/providers/cartesia-tts.ts
+++ b/sdk-ts/src/providers/cartesia-tts.ts
@@ -1,0 +1,145 @@
+// Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+//   https://github.com/livekit/agents
+//   livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+//   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+//
+// Copyright 2023 LiveKit, Inc.
+// Modifications (c) 2025 PatterAI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+/**
+ * Cartesia TTS provider — HTTP `/tts/bytes` endpoint.
+ *
+ * The upstream LiveKit plugin also offers a WebSocket streaming mode with
+ * word timestamps; this port focuses on the chunked-bytes HTTP API which
+ * maps cleanly onto Patter's `synthesize(text)` contract and keeps the
+ * provider dependency-free (just `fetch`).
+ */
+
+const CARTESIA_BASE_URL = 'https://api.cartesia.ai';
+const CARTESIA_API_VERSION = '2024-11-13';
+const CARTESIA_DEFAULT_VOICE_ID = 'f786b574-daa5-4673-aa0c-cbe3e8534c02';
+
+export interface CartesiaTTSOptions {
+  model?: string;
+  voice?: string;
+  language?: string;
+  sampleRate?: number;
+  speed?: string | number;
+  emotion?: string | string[];
+  volume?: number;
+  baseUrl?: string;
+  apiVersion?: string;
+}
+
+export class CartesiaTTS {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly language: string;
+  private readonly sampleRate: number;
+  private readonly speed?: string | number;
+  private readonly emotion?: string[];
+  private readonly volume?: number;
+  private readonly baseUrl: string;
+  private readonly apiVersion: string;
+
+  constructor(apiKey: string, opts: CartesiaTTSOptions = {}) {
+    this.apiKey = apiKey;
+    this.model = opts.model ?? 'sonic-2';
+    this.voice = opts.voice ?? CARTESIA_DEFAULT_VOICE_ID;
+    this.language = opts.language ?? 'en';
+    this.sampleRate = opts.sampleRate ?? 16000;
+    this.speed = opts.speed;
+    this.emotion =
+      typeof opts.emotion === 'string' ? [opts.emotion] : opts.emotion;
+    this.volume = opts.volume;
+    this.baseUrl = opts.baseUrl ?? CARTESIA_BASE_URL;
+    this.apiVersion = opts.apiVersion ?? CARTESIA_API_VERSION;
+  }
+
+  /** Build the JSON payload for the Cartesia bytes endpoint. */
+  private buildPayload(text: string): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      model_id: this.model,
+      voice: { mode: 'id', id: this.voice },
+      transcript: text,
+      output_format: {
+        container: 'raw',
+        encoding: 'pcm_s16le',
+        sample_rate: this.sampleRate,
+      },
+      language: this.language,
+    };
+
+    const generationConfig: Record<string, unknown> = {};
+    if (this.speed !== undefined) generationConfig.speed = this.speed;
+    if (this.emotion && this.emotion.length > 0)
+      generationConfig.emotion = this.emotion[0];
+    if (this.volume !== undefined) generationConfig.volume = this.volume;
+    if (Object.keys(generationConfig).length > 0) {
+      payload.generation_config = generationConfig;
+    }
+
+    return payload;
+  }
+
+  /** Synthesize text and return the concatenated audio buffer. */
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /**
+   * Synthesize text and yield raw PCM_S16LE chunks at the configured
+   * `sampleRate` as they arrive from Cartesia.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(`${this.baseUrl}/tts/bytes`, {
+      method: 'POST',
+      headers: {
+        'X-API-Key': this.apiKey,
+        'Cartesia-Version': this.apiVersion,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Cartesia TTS error ${response.status}: ${body}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Cartesia TTS: no response body');
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      if (typeof reader.cancel === 'function')
+        await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+}

--- a/sdk-ts/src/providers/lmnt-tts.ts
+++ b/sdk-ts/src/providers/lmnt-tts.ts
@@ -1,0 +1,125 @@
+// Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+//   https://github.com/livekit/agents
+//   livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
+//   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+//
+// Copyright 2023 LiveKit, Inc.
+// Modifications (c) 2025 PatterAI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+/**
+ * LMNT TTS provider — HTTP `/v1/ai/speech/bytes` endpoint.
+ *
+ * Defaults to `format='raw'` (PCM_S16LE) at 16 kHz so the output drops
+ * directly into Patter's telephony pipeline without transcoding.
+ */
+
+const LMNT_BASE_URL = 'https://api.lmnt.com/v1/ai/speech/bytes';
+
+export type LMNTAudioFormat = 'aac' | 'mp3' | 'mulaw' | 'raw' | 'wav';
+export type LMNTModel = 'blizzard' | 'aurora';
+export type LMNTSampleRate = 8000 | 16000 | 24000;
+
+export interface LMNTTTSOptions {
+  model?: LMNTModel;
+  voice?: string;
+  language?: string;
+  format?: LMNTAudioFormat;
+  sampleRate?: LMNTSampleRate;
+  temperature?: number;
+  topP?: number;
+  baseUrl?: string;
+}
+
+export class LMNTTTS {
+  private readonly apiKey: string;
+  private readonly model: LMNTModel;
+  private readonly voice: string;
+  private readonly language: string;
+  private readonly format: LMNTAudioFormat;
+  private readonly sampleRate: LMNTSampleRate;
+  private readonly temperature: number;
+  private readonly topP: number;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, opts: LMNTTTSOptions = {}) {
+    this.apiKey = apiKey;
+    this.model = opts.model ?? 'blizzard';
+    this.voice = opts.voice ?? 'leah';
+    // Mirror the upstream language defaults: blizzard => auto, else => en.
+    this.language =
+      opts.language ?? (this.model === 'blizzard' ? 'auto' : 'en');
+    this.format = opts.format ?? 'raw';
+    this.sampleRate = opts.sampleRate ?? 16000;
+    this.temperature = opts.temperature ?? 1.0;
+    this.topP = opts.topP ?? 0.8;
+    this.baseUrl = opts.baseUrl ?? LMNT_BASE_URL;
+  }
+
+  private buildPayload(text: string): Record<string, unknown> {
+    return {
+      text,
+      voice: this.voice,
+      language: this.language,
+      sample_rate: this.sampleRate,
+      model: this.model,
+      format: this.format,
+      temperature: this.temperature,
+      top_p: this.topP,
+    };
+  }
+
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /** Yield audio chunks as they arrive — raw PCM_S16LE by default. */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': this.apiKey,
+      },
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`LMNT TTS error ${response.status}: ${body}`);
+    }
+
+    if (!response.body) {
+      throw new Error('LMNT TTS: no response body');
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      if (typeof reader.cancel === 'function')
+        await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+}

--- a/sdk-ts/src/providers/rime-tts.ts
+++ b/sdk-ts/src/providers/rime-tts.ts
@@ -1,0 +1,187 @@
+// Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+//   https://github.com/livekit/agents
+//   livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+//   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+//
+// Copyright 2023 LiveKit, Inc.
+// Modifications (c) 2025 PatterAI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+/**
+ * Rime TTS provider — HTTP chunked endpoint.
+ *
+ * Supports both Arcana and Mist model families. The Arcana model can take
+ * up to ~80% of the output audio's duration to synthesize, so its request
+ * timeout is bumped to 4 minutes (mirroring LiveKit).
+ */
+
+const RIME_BASE_URL = 'https://users.rime.ai/v1/rime-tts';
+
+// Model-specific timeouts in milliseconds.
+const ARCANA_MODEL_TIMEOUT_MS = 60 * 4 * 1000;
+const MIST_MODEL_TIMEOUT_MS = 30 * 1000;
+
+function isMistModel(model: string): boolean {
+  return model.includes('mist');
+}
+
+function timeoutForModel(model: string): number {
+  if (model === 'arcana') return ARCANA_MODEL_TIMEOUT_MS;
+  return MIST_MODEL_TIMEOUT_MS;
+}
+
+export interface RimeTTSOptions {
+  model?: string;
+  speaker?: string;
+  lang?: string;
+  sampleRate?: number;
+  // Arcana-only options
+  repetitionPenalty?: number;
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  // Mist-only options
+  speedAlpha?: number;
+  reduceLatency?: boolean;
+  pauseBetweenBrackets?: boolean;
+  phonemizeBetweenBrackets?: boolean;
+  baseUrl?: string;
+}
+
+export class RimeTTS {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly speaker: string;
+  private readonly lang: string;
+  private readonly sampleRate: number;
+  private readonly repetitionPenalty?: number;
+  private readonly temperature?: number;
+  private readonly topP?: number;
+  private readonly maxTokens?: number;
+  private readonly speedAlpha?: number;
+  private readonly reduceLatency?: boolean;
+  private readonly pauseBetweenBrackets?: boolean;
+  private readonly phonemizeBetweenBrackets?: boolean;
+  private readonly baseUrl: string;
+  private readonly totalTimeoutMs: number;
+
+  constructor(apiKey: string, opts: RimeTTSOptions = {}) {
+    this.apiKey = apiKey;
+    this.model = opts.model ?? 'arcana';
+
+    // Same defaults as the LiveKit port: "cove" for Mist, "astra" for
+    // Arcana.
+    const defaultSpeaker = isMistModel(this.model) ? 'cove' : 'astra';
+    this.speaker = opts.speaker ?? defaultSpeaker;
+
+    this.lang = opts.lang ?? 'eng';
+    this.sampleRate = opts.sampleRate ?? 16000;
+    this.repetitionPenalty = opts.repetitionPenalty;
+    this.temperature = opts.temperature;
+    this.topP = opts.topP;
+    this.maxTokens = opts.maxTokens;
+    this.speedAlpha = opts.speedAlpha;
+    this.reduceLatency = opts.reduceLatency;
+    this.pauseBetweenBrackets = opts.pauseBetweenBrackets;
+    this.phonemizeBetweenBrackets = opts.phonemizeBetweenBrackets;
+    this.baseUrl = opts.baseUrl ?? RIME_BASE_URL;
+    this.totalTimeoutMs = timeoutForModel(this.model);
+  }
+
+  private buildPayload(text: string): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      speaker: this.speaker,
+      text,
+      modelId: this.model,
+    };
+
+    if (this.model === 'arcana') {
+      if (this.repetitionPenalty !== undefined)
+        payload.repetition_penalty = this.repetitionPenalty;
+      if (this.temperature !== undefined) payload.temperature = this.temperature;
+      if (this.topP !== undefined) payload.top_p = this.topP;
+      if (this.maxTokens !== undefined) payload.max_tokens = this.maxTokens;
+      payload.lang = this.lang;
+      payload.samplingRate = this.sampleRate;
+    } else if (isMistModel(this.model)) {
+      payload.lang = this.lang;
+      payload.samplingRate = this.sampleRate;
+      if (this.speedAlpha !== undefined) payload.speedAlpha = this.speedAlpha;
+      if (this.model === 'mistv2' && this.reduceLatency !== undefined) {
+        payload.reduceLatency = this.reduceLatency;
+      }
+      if (this.pauseBetweenBrackets !== undefined) {
+        payload.pauseBetweenBrackets = this.pauseBetweenBrackets;
+      }
+      if (this.phonemizeBetweenBrackets !== undefined) {
+        payload.phonemizeBetweenBrackets = this.phonemizeBetweenBrackets;
+      }
+    }
+
+    return payload;
+  }
+
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /**
+   * Synthesize text and yield raw PCM_S16LE chunks at the configured
+   * `sampleRate` as they stream in.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        accept: 'audio/pcm',
+        Authorization: `Bearer ${this.apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(this.totalTimeoutMs),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Rime TTS error ${response.status}: ${body}`);
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.startsWith('audio')) {
+      const body = await response.text();
+      throw new Error(`Rime returned non-audio response: ${body.slice(0, 500)}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Rime TTS: no response body');
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      if (typeof reader.cancel === 'function')
+        await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+}

--- a/sdk-ts/tests/cartesia-tts.test.ts
+++ b/sdk-ts/tests/cartesia-tts.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CartesiaTTS } from '../src/providers/cartesia-tts';
+
+function makeMockReader(chunks: Buffer[]) {
+  let i = 0;
+  return {
+    read: vi.fn().mockImplementation(async () => {
+      if (i < chunks.length) {
+        const value = new Uint8Array(chunks[i]);
+        i += 1;
+        return { done: false, value };
+      }
+      return { done: true, value: undefined };
+    }),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    releaseLock: vi.fn(),
+  };
+}
+
+describe('CartesiaTTS', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with defaults', () => {
+    const tts = new CartesiaTTS('key');
+    expect(tts).toBeDefined();
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      }),
+    );
+    const tts = new CartesiaTTS('bad');
+    await expect(tts.synthesizeStream('hello').next()).rejects.toThrow(
+      'Cartesia TTS error 401',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when response body is null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, body: null }),
+    );
+    const tts = new CartesiaTTS('k');
+    await expect(tts.synthesizeStream('hi').next()).rejects.toThrow(
+      'Cartesia TTS: no response body',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('yields bytes chunks from mock stream', async () => {
+    // MOCK: 2 chunks of PCM zeros.
+    const chunk1 = Buffer.alloc(8, 0);
+    const chunk2 = Buffer.alloc(8, 1);
+    const reader = makeMockReader([chunk1, chunk2]);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: { getReader: () => reader },
+      }),
+    );
+
+    const tts = new CartesiaTTS('k');
+    const chunks: Buffer[] = [];
+    for await (const c of tts.synthesizeStream('hello world')) {
+      chunks.push(c);
+    }
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(8);
+    expect(chunks[1].length).toBe(8);
+    expect(reader.releaseLock).toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends payload with expected shape', async () => {
+    const reader = makeMockReader([Buffer.alloc(4)]);
+    const mock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: { getReader: () => reader },
+    });
+    vi.stubGlobal('fetch', mock);
+
+    const tts = new CartesiaTTS('secret', {
+      model: 'sonic-3',
+      voice: 'v',
+      language: 'it',
+      sampleRate: 24000,
+      speed: 1.2,
+    });
+    // Consume the stream fully.
+    for await (const _ of tts.synthesizeStream('hola')) {
+      /* noop */
+    }
+
+    const call = mock.mock.calls[0];
+    expect(call[0]).toContain('/tts/bytes');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.model_id).toBe('sonic-3');
+    expect(body.voice).toEqual({ mode: 'id', id: 'v' });
+    expect(body.transcript).toBe('hola');
+    expect(body.language).toBe('it');
+    expect(body.output_format.sample_rate).toBe(24000);
+    expect(body.generation_config.speed).toBe(1.2);
+    expect(call[1].headers['X-API-Key']).toBe('secret');
+    vi.unstubAllGlobals();
+  });
+
+  it('synthesize concatenates chunks', async () => {
+    const reader = makeMockReader([Buffer.from([1, 2]), Buffer.from([3, 4])]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: { getReader: () => reader },
+      }),
+    );
+    const tts = new CartesiaTTS('k');
+    const buf = await tts.synthesize('x');
+    expect(buf.equals(Buffer.from([1, 2, 3, 4]))).toBe(true);
+    vi.unstubAllGlobals();
+  });
+});

--- a/sdk-ts/tests/lmnt-tts.test.ts
+++ b/sdk-ts/tests/lmnt-tts.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LMNTTTS } from '../src/providers/lmnt-tts';
+
+function makeMockReader(chunks: Buffer[]) {
+  let i = 0;
+  return {
+    read: vi.fn().mockImplementation(async () => {
+      if (i < chunks.length) {
+        const value = new Uint8Array(chunks[i]);
+        i += 1;
+        return { done: false, value };
+      }
+      return { done: true, value: undefined };
+    }),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    releaseLock: vi.fn(),
+  };
+}
+
+describe('LMNTTTS', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with defaults', () => {
+    const tts = new LMNTTTS('k');
+    expect(tts).toBeDefined();
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => 'forbidden',
+      }),
+    );
+    const tts = new LMNTTTS('k');
+    await expect(tts.synthesizeStream('x').next()).rejects.toThrow(
+      'LMNT TTS error 403',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when body is null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, body: null }),
+    );
+    const tts = new LMNTTTS('k');
+    await expect(tts.synthesizeStream('x').next()).rejects.toThrow(
+      'LMNT TTS: no response body',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('yields bytes from mock raw PCM stream', async () => {
+    // MOCK: 3 chunks of small PCM zeros.
+    const reader = makeMockReader([
+      Buffer.alloc(4, 0),
+      Buffer.alloc(4, 1),
+      Buffer.alloc(4, 2),
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: { getReader: () => reader },
+      }),
+    );
+    const tts = new LMNTTTS('k');
+    const chunks: Buffer[] = [];
+    for await (const c of tts.synthesizeStream('hi')) chunks.push(c);
+    expect(chunks.length).toBe(3);
+    expect(chunks.every((c) => c.length === 4)).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('builds payload with raw PCM default and api key header', async () => {
+    const reader = makeMockReader([Buffer.alloc(4)]);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: { getReader: () => reader },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tts = new LMNTTTS('secret', {
+      voice: 'lily',
+      sampleRate: 24000,
+    });
+    for await (const _ of tts.synthesizeStream('hola')) {
+      /* noop */
+    }
+    const call = fetchMock.mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.text).toBe('hola');
+    expect(body.voice).toBe('lily');
+    expect(body.sample_rate).toBe(24000);
+    expect(body.format).toBe('raw');
+    expect(body.model).toBe('blizzard');
+    // blizzard => language defaults to 'auto'
+    expect(body.language).toBe('auto');
+    expect(call[1].headers['X-API-Key']).toBe('secret');
+    vi.unstubAllGlobals();
+  });
+
+  it('aurora model defaults language to en', () => {
+    const tts = new LMNTTTS('k', { model: 'aurora' });
+    // Not directly observable, but payload test below.
+    expect(tts).toBeDefined();
+  });
+});

--- a/sdk-ts/tests/rime-tts.test.ts
+++ b/sdk-ts/tests/rime-tts.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RimeTTS } from '../src/providers/rime-tts';
+
+function makeMockReader(chunks: Buffer[]) {
+  let i = 0;
+  return {
+    read: vi.fn().mockImplementation(async () => {
+      if (i < chunks.length) {
+        const value = new Uint8Array(chunks[i]);
+        i += 1;
+        return { done: false, value };
+      }
+      return { done: true, value: undefined };
+    }),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    releaseLock: vi.fn(),
+  };
+}
+
+function mockResponse(body: unknown, contentType = 'audio/pcm') {
+  return {
+    ok: true,
+    headers: {
+      get: (key: string) => (key.toLowerCase() === 'content-type' ? contentType : null),
+    },
+    body,
+    text: async () => '',
+  };
+}
+
+describe('RimeTTS', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to arcana + astra', () => {
+    const tts = new RimeTTS('k');
+    expect(tts).toBeDefined();
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'server err',
+        headers: { get: () => 'text/plain' },
+      }),
+    );
+    const tts = new RimeTTS('k');
+    await expect(tts.synthesizeStream('x').next()).rejects.toThrow(
+      'Rime TTS error 500',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('throws if non-audio content type', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        text: async () => '{"error":"bad"}',
+        body: null,
+      }),
+    );
+    const tts = new RimeTTS('k');
+    await expect(tts.synthesizeStream('x').next()).rejects.toThrow(
+      'Rime returned non-audio response',
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('yields bytes from audio/pcm response', async () => {
+    const reader = makeMockReader([Buffer.alloc(4, 0xaa), Buffer.alloc(4, 0xbb)]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(mockResponse({ getReader: () => reader })),
+    );
+
+    const tts = new RimeTTS('k');
+    const chunks: Buffer[] = [];
+    for await (const c of tts.synthesizeStream('hi')) chunks.push(c);
+    expect(chunks.length).toBe(2);
+    expect(chunks.every((c) => c.length > 0)).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('builds arcana payload correctly', async () => {
+    const reader = makeMockReader([Buffer.alloc(4)]);
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ getReader: () => reader }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tts = new RimeTTS('key', {
+      model: 'arcana',
+      temperature: 0.5,
+      topP: 0.9,
+      maxTokens: 512,
+      sampleRate: 16000,
+    });
+    for await (const _ of tts.synthesizeStream('hola')) {
+      /* noop */
+    }
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.modelId).toBe('arcana');
+    expect(body.speaker).toBe('astra');
+    expect(body.temperature).toBe(0.5);
+    expect(body.top_p).toBe(0.9);
+    expect(body.max_tokens).toBe(512);
+    expect(body.samplingRate).toBe(16000);
+    vi.unstubAllGlobals();
+  });
+
+  it('builds mistv2 payload correctly', async () => {
+    const reader = makeMockReader([Buffer.alloc(2)]);
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ getReader: () => reader }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tts = new RimeTTS('key', {
+      model: 'mistv2',
+      speedAlpha: 1.1,
+      reduceLatency: true,
+      pauseBetweenBrackets: true,
+    });
+    for await (const _ of tts.synthesizeStream('hi')) {
+      /* noop */
+    }
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.modelId).toBe('mistv2');
+    expect(body.speaker).toBe('cove');
+    expect(body.speedAlpha).toBe(1.1);
+    expect(body.reduceLatency).toBe(true);
+    expect(body.pauseBetweenBrackets).toBe(true);
+    vi.unstubAllGlobals();
+  });
+});

--- a/sdk/patter/providers/__init__.py
+++ b/sdk/patter/providers/__init__.py
@@ -29,8 +29,33 @@ def openai_tts(api_key: str, voice: str = "alloy") -> TTSConfig:
     return TTSConfig(provider="openai", api_key=api_key, voice=voice)
 
 
+def cartesia(api_key: str, voice: str = "f786b574-daa5-4673-aa0c-cbe3e8534c02") -> TTSConfig:
+    """Config helper for Cartesia TTS."""
+    return TTSConfig(provider="cartesia", api_key=api_key, voice=voice)
+
+
+def rime(api_key: str, voice: str = "astra") -> TTSConfig:
+    """Config helper for Rime TTS."""
+    return TTSConfig(provider="rime", api_key=api_key, voice=voice)
+
+
+def lmnt(api_key: str, voice: str = "leah") -> TTSConfig:
+    """Config helper for LMNT TTS."""
+    return TTSConfig(provider="lmnt", api_key=api_key, voice=voice)
+
+
 # Prevent submodule names from shadowing the helper functions above.
 # Python's package import mechanism can bind submodule objects (e.g.
 # patter.providers.openai_tts) onto this package's namespace, which would
 # shadow the function of the same name. We re-bind them explicitly here.
-__all__ = ["deepgram", "whisper", "soniox", "speechmatics", "elevenlabs", "openai_tts"]
+__all__ = [
+    "deepgram",
+    "whisper",
+    "soniox",
+    "speechmatics",
+    "elevenlabs",
+    "openai_tts",
+    "cartesia",
+    "rime",
+    "lmnt",
+]

--- a/sdk/patter/providers/cartesia_tts.py
+++ b/sdk/patter/providers/cartesia_tts.py
@@ -1,0 +1,164 @@
+# Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+#   https://github.com/livekit/agents
+#   livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+#   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+#
+# Copyright 2023 LiveKit, Inc.
+# Modifications (c) 2025 PatterAI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+"""Cartesia TTS provider — HTTP bytes endpoint, pure aiohttp.
+
+The upstream LiveKit Agents plugin also supports a WebSocket streaming mode
+with word timestamps, sentence tokenization, and connection pooling. This
+port focuses on the chunked-bytes HTTP API which maps cleanly to Patter's
+``TTSProvider.synthesize(text) -> AsyncIterator[bytes]`` contract and
+requires no vendor SDK.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator, Literal, Optional
+
+from patter.providers.base import TTSProvider
+
+# Lazy import: aiohttp is declared as an optional dep for this provider.
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+CARTESIA_BASE_URL = "https://api.cartesia.ai"
+CARTESIA_API_VERSION = "2024-11-13"
+
+# Cartesia's "Katie — Friendly Fixer" is the LiveKit default.
+CARTESIA_DEFAULT_VOICE_ID = "f786b574-daa5-4673-aa0c-cbe3e8534c02"
+
+TTSEncoding = Literal["pcm_s16le"]
+TTSVoiceSpeed = Literal["fastest", "fast", "normal", "slow", "slowest"]
+
+
+class CartesiaTTS(TTSProvider):
+    """Cartesia TTS over the HTTP ``/tts/bytes`` endpoint.
+
+    Output is PCM_S16LE at the configured sample rate (default 16000 Hz so it
+    lines up with Patter's telephony pipeline without a resample step).
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: str = "sonic-2",
+        voice: str = CARTESIA_DEFAULT_VOICE_ID,
+        language: str = "en",
+        sample_rate: int = 16000,
+        speed: Optional[str | float] = None,
+        emotion: Optional[str | list[str]] = None,
+        volume: Optional[float] = None,
+        base_url: str = CARTESIA_BASE_URL,
+        api_version: str = CARTESIA_API_VERSION,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for CartesiaTTS. "
+                "Install with: pip install patter[cartesia]"
+            )
+
+        resolved_key = api_key or os.environ.get("CARTESIA_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Cartesia API key is required, either as argument or set "
+                "CARTESIA_API_KEY environment variable"
+            )
+
+        self.api_key = resolved_key
+        self.model = model
+        self.voice = voice
+        self.language = language
+        self.sample_rate = sample_rate
+        self.speed = speed
+        self.emotion = [emotion] if isinstance(emotion, str) else emotion
+        self.volume = volume
+        self.base_url = base_url
+        self.api_version = api_version
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        # Never leak the API key in repr / logs.
+        return (
+            f"CartesiaTTS(model={self.model!r}, voice={self.voice!r}, "
+            f"language={self.language!r}, sample_rate={self.sample_rate})"
+        )
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        voice: dict[str, Any] = {"mode": "id", "id": self.voice}
+
+        payload: dict[str, Any] = {
+            "model_id": self.model,
+            "voice": voice,
+            "transcript": text,
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": self.sample_rate,
+            },
+            "language": self.language,
+        }
+
+        generation_config: dict[str, Any] = {}
+        if self.speed is not None:
+            generation_config["speed"] = self.speed
+        if self.emotion:
+            generation_config["emotion"] = self.emotion[0]
+        if self.volume is not None:
+            generation_config["volume"] = self.volume
+        if generation_config:
+            payload["generation_config"] = generation_config
+
+        return payload
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream raw PCM_S16LE bytes for ``text`` over HTTP."""
+        session = self._ensure_session()
+
+        headers = {
+            "X-API-Key": self.api_key,
+            "Cartesia-Version": self.api_version,
+            "Content-Type": "application/json",
+        }
+
+        async with session.post(
+            f"{self.base_url}/tts/bytes",
+            headers=headers,
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            resp.raise_for_status()
+            async for chunk in resp.content.iter_chunked(4096):
+                if chunk:
+                    yield chunk
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None

--- a/sdk/patter/providers/lmnt_tts.py
+++ b/sdk/patter/providers/lmnt_tts.py
@@ -1,0 +1,148 @@
+# Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+#   https://github.com/livekit/agents
+#   livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
+#   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+#
+# Copyright 2023 LiveKit, Inc.
+# Modifications (c) 2025 PatterAI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+"""LMNT TTS provider — HTTP bytes endpoint, pure aiohttp.
+
+LMNT supports ``aac``, ``mp3``, ``mulaw``, ``raw`` and ``wav`` outputs. This
+port defaults to ``raw`` (PCM_S16LE) at 16000 Hz so the output integrates
+with Patter's telephony pipeline without transcoding.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator, Literal, Optional
+
+from patter.providers.base import TTSProvider
+
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+LMNT_BASE_URL = "https://api.lmnt.com/v1/ai/speech/bytes"
+
+LMNTAudioFormats = Literal["aac", "mp3", "mulaw", "raw", "wav"]
+LMNTModels = Literal["blizzard", "aurora"]
+LMNTSampleRate = Literal[8000, 16000, 24000]
+
+
+class LMNTTTS(TTSProvider):
+    """LMNT TTS over the HTTP ``/v1/ai/speech/bytes`` endpoint.
+
+    Default output is 16 kHz PCM_S16LE (``format='raw'``) which matches the
+    Patter pipeline's standard telephony sample rate.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: LMNTModels = "blizzard",
+        voice: str = "leah",
+        language: Optional[str] = None,
+        format: LMNTAudioFormats = "raw",
+        sample_rate: LMNTSampleRate = 16000,
+        temperature: float = 1.0,
+        top_p: float = 0.8,
+        base_url: str = LMNT_BASE_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for LMNTTTS. "
+                "Install with: pip install patter[lmnt]"
+            )
+
+        resolved_key = api_key or os.environ.get("LMNT_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "LMNT API key is required, either as argument or set "
+                "LMNT_API_KEY environment variable"
+            )
+
+        # Mirror the upstream language defaults.
+        if language is None:
+            language = "auto" if model == "blizzard" else "en"
+
+        self.api_key = resolved_key
+        self.model = model
+        self.voice = voice
+        self.language = language
+        self.format = format
+        self.sample_rate = sample_rate
+        self.temperature = temperature
+        self.top_p = top_p
+        self.base_url = base_url
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        return (
+            f"LMNTTTS(model={self.model!r}, voice={self.voice!r}, "
+            f"language={self.language!r}, format={self.format!r}, "
+            f"sample_rate={self.sample_rate})"
+        )
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        return {
+            "text": text,
+            "voice": self.voice,
+            "language": self.language,
+            "sample_rate": self.sample_rate,
+            "model": self.model,
+            "format": self.format,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+        }
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream audio bytes for ``text``.
+
+        With the default ``format='raw'`` these are PCM_S16LE chunks at the
+        configured ``sample_rate``.
+        """
+        session = self._ensure_session()
+
+        headers = {
+            "Content-Type": "application/json",
+            "X-API-Key": self.api_key,
+        }
+
+        async with session.post(
+            self.base_url,
+            headers=headers,
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            resp.raise_for_status()
+            async for chunk in resp.content.iter_chunked(4096):
+                if chunk:
+                    yield chunk
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None

--- a/sdk/patter/providers/rime_tts.py
+++ b/sdk/patter/providers/rime_tts.py
@@ -1,0 +1,198 @@
+# Portions of this file are adapted from LiveKit Agents (Apache License 2.0):
+#   https://github.com/livekit/agents
+#   livekit-plugins/livekit-plugins-rime/livekit/plugins/rime/tts.py
+#   Source commit: 78a66bcf79c5cea82989401c408f1dff4b961a5b
+#
+# Copyright 2023 LiveKit, Inc.
+# Modifications (c) 2025 PatterAI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+"""Rime TTS provider — HTTP chunked PCM endpoint, pure aiohttp.
+
+Both Arcana and Mist model families are supported. Requests Rime's
+``audio/pcm`` accept header so chunks are raw PCM_S16LE suitable for direct
+use in Patter's pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncIterator, Optional
+
+from patter.providers.base import TTSProvider
+
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+RIME_BASE_URL = "https://users.rime.ai/v1/rime-tts"
+
+# Model-specific timeouts — Arcana can take up to ~80% of the audio duration
+# it is synthesizing.
+ARCANA_MODEL_TIMEOUT = 60 * 4
+MIST_MODEL_TIMEOUT = 30
+
+
+def _is_mist_model(model: str) -> bool:
+    return "mist" in model
+
+
+def _timeout_for_model(model: str) -> int:
+    if model == "arcana":
+        return ARCANA_MODEL_TIMEOUT
+    return MIST_MODEL_TIMEOUT
+
+
+class RimeTTS(TTSProvider):
+    """Rime TTS over the HTTP chunked endpoint.
+
+    Defaults to the ``arcana`` model with the ``astra`` voice. Output is
+    PCM_S16LE at the configured ``sample_rate`` (default 16000 Hz).
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: str = "arcana",
+        speaker: Optional[str] = None,
+        lang: str = "eng",
+        sample_rate: int = 16000,
+        # Arcana-only options
+        repetition_penalty: Optional[float] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        # Mist-only options
+        speed_alpha: Optional[float] = None,
+        reduce_latency: Optional[bool] = None,
+        pause_between_brackets: Optional[bool] = None,
+        phonemize_between_brackets: Optional[bool] = None,
+        base_url: str = RIME_BASE_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for RimeTTS. "
+                "Install with: pip install patter[rime]"
+            )
+
+        resolved_key = api_key or os.environ.get("RIME_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Rime API key is required, either as argument or set "
+                "RIME_API_KEY environment variable"
+            )
+
+        if speaker is None:
+            # Upstream LiveKit uses "cove" (DefaultMistVoice) for Mist models
+            # and "astra" for Arcana. We mirror the Arcana default here and
+            # let callers override for Mist.
+            speaker = "cove" if _is_mist_model(model) else "astra"
+
+        self.api_key = resolved_key
+        self.model = model
+        self.speaker = speaker
+        self.lang = lang
+        self.sample_rate = sample_rate
+        self.repetition_penalty = repetition_penalty
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_tokens = max_tokens
+        self.speed_alpha = speed_alpha
+        self.reduce_latency = reduce_latency
+        self.pause_between_brackets = pause_between_brackets
+        self.phonemize_between_brackets = phonemize_between_brackets
+        self.base_url = base_url
+        self._total_timeout = _timeout_for_model(model)
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        return (
+            f"RimeTTS(model={self.model!r}, speaker={self.speaker!r}, "
+            f"lang={self.lang!r}, sample_rate={self.sample_rate})"
+        )
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "speaker": self.speaker,
+            "text": text,
+            "modelId": self.model,
+        }
+
+        if self.model == "arcana":
+            if self.repetition_penalty is not None:
+                payload["repetition_penalty"] = self.repetition_penalty
+            if self.temperature is not None:
+                payload["temperature"] = self.temperature
+            if self.top_p is not None:
+                payload["top_p"] = self.top_p
+            if self.max_tokens is not None:
+                payload["max_tokens"] = self.max_tokens
+            payload["lang"] = self.lang
+            payload["samplingRate"] = self.sample_rate
+        elif _is_mist_model(self.model):
+            payload["lang"] = self.lang
+            payload["samplingRate"] = self.sample_rate
+            if self.speed_alpha is not None:
+                payload["speedAlpha"] = self.speed_alpha
+            if self.model == "mistv2" and self.reduce_latency is not None:
+                payload["reduceLatency"] = self.reduce_latency
+            if self.pause_between_brackets is not None:
+                payload["pauseBetweenBrackets"] = self.pause_between_brackets
+            if self.phonemize_between_brackets is not None:
+                payload["phonemizeBetweenBrackets"] = self.phonemize_between_brackets
+
+        return payload
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream raw PCM_S16LE bytes for ``text`` over HTTP."""
+        session = self._ensure_session()
+        accept = "audio/pcm"
+
+        headers = {
+            "accept": accept,
+            "Authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+
+        async with session.post(
+            self.base_url,
+            headers=headers,
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=self._total_timeout),
+        ) as resp:
+            resp.raise_for_status()
+            # Rime returns audio/pcm on success; any other content type is a
+            # surface-level error (e.g. JSON error payload).
+            content_type = resp.headers.get("Content-Type", "")
+            if not content_type.startswith("audio"):
+                body = await resp.text()
+                raise RuntimeError(f"Rime returned non-audio response: {body[:500]}")
+
+            async for chunk in resp.content.iter_chunked(4096):
+                if chunk:
+                    yield chunk
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -96,6 +96,8 @@ background-audio = [
     "numpy>=1.26",
     "soundfile>=0.12",
 ]
+rime = ["aiohttp>=3.10"]
+lmnt = ["aiohttp>=3.10"]
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/sdk/tests/test_tts_cartesia_rime_lmnt.py
+++ b/sdk/tests/test_tts_cartesia_rime_lmnt.py
@@ -1,0 +1,400 @@
+"""Tests for Cartesia + Rime + LMNT TTS providers.
+
+Most tests use MOCK aiohttp responses so they run offline. Integration
+tests that hit the real provider SKIP automatically when the corresponding
+API key is not set in the environment.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import struct
+from typing import AsyncIterator
+
+import pytest
+
+aiohttp = pytest.importorskip("aiohttp")
+
+from patter.providers.cartesia_tts import CartesiaTTS
+from patter.providers.lmnt_tts import LMNTTTS
+from patter.providers.rime_tts import RimeTTS
+
+
+# ---------------------------------------------------------------------------
+# Helpers: MOCK aiohttp stream — emits a synthetic PCM sine wave as "audio".
+# ---------------------------------------------------------------------------
+
+
+def _mock_pcm_sine_chunks(n_chunks: int = 4, samples_per_chunk: int = 800) -> list[bytes]:
+    """Return a list of bytes chunks representing a sine wave in PCM_S16LE.
+
+    MOCK data — used purely to prove the HTTP streaming plumbing works and
+    yields non-empty bytes.
+    """
+    chunks: list[bytes] = []
+    for c in range(n_chunks):
+        samples = [
+            int(32767 * 0.25 * math.sin(2 * math.pi * (c * samples_per_chunk + i) / 40))
+            for i in range(samples_per_chunk)
+        ]
+        chunks.append(struct.pack(f"<{samples_per_chunk}h", *samples))
+    return chunks
+
+
+class _MockContent:
+    """Mimics ``aiohttp.StreamReader`` for the slice we actually use."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    async def iter_chunked(self, _size: int):
+        for c in self._chunks:
+            yield c
+
+
+class _MockResponse:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        status: int = 200,
+        content_type: str = "audio/pcm",
+    ):
+        self.status = status
+        self.content = _MockContent(chunks)
+        self.headers = {"Content-Type": content_type}
+
+    async def __aenter__(self) -> "_MockResponse":
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                request_info=None,  # type: ignore
+                history=(),
+                status=self.status,
+                message="MOCK HTTP error",
+            )
+
+    async def text(self) -> str:
+        return b"".join(self.content._chunks).decode("utf-8", errors="replace")
+
+
+class _MockSession:
+    """Drop-in replacement for ``aiohttp.ClientSession`` in tests."""
+
+    def __init__(self, response: _MockResponse):
+        self._response = response
+        self.closed = False
+        self.last_request: dict | None = None
+
+    def post(self, url, **kwargs):
+        self.last_request = {"url": url, **kwargs}
+        return self._response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _drain(it: AsyncIterator[bytes]) -> list[bytes]:
+    out: list[bytes] = []
+    async for chunk in it:
+        out.append(chunk)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CartesiaTTS
+# ---------------------------------------------------------------------------
+
+
+def test_cartesia_requires_api_key(monkeypatch):
+    monkeypatch.delenv("CARTESIA_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        CartesiaTTS()
+
+
+def test_cartesia_picks_up_env_key(monkeypatch):
+    monkeypatch.setenv("CARTESIA_API_KEY", "env_key")
+    tts = CartesiaTTS()
+    assert tts.api_key == "env_key"
+
+
+def test_cartesia_defaults():
+    tts = CartesiaTTS(api_key="key")
+    assert tts.model == "sonic-2"
+    assert tts.sample_rate == 16000
+    assert tts.language == "en"
+    # Default voice is Katie — Friendly Fixer from upstream LiveKit.
+    assert tts.voice == "f786b574-daa5-4673-aa0c-cbe3e8534c02"
+
+
+def test_cartesia_repr_does_not_leak_api_key():
+    tts = CartesiaTTS(api_key="secret_key_abc")
+    assert "secret_key_abc" not in repr(tts)
+
+
+def test_cartesia_build_payload_shape():
+    tts = CartesiaTTS(
+        api_key="k",
+        model="sonic-3",
+        voice="v1",
+        language="it",
+        sample_rate=24000,
+        speed=1.2,
+        volume=0.9,
+    )
+    payload = tts._build_payload("ciao")
+    assert payload["model_id"] == "sonic-3"
+    assert payload["voice"] == {"mode": "id", "id": "v1"}
+    assert payload["transcript"] == "ciao"
+    assert payload["language"] == "it"
+    assert payload["output_format"] == {
+        "container": "raw",
+        "encoding": "pcm_s16le",
+        "sample_rate": 24000,
+    }
+    assert payload["generation_config"]["speed"] == 1.2
+    assert payload["generation_config"]["volume"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_cartesia_synthesize_streams_mock_bytes():
+    """MOCK: simulate HTTP stream, verify yielded bytes are non-empty."""
+    chunks = _mock_pcm_sine_chunks(n_chunks=3, samples_per_chunk=400)
+    session = _MockSession(_MockResponse(chunks))
+
+    tts = CartesiaTTS(api_key="k", session=session)  # type: ignore[arg-type]
+    out = await _drain(tts.synthesize("hello world"))
+
+    assert len(out) == 3
+    assert all(len(c) > 0 for c in out)
+    assert out == chunks
+    # URL should target /tts/bytes
+    assert session.last_request and session.last_request["url"].endswith("/tts/bytes")
+
+
+@pytest.mark.asyncio
+async def test_cartesia_close_is_idempotent():
+    tts = CartesiaTTS(api_key="k")
+    await tts.close()
+    await tts.close()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_cartesia_close_does_not_close_external_session():
+    session = _MockSession(_MockResponse([]))
+    tts = CartesiaTTS(api_key="k", session=session)  # type: ignore[arg-type]
+    await tts.close()
+    assert session.closed is False
+
+
+# ---------------------------------------------------------------------------
+# RimeTTS
+# ---------------------------------------------------------------------------
+
+
+def test_rime_requires_api_key(monkeypatch):
+    monkeypatch.delenv("RIME_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        RimeTTS()
+
+
+def test_rime_default_speaker_arcana():
+    tts = RimeTTS(api_key="k")
+    assert tts.model == "arcana"
+    assert tts.speaker == "astra"
+
+
+def test_rime_default_speaker_mist():
+    tts = RimeTTS(api_key="k", model="mistv2")
+    assert tts.speaker == "cove"
+
+
+def test_rime_arcana_payload():
+    tts = RimeTTS(
+        api_key="k",
+        model="arcana",
+        temperature=0.5,
+        top_p=0.9,
+        max_tokens=512,
+        sample_rate=16000,
+    )
+    payload = tts._build_payload("hello")
+    assert payload["speaker"] == "astra"
+    assert payload["modelId"] == "arcana"
+    assert payload["temperature"] == 0.5
+    assert payload["top_p"] == 0.9
+    assert payload["max_tokens"] == 512
+    assert payload["samplingRate"] == 16000
+    assert payload["lang"] == "eng"
+
+
+def test_rime_mist_payload():
+    tts = RimeTTS(
+        api_key="k",
+        model="mistv2",
+        speed_alpha=1.1,
+        reduce_latency=True,
+        pause_between_brackets=True,
+    )
+    payload = tts._build_payload("hi")
+    assert payload["modelId"] == "mistv2"
+    assert payload["speaker"] == "cove"
+    assert payload["speedAlpha"] == 1.1
+    assert payload["reduceLatency"] is True
+    assert payload["pauseBetweenBrackets"] is True
+
+
+def test_rime_timeout_arcana_vs_mist():
+    assert RimeTTS(api_key="k", model="arcana")._total_timeout == 60 * 4
+    assert RimeTTS(api_key="k", model="mistv2")._total_timeout == 30
+
+
+@pytest.mark.asyncio
+async def test_rime_synthesize_streams_mock_bytes():
+    """MOCK: audio/pcm response yields bytes."""
+    chunks = _mock_pcm_sine_chunks(n_chunks=2, samples_per_chunk=400)
+    session = _MockSession(_MockResponse(chunks, content_type="audio/pcm"))
+
+    tts = RimeTTS(api_key="k", session=session)  # type: ignore[arg-type]
+    out = await _drain(tts.synthesize("ciao"))
+
+    assert len(out) == 2
+    assert all(len(c) > 0 for c in out)
+
+
+@pytest.mark.asyncio
+async def test_rime_rejects_non_audio_response():
+    """MOCK: if Rime responds with JSON/text, we raise."""
+    session = _MockSession(
+        _MockResponse([b'{"error":"bad"}'], content_type="application/json")
+    )
+    tts = RimeTTS(api_key="k", session=session)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError):
+        await _drain(tts.synthesize("hi"))
+
+
+@pytest.mark.asyncio
+async def test_rime_close_is_idempotent():
+    tts = RimeTTS(api_key="k")
+    await tts.close()
+    await tts.close()
+
+
+# ---------------------------------------------------------------------------
+# LMNTTTS
+# ---------------------------------------------------------------------------
+
+
+def test_lmnt_requires_api_key(monkeypatch):
+    monkeypatch.delenv("LMNT_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        LMNTTTS()
+
+
+def test_lmnt_defaults():
+    tts = LMNTTTS(api_key="k")
+    # Patter defaults to raw PCM for telephony output.
+    assert tts.format == "raw"
+    assert tts.sample_rate == 16000
+    assert tts.voice == "leah"
+    assert tts.model == "blizzard"
+    # blizzard => language defaults to 'auto'
+    assert tts.language == "auto"
+
+
+def test_lmnt_language_default_aurora():
+    tts = LMNTTTS(api_key="k", model="aurora")
+    assert tts.language == "en"
+
+
+def test_lmnt_payload_shape():
+    tts = LMNTTTS(api_key="k", voice="lily", format="raw", sample_rate=24000)
+    payload = tts._build_payload("hola")
+    assert payload["text"] == "hola"
+    assert payload["voice"] == "lily"
+    assert payload["sample_rate"] == 24000
+    assert payload["format"] == "raw"
+    assert payload["temperature"] == 1.0
+    assert payload["top_p"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_lmnt_synthesize_streams_mock_bytes():
+    """MOCK: raw PCM response yields bytes."""
+    chunks = _mock_pcm_sine_chunks(n_chunks=4, samples_per_chunk=200)
+    session = _MockSession(_MockResponse(chunks, content_type="application/octet-stream"))
+
+    tts = LMNTTTS(api_key="k", session=session)  # type: ignore[arg-type]
+    out = await _drain(tts.synthesize("hello"))
+
+    assert len(out) == 4
+    assert all(len(c) > 0 for c in out)
+
+
+@pytest.mark.asyncio
+async def test_lmnt_close_is_idempotent():
+    tts = LMNTTTS(api_key="k")
+    await tts.close()
+    await tts.close()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — SKIP without real API keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cartesia_integration():
+    if not os.environ.get("CARTESIA_API_KEY"):
+        pytest.skip("CARTESIA_API_KEY not set")
+    tts = CartesiaTTS(sample_rate=16000)
+    try:
+        collected = 0
+        async for chunk in tts.synthesize("Hello from Patter integration test."):
+            collected += len(chunk)
+            if collected > 4000:
+                break
+        assert collected > 0
+    finally:
+        await tts.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_rime_integration():
+    if not os.environ.get("RIME_API_KEY"):
+        pytest.skip("RIME_API_KEY not set")
+    tts = RimeTTS(model="mistv2")
+    try:
+        collected = 0
+        async for chunk in tts.synthesize("Hello from Patter integration test."):
+            collected += len(chunk)
+            if collected > 4000:
+                break
+        assert collected > 0
+    finally:
+        await tts.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lmnt_integration():
+    if not os.environ.get("LMNT_API_KEY"):
+        pytest.skip("LMNT_API_KEY not set")
+    tts = LMNTTTS()
+    try:
+        collected = 0
+        async for chunk in tts.synthesize("Hello from Patter integration test."):
+            collected += len(chunk)
+            if collected > 4000:
+                break
+        assert collected > 0
+    finally:
+        await tts.close()


### PR DESCRIPTION
## Summary

Stream G1 of the LiveKit port — adds three HTTP-based TTS providers to Patter's pipeline, ported from [LiveKit Agents](https://github.com/livekit/agents) (Apache 2.0, source commit `78a66bcf79c5cea82989401c408f1dff4b961a5b`):

- **Cartesia TTS** (`sdk/patter/providers/cartesia_tts.py`, `sdk-ts/src/providers/cartesia-tts.ts`) — HTTP bytes endpoint with PCM_S16LE streaming.
- **Rime TTS** (`rime_tts.py`, `rime-tts.ts`) — supports both Arcana (high fidelity, 4 min timeout) and Mist (low latency) model families, `audio/pcm` response.
- **LMNT TTS** (`lmnt_tts.py`, `lmnt-tts.ts`) — defaults to `format=raw` PCM_S16LE at 16 kHz for telephony use.

## Adaptations from LiveKit

- `tts.TTS` -> Patter's `TTSProvider` ABC (`synthesize(text) -> AsyncIterator[bytes]`, `close()`).
- Dropped the WebSocket / word-timestamp / ConnectionPool / SentenceTokenizer paths — HTTP chunked bytes only, streaming via async generator.
- Output standardized on PCM_S16LE @ 16 kHz so Patter's pipeline can consume it with no resample step.
- Apache 2.0 attribution header on every ported file, noting the upstream path and commit SHA.

## Package additions

```toml
# sdk/pyproject.toml
cartesia = ["aiohttp>=3.10"]
rime = ["aiohttp>=3.10"]
lmnt = ["aiohttp>=3.10"]
```

TypeScript uses `fetch` (no extra dep).

## Tests

- **Python**: 23 unit tests + 3 integration tests (skip without `CARTESIA_API_KEY` / `RIME_API_KEY` / `LMNT_API_KEY`). Mocks simulate aiohttp streaming with a synthetic PCM sine wave.
- **TypeScript**: 18 unit tests using `vi.stubGlobal('fetch', ...)` plus a mock ReadableStream reader.
- Full Python suite: **1256 passed / 3 skipped**. Full TS suite: **903 passed**.

## Docs

New pages under `docs/python-sdk/providers/{cartesia,rime,lmnt}.mdx` with install, usage, options tables, and attribution. Navigation registered in `docs/docs.json`.

## Test plan

- [x] `cd sdk && python3 -m pytest tests/ -x --tb=short` -> 1256 passed, 3 skipped
- [x] `cd sdk-ts && npx tsc --noEmit` -> clean
- [x] `cd sdk-ts && npx vitest run` -> 903 passed
- [ ] Integration test against real Cartesia/Rime/LMNT keys (automatically skipped in CI)