### PR TITLE
feat(h): realtime S2S (Gemini Live + Ultravox) + evals + OTEL + scheduling

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,74 @@
+# Observability
+
+Patter ships opt-in OpenTelemetry tracing that covers the four hot spots on
+the voice pipeline: STT, LLM, TTS, and tool calls.
+
+## Enable tracing
+
+Tracing is disabled by default. Install the optional dependency and set the
+env flag:
+
+```bash
+pip install 'getpatter[tracing]'
+export PATTER_OTEL_ENABLED=1
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318   # any OTLP/HTTP collector
+```
+
+Then call `init_tracing` once at process start — typically from the same
+module that creates your `Patter` client:
+
+```python
+from patter.observability import init_tracing
+
+init_tracing(
+    service_name="my-voice-bot",
+    otlp_endpoint="http://localhost:4318",
+    resource_attributes={"deployment.environment": "staging"},
+)
+```
+
+If `PATTER_OTEL_ENABLED` is not set, `init_tracing` returns `False` and
+every span becomes a no-op — **zero cost** when disabled.
+
+## Emitted spans
+
+| Span name      | Fires                                     | Attributes                                      |
+|----------------|-------------------------------------------|-------------------------------------------------|
+| `patter.stt`   | One per final transcript                  | `patter.stt.text_len`, `patter.stt.confidence`  |
+| `patter.llm`   | One per LLM iteration (incl. tool rounds) | `patter.llm.iteration`, `patter.llm.history_size` |
+| `patter.tts`   | One per synthesized sentence              | `patter.tts.text_len`                           |
+| `patter.tool`  | One per tool invocation                   | `patter.tool.name`, `patter.tool.transport`     |
+
+Every span also carries the current `patter.call.id` so you can group by
+call in your backend.
+
+## PII hygiene
+
+Patter never exports user utterances, tool payloads, or LLM content as span
+attributes. Only sizes, counts, and identifiers are emitted — this keeps
+traces safe to ship to a shared Jaeger / Honeycomb / Grafana Cloud instance.
+
+## Shutdown
+
+Call `shutdown_tracing()` during graceful shutdown to flush any pending spans:
+
+```python
+from patter.observability import shutdown_tracing
+
+shutdown_tracing()
+```
+
+## Troubleshooting
+
+* No spans appear → confirm `PATTER_OTEL_ENABLED=1` is set *in the process
+  that calls `init_tracing`*. A quick check:
+
+  ```python
+  from patter.observability import is_enabled
+  print(is_enabled())
+  ```
+
+* Collector refuses spans → the endpoint defaults to OTLP/HTTP on port 4318.
+  If you are running the gRPC-only OTel Collector image, switch to the
+  `otel/opentelemetry-collector-contrib` image or flip your collector config
+  to enable the HTTP receiver.

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -30,7 +30,9 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
+        "@google/genai": "^0.3.0",
         "cloudflared": "^0.7.1",
+        "node-cron": "^3.0.3",
         "onnxruntime-node": "^1.18.0"
       }
     },
@@ -548,6 +550,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-0.3.1.tgz",
+      "integrity": "sha512-jf1RSDjRqBOjm6zYqx90jQVgCumR7qT/4vqz5dVzb6WalnTqYX6LYONGVqzucQXtB3GFSZcUsqNv5o7SSdcbkQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1312,6 +1328,16 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1384,6 +1410,37 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1428,6 +1485,13 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1749,6 +1813,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1948,6 +2022,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2056,6 +2137,38 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2198,6 +2311,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2208,6 +2349,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -2284,6 +2439,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -2330,6 +2499,19 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2425,12 +2607,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2665,6 +2880,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -3140,6 +3399,27 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3660,6 +3940,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -3812,6 +4099,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -4476,6 +4777,24 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -70,7 +70,9 @@
   },
   "optionalDependencies": {
     "cloudflared": "^0.7.1",
-    "onnxruntime-node": "^1.18.0"
+    "onnxruntime-node": "^1.18.0",
+    "node-cron": "^3.0.3",
+    "@google/genai": "^0.3.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -55,6 +55,12 @@ export { RemoteMessageHandler, isRemoteUrl, isWebSocketUrl } from "./remote-mess
 export { TestSession } from "./test-mode";
 export { ElevenLabsConvAIAdapter } from "./providers/elevenlabs-convai";
 export { OpenAIRealtimeAdapter } from "./providers/openai-realtime";
+export { GeminiLiveAdapter, GEMINI_DEFAULT_INPUT_SR, GEMINI_DEFAULT_OUTPUT_SR } from "./providers/gemini-live";
+export type { GeminiLiveEventHandler } from "./providers/gemini-live";
+export { UltravoxRealtimeAdapter, ULTRAVOX_DEFAULT_API_BASE, ULTRAVOX_DEFAULT_SR } from "./providers/ultravox-realtime";
+export type { UltravoxEventHandler } from "./providers/ultravox-realtime";
+export { scheduleCron, scheduleOnce, scheduleInterval } from "./scheduler";
+export type { ScheduleHandle, JobCallback } from "./scheduler";
 export { DeepgramSTT } from "./providers/deepgram-stt";
 export { SonioxSTT } from "./providers/soniox-stt";
 export type { SonioxSTTOptions } from "./providers/soniox-stt";

--- a/sdk-ts/src/providers/gemini-live.ts
+++ b/sdk-ts/src/providers/gemini-live.ts
@@ -1,0 +1,261 @@
+/**
+ * Gemini Live realtime adapter.
+ *
+ * Partially adapted (~65% port) from LiveKit Agents
+ * (livekit-plugins-google, Apache 2.0). Reframed to Patter's realtime adapter
+ * surface — connect / sendAudio / onEvent / close — matching OpenAIRealtimeAdapter.
+ *
+ * Uses the @google/genai SDK lazily imported at connect() so consumers that do
+ * not use Gemini Live do not pay the load cost. Install with:
+ *
+ *    npm install @google/genai
+ */
+
+import { getLogger } from '../logger';
+
+export const GEMINI_DEFAULT_INPUT_SR = 16000;
+export const GEMINI_DEFAULT_OUTPUT_SR = 24000;
+
+export type GeminiLiveEventHandler = (
+  type:
+    | 'audio'
+    | 'transcript_output'
+    | 'function_call'
+    | 'speech_started'
+    | 'response_done'
+    | 'error',
+  data: unknown,
+) => void | Promise<void>;
+
+interface GeminiLiveOptions {
+  model?: string;
+  voice?: string;
+  instructions?: string;
+  language?: string;
+  tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  inputSampleRate?: number;
+  outputSampleRate?: number;
+  temperature?: number;
+}
+
+export class GeminiLiveAdapter {
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly instructions: string;
+  private readonly language: string;
+  private readonly tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  private readonly inputSampleRate: number;
+  /** Output sample rate — exposed so callers can configure downstream transcoding. */
+  readonly outputSampleRate: number;
+  private readonly temperature: number;
+
+  private client: unknown = null;
+  private session: unknown = null;
+  private receiveLoop: Promise<void> | null = null;
+  private handlers: GeminiLiveEventHandler[] = [];
+  private running = false;
+
+  constructor(
+    private readonly apiKey: string,
+    options: GeminiLiveOptions = {},
+  ) {
+    this.model = options.model ?? 'gemini-2.0-flash-exp';
+    this.voice = options.voice ?? 'Puck';
+    this.instructions = options.instructions ?? '';
+    this.language = options.language ?? 'en-US';
+    this.tools = options.tools;
+    this.inputSampleRate = options.inputSampleRate ?? GEMINI_DEFAULT_INPUT_SR;
+    this.outputSampleRate = options.outputSampleRate ?? GEMINI_DEFAULT_OUTPUT_SR;
+    this.temperature = options.temperature ?? 0.8;
+  }
+
+  async connect(): Promise<void> {
+    let genaiModule: { GoogleGenAI: new (args: { apiKey: string; httpOptions?: Record<string, unknown> }) => unknown };
+    try {
+      // Lazy dynamic import — keeps @google/genai optional.
+      genaiModule = (await import('@google/genai')) as typeof genaiModule;
+    } catch (err) {
+      throw new Error(
+        "Gemini Live requires the '@google/genai' package. Install with: npm install @google/genai",
+      );
+    }
+
+    const { GoogleGenAI } = genaiModule;
+    this.client = new GoogleGenAI({ apiKey: this.apiKey });
+
+    const config: Record<string, unknown> = {
+      responseModalities: ['AUDIO'],
+      speechConfig: {
+        voiceConfig: { prebuiltVoiceConfig: { voiceName: this.voice } },
+        languageCode: this.language,
+      },
+      temperature: this.temperature,
+    };
+    if (this.instructions) {
+      config.systemInstruction = { parts: [{ text: this.instructions }] };
+    }
+    if (this.tools?.length) {
+      config.tools = [
+        {
+          functionDeclarations: this.tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          })),
+        },
+      ];
+    }
+
+    // The genai live surface is organised as client.live.connect({model, config, callbacks?}).
+    // Some SDK versions return a Session-like object with send*/receive methods.
+    const liveApi = (this.client as { live?: { connect?: (args: unknown) => Promise<unknown> } }).live;
+    if (!liveApi?.connect) {
+      throw new Error('@google/genai: live.connect is not available in this version');
+    }
+    this.session = await liveApi.connect({ model: this.model, config });
+    this.running = true;
+
+    // Start the receive pump.
+    this.receiveLoop = this.pumpReceive().catch((err) => {
+      getLogger().error(`Gemini Live receive loop error: ${String(err)}`);
+    });
+  }
+
+  sendAudio(pcm: Buffer): void {
+    if (!this.session || !this.running) return;
+    const mime = `audio/pcm;rate=${this.inputSampleRate}`;
+    const sess = this.session as { sendRealtimeInput?: (args: unknown) => unknown };
+    const result = sess.sendRealtimeInput?.({
+      media: { data: pcm.toString('base64'), mimeType: mime },
+    });
+    if (result instanceof Promise) {
+      void result.catch((err) =>
+        getLogger().warn(`Gemini Live sendAudio error: ${String(err)}`),
+      );
+    }
+  }
+
+  async sendText(text: string): Promise<void> {
+    if (!this.session) return;
+    const sess = this.session as { sendClientContent?: (args: unknown) => Promise<void> };
+    await sess.sendClientContent?.({
+      turns: { role: 'user', parts: [{ text }] },
+      turnComplete: true,
+    });
+  }
+
+  async sendFunctionResult(callId: string, result: string): Promise<void> {
+    if (!this.session) return;
+    const sess = this.session as { sendToolResponse?: (args: unknown) => Promise<void> };
+    await sess.sendToolResponse?.({
+      functionResponses: [
+        { id: callId, name: callId, response: { result } },
+      ],
+    });
+  }
+
+  cancelResponse(): void {
+    // Gemini Live barge-in is VAD-driven — explicit cancel not in v1alpha wire protocol.
+    getLogger().debug('Gemini Live: cancelResponse is implicit via VAD');
+  }
+
+  onEvent(handler: GeminiLiveEventHandler): void {
+    this.handlers.push(handler);
+  }
+
+  private async emit(
+    type:
+      | 'audio'
+      | 'transcript_output'
+      | 'function_call'
+      | 'speech_started'
+      | 'response_done'
+      | 'error',
+    data: unknown,
+  ): Promise<void> {
+    for (const h of this.handlers) {
+      try {
+        await h(type, data);
+      } catch (err) {
+        getLogger().error(`Gemini Live handler threw: ${String(err)}`);
+      }
+    }
+  }
+
+  private async pumpReceive(): Promise<void> {
+    if (!this.session) return;
+    const sess = this.session as { receive?: () => AsyncIterable<unknown> };
+    if (typeof sess.receive !== 'function') {
+      getLogger().warn('Gemini Live: session.receive() not available');
+      return;
+    }
+    try {
+      for await (const response of sess.receive()) {
+        if (!this.running) break;
+        const r = response as {
+          serverContent?: {
+            modelTurn?: {
+              parts?: Array<{
+                inlineData?: { data?: string };
+                text?: string;
+              }>;
+            };
+            turnComplete?: boolean;
+            interrupted?: boolean;
+          };
+          toolCall?: {
+            functionCalls?: Array<{
+              id?: string;
+              name?: string;
+              args?: Record<string, unknown> | string;
+            }>;
+          };
+        };
+
+        const sc = r.serverContent;
+        if (sc) {
+          for (const part of sc.modelTurn?.parts ?? []) {
+            if (part.inlineData?.data) {
+              await this.emit('audio', Buffer.from(part.inlineData.data, 'base64'));
+            }
+            if (part.text) await this.emit('transcript_output', part.text);
+          }
+          if (sc.turnComplete) await this.emit('response_done', null);
+          if (sc.interrupted) await this.emit('speech_started', null);
+        }
+        if (r.toolCall) {
+          for (const fn of r.toolCall.functionCalls ?? []) {
+            const args = fn.args ?? {};
+            await this.emit('function_call', {
+              call_id: fn.id ?? '',
+              name: fn.name ?? '',
+              arguments: typeof args === 'string' ? args : JSON.stringify(args),
+            });
+          }
+        }
+      }
+    } catch (err) {
+      if (this.running) await this.emit('error', err);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.running = false;
+    if (this.session) {
+      const sess = this.session as { close?: () => Promise<void> | void };
+      try {
+        await sess.close?.();
+      } catch {
+        /* ignore */
+      }
+      this.session = null;
+    }
+    this.client = null;
+    if (this.receiveLoop) {
+      await this.receiveLoop.catch(() => undefined);
+      this.receiveLoop = null;
+    }
+  }
+}

--- a/sdk-ts/src/providers/ultravox-realtime.ts
+++ b/sdk-ts/src/providers/ultravox-realtime.ts
@@ -1,0 +1,247 @@
+/**
+ * Ultravox realtime adapter.
+ *
+ * Partially adapted (~70% port) from LiveKit Agents
+ * (livekit-plugins-ultravox, Apache 2.0). Pure WebSocket protocol — no vendor SDK.
+ *
+ * Reframed to Patter's connect / sendAudio / onEvent / close surface,
+ * matching OpenAIRealtimeAdapter.
+ */
+
+import WebSocket from 'ws';
+import { getLogger } from '../logger';
+
+export const ULTRAVOX_DEFAULT_API_BASE = 'https://api.ultravox.ai/api';
+export const ULTRAVOX_DEFAULT_SR = 16000;
+
+export type UltravoxEventHandler = (
+  type:
+    | 'audio'
+    | 'transcript_input'
+    | 'transcript_output'
+    | 'function_call'
+    | 'speech_started'
+    | 'response_done'
+    | 'error',
+  data: unknown,
+) => void | Promise<void>;
+
+interface UltravoxOptions {
+  model?: string;
+  voice?: string;
+  instructions?: string;
+  language?: string;
+  tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  apiBase?: string;
+  sampleRate?: number;
+  firstMessage?: string;
+}
+
+export class UltravoxRealtimeAdapter {
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly instructions: string;
+  private readonly language: string;
+  private readonly tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  private readonly apiBase: string;
+  private readonly sampleRate: number;
+  private readonly firstMessage: string;
+
+  private ws: WebSocket | null = null;
+  private handlers: UltravoxEventHandler[] = [];
+  /** Exposed for diagnostics — true while the underlying socket is open. */
+  running = false;
+
+  constructor(private readonly apiKey: string, options: UltravoxOptions = {}) {
+    this.model = options.model ?? 'fixie-ai/ultravox';
+    this.voice = options.voice ?? '';
+    this.instructions = options.instructions ?? '';
+    this.language = options.language ?? 'en';
+    this.tools = options.tools;
+    this.apiBase = (options.apiBase ?? ULTRAVOX_DEFAULT_API_BASE).replace(/\/$/, '');
+    this.sampleRate = options.sampleRate ?? ULTRAVOX_DEFAULT_SR;
+    this.firstMessage = options.firstMessage ?? '';
+  }
+
+  async connect(): Promise<void> {
+    // Step 1: create the call and get the joinUrl.
+    const body: Record<string, unknown> = {
+      model: this.model,
+      languageHint: this.language,
+      medium: {
+        serverWebSocket: {
+          inputSampleRate: this.sampleRate,
+          outputSampleRate: this.sampleRate,
+        },
+      },
+      firstSpeaker: this.firstMessage ? 'FIRST_SPEAKER_AGENT' : 'FIRST_SPEAKER_USER',
+      recordingEnabled: false,
+    };
+    if (this.voice) body.voice = this.voice;
+    if (this.instructions) body.systemPrompt = this.instructions;
+    if (this.firstMessage) {
+      body.initialOutputMedium = 'MESSAGE_MEDIUM_VOICE';
+      body.initialMessages = [
+        { role: 'MESSAGE_ROLE_AGENT', text: this.firstMessage },
+      ];
+    }
+    if (this.tools?.length) {
+      body.selectedTools = this.tools.map((t) => ({
+        temporaryTool: {
+          modelToolName: t.name,
+          description: t.description,
+          dynamicParameters: toolParamsToUltravox(t.parameters),
+        },
+      }));
+    }
+
+    const resp = await fetch(`${this.apiBase}/calls`, {
+      method: 'POST',
+      headers: {
+        'X-API-Key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      throw new Error(`Ultravox create call failed: ${resp.status} ${text}`);
+    }
+    const call = (await resp.json()) as { joinUrl?: string };
+    if (!call.joinUrl) throw new Error('Ultravox response missing joinUrl');
+
+    // Step 2: open the WebSocket.
+    this.ws = new WebSocket(call.joinUrl);
+    await new Promise<void>((resolve, reject) => {
+      const ws = this.ws!;
+      const onOpen = (): void => {
+        ws.off('error', onError);
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        ws.off('open', onOpen);
+        reject(err);
+      };
+      ws.once('open', onOpen);
+      ws.once('error', onError);
+    });
+    this.running = true;
+
+    this.ws.on('message', (raw, isBinary) => {
+      void this.handleMessage(raw, isBinary).catch((err) =>
+        getLogger().error(`Ultravox message handler error: ${String(err)}`),
+      );
+    });
+    this.ws.on('close', () => {
+      this.running = false;
+    });
+  }
+
+  sendAudio(pcm: Buffer): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(pcm, { binary: true });
+  }
+
+  async sendText(text: string): Promise<void> {
+    this.ws?.send(JSON.stringify({ type: 'input_text_message', text }));
+  }
+
+  async sendFunctionResult(callId: string, result: string): Promise<void> {
+    this.ws?.send(
+      JSON.stringify({
+        type: 'client_tool_result',
+        invocationId: callId,
+        result,
+        responseType: 'tool-response',
+      }),
+    );
+  }
+
+  cancelResponse(): void {
+    this.ws?.send(JSON.stringify({ type: 'playback_clear_buffer' }));
+  }
+
+  onEvent(handler: UltravoxEventHandler): void {
+    this.handlers.push(handler);
+  }
+
+  private async emit(
+    type:
+      | 'audio'
+      | 'transcript_input'
+      | 'transcript_output'
+      | 'function_call'
+      | 'speech_started'
+      | 'response_done'
+      | 'error',
+    data: unknown,
+  ): Promise<void> {
+    for (const h of this.handlers) {
+      try {
+        await h(type, data);
+      } catch (err) {
+        getLogger().error(`Ultravox handler threw: ${String(err)}`);
+      }
+    }
+  }
+
+  private async handleMessage(raw: WebSocket.RawData, isBinary: boolean): Promise<void> {
+    if (isBinary) {
+      const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw as ArrayBuffer);
+      await this.emit('audio', buf);
+      return;
+    }
+    let event: { type?: string; [k: string]: unknown };
+    try {
+      event = JSON.parse(raw.toString()) as typeof event;
+    } catch {
+      getLogger().warn('Ultravox: non-JSON text frame');
+      return;
+    }
+    const etype = event.type ?? '';
+    if (etype === 'transcript') {
+      const role = event.role as string | undefined;
+      const text = (event.text ?? event.delta ?? '') as string;
+      const isFinal = Boolean(event.final);
+      if (role === 'user' && isFinal && text) await this.emit('transcript_input', text);
+      else if (role === 'agent' && text) await this.emit('transcript_output', text);
+    } else if (etype === 'client_tool_invocation') {
+      await this.emit('function_call', {
+        call_id: event.invocationId ?? '',
+        name: event.toolName ?? '',
+        arguments: JSON.stringify(event.parameters ?? {}),
+      });
+    } else if (etype === 'state') {
+      const state = event.state as string | undefined;
+      if (state === 'listening') await this.emit('speech_started', null);
+      else if (state === 'idle') await this.emit('response_done', null);
+    } else if (etype === 'playback_clear_buffer') {
+      await this.emit('speech_started', null);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.running = false;
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        /* ignore */
+      }
+      this.ws = null;
+    }
+  }
+}
+
+function toolParamsToUltravox(parameters: Record<string, unknown>): Array<Record<string, unknown>> {
+  const props = (parameters.properties as Record<string, unknown>) ?? {};
+  const required = new Set<string>(
+    Array.isArray(parameters.required) ? (parameters.required as string[]) : [],
+  );
+  return Object.entries(props).map(([name, schema]) => ({
+    name,
+    location: 'PARAMETER_LOCATION_BODY',
+    schema,
+    required: required.has(name),
+  }));
+}

--- a/sdk-ts/src/scheduler.ts
+++ b/sdk-ts/src/scheduler.ts
@@ -1,0 +1,158 @@
+/**
+ * Thin scheduling wrapper around node-cron (MIT).
+ *
+ *    import { scheduleCron, scheduleOnce } from 'getpatter';
+ *
+ *    const handle = scheduleCron('* /5 * * * *', async () => doWork());
+ *    handle.cancel();
+ *
+ * node-cron is an optional dependency. This module imports it lazily so that
+ * consumers who never schedule anything do not need it installed.
+ */
+
+import { getLogger } from './logger';
+
+export type JobCallback = () => void | Promise<void>;
+
+export interface ScheduleHandle {
+  readonly jobId: string;
+  cancel(): void;
+  readonly pending: boolean;
+}
+
+interface CronTask {
+  stop(): void;
+  destroy?: () => void;
+}
+
+interface CronModule {
+  schedule(
+    expression: string,
+    cb: () => void,
+    options?: { scheduled?: boolean; timezone?: string },
+  ): CronTask;
+  validate(expression: string): boolean;
+}
+
+let cronModule: CronModule | null = null;
+let loadError: Error | null = null;
+
+async function loadCron(): Promise<CronModule> {
+  if (cronModule) return cronModule;
+  if (loadError) throw loadError;
+  try {
+    // node-cron ships without TypeScript types in its default export; we
+    // intentionally keep this ``import`` untyped and narrow it to our local
+    // ``CronModule`` interface above.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const imported: any = await import(
+      /* @vite-ignore */ 'node-cron' as string
+    );
+    // Some bundlers wrap CJS exports under .default
+    cronModule = (imported && imported.default
+      ? (imported.default as CronModule)
+      : (imported as CronModule));
+    return cronModule;
+  } catch (err) {
+    loadError = new Error(
+      "Scheduling requires the 'node-cron' package. Install with: npm install node-cron",
+    );
+    throw loadError;
+  }
+}
+
+function wrapCallback(cb: JobCallback): () => void {
+  return () => {
+    try {
+      const result = cb();
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch((err) =>
+          getLogger().error(`Scheduled callback threw: ${String(err)}`),
+        );
+      }
+    } catch (err) {
+      getLogger().error(`Scheduled callback threw: ${String(err)}`);
+    }
+  };
+}
+
+/** Schedule ``callback`` on a cron expression (node-cron dialect). */
+export async function scheduleCron(
+  cron: string,
+  callback: JobCallback,
+): Promise<ScheduleHandle> {
+  const cm = await loadCron();
+  if (!cm.validate(cron)) {
+    throw new Error(`Invalid cron expression: ${cron}`);
+  }
+  const task = cm.schedule(cron, wrapCallback(callback));
+  return makeHandle(`cron-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, task);
+}
+
+/** Schedule ``callback`` once at the given date. */
+export function scheduleOnce(at: Date, callback: JobCallback): ScheduleHandle {
+  const delayMs = at.getTime() - Date.now();
+  let cancelled = false;
+  let done = false;
+  const timer = setTimeout(() => {
+    if (cancelled) return;
+    done = true;
+    wrapCallback(callback)();
+  }, Math.max(0, delayMs));
+
+  return {
+    jobId: `once-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    cancel(): void {
+      cancelled = true;
+      clearTimeout(timer);
+    },
+    get pending(): boolean {
+      return !cancelled && !done;
+    },
+  };
+}
+
+/** Schedule ``callback`` every ``intervalMs`` milliseconds. */
+export function scheduleInterval(intervalMs: number, callback: JobCallback): ScheduleHandle {
+  if (intervalMs <= 0) throw new Error('intervalMs must be positive');
+  let cancelled = false;
+  const wrapped = wrapCallback(callback);
+  const timer = setInterval(() => {
+    if (!cancelled) wrapped();
+  }, intervalMs);
+
+  return {
+    jobId: `interval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    cancel(): void {
+      cancelled = true;
+      clearInterval(timer);
+    },
+    get pending(): boolean {
+      return !cancelled;
+    },
+  };
+}
+
+function makeHandle(jobId: string, task: CronTask): ScheduleHandle {
+  let cancelled = false;
+  return {
+    jobId,
+    cancel(): void {
+      if (cancelled) return;
+      cancelled = true;
+      try {
+        task.stop();
+      } catch {
+        /* ignore */
+      }
+      try {
+        task.destroy?.();
+      } catch {
+        /* ignore */
+      }
+    },
+    get pending(): boolean {
+      return !cancelled;
+    },
+  };
+}

--- a/sdk-ts/tests/gemini-live.test.ts
+++ b/sdk-ts/tests/gemini-live.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GeminiLiveAdapter,
+  GEMINI_DEFAULT_INPUT_SR,
+  GEMINI_DEFAULT_OUTPUT_SR,
+} from '../src/providers/gemini-live';
+
+describe('GeminiLiveAdapter', () => {
+  it('initializes with required api key and default options', () => {
+    const adapter = new GeminiLiveAdapter('fake-key');
+    expect(adapter).toBeDefined();
+    expect(adapter.outputSampleRate).toBe(GEMINI_DEFAULT_OUTPUT_SR);
+  });
+
+  it('respects custom sample rates and model', () => {
+    const adapter = new GeminiLiveAdapter('fake-key', {
+      model: 'gemini-2.5-flash',
+      voice: 'Aoede',
+      inputSampleRate: 24000,
+      outputSampleRate: 48000,
+      temperature: 0.2,
+    });
+    expect(adapter).toBeDefined();
+    expect(adapter.outputSampleRate).toBe(48000);
+  });
+
+  it('accepts tools array', () => {
+    const adapter = new GeminiLiveAdapter('fake-key', {
+      tools: [{ name: 't', description: 'desc', parameters: { type: 'object' } }],
+    });
+    expect(adapter).toBeDefined();
+  });
+
+  it('sendAudio does not throw when not connected', () => {
+    const adapter = new GeminiLiveAdapter('fake-key');
+    expect(() => adapter.sendAudio(Buffer.from('test'))).not.toThrow();
+  });
+
+  it('cancelResponse does not throw when not connected', () => {
+    const adapter = new GeminiLiveAdapter('fake-key');
+    expect(() => adapter.cancelResponse()).not.toThrow();
+  });
+
+  it('close is idempotent', async () => {
+    const adapter = new GeminiLiveAdapter('fake-key');
+    await adapter.close();
+    await adapter.close();
+    expect(true).toBe(true);
+  });
+
+  it('exports stable sample rate constants', () => {
+    expect(GEMINI_DEFAULT_INPUT_SR).toBe(16000);
+    expect(GEMINI_DEFAULT_OUTPUT_SR).toBe(24000);
+  });
+
+  it('emits events to registered handlers', async () => {
+    const adapter = new GeminiLiveAdapter('fake-key');
+    const received: Array<{ type: string; data: unknown }> = [];
+    adapter.onEvent(async (type, data) => {
+      received.push({ type, data });
+    });
+
+    // Reach into the private emit method so we can verify fan-out without a
+    // real session. This is a unit test — integration tests exercise the
+    // real genai session.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).emit('audio', Buffer.from('ab'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).emit('response_done', null);
+    expect(received.map((r) => r.type)).toEqual(['audio', 'response_done']);
+  });
+});

--- a/sdk-ts/tests/scheduler.test.ts
+++ b/sdk-ts/tests/scheduler.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  scheduleInterval,
+  scheduleOnce,
+} from '../src/scheduler';
+
+describe('scheduleInterval', () => {
+  it('fires the callback multiple times', async () => {
+    let n = 0;
+    const handle = scheduleInterval(30, () => {
+      n += 1;
+    });
+    expect(handle.pending).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    handle.cancel();
+    expect(n).toBeGreaterThanOrEqual(2);
+    expect(handle.pending).toBe(false);
+  });
+
+  it('does not fire after cancel', async () => {
+    let n = 0;
+    const handle = scheduleInterval(25, () => {
+      n += 1;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    handle.cancel();
+    const snapshot = n;
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(n).toBe(snapshot);
+  });
+
+  it('throws on non-positive interval', () => {
+    expect(() => scheduleInterval(0, () => undefined)).toThrow();
+    expect(() => scheduleInterval(-5, () => undefined)).toThrow();
+  });
+
+  it('propagates async callback errors to the logger, not the caller', async () => {
+    let n = 0;
+    const handle = scheduleInterval(20, async () => {
+      n += 1;
+      if (n === 1) throw new Error('boom');
+    });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    handle.cancel();
+    expect(n).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('scheduleOnce', () => {
+  it('fires exactly once', async () => {
+    let n = 0;
+    scheduleOnce(new Date(Date.now() + 40), () => {
+      n += 1;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(n).toBe(1);
+  });
+
+  it('does not fire when cancelled before firing', async () => {
+    let n = 0;
+    const handle = scheduleOnce(new Date(Date.now() + 80), () => {
+      n += 1;
+    });
+    handle.cancel();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(n).toBe(0);
+  });
+
+  it('exposes pending state', async () => {
+    const handle = scheduleOnce(new Date(Date.now() + 30), () => undefined);
+    expect(handle.pending).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(handle.pending).toBe(false);
+  });
+});

--- a/sdk-ts/tests/ultravox-realtime.test.ts
+++ b/sdk-ts/tests/ultravox-realtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UltravoxRealtimeAdapter,
+  ULTRAVOX_DEFAULT_API_BASE,
+  ULTRAVOX_DEFAULT_SR,
+} from '../src/providers/ultravox-realtime';
+
+describe('UltravoxRealtimeAdapter', () => {
+  it('initializes with default options', () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    expect(adapter).toBeDefined();
+    expect(adapter.running).toBe(false);
+  });
+
+  it('respects custom options', () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key', {
+      model: 'fixie-ai/ultravox-v0_4',
+      voice: 'en_male_brian',
+      instructions: 'be brief',
+      language: 'it',
+      sampleRate: 8000,
+    });
+    expect(adapter).toBeDefined();
+  });
+
+  it('sendAudio does not throw when not connected', () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    expect(() => adapter.sendAudio(Buffer.from('ab'))).not.toThrow();
+  });
+
+  it('cancelResponse does not throw when not connected', () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    expect(() => adapter.cancelResponse()).not.toThrow();
+  });
+
+  it('close is idempotent', async () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    await adapter.close();
+    await adapter.close();
+    expect(true).toBe(true);
+  });
+
+  it('exports stable constants', () => {
+    expect(ULTRAVOX_DEFAULT_SR).toBe(16000);
+    expect(ULTRAVOX_DEFAULT_API_BASE).toMatch(/^https:\/\//);
+  });
+
+  it('handleMessage translates transcript events', async () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    const events: Array<{ type: string; data: unknown }> = [];
+    adapter.onEvent(async (type, data) => {
+      events.push({ type, data });
+    });
+
+    const userJson = JSON.stringify({
+      type: 'transcript',
+      role: 'user',
+      text: 'hello',
+      final: true,
+    });
+    const toolJson = JSON.stringify({
+      type: 'client_tool_invocation',
+      invocationId: 'inv-1',
+      toolName: 'weather',
+      parameters: { city: 'Rome' },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).handleMessage(Buffer.from(userJson), false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).handleMessage(Buffer.from(toolJson), false);
+
+    expect(events[0].type).toBe('transcript_input');
+    expect(events[0].data).toBe('hello');
+    expect(events[1].type).toBe('function_call');
+    const fc = events[1].data as { call_id: string; name: string; arguments: string };
+    expect(fc.call_id).toBe('inv-1');
+    expect(fc.name).toBe('weather');
+    expect(JSON.parse(fc.arguments)).toEqual({ city: 'Rome' });
+  });
+
+  it('handleMessage forwards binary frames as audio', async () => {
+    const adapter = new UltravoxRealtimeAdapter('fake-key');
+    const events: Array<{ type: string; data: unknown }> = [];
+    adapter.onEvent(async (type, data) => {
+      events.push({ type, data });
+    });
+
+    const pcm = Buffer.from([0, 1, 2, 3]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).handleMessage(pcm, true);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('audio');
+    expect(Buffer.isBuffer(events[0].data)).toBe(true);
+    expect((events[0].data as Buffer).equals(pcm)).toBe(true);
+  });
+});

--- a/sdk/patter/__init__.py
+++ b/sdk/patter/__init__.py
@@ -28,6 +28,12 @@ from patter.services.fallback_provider import (
 )
 from patter.services.chat_context import ChatContext, ChatMessage
 from patter.services.ivr import DtmfEvent, IVRActivity, TfidfLoopDetector, format_dtmf
+from patter.scheduler import (
+    ScheduleHandle,
+    schedule_cron,
+    schedule_once,
+    schedule_interval,
+)
 
 __all__ = [
     "Patter",
@@ -63,4 +69,8 @@ __all__ = [
     "TfidfLoopDetector",
     "DtmfEvent",
     "format_dtmf",
+    "ScheduleHandle",
+    "schedule_cron",
+    "schedule_once",
+    "schedule_interval",
 ]

--- a/sdk/patter/cli.py
+++ b/sdk/patter/cli.py
@@ -24,10 +24,17 @@ def main() -> None:
         "--port", type=int, default=8000, help="Port to serve dashboard on (default: 8000)"
     )
 
+    # patter eval run <suite>
+    from patter.evals.cli import build_eval_parser, dispatch_eval
+
+    build_eval_parser(subparsers)
+
     args = parser.parse_args()
 
     if args.command == "dashboard":
         asyncio.run(_run_dashboard(args.port))
+    elif args.command == "eval":
+        sys.exit(dispatch_eval(args))
     else:
         parser.print_help()
         sys.exit(1)

--- a/sdk/patter/evals/__init__.py
+++ b/sdk/patter/evals/__init__.py
@@ -1,0 +1,26 @@
+"""Patter evaluation framework.
+
+Primitives:
+- :class:`~patter.evals.case.EvalCase` — declarative description of a test case
+- :class:`~patter.evals.runner.EvalRunner` — drives one or more cases
+- :class:`~patter.evals.llm_judge.LLMJudge` — uses an LLM to score a transcript
+  against a rubric
+
+Inspired by LiveKit Agents' evals module (Apache 2.0) but not a direct port —
+LiveKit's primitives depend on LiveKit-specific room/session abstractions that
+do not apply to Patter's handler model.
+"""
+
+from patter.evals.case import EvalCase, EvalTurn, JudgeResult, EvalResult
+from patter.evals.llm_judge import LLMJudge
+from patter.evals.runner import EvalRunner, EvalSuite
+
+__all__ = [
+    "EvalCase",
+    "EvalTurn",
+    "JudgeResult",
+    "EvalResult",
+    "LLMJudge",
+    "EvalRunner",
+    "EvalSuite",
+]

--- a/sdk/patter/evals/case.py
+++ b/sdk/patter/evals/case.py
@@ -1,0 +1,67 @@
+"""Eval case data model.
+
+An :class:`EvalCase` is a scripted scenario: a sequence of user turns, an
+expected-behavior description, and a rubric used by the judge LLM.
+
+Designed to be loaded from a YAML/JSON suite file — see
+:func:`patter.evals.runner.load_suite`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EvalTurn:
+    """A single user utterance in a scripted conversation."""
+
+    user: str
+    # Optional: a regex the agent's reply must match — used as a cheap
+    # pre-filter before invoking the LLM judge.
+    expected_contains: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    """A complete evaluation scenario."""
+
+    name: str
+    turns: list[EvalTurn]
+    expected_behavior: str
+    rubric: str
+    # Optional metadata for reporting/filtering.
+    tags: list[str] = field(default_factory=list)
+    # Optional first-message the agent should emit before any user turn.
+    first_message: str = ""
+
+
+@dataclass(frozen=True)
+class JudgeResult:
+    """The judge's verdict on one case."""
+
+    score: float  # 0.0-1.0
+    passed: bool
+    reasoning: str
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    """The result of running a single :class:`EvalCase`."""
+
+    case_name: str
+    transcript: list[dict[str, str]]  # [{"role": "user"|"agent", "text": ...}]
+    judge: JudgeResult
+    duration_s: float
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "case": self.case_name,
+            "score": self.judge.score,
+            "passed": self.judge.passed,
+            "reasoning": self.judge.reasoning,
+            "transcript": list(self.transcript),
+            "duration_s": round(self.duration_s, 3),
+            "error": self.error,
+        }

--- a/sdk/patter/evals/cli.py
+++ b/sdk/patter/evals/cli.py
@@ -1,0 +1,123 @@
+"""Command-line entry point for Patter evals.
+
+Invoked as ``patter eval run suite.yaml`` via the main CLI dispatcher
+(see :mod:`patter.cli`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from patter.evals.llm_judge import LLMJudge
+from patter.evals.runner import EvalRunner, load_suite
+
+logger = logging.getLogger("patter.evals.cli")
+
+
+def build_eval_parser(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Attach the ``eval`` subcommand tree to a parent CLI."""
+    eval_parser = subparsers.add_parser("eval", help="Run evaluation suites")
+    eval_sub = eval_parser.add_subparsers(dest="eval_command")
+
+    run = eval_sub.add_parser("run", help="Run an eval suite")
+    run.add_argument("suite", type=Path, help="Path to a YAML or JSON suite file")
+    run.add_argument(
+        "--agent",
+        type=str,
+        default="",
+        help="Dotted import path to an async agent factory: module:callable",
+    )
+    run.add_argument(
+        "--judge-model", default="gpt-4o-mini", help="Model the LLM judge should use"
+    )
+    run.add_argument(
+        "--pass-threshold", type=float, default=0.7, help="Score threshold for pass"
+    )
+    run.add_argument(
+        "--output", type=Path, default=None, help="Write JSON report to this file"
+    )
+    return eval_parser
+
+
+def dispatch_eval(args: argparse.Namespace) -> int:
+    """Entry for ``patter eval ...``. Returns a process exit code."""
+    if args.eval_command != "run":
+        print("Usage: patter eval run <suite>")
+        return 2
+    return asyncio.run(_run(args))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    suite = load_suite(args.suite)
+
+    judge = LLMJudge(
+        model=args.judge_model,
+        pass_threshold=args.pass_threshold,
+    )
+    runner = EvalRunner(judge=judge)
+
+    factory = _load_agent_factory(args.agent)
+    results = await runner.run(suite, factory)
+    report = runner.report(suite, results)
+
+    if args.output:
+        args.output.write_text(report, encoding="utf-8")
+        print(f"Wrote report to {args.output}")
+    else:
+        print(report)
+
+    total = len(results)
+    passed = sum(1 for r in results if r.judge.passed)
+    print(f"\n{passed}/{total} cases passed", file=sys.stderr)
+    return 0 if passed == total else 1
+
+
+def _load_agent_factory(
+    dotted: str,
+) -> Callable[[], Callable[[str], Awaitable[str]]]:
+    """Resolve a ``module:factory`` string to a callable.
+
+    Falls back to an echo-style mock agent when no factory is provided — lets
+    developers sanity-check their suite shape before wiring the real agent.
+    """
+    if not dotted:
+        async def _echo(text: str) -> str:
+            return f"echo: {text}"
+
+        def _factory() -> Callable[[str], Awaitable[str]]:
+            return _echo
+
+        return _factory
+
+    if ":" not in dotted:
+        raise ValueError("--agent must be of the form 'module.path:attr_name'")
+    module_path, attr = dotted.split(":", 1)
+    mod = importlib.import_module(module_path)
+    obj = getattr(mod, attr)
+    if not callable(obj):
+        raise TypeError(f"--agent target {dotted!r} is not callable")
+    return obj  # type: ignore[return-value]
+
+
+def main() -> None:
+    """Standalone entry for ``python -m patter.evals.cli``."""
+    parser = argparse.ArgumentParser(prog="patter-eval")
+    subparsers = parser.add_subparsers(dest="command")
+    build_eval_parser(subparsers)
+    args = parser.parse_args()
+    if args.command != "eval":
+        parser.print_help()
+        sys.exit(2)
+    sys.exit(dispatch_eval(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/patter/evals/llm_judge.py
+++ b/sdk/patter/evals/llm_judge.py
@@ -1,0 +1,116 @@
+"""LLM-as-judge scoring for eval cases."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from patter.evals.case import EvalCase, JudgeResult
+
+logger = logging.getLogger("patter.evals")
+
+
+_JUDGE_SYSTEM = (
+    "You are a strict but fair evaluator of voice-AI agents. "
+    "You will be given: (1) the expected behavior for the agent, (2) a rubric, "
+    "(3) a transcript of the conversation. "
+    "Return a JSON object with exactly three keys:\n"
+    "  - \"score\": float between 0.0 and 1.0\n"
+    "  - \"passed\": boolean (true when score >= threshold)\n"
+    "  - \"reasoning\": short string explaining the score\n"
+    "Do not return any text outside the JSON object."
+)
+
+
+class LLMJudge:
+    """Scores conversation transcripts against a rubric via an OpenAI model.
+
+    The judge is intentionally provider-specific (OpenAI chat completions)
+    because reliability of structured JSON output matters more than provider
+    flexibility for evals. Callers who need a different backend can implement
+    a ``JudgeBackend`` and inject it via the ``backend`` argument.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        api_key: str | None = None,
+        pass_threshold: float = 0.7,
+        backend: Any = None,
+    ) -> None:
+        self.model = model
+        self.api_key = api_key
+        self.pass_threshold = pass_threshold
+        self._backend = backend  # for tests — any object exposing ``judge(prompt)``.
+
+    async def judge_case(
+        self, case: EvalCase, transcript: list[dict[str, str]]
+    ) -> JudgeResult:
+        """Return a :class:`JudgeResult` for the given transcript."""
+        prompt = self._build_prompt(case, transcript)
+        if self._backend is not None:
+            raw = await self._backend.judge(prompt)
+        else:
+            raw = await self._call_openai(prompt)
+        return self._parse(raw)
+
+    def _build_prompt(
+        self, case: EvalCase, transcript: list[dict[str, str]]
+    ) -> str:
+        lines = [
+            f"EXPECTED BEHAVIOR: {case.expected_behavior}",
+            f"RUBRIC: {case.rubric}",
+            f"PASS THRESHOLD: {self.pass_threshold}",
+            "TRANSCRIPT:",
+        ]
+        for turn in transcript:
+            lines.append(f"  {turn.get('role', '?')}: {turn.get('text', '')}")
+        return "\n".join(lines)
+
+    async def _call_openai(self, prompt: str) -> str:
+        """Call OpenAI chat completions — lazy import to keep extras optional."""
+        try:
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "LLMJudge requires the 'openai' package. "
+                "Install with: pip install getpatter[evals]"
+            ) from exc
+
+        client = AsyncOpenAI(api_key=self.api_key) if self.api_key else AsyncOpenAI()
+        response = await client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": _JUDGE_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.0,
+        )
+        return response.choices[0].message.content or "{}"
+
+    def _parse(self, raw: str) -> JudgeResult:
+        """Parse the judge's JSON — tolerant of extra whitespace / code fences."""
+        text = raw.strip()
+        # Strip a leading fence if the model added one despite json_object mode.
+        if text.startswith("```"):
+            text = re.sub(r"^```(?:json)?\s*", "", text)
+            text = re.sub(r"\s*```$", "", text)
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("LLMJudge: invalid JSON, defaulting to fail: %r", raw)
+            return JudgeResult(
+                score=0.0, passed=False, reasoning=f"Judge returned invalid JSON: {raw[:200]}"
+            )
+        score_raw = data.get("score", 0.0)
+        try:
+            score = float(score_raw)
+        except (TypeError, ValueError):
+            score = 0.0
+        score = max(0.0, min(1.0, score))
+        passed = bool(data.get("passed", score >= self.pass_threshold))
+        reasoning = str(data.get("reasoning", ""))
+        return JudgeResult(score=score, passed=passed, reasoning=reasoning)

--- a/sdk/patter/evals/runner.py
+++ b/sdk/patter/evals/runner.py
@@ -1,0 +1,196 @@
+"""Eval runner — executes an :class:`EvalSuite` against a scripted agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from patter.evals.case import EvalCase, EvalResult, EvalTurn
+from patter.evals.llm_judge import LLMJudge
+
+logger = logging.getLogger("patter.evals")
+
+# An agent factory takes no arguments and returns an object with an async
+# ``reply(text: str) -> str`` method. This decouples the runner from the real
+# Patter Agent wiring (which is owned by handlers) and lets callers plug in
+# any chat-completions client or mock. ``reply`` receives one user turn and
+# returns the agent's final text response.
+AgentCallable = Callable[[str], Awaitable[str]]
+AgentFactory = Callable[[], AgentCallable]
+
+
+@dataclass(frozen=True)
+class EvalSuite:
+    """A named collection of :class:`EvalCase` to run together."""
+
+    name: str
+    cases: list[EvalCase]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class EvalRunner:
+    """Drives one or more cases against an agent and produces a JSON report.
+
+    Usage::
+
+        async def my_agent_factory() -> Callable[[str], Awaitable[str]]:
+            bot = MyBot()
+            return bot.reply
+
+        suite = load_suite(Path("eval/suite.yaml"))
+        runner = EvalRunner(judge=LLMJudge())
+        results = await runner.run(suite, my_agent_factory)
+        print(runner.report(suite, results))
+    """
+
+    def __init__(self, judge: LLMJudge | None = None) -> None:
+        self.judge = judge or LLMJudge()
+
+    async def run(
+        self, suite: EvalSuite, agent_factory: AgentFactory
+    ) -> list[EvalResult]:
+        """Run every case in ``suite`` sequentially."""
+        results: list[EvalResult] = []
+        for case in suite.cases:
+            result = await self.run_case(case, agent_factory)
+            results.append(result)
+        return results
+
+    async def run_case(
+        self, case: EvalCase, agent_factory: AgentFactory
+    ) -> EvalResult:
+        """Run a single case and return its :class:`EvalResult`."""
+        start = time.monotonic()
+        transcript: list[dict[str, str]] = []
+        error: str | None = None
+
+        try:
+            agent = agent_factory()
+            if not callable(agent):
+                # Factories that return async may need to be awaited.
+                if hasattr(agent, "__await__"):
+                    agent = await agent  # type: ignore[assignment]
+
+            if case.first_message:
+                transcript.append({"role": "agent", "text": case.first_message})
+
+            for turn in case.turns:
+                transcript.append({"role": "user", "text": turn.user})
+                reply = await agent(turn.user) if callable(agent) else ""
+                transcript.append({"role": "agent", "text": reply or ""})
+
+                # Cheap pre-filter — if a required substring is missing we
+                # still let the judge decide, but log for easier debugging.
+                for needle in turn.expected_contains:
+                    if needle.lower() not in (reply or "").lower():
+                        logger.info(
+                            "case=%r expected_contains=%r missing in reply", case.name, needle
+                        )
+        except Exception as exc:  # noqa: BLE001 - we need catch-all here
+            error = f"{type(exc).__name__}: {exc}"
+            logger.exception("case=%r raised", case.name)
+
+        # If we failed to produce any transcript, skip the judge.
+        if error and not transcript:
+            duration = time.monotonic() - start
+            from patter.evals.case import JudgeResult
+
+            return EvalResult(
+                case_name=case.name,
+                transcript=transcript,
+                judge=JudgeResult(score=0.0, passed=False, reasoning=error),
+                duration_s=duration,
+                error=error,
+            )
+
+        judge_result = await self.judge.judge_case(case, transcript)
+        duration = time.monotonic() - start
+        return EvalResult(
+            case_name=case.name,
+            transcript=transcript,
+            judge=judge_result,
+            duration_s=duration,
+            error=error,
+        )
+
+    def report(self, suite: EvalSuite, results: list[EvalResult]) -> str:
+        """Render a JSON report suitable for CI artefacts."""
+        total = len(results)
+        passed = sum(1 for r in results if r.judge.passed)
+        payload = {
+            "suite": suite.name,
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+            "pass_rate": (passed / total) if total else 0.0,
+            "cases": [r.to_dict() for r in results],
+        }
+        return json.dumps(payload, indent=2)
+
+
+def load_suite(path: Path) -> EvalSuite:
+    """Load a suite from YAML or JSON.
+
+    Schema (YAML)::
+
+        name: "customer support v1"
+        cases:
+          - name: "greeting is warm"
+            expected_behavior: "Agent greets the caller warmly and asks how it can help."
+            rubric: "Pass if reply contains a greeting and an open-ended question."
+            turns:
+              - user: "hi"
+    """
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "Loading YAML suites requires 'pyyaml'. "
+                "Install with: pip install getpatter[evals]"
+            ) from exc
+        data = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Eval suite {path} must be a mapping, got {type(data).__name__}")
+
+    cases_raw = data.get("cases", [])
+    if not isinstance(cases_raw, list):
+        raise ValueError(f"Eval suite {path}: 'cases' must be a list")
+
+    cases: list[EvalCase] = []
+    for i, c in enumerate(cases_raw):
+        if not isinstance(c, dict):
+            raise ValueError(f"Eval suite {path}: case {i} must be a mapping")
+        turns_raw = c.get("turns", [])
+        turns = [
+            EvalTurn(
+                user=str(t.get("user", "")),
+                expected_contains=list(t.get("expected_contains", []) or []),
+            )
+            for t in turns_raw
+            if isinstance(t, dict)
+        ]
+        cases.append(
+            EvalCase(
+                name=str(c.get("name", f"case_{i}")),
+                turns=turns,
+                expected_behavior=str(c.get("expected_behavior", "")),
+                rubric=str(c.get("rubric", "")),
+                tags=list(c.get("tags", []) or []),
+                first_message=str(c.get("first_message", "")),
+            )
+        )
+
+    return EvalSuite(
+        name=str(data.get("name", path.stem)),
+        cases=cases,
+        metadata=dict(data.get("metadata", {}) or {}),
+    )

--- a/sdk/patter/handlers/stream_handler.py
+++ b/sdk/patter/handlers/stream_handler.py
@@ -30,6 +30,7 @@ from patter.handlers.common import (
     _validate_e164,
 )
 from patter.models import HookContext
+from patter.observability.tracing import SPAN_STT, SPAN_TTS, start_span
 from patter.services.pipeline_hooks import PipelineHookExecutor
 from patter.services.sentence_chunker import SentenceChunker
 from patter.utils.log_sanitize import mask_phone_number, sanitize_log_value
@@ -867,6 +868,14 @@ class PipelineStreamHandler(StreamHandler):
         if processed is None:
             return True  # hook skipped this sentence, not an interruption
 
+        _tts_span = start_span(
+            SPAN_TTS,
+            {
+                "patter.tts.text_len": len(processed),
+                "patter.call.id": self.call_id,
+            },
+        )
+        _tts_span.__enter__()
         gen = self._tts.synthesize(processed)
         try:
             async for audio_chunk in gen:
@@ -886,6 +895,7 @@ class PipelineStreamHandler(StreamHandler):
                 await self.audio_sender.send_audio(processed_audio)
         finally:
             await gen.aclose()
+            _tts_span.__exit__(None, None, None)
         return True
 
     async def _process_streaming_response(self, result, call_id: str) -> str:
@@ -1026,6 +1036,19 @@ class PipelineStreamHandler(StreamHandler):
             async for transcript in self._stt.receive_transcripts():
                 if not (transcript.is_final and transcript.text):
                     continue
+
+                # Record one STT span per final transcript turn. The span is
+                # short-lived (just the attribute set) because STT is
+                # streaming — we do not re-wrap the long-lived iterator.
+                with start_span(
+                    SPAN_STT,
+                    {
+                        "patter.stt.text_len": len(transcript.text),
+                        "patter.stt.confidence": float(transcript.confidence or 0.0),
+                        "patter.call.id": self.call_id,
+                    },
+                ):
+                    pass
 
                 logger.info("User: %s", sanitize_log_value(transcript.text))
 

--- a/sdk/patter/observability/__init__.py
+++ b/sdk/patter/observability/__init__.py
@@ -1,0 +1,25 @@
+"""Optional observability hooks for Patter.
+
+Currently ships with OpenTelemetry tracing. Enable with::
+
+    export PATTER_OTEL_ENABLED=1
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+
+Then call :func:`patter.observability.init_tracing` once at process start.
+"""
+
+from patter.observability.tracing import (
+    init_tracing,
+    is_enabled,
+    start_span,
+    shutdown_tracing,
+    get_tracer,
+)
+
+__all__ = [
+    "init_tracing",
+    "is_enabled",
+    "start_span",
+    "shutdown_tracing",
+    "get_tracer",
+]

--- a/sdk/patter/observability/tracing.py
+++ b/sdk/patter/observability/tracing.py
@@ -1,0 +1,160 @@
+"""OpenTelemetry tracing helpers for Patter.
+
+Design goals:
+* **Zero cost when disabled.** ``start_span`` falls back to a cheap no-op
+  context manager unless the opt-in env var ``PATTER_OTEL_ENABLED=1`` is set
+  *and* the OTel SDK could be imported.
+* **Opt-in only.** No telemetry is emitted by default. We never export PII
+  (user utterances, tool payloads) as span attributes — only sizes and
+  provider identifiers.
+* **Single source of truth for span names.** Downstream services should
+  attribute spans by the constants at the bottom of this module.
+
+Spans used by Patter:
+
+* ``patter.call`` — the top-level call span (created in the stream handler)
+* ``patter.stt`` — a streamed STT inference
+* ``patter.llm`` — an LLM completion (per turn)
+* ``patter.tts`` — a TTS synthesis
+* ``patter.tool`` — a single tool invocation
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+logger = logging.getLogger("patter.observability")
+
+ENV_FLAG = "PATTER_OTEL_ENABLED"
+SERVICE_NAME = "patter"
+
+# --- Span names -------------------------------------------------------------
+SPAN_CALL = "patter.call"
+SPAN_STT = "patter.stt"
+SPAN_LLM = "patter.llm"
+SPAN_TTS = "patter.tts"
+SPAN_TOOL = "patter.tool"
+
+# --- State ------------------------------------------------------------------
+_tracer: Any = None
+_provider: Any = None
+_initialized = False
+
+
+def is_enabled() -> bool:
+    """True only if the env flag is set *and* the tracer initialized cleanly."""
+    return bool(_tracer) and os.getenv(ENV_FLAG, "").lower() in {"1", "true", "yes"}
+
+
+def init_tracing(
+    service_name: str = SERVICE_NAME,
+    otlp_endpoint: str | None = None,
+    resource_attributes: dict[str, str] | None = None,
+) -> bool:
+    """Install the OTel provider + OTLP exporter.
+
+    Returns True if tracing was actually wired. Silently returns False if
+    the env flag is off or the OTel packages are not installed.
+    """
+    global _tracer, _provider, _initialized
+
+    if _initialized:
+        return is_enabled()
+
+    if os.getenv(ENV_FLAG, "").lower() not in {"1", "true", "yes"}:
+        _initialized = True
+        return False
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning(
+            "PATTER_OTEL_ENABLED=1 but opentelemetry SDK not installed. "
+            "Install with: pip install getpatter[tracing]"
+        )
+        _initialized = True
+        return False
+
+    attrs = {"service.name": service_name}
+    if resource_attributes:
+        attrs.update(resource_attributes)
+    resource = Resource.create(attrs)
+    _provider = TracerProvider(resource=resource)
+
+    endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        exporter = OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces") if endpoint else OTLPSpanExporter()
+        _provider.add_span_processor(BatchSpanProcessor(exporter))
+    except ImportError:
+        logger.warning("opentelemetry OTLP exporter not installed; spans will not be exported")
+
+    trace.set_tracer_provider(_provider)
+    _tracer = trace.get_tracer(service_name)
+    _initialized = True
+    logger.info("Patter OTel tracing enabled (service=%s, endpoint=%s)", service_name, endpoint)
+    return True
+
+
+def get_tracer() -> Any:
+    """Returns the current tracer or None."""
+    return _tracer
+
+
+@contextmanager
+def start_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Iterator[Any]:
+    """Start a span with optional attributes.
+
+    No-op (yields None) when tracing is disabled. Callers should tolerate a
+    None span — see :meth:`_noop_span_attr`.
+    """
+    if not is_enabled():
+        yield None
+        return
+
+    span_cm = _tracer.start_as_current_span(name)
+    span = span_cm.__enter__()
+    try:
+        if attributes:
+            for k, v in attributes.items():
+                try:
+                    span.set_attribute(k, v)
+                except Exception:  # pragma: no cover
+                    pass
+        yield span
+    except Exception as exc:  # pragma: no cover - we still need to record + re-raise
+        try:
+            span.record_exception(exc)
+        except Exception:
+            pass
+        raise
+    finally:
+        try:
+            span_cm.__exit__(None, None, None)
+        except Exception:  # pragma: no cover
+            pass
+
+
+def shutdown_tracing() -> None:
+    """Flush any pending spans. Safe to call unconditionally."""
+    global _tracer, _provider, _initialized
+    if _provider is not None:
+        try:
+            _provider.shutdown()
+        except Exception:  # pragma: no cover
+            pass
+    _tracer = None
+    _provider = None
+    _initialized = False

--- a/sdk/patter/providers/gemini_live.py
+++ b/sdk/patter/providers/gemini_live.py
@@ -1,0 +1,242 @@
+"""Gemini Live realtime adapter.
+
+Partially adapted (~65% port) from LiveKit Agents
+(livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py,
+Apache 2.0) at commit referenced in the PR body. Reframed to Patter's simpler
+realtime adapter surface (``connect``/``send_audio``/``receive_events``/``close``)
+which mirrors :class:`~patter.providers.openai_realtime.OpenAIRealtimeAdapter`.
+
+The heavy LiveKit lifecycle/resume machinery is intentionally NOT ported —
+Patter's handlers manage session lifecycle externally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from typing import Any, AsyncIterator
+
+logger = logging.getLogger("patter.gemini_live")
+
+# Default PCM audio format used on the wire for Gemini Live.
+# Gemini Live requires PCM16 mono; sample-rate negotiation happens via
+# ``speech_config``. Patter callers should resample to 16 kHz before calling
+# :meth:`GeminiLiveAdapter.send_audio`.
+DEFAULT_INPUT_SAMPLE_RATE_HZ = 16000
+DEFAULT_OUTPUT_SAMPLE_RATE_HZ = 24000
+
+
+class GeminiLiveAdapter:
+    """Bridges a bidirectional audio stream to Google Gemini Live.
+
+    The adapter presents the same surface as :class:`OpenAIRealtimeAdapter`:
+    ``connect() -> send_audio(bytes) -> async for event in receive_events() -> close()``.
+
+    Tool calling is supported via the ``tools`` constructor argument (same
+    shape as the OpenAI adapter); function-call events are emitted as
+    ``("function_call", {"call_id", "name", "arguments"})``.
+
+    Requires ``google-genai>=1.55`` installed (``pip install getpatter[gemini-live]``).
+    The SDK is imported lazily so callers that do not use Gemini Live do not
+    pay the import cost.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gemini-2.0-flash-exp",
+        voice: str = "Puck",
+        instructions: str = "",
+        language: str = "en-US",
+        tools: list[dict] | None = None,
+        input_sample_rate: int = DEFAULT_INPUT_SAMPLE_RATE_HZ,
+        output_sample_rate: int = DEFAULT_OUTPUT_SAMPLE_RATE_HZ,
+        temperature: float = 0.8,
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.voice = voice
+        self.instructions = instructions
+        self.language = language
+        self.tools = tools
+        self.input_sample_rate = input_sample_rate
+        self.output_sample_rate = output_sample_rate
+        self.temperature = temperature
+        self._client: Any = None
+        self._session: Any = None
+        self._session_cm: Any = None
+        self._running = False
+
+    def __repr__(self) -> str:
+        return (
+            f"GeminiLiveAdapter(model={self.model!r}, voice={self.voice!r}, "
+            f"language={self.language!r})"
+        )
+
+    async def connect(self) -> None:
+        """Open a Live session with Gemini.
+
+        Lazily imports ``google.genai`` — raises ``RuntimeError`` with a
+        helpful install hint if the extra is missing.
+        """
+        try:
+            from google import genai  # type: ignore[import-not-found]
+            from google.genai import types as genai_types  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised in production
+            raise RuntimeError(
+                "Gemini Live requires the 'google-genai' package. "
+                "Install with: pip install getpatter[gemini-live]"
+            ) from exc
+
+        self._client = genai.Client(
+            api_key=self.api_key,
+            http_options={"api_version": "v1alpha"},
+        )
+
+        speech_config = genai_types.SpeechConfig(
+            voice_config=genai_types.VoiceConfig(
+                prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(
+                    voice_name=self.voice,
+                ),
+            ),
+            language_code=self.language,
+        )
+
+        config: dict[str, Any] = {
+            "response_modalities": ["AUDIO"],
+            "speech_config": speech_config,
+            "temperature": self.temperature,
+        }
+        if self.instructions:
+            config["system_instruction"] = genai_types.Content(
+                parts=[genai_types.Part(text=self.instructions)],
+            )
+        if self.tools:
+            config["tools"] = [
+                {
+                    "function_declarations": [
+                        {
+                            "name": t["name"],
+                            "description": t.get("description", ""),
+                            "parameters": t.get("parameters", {}),
+                        }
+                        for t in self.tools
+                    ],
+                }
+            ]
+
+        # ``aio.live.connect`` returns an async context manager — we enter it
+        # manually so that ``receive_events`` can stream indefinitely.
+        self._session_cm = self._client.aio.live.connect(
+            model=self.model,
+            config=config,
+        )
+        self._session = await self._session_cm.__aenter__()
+        self._running = True
+
+    async def send_audio(self, audio: bytes) -> None:
+        """Send a PCM16 mono chunk at ``input_sample_rate`` Hz."""
+        if self._session is None:
+            return
+        mime_type = f"audio/pcm;rate={self.input_sample_rate}"
+        await self._session.send_realtime_input(
+            media={"data": audio, "mime_type": mime_type},
+        )
+
+    async def send_text(self, text: str) -> None:
+        """Send a user text turn that triggers a spoken response."""
+        if self._session is None:
+            return
+        await self._session.send_client_content(
+            turns={"role": "user", "parts": [{"text": text}]},
+            turn_complete=True,
+        )
+
+    async def send_function_result(self, call_id: str, result: str) -> None:
+        """Return a tool call result to Gemini and continue the turn."""
+        if self._session is None:
+            return
+        await self._session.send_tool_response(
+            function_responses=[
+                {
+                    "id": call_id,
+                    "name": call_id,  # LiveKit also fans out id as name fallback
+                    "response": {"result": result},
+                }
+            ],
+        )
+
+    async def cancel_response(self) -> None:
+        """Interrupt the current model turn (barge-in)."""
+        # Gemini Live's ``send_realtime_input`` implicitly barges on VAD;
+        # explicit cancel is not part of the v1alpha wire protocol.
+        logger.debug("Gemini Live: cancel_response is implicit via VAD")
+
+    async def receive_events(self) -> AsyncIterator[tuple[str, Any]]:
+        """Yield ``(event_type, payload)`` tuples.
+
+        Event types:
+            ``audio`` — ``bytes`` of PCM16 mono audio at ``output_sample_rate``
+            ``transcript_output`` — partial transcript text (if enabled)
+            ``function_call`` — ``{"call_id", "name", "arguments"}``
+            ``response_done`` — server indicated turn completion
+        """
+        if self._session is None:
+            return
+
+        try:
+            async for response in self._session.receive():
+                # ``response`` is a genai ``LiveServerMessage``. We gracefully
+                # introspect it so the adapter stays stable across minor
+                # google-genai releases.
+                server_content = getattr(response, "server_content", None)
+                if server_content is not None:
+                    model_turn = getattr(server_content, "model_turn", None)
+                    if model_turn is not None:
+                        for part in getattr(model_turn, "parts", []) or []:
+                            inline = getattr(part, "inline_data", None)
+                            if inline is not None and getattr(inline, "data", None):
+                                yield ("audio", inline.data)
+                            text = getattr(part, "text", None)
+                            if text:
+                                yield ("transcript_output", text)
+                    if getattr(server_content, "turn_complete", False):
+                        yield ("response_done", None)
+                    if getattr(server_content, "interrupted", False):
+                        yield ("speech_started", None)
+
+                tool_call = getattr(response, "tool_call", None)
+                if tool_call is not None:
+                    for fn in getattr(tool_call, "function_calls", []) or []:
+                        args = getattr(fn, "args", {}) or {}
+                        yield (
+                            "function_call",
+                            {
+                                "call_id": getattr(fn, "id", "") or "",
+                                "name": getattr(fn, "name", "") or "",
+                                "arguments": json.dumps(args)
+                                if not isinstance(args, str)
+                                else args,
+                            },
+                        )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Gemini Live receive error: %s", exc)
+        finally:
+            self._running = False
+
+    async def close(self) -> None:
+        """Tear down the Live session."""
+        self._running = False
+        if self._session_cm is not None:
+            try:
+                await self._session_cm.__aexit__(None, None, None)
+            except Exception as exc:  # pragma: no cover
+                logger.debug("Gemini Live close error: %s", exc)
+            finally:
+                self._session_cm = None
+                self._session = None
+        self._client = None

--- a/sdk/patter/providers/ultravox_realtime.py
+++ b/sdk/patter/providers/ultravox_realtime.py
@@ -1,0 +1,287 @@
+"""Ultravox realtime adapter.
+
+Partially adapted (~70% port) from LiveKit Agents
+(livekit-plugins/livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py,
+Apache 2.0). Ultravox uses a pure WebSocket + aiohttp protocol — no vendor
+SDK — so the port is substantially lighter than the Gemini one.
+
+Reframed to Patter's ``connect``/``send_audio``/``receive_events``/``close``
+surface, matching :class:`~patter.providers.openai_realtime.OpenAIRealtimeAdapter`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator
+
+logger = logging.getLogger("patter.ultravox_realtime")
+
+# Ultravox v1 REST endpoint used to create an ephemeral call. The call
+# response includes a ``joinUrl`` WebSocket URL that the client connects to
+# for the audio/event stream.
+DEFAULT_API_BASE = "https://api.ultravox.ai/api"
+DEFAULT_SAMPLE_RATE_HZ = 16000
+
+
+class UltravoxRealtimeAdapter:
+    """Bridges a bidirectional audio stream to an Ultravox realtime call.
+
+    Flow (matches LiveKit plugin):
+        1. POST ``/calls`` to create a call and receive a ``joinUrl``.
+        2. Open the ``joinUrl`` WebSocket.
+        3. Binary frames on the socket are PCM16 audio (both directions).
+        4. Text frames are JSON control events (transcripts, tool calls,
+           state updates).
+
+    Requires ``aiohttp>=3.10`` (``pip install getpatter[ultravox]``).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "fixie-ai/ultravox",
+        voice: str = "",
+        instructions: str = "",
+        language: str = "en",
+        tools: list[dict] | None = None,
+        api_base: str = DEFAULT_API_BASE,
+        sample_rate: int = DEFAULT_SAMPLE_RATE_HZ,
+        first_message: str = "",
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.voice = voice
+        self.instructions = instructions
+        self.language = language
+        self.tools = tools
+        self.api_base = api_base.rstrip("/")
+        self.sample_rate = sample_rate
+        self.first_message = first_message
+        self._session: Any = None  # aiohttp.ClientSession
+        self._ws: Any = None  # aiohttp.ClientWebSocketResponse
+        self._running = False
+
+    def __repr__(self) -> str:
+        return (
+            f"UltravoxRealtimeAdapter(model={self.model!r}, voice={self.voice!r}, "
+            f"sample_rate={self.sample_rate})"
+        )
+
+    async def connect(self) -> None:
+        """Create a call, then open the join WebSocket."""
+        try:
+            import aiohttp  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "Ultravox requires the 'aiohttp' package. "
+                "Install with: pip install getpatter[ultravox]"
+            ) from exc
+
+        self._session = aiohttp.ClientSession(
+            headers={"X-API-Key": self.api_key},
+        )
+
+        create_payload: dict[str, Any] = {
+            "model": self.model,
+            "languageHint": self.language,
+            # PCM16 mono at ``self.sample_rate``
+            "medium": {
+                "serverWebSocket": {
+                    "inputSampleRate": self.sample_rate,
+                    "outputSampleRate": self.sample_rate,
+                }
+            },
+            "firstSpeaker": "FIRST_SPEAKER_AGENT" if self.first_message else "FIRST_SPEAKER_USER",
+            "recordingEnabled": False,
+        }
+        if self.voice:
+            create_payload["voice"] = self.voice
+        if self.instructions:
+            create_payload["systemPrompt"] = self.instructions
+        if self.first_message:
+            create_payload["initialOutputMedium"] = "MESSAGE_MEDIUM_VOICE"
+            create_payload["initialMessages"] = [
+                {"role": "MESSAGE_ROLE_AGENT", "text": self.first_message},
+            ]
+        if self.tools:
+            create_payload["selectedTools"] = [
+                {
+                    "temporaryTool": {
+                        "modelToolName": t["name"],
+                        "description": t.get("description", ""),
+                        "dynamicParameters": _tool_params_to_ultravox(t.get("parameters", {})),
+                    }
+                }
+                for t in self.tools
+            ]
+
+        try:
+            async with self._session.post(
+                f"{self.api_base}/calls",
+                json=create_payload,
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    raise RuntimeError(
+                        f"Ultravox create call failed: {resp.status} {body}"
+                    )
+                call = await resp.json()
+        except Exception:
+            await self._session.close()
+            self._session = None
+            raise
+
+        join_url = call.get("joinUrl")
+        if not join_url:
+            await self._session.close()
+            self._session = None
+            raise RuntimeError("Ultravox response missing joinUrl")
+
+        self._ws = await self._session.ws_connect(join_url, heartbeat=20.0)
+        self._running = True
+
+    async def send_audio(self, audio: bytes) -> None:
+        """Send a PCM16 mono binary frame at ``self.sample_rate``."""
+        if self._ws is None:
+            return
+        await self._ws.send_bytes(audio)
+
+    async def send_text(self, text: str) -> None:
+        """Send a text turn. Ultravox treats this as ``input_text_message``."""
+        if self._ws is None:
+            return
+        await self._ws.send_str(json.dumps({
+            "type": "input_text_message",
+            "text": text,
+        }))
+
+    async def send_function_result(self, call_id: str, result: str) -> None:
+        """Return a client tool result."""
+        if self._ws is None:
+            return
+        await self._ws.send_str(json.dumps({
+            "type": "client_tool_result",
+            "invocationId": call_id,
+            "result": result,
+            "responseType": "tool-response",
+        }))
+
+    async def cancel_response(self) -> None:
+        """Ask the agent to stop speaking immediately (barge-in)."""
+        if self._ws is None:
+            return
+        await self._ws.send_str(json.dumps({"type": "playback_clear_buffer"}))
+
+    async def receive_events(self) -> AsyncIterator[tuple[str, Any]]:
+        """Yield ``(event_type, payload)`` tuples from the Ultravox WebSocket.
+
+        Yields:
+            ``("audio", bytes)`` — PCM16 chunks from the agent
+            ``("transcript_input", str)`` — user transcript (final)
+            ``("transcript_output", str)`` — agent transcript delta
+            ``("function_call", {"call_id", "name", "arguments"})``
+            ``("speech_started", None)`` — user began speaking
+            ``("response_done", None)`` — agent finished current turn
+        """
+        if self._ws is None:
+            return
+
+        try:
+            import aiohttp  # type: ignore[import-not-found]
+        except ImportError:  # pragma: no cover
+            return
+
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.BINARY:
+                    yield ("audio", msg.data)
+                elif msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        event = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        logger.warning("Ultravox: non-JSON text frame")
+                        continue
+                    async for item in self._translate_event(event):
+                        yield item
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.ERROR,
+                    aiohttp.WSMsgType.CLOSING,
+                ):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover
+            logger.error("Ultravox receive error: %s", exc)
+        finally:
+            self._running = False
+
+    async def _translate_event(
+        self, event: dict[str, Any]
+    ) -> AsyncIterator[tuple[str, Any]]:
+        """Map an Ultravox JSON event to Patter adapter event tuples."""
+        etype = event.get("type", "")
+        if etype == "transcript":
+            role = event.get("role", "")
+            text = event.get("text", "") or event.get("delta", "")
+            is_final = bool(event.get("final", False))
+            if role == "user" and is_final and text:
+                yield ("transcript_input", text)
+            elif role == "agent" and text:
+                yield ("transcript_output", text)
+        elif etype == "client_tool_invocation":
+            yield (
+                "function_call",
+                {
+                    "call_id": event.get("invocationId", ""),
+                    "name": event.get("toolName", ""),
+                    "arguments": json.dumps(event.get("parameters", {})),
+                },
+            )
+        elif etype == "state":
+            state = event.get("state", "")
+            if state == "listening":
+                yield ("speech_started", None)
+            elif state == "idle":
+                yield ("response_done", None)
+        elif etype == "playback_clear_buffer":
+            yield ("speech_started", None)
+
+    async def close(self) -> None:
+        """Close the WebSocket and underlying HTTP session."""
+        self._running = False
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:  # pragma: no cover
+                pass
+            self._ws = None
+        if self._session is not None:
+            try:
+                await self._session.close()
+            except Exception:  # pragma: no cover
+                pass
+            self._session = None
+
+
+def _tool_params_to_ultravox(parameters: dict[str, Any]) -> list[dict[str, Any]]:
+    """Translate OpenAI-style JSON Schema to Ultravox ``dynamicParameters``.
+
+    Ultravox expects a flat list of parameter descriptors. This converts the
+    typical ``{"type": "object", "properties": {...}, "required": [...]}``
+    shape passed through Patter into Ultravox's format. Kept deliberately
+    permissive — unknown shapes pass through as a single blob.
+    """
+    props = parameters.get("properties", {}) if isinstance(parameters, dict) else {}
+    required = set(parameters.get("required", []) or [])
+    out: list[dict[str, Any]] = []
+    for name, schema in props.items():
+        out.append({
+            "name": name,
+            "location": "PARAMETER_LOCATION_BODY",
+            "schema": schema,
+            "required": name in required,
+        })
+    return out

--- a/sdk/patter/scheduler.py
+++ b/sdk/patter/scheduler.py
@@ -1,0 +1,177 @@
+"""Thin scheduling wrapper around APScheduler.
+
+Provides a minimal, async-friendly surface::
+
+    import patter
+
+    handle = patter.schedule_cron("*/5 * * * *", my_async_callback)
+    once = patter.schedule_once(when=datetime(...), callback=my_async_callback)
+
+    handle.cancel()
+
+Design choices:
+
+* APScheduler is the de-facto Python scheduling lib (BSD 3-clause). We wrap it
+  so callers do not couple to the specific vendor API — if we ever swap it,
+  only :class:`ScheduleHandle` needs to keep its contract.
+* Both sync and async callbacks are accepted. Async callbacks run on the
+  scheduler's own loop.
+* The scheduler is lazily created on first use — callers do not pay the cost
+  if they never schedule anything.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Coroutine, Union
+
+logger = logging.getLogger("patter.scheduler")
+
+JobCallback = Callable[[], Union[None, Coroutine[Any, Any, None]]]
+
+
+@dataclass
+class ScheduleHandle:
+    """Returned from every schedule call — used to cancel."""
+
+    job_id: str
+    _scheduler: Any  # AsyncIOScheduler
+
+    def cancel(self) -> None:
+        """Cancel a scheduled job; safe to call after it has already run."""
+        try:
+            self._scheduler.remove_job(self.job_id)
+        except Exception as exc:  # pragma: no cover - APScheduler-specific
+            logger.debug("ScheduleHandle.cancel: %s", exc)
+
+    @property
+    def pending(self) -> bool:
+        """True if the job is still registered."""
+        try:
+            return self._scheduler.get_job(self.job_id) is not None
+        except Exception:  # pragma: no cover
+            return False
+
+
+_scheduler_singleton: Any = None
+
+
+def _get_scheduler() -> Any:
+    """Lazily construct the APScheduler ``AsyncIOScheduler`` and start it."""
+    global _scheduler_singleton
+    if _scheduler_singleton is not None:
+        return _scheduler_singleton
+
+    try:
+        from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "Scheduling requires the 'apscheduler' package. "
+            "Install with: pip install getpatter[scheduling]"
+        ) from exc
+
+    scheduler = AsyncIOScheduler()
+    scheduler.start()
+    _scheduler_singleton = scheduler
+    return scheduler
+
+
+def _wrap_callback(cb: JobCallback) -> Callable[[], Any]:
+    """Run sync and async callbacks uniformly on the scheduler loop."""
+    if inspect.iscoroutinefunction(cb):
+        async def runner() -> None:
+            try:
+                await cb()  # type: ignore[misc]
+            except Exception:
+                logger.exception("Scheduled async callback raised")
+        return runner
+
+    def sync_runner() -> None:
+        try:
+            result = cb()
+            if inspect.iscoroutine(result):
+                # Callback returned a coroutine despite not being flagged as
+                # async — schedule it on the running loop.
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(result)
+                except RuntimeError:
+                    asyncio.run(result)
+        except Exception:
+            logger.exception("Scheduled callback raised")
+
+    return sync_runner
+
+
+def schedule_cron(cron: str, callback: JobCallback) -> ScheduleHandle:
+    """Schedule ``callback`` on a cron expression (5-field: m h dom mon dow).
+
+    Example::
+
+        schedule_cron("0 9 * * 1-5", send_morning_reminder)
+    """
+    try:
+        from apscheduler.triggers.cron import CronTrigger  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Scheduling requires the 'apscheduler' package."
+        ) from exc
+
+    scheduler = _get_scheduler()
+    trigger = CronTrigger.from_crontab(cron)
+    job_id = f"cron-{uuid.uuid4().hex}"
+    scheduler.add_job(_wrap_callback(callback), trigger=trigger, id=job_id)
+    return ScheduleHandle(job_id=job_id, _scheduler=scheduler)
+
+
+def schedule_once(at: datetime, callback: JobCallback) -> ScheduleHandle:
+    """Schedule ``callback`` to run once at the given datetime."""
+    try:
+        from apscheduler.triggers.date import DateTrigger  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Scheduling requires the 'apscheduler' package."
+        ) from exc
+
+    scheduler = _get_scheduler()
+    trigger = DateTrigger(run_date=at)
+    job_id = f"once-{uuid.uuid4().hex}"
+    scheduler.add_job(_wrap_callback(callback), trigger=trigger, id=job_id)
+    return ScheduleHandle(job_id=job_id, _scheduler=scheduler)
+
+
+def schedule_interval(seconds: float, callback: JobCallback) -> ScheduleHandle:
+    """Schedule ``callback`` to run every ``seconds`` seconds.
+
+    Convenience wrapper on top of APScheduler's ``IntervalTrigger`` — used by
+    the test suite and by callers that don't want to write a cron spec.
+    """
+    try:
+        from apscheduler.triggers.interval import IntervalTrigger  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError(
+            "Scheduling requires the 'apscheduler' package."
+        ) from exc
+
+    scheduler = _get_scheduler()
+    trigger = IntervalTrigger(seconds=seconds)
+    job_id = f"interval-{uuid.uuid4().hex}"
+    scheduler.add_job(_wrap_callback(callback), trigger=trigger, id=job_id)
+    return ScheduleHandle(job_id=job_id, _scheduler=scheduler)
+
+
+def shutdown() -> None:
+    """Tear down the scheduler. Safe to call even if never initialised."""
+    global _scheduler_singleton
+    if _scheduler_singleton is None:
+        return
+    try:
+        _scheduler_singleton.shutdown(wait=False)
+    except Exception:  # pragma: no cover
+        pass
+    _scheduler_singleton = None

--- a/sdk/patter/services/llm_loop.py
+++ b/sdk/patter/services/llm_loop.py
@@ -13,6 +13,8 @@ import json
 import logging
 from typing import AsyncGenerator, AsyncIterator, Protocol, runtime_checkable
 
+from patter.observability.tracing import SPAN_LLM, SPAN_TOOL, start_span
+
 logger = logging.getLogger("patter")
 
 
@@ -185,35 +187,51 @@ class LLMLoop:
 
         # Loop to handle tool calls — the LLM may call tools multiple times
         max_iterations = 10
-        for _ in range(max_iterations):
+        for iteration in range(max_iterations):
             tool_calls_accumulated: dict[int, dict] = {}
             text_parts: list[str] = []
             has_tool_calls = False
 
-            async for chunk in self._provider.stream(messages, self._openai_tools):
-                chunk_type = chunk.get("type")
+            # Open a span around the provider streaming call. Kept as an
+            # explicit __enter__/__exit__ (rather than ``with``) because we
+            # need to ``yield`` from inside the span which ``with`` + async
+            # generators makes awkward.
+            _span_cm = start_span(
+                SPAN_LLM,
+                {
+                    "patter.llm.iteration": iteration,
+                    "patter.llm.history_size": len(history),
+                    "patter.call.id": call_context.get("call_id", ""),
+                },
+            )
+            _span_cm.__enter__()
+            try:
+                async for chunk in self._provider.stream(messages, self._openai_tools):
+                    chunk_type = chunk.get("type")
 
-                if chunk_type == "text":
-                    content = chunk.get("content", "")
-                    if content:
-                        text_parts.append(content)
-                        yield content
+                    if chunk_type == "text":
+                        content = chunk.get("content", "")
+                        if content:
+                            text_parts.append(content)
+                            yield content
 
-                elif chunk_type == "tool_call":
-                    has_tool_calls = True
-                    idx = chunk["index"]
-                    if idx not in tool_calls_accumulated:
-                        tool_calls_accumulated[idx] = {
-                            "id": "",
-                            "name": "",
-                            "arguments": "",
-                        }
-                    if chunk.get("id"):
-                        tool_calls_accumulated[idx]["id"] = chunk["id"]
-                    if chunk.get("name"):
-                        tool_calls_accumulated[idx]["name"] = chunk["name"]
-                    if chunk.get("arguments"):
-                        tool_calls_accumulated[idx]["arguments"] += chunk["arguments"]
+                    elif chunk_type == "tool_call":
+                        has_tool_calls = True
+                        idx = chunk["index"]
+                        if idx not in tool_calls_accumulated:
+                            tool_calls_accumulated[idx] = {
+                                "id": "",
+                                "name": "",
+                                "arguments": "",
+                            }
+                        if chunk.get("id"):
+                            tool_calls_accumulated[idx]["id"] = chunk["id"]
+                        if chunk.get("name"):
+                            tool_calls_accumulated[idx]["name"] = chunk["name"]
+                        if chunk.get("arguments"):
+                            tool_calls_accumulated[idx]["arguments"] += chunk["arguments"]
+            finally:
+                _span_cm.__exit__(None, None, None)
 
             # If no tool calls, we're done
             if not has_tool_calls:

--- a/sdk/patter/services/tool_executor.py
+++ b/sdk/patter/services/tool_executor.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from patter.observability.tracing import SPAN_TOOL, start_span
+
 logger = logging.getLogger("patter")
 
 # Maximum size of a tool webhook response (1 MB).  Responses larger than this
@@ -86,11 +88,19 @@ class ToolExecutor:
         If *handler* is provided, it is called directly (sync or async).
         Otherwise, falls back to POSTing to *webhook_url*.
         """
-        if handler is not None:
-            return await self._execute_handler(tool_name, arguments, call_context, handler)
-        if webhook_url:
-            return await self._execute_webhook(tool_name, arguments, call_context, webhook_url)
-        return json.dumps({"error": f"Tool '{tool_name}' has no handler or webhook_url", "fallback": True})
+        with start_span(
+            SPAN_TOOL,
+            {
+                "patter.tool.name": tool_name,
+                "patter.tool.transport": "handler" if handler is not None else ("webhook" if webhook_url else "none"),
+                "patter.call.id": call_context.get("call_id", ""),
+            },
+        ):
+            if handler is not None:
+                return await self._execute_handler(tool_name, arguments, call_context, handler)
+            if webhook_url:
+                return await self._execute_webhook(tool_name, arguments, call_context, webhook_url)
+            return json.dumps({"error": f"Tool '{tool_name}' has no handler or webhook_url", "fallback": True})
 
     async def _execute_handler(
         self,

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -122,6 +122,24 @@ background-audio = [
 ]
 rime = ["aiohttp>=3.10"]
 lmnt = ["aiohttp>=3.10"]
+gemini-live = [
+    "google-genai>=1.55",
+]
+ultravox = [
+    "aiohttp>=3.10",
+]
+evals = [
+    "pyyaml>=6.0",
+    "openai>=1.0",
+]
+tracing = [
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp>=1.27",
+]
+scheduling = [
+    "apscheduler>=3.10",
+]
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/sdk/tests/integration/test_evals_integration.py
+++ b/sdk/tests/integration/test_evals_integration.py
@@ -1,0 +1,77 @@
+"""Integration test for the evals framework against real OpenAI.
+
+Skipped when ``OPENAI_API_KEY`` is not set. This is the only place the judge
+is exercised against the real API — all other tests use a mock backend.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from patter.evals import EvalCase, EvalRunner, EvalSuite, EvalTurn, LLMJudge
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+@pytest.mark.asyncio
+async def test_llm_judge_scores_polite_reply_higher_than_rude():
+    """End-to-end smoke: judge must prefer a polite reply over a rude one."""
+    case = EvalCase(
+        name="polite-reply",
+        turns=[EvalTurn(user="Hi, is this customer support?")],
+        expected_behavior=(
+            "Agent greets the caller warmly and offers to help with a "
+            "support issue."
+        ),
+        rubric=(
+            "Pass if the agent's reply is polite, acknowledges the caller, "
+            "and offers to help. Fail if the agent is rude, dismissive, or "
+            "does not acknowledge the caller."
+        ),
+    )
+
+    judge = LLMJudge(model="gpt-4o-mini", pass_threshold=0.7)
+
+    polite_transcript = [
+        {"role": "user", "text": "Hi, is this customer support?"},
+        {"role": "agent", "text": "Hi there! Yes, you've reached support. How can I help you today?"},
+    ]
+    rude_transcript = [
+        {"role": "user", "text": "Hi, is this customer support?"},
+        {"role": "agent", "text": "What do you want."},
+    ]
+
+    polite = await judge.judge_case(case, polite_transcript)
+    rude = await judge.judge_case(case, rude_transcript)
+
+    assert polite.score > rude.score
+    assert polite.passed is True
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set")
+@pytest.mark.asyncio
+async def test_runner_produces_valid_json_report():
+    case = EvalCase(
+        name="echo",
+        turns=[EvalTurn(user="hello")],
+        expected_behavior="Agent responds with any non-empty text.",
+        rubric="Pass if reply is non-empty and grammatically sensible.",
+    )
+    suite = EvalSuite(name="smoke", cases=[case])
+    runner = EvalRunner()
+
+    async def reply(text: str) -> str:
+        return "Hello! How can I help?"
+
+    results = await runner.run(suite, lambda: reply)
+    report_json = runner.report(suite, results)
+
+    import json
+
+    payload = json.loads(report_json)
+    assert payload["suite"] == "smoke"
+    assert payload["total"] == 1
+    assert "cases" in payload

--- a/sdk/tests/test_evals.py
+++ b/sdk/tests/test_evals.py
@@ -1,0 +1,209 @@
+"""Unit tests for the Patter evals framework.
+
+These tests MOCK the OpenAI judge backend — integration tests against the
+real OpenAI API live in ``tests/integration/`` and skip if ``OPENAI_API_KEY``
+is not set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from patter.evals import (
+    EvalCase,
+    EvalResult,
+    EvalRunner,
+    EvalSuite,
+    EvalTurn,
+    JudgeResult,
+    LLMJudge,
+)
+from patter.evals.runner import load_suite
+
+
+class FakeBackend:
+    """Test double for the judge backend — returns a canned JSON string."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = 0
+
+    async def judge(self, prompt: str) -> str:
+        self.calls += 1
+        return json.dumps(self.payload)
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_parses_score_and_reasoning():
+    judge = LLMJudge(
+        backend=FakeBackend({"score": 0.9, "passed": True, "reasoning": "great"})
+    )
+    case = EvalCase(
+        name="test",
+        turns=[EvalTurn(user="hi")],
+        expected_behavior="reply politely",
+        rubric="pass if polite",
+    )
+    result = await judge.judge_case(case, [{"role": "user", "text": "hi"}])
+    assert isinstance(result, JudgeResult)
+    assert result.score == pytest.approx(0.9)
+    assert result.passed is True
+    assert result.reasoning == "great"
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_tolerates_code_fences():
+    judge = LLMJudge(backend=FakeBackend({"score": 0.5, "passed": False, "reasoning": "meh"}))
+    # Replace backend to return a fenced string instead of the raw dict.
+    fenced = '```json\n{"score": 0.5, "passed": false, "reasoning": "meh"}\n```'
+
+    class Fenced:
+        async def judge(self, _):
+            return fenced
+
+    judge._backend = Fenced()
+    case = EvalCase(name="t", turns=[], expected_behavior="", rubric="")
+    result = await judge.judge_case(case, [])
+    assert result.score == pytest.approx(0.5)
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_fails_safely_on_invalid_json():
+    class BadBackend:
+        async def judge(self, _):
+            return "not json at all"
+
+    judge = LLMJudge(backend=BadBackend())
+    case = EvalCase(name="t", turns=[], expected_behavior="", rubric="")
+    result = await judge.judge_case(case, [])
+    assert result.score == 0.0
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_clamps_score_to_unit_range():
+    judge = LLMJudge(backend=FakeBackend({"score": 1.5, "passed": True, "reasoning": ""}))
+    case = EvalCase(name="t", turns=[], expected_behavior="", rubric="")
+    result = await judge.judge_case(case, [])
+    assert result.score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_runner_end_to_end_produces_transcript_and_report():
+    case = EvalCase(
+        name="greeting",
+        turns=[EvalTurn(user="hello"), EvalTurn(user="how are you?")],
+        expected_behavior="greet and respond",
+        rubric="pass if reply is non-empty",
+        first_message="Hi, how can I help?",
+    )
+    suite = EvalSuite(name="demo", cases=[case])
+    judge = LLMJudge(
+        backend=FakeBackend({"score": 1.0, "passed": True, "reasoning": "looks good"})
+    )
+    runner = EvalRunner(judge=judge)
+
+    async def reply(text: str) -> str:
+        return f"echo:{text}"
+
+    def factory():
+        return reply
+
+    results = await runner.run(suite, factory)
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.case_name == "greeting"
+    assert result.judge.passed is True
+    # transcript has: first_message (agent) + user + agent + user + agent = 5 entries
+    assert len(result.transcript) == 5
+    assert result.transcript[0] == {"role": "agent", "text": "Hi, how can I help?"}
+    assert result.transcript[1] == {"role": "user", "text": "hello"}
+    assert result.transcript[2]["role"] == "agent"
+    assert result.transcript[2]["text"] == "echo:hello"
+
+    # Report should be valid JSON and contain pass-rate.
+    report = json.loads(runner.report(suite, results))
+    assert report["suite"] == "demo"
+    assert report["total"] == 1
+    assert report["passed"] == 1
+    assert report["pass_rate"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_runner_handles_agent_exception():
+    case = EvalCase(
+        name="boom",
+        turns=[EvalTurn(user="hi")],
+        expected_behavior="",
+        rubric="",
+    )
+    suite = EvalSuite(name="s", cases=[case])
+    judge = LLMJudge(backend=FakeBackend({"score": 0, "passed": False, "reasoning": ""}))
+    runner = EvalRunner(judge=judge)
+
+    async def broken(_: str) -> str:
+        raise RuntimeError("agent died")
+
+    def factory():
+        return broken
+
+    results = await runner.run(suite, factory)
+    assert len(results) == 1
+    assert results[0].error is not None
+    assert "agent died" in results[0].error
+    assert results[0].judge.passed is False
+
+
+def test_load_suite_yaml(tmp_path: Path):
+    pytest.importorskip("yaml")
+    src = tmp_path / "suite.yaml"
+    src.write_text(
+        """
+name: test-suite
+cases:
+  - name: greeting
+    expected_behavior: greet
+    rubric: pass if greeting
+    turns:
+      - user: hi
+        expected_contains: [hello, hi]
+    tags: [smoke]
+""",
+        encoding="utf-8",
+    )
+    suite = load_suite(src)
+    assert suite.name == "test-suite"
+    assert len(suite.cases) == 1
+    case = suite.cases[0]
+    assert case.name == "greeting"
+    assert case.turns[0].user == "hi"
+    assert case.tags == ["smoke"]
+
+
+def test_load_suite_json(tmp_path: Path):
+    src = tmp_path / "suite.json"
+    src.write_text(
+        json.dumps(
+            {
+                "name": "json-suite",
+                "cases": [
+                    {
+                        "name": "t1",
+                        "expected_behavior": "b",
+                        "rubric": "r",
+                        "turns": [{"user": "hey"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    suite = load_suite(src)
+    assert suite.name == "json-suite"
+    assert suite.cases[0].turns[0].user == "hey"

--- a/sdk/tests/test_gemini_live.py
+++ b/sdk/tests/test_gemini_live.py
@@ -1,0 +1,222 @@
+"""Tests for GeminiLiveAdapter.
+
+These are unit tests that stub out the google-genai client — the adapter
+itself is pure orchestration logic, so end-to-end tests against the real
+Gemini Live endpoint live in ``tests/integration`` and skip when the extra
+is not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.providers.gemini_live import (
+    DEFAULT_INPUT_SAMPLE_RATE_HZ,
+    DEFAULT_OUTPUT_SAMPLE_RATE_HZ,
+    GeminiLiveAdapter,
+)
+
+
+def _install_fake_genai(monkeypatch: pytest.MonkeyPatch, session_mock: MagicMock) -> None:
+    """Install a minimal fake ``google.genai`` module into sys.modules."""
+    genai_pkg = types.ModuleType("google")
+    genai_mod = types.ModuleType("google.genai")
+    genai_types_mod = types.ModuleType("google.genai.types")
+
+    # Types used at connect time — fake constructors that just record args.
+    class _Box:
+        def __init__(self, **kwargs: object) -> None:
+            self.__dict__.update(kwargs)
+
+    genai_types_mod.SpeechConfig = _Box
+    genai_types_mod.VoiceConfig = _Box
+    genai_types_mod.PrebuiltVoiceConfig = _Box
+    genai_types_mod.Content = _Box
+    genai_types_mod.Part = _Box
+
+    # Client → aio.live.connect returns an async CM that yields the session.
+    class _AioLive:
+        def connect(self, **kwargs: object) -> object:  # noqa: D401
+            return session_mock.connect(**kwargs)
+
+    class _Aio:
+        live = _AioLive()
+
+    class _Client:
+        def __init__(self, **_: object) -> None:
+            self.aio = _Aio()
+
+    genai_mod.Client = _Client
+    genai_mod.types = genai_types_mod
+
+    monkeypatch.setitem(sys.modules, "google", genai_pkg)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.genai.types", genai_types_mod)
+
+
+class _FakeSessionCM:
+    """Async context manager that yields a session mock."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _make_session_mock():
+    session = MagicMock()
+    session.send_realtime_input = AsyncMock()
+    session.send_client_content = AsyncMock()
+    session.send_tool_response = AsyncMock()
+
+    factory = MagicMock()
+    factory.connect = MagicMock(return_value=_FakeSessionCM(session))
+    factory._session = session
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_client_and_enters_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_session_mock()
+    _install_fake_genai(monkeypatch, factory)
+
+    adapter = GeminiLiveAdapter(
+        api_key="fake",
+        instructions="be polite",
+        tools=[{"name": "weather", "description": "get weather", "parameters": {"type": "object"}}],
+    )
+    await adapter.connect()
+
+    assert adapter._session is not None
+    # The fake connect() should have been called once
+    assert factory.connect.called
+    kwargs = factory.connect.call_args.kwargs
+    assert kwargs["model"] == adapter.model
+    assert "tools" in kwargs["config"]
+    assert "system_instruction" in kwargs["config"]
+
+
+@pytest.mark.asyncio
+async def test_send_audio_uses_correct_mime(monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_session_mock()
+    _install_fake_genai(monkeypatch, factory)
+
+    adapter = GeminiLiveAdapter(api_key="fake", input_sample_rate=16000)
+    await adapter.connect()
+    await adapter.send_audio(b"\x01\x02\x03")
+
+    call = adapter._session.send_realtime_input.await_args
+    assert call is not None
+    assert call.kwargs["media"]["mime_type"] == "audio/pcm;rate=16000"
+    assert call.kwargs["media"]["data"] == b"\x01\x02\x03"
+
+
+@pytest.mark.asyncio
+async def test_missing_google_genai_raises_helpful_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Remove any genai import that may have leaked in.
+    for k in list(sys.modules):
+        if k == "google" or k.startswith("google.genai"):
+            monkeypatch.delitem(sys.modules, k, raising=False)
+
+    # Force import to fail by injecting a blocker.
+    class _Blocker:
+        def find_module(self, name, path=None):
+            if name == "google.genai" or name == "google":
+                return self
+            return None
+
+        def load_module(self, name):  # pragma: no cover - exercised via import
+            raise ImportError(f"blocked: {name}")
+
+    sys.meta_path.insert(0, _Blocker())
+    try:
+        adapter = GeminiLiveAdapter(api_key="fake")
+        with pytest.raises(RuntimeError, match="google-genai"):
+            await adapter.connect()
+    finally:
+        sys.meta_path.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_receive_events_translates_audio_and_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_session_mock()
+    _install_fake_genai(monkeypatch, factory)
+
+    adapter = GeminiLiveAdapter(api_key="fake")
+    await adapter.connect()
+
+    # Craft fake server messages using simple namespace objects so attribute
+    # access returns real values rather than auto-generated MagicMocks.
+    from types import SimpleNamespace as NS
+
+    audio_msg = NS(
+        server_content=NS(
+            model_turn=NS(parts=[NS(inline_data=NS(data=b"\xAA\xBB"), text=None)]),
+            turn_complete=False,
+            interrupted=False,
+        ),
+        tool_call=None,
+    )
+    tool_msg = NS(
+        server_content=None,
+        tool_call=NS(
+            function_calls=[NS(id="abc", name="lookup", args={"q": "pizza"})]
+        ),
+    )
+    done_msg = NS(
+        server_content=NS(model_turn=None, turn_complete=True, interrupted=False),
+        tool_call=None,
+    )
+
+    async def fake_receive():
+        for m in [audio_msg, tool_msg, done_msg]:
+            yield m
+
+    adapter._session.receive = fake_receive
+
+    events = []
+    async for ev in adapter.receive_events():
+        events.append(ev)
+
+    types_ = [e[0] for e in events]
+    assert "audio" in types_
+    assert "function_call" in types_
+    assert "response_done" in types_
+    fn_call = next(e for e in events if e[0] == "function_call")
+    assert fn_call[1]["call_id"] == "abc"
+    assert fn_call[1]["name"] == "lookup"
+    # arguments is JSON-serialised when args is a dict
+    assert json.loads(fn_call[1]["arguments"]) == {"q": "pizza"}
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    factory = _make_session_mock()
+    _install_fake_genai(monkeypatch, factory)
+
+    adapter = GeminiLiveAdapter(api_key="fake")
+    await adapter.connect()
+    await adapter.close()
+    await adapter.close()  # must not raise
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_defaults_are_sane() -> None:
+    adapter = GeminiLiveAdapter(api_key="fake")
+    assert adapter.model.startswith("gemini")
+    assert adapter.voice == "Puck"
+    assert adapter.language == "en-US"
+    assert adapter.input_sample_rate == DEFAULT_INPUT_SAMPLE_RATE_HZ
+    assert adapter.output_sample_rate == DEFAULT_OUTPUT_SAMPLE_RATE_HZ

--- a/sdk/tests/test_observability_tracing.py
+++ b/sdk/tests/test_observability_tracing.py
@@ -1,0 +1,78 @@
+"""Unit tests for the observability module."""
+
+from __future__ import annotations
+
+import pytest
+
+from patter.observability import tracing
+
+
+def test_is_enabled_false_when_flag_unset(monkeypatch):
+    monkeypatch.delenv(tracing.ENV_FLAG, raising=False)
+    tracing.shutdown_tracing()
+    assert tracing.is_enabled() is False
+
+
+def test_start_span_is_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv(tracing.ENV_FLAG, raising=False)
+    tracing.shutdown_tracing()
+    with tracing.start_span("patter.stt", {"a": 1}) as span:
+        assert span is None  # no-op mode yields None
+
+
+def test_init_tracing_returns_false_when_flag_unset(monkeypatch):
+    monkeypatch.delenv(tracing.ENV_FLAG, raising=False)
+    tracing.shutdown_tracing()
+    assert tracing.init_tracing() is False
+
+
+def test_init_tracing_warns_when_sdk_missing(monkeypatch, caplog):
+    # Simulate OTel SDK being unavailable by making the import fail.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name.startswith("opentelemetry"):
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setenv(tracing.ENV_FLAG, "1")
+    tracing.shutdown_tracing()
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+
+    result = tracing.init_tracing()
+    assert result is False
+
+
+def test_init_tracing_with_sdk_sets_is_enabled(monkeypatch):
+    # Only run if the SDK is actually installed.
+    try:
+        import opentelemetry  # noqa: F401
+        import opentelemetry.sdk  # noqa: F401
+        import opentelemetry.sdk.resources  # noqa: F401
+        import opentelemetry.sdk.trace  # noqa: F401
+    except ImportError:
+        pytest.skip("opentelemetry SDK not installed")
+
+    monkeypatch.setenv(tracing.ENV_FLAG, "1")
+    tracing.shutdown_tracing()
+
+    try:
+        ok = tracing.init_tracing(service_name="patter-test")
+        assert ok is True
+        assert tracing.is_enabled() is True
+
+        # A span context manager should succeed and yield a real span.
+        with tracing.start_span("patter.stt", {"patter.stt.text_len": 4}) as span:
+            assert span is not None
+    finally:
+        tracing.shutdown_tracing()
+
+
+def test_span_names_are_stable():
+    assert tracing.SPAN_STT == "patter.stt"
+    assert tracing.SPAN_LLM == "patter.llm"
+    assert tracing.SPAN_TTS == "patter.tts"
+    assert tracing.SPAN_TOOL == "patter.tool"
+    assert tracing.SPAN_CALL == "patter.call"

--- a/sdk/tests/test_scheduler.py
+++ b/sdk/tests/test_scheduler.py
@@ -1,0 +1,111 @@
+"""Unit tests for the scheduler wrapper.
+
+Use short real intervals (0.05-0.15 s) to exercise the real APScheduler
+loop — no mocking of time libraries per Patter testing policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("apscheduler")
+
+from patter.scheduler import (  # noqa: E402
+    ScheduleHandle,
+    schedule_interval,
+    schedule_once,
+    shutdown,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler():
+    """Each test creates its own scheduler — APScheduler binds to the loop
+    that instantiated it, so the singleton must be rebuilt every time when
+    pytest-asyncio creates a fresh loop per function."""
+    shutdown()
+    yield
+    shutdown()
+
+
+@pytest.mark.asyncio
+async def test_schedule_interval_fires_multiple_times():
+    counter = {"n": 0}
+
+    async def cb():
+        counter["n"] += 1
+
+    handle = schedule_interval(0.05, cb)
+    assert isinstance(handle, ScheduleHandle)
+    assert handle.pending
+
+    await asyncio.sleep(0.25)
+    handle.cancel()
+    # Expect at least 3 fires in ~250ms at 50ms interval — be generous for CI.
+    assert counter["n"] >= 2
+    assert not handle.pending
+
+
+@pytest.mark.asyncio
+async def test_schedule_once_fires_once_and_stops():
+    counter = {"n": 0}
+
+    async def cb():
+        counter["n"] += 1
+
+    at = datetime.now() + timedelta(milliseconds=80)
+    handle = schedule_once(at, cb)
+    await asyncio.sleep(0.3)
+    assert counter["n"] == 1
+    assert not handle.pending
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_fire_prevents_invocation():
+    counter = {"n": 0}
+
+    def cb():
+        counter["n"] += 1
+
+    at = datetime.now() + timedelta(milliseconds=200)
+    handle = schedule_once(at, cb)
+    handle.cancel()
+    await asyncio.sleep(0.3)
+    assert counter["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_callback_is_supported():
+    counter = {"n": 0}
+
+    def cb():
+        counter["n"] += 1
+
+    handle = schedule_interval(0.05, cb)
+    await asyncio.sleep(0.2)
+    handle.cancel()
+    assert counter["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_exception_in_callback_does_not_cancel_job(caplog):
+    counter = {"n": 0}
+
+    async def cb():
+        counter["n"] += 1
+        if counter["n"] == 1:
+            raise RuntimeError("boom")
+
+    handle = schedule_interval(0.05, cb)
+    await asyncio.sleep(0.25)
+    handle.cancel()
+    # Should still have been called more than once despite the first failing.
+    assert counter["n"] >= 2
+
+
+def test_shutdown_is_idempotent():
+    shutdown()
+    shutdown()  # must not raise

--- a/sdk/tests/test_ultravox_realtime.py
+++ b/sdk/tests/test_ultravox_realtime.py
@@ -1,0 +1,191 @@
+"""Tests for UltravoxRealtimeAdapter.
+
+The adapter uses aiohttp for both the REST create-call call and the
+WebSocket. We stub those surfaces with lightweight fakes.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.providers.ultravox_realtime import (
+    DEFAULT_API_BASE,
+    DEFAULT_SAMPLE_RATE_HZ,
+    UltravoxRealtimeAdapter,
+    _tool_params_to_ultravox,
+)
+
+
+pytest.importorskip("aiohttp")
+
+
+class _FakeMsg:
+    def __init__(self, type_, data):
+        self.type = type_
+        self.data = data
+
+
+class _FakeWS:
+    def __init__(self, messages):
+        self._messages = messages
+        self.sent_bytes: list[bytes] = []
+        self.sent_strs: list[str] = []
+        self.closed = False
+
+    async def send_bytes(self, data):
+        self.sent_bytes.append(data)
+
+    async def send_str(self, data):
+        self.sent_strs.append(data)
+
+    async def close(self):
+        self.closed = True
+
+    def __aiter__(self):
+        return self._iter_impl()
+
+    async def _iter_impl(self):
+        for m in self._messages:
+            yield m
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: dict):
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return json.dumps(self._body)
+
+
+class _FakeSession:
+    def __init__(self, call_response: dict, ws: _FakeWS):
+        self._call_response = call_response
+        self._ws = ws
+        self.closed = False
+
+    def post(self, url, json=None):
+        return _FakeResp(200, self._call_response)
+
+    async def ws_connect(self, url, heartbeat=None):
+        return self._ws
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_connect_posts_call_then_opens_websocket(monkeypatch):
+    ws = _FakeWS([])
+    session = _FakeSession({"joinUrl": "ws://ultravox/join/1"}, ws)
+
+    import patter.providers.ultravox_realtime as uvx
+
+    class _FakeAiohttp:
+        WSMsgType = MagicMock(BINARY=1, TEXT=2, CLOSED=3, ERROR=4, CLOSING=5)
+
+        def ClientSession(self, headers=None):  # noqa: N802 - matches aiohttp.ClientSession
+            return session
+
+    monkeypatch.setattr(uvx, "aiohttp", _FakeAiohttp(), raising=False)
+    # Replace the lazy import: overwrite the builtin lookup via sys.modules.
+    # Use monkeypatch.setitem so pytest restores the real aiohttp after the
+    # test, preventing pollution of unrelated tests that import aiohttp.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "aiohttp", _FakeAiohttp())
+
+    adapter = UltravoxRealtimeAdapter(api_key="fake", instructions="be brief")
+    await adapter.connect()
+
+    assert adapter._ws is ws
+    assert adapter._session is session
+
+
+@pytest.mark.asyncio
+async def test_send_audio_is_binary(monkeypatch):
+    import sys
+
+    class _FakeAiohttp:
+        WSMsgType = MagicMock(BINARY=1, TEXT=2, CLOSED=3, ERROR=4, CLOSING=5)
+
+        def ClientSession(self, headers=None):  # noqa: N802
+            return session
+
+    ws = _FakeWS([])
+    session = _FakeSession({"joinUrl": "ws://x"}, ws)
+    monkeypatch.setitem(sys.modules, "aiohttp", _FakeAiohttp())
+
+    adapter = UltravoxRealtimeAdapter(api_key="fake")
+    await adapter.connect()
+    await adapter.send_audio(b"\x00\x01\x02")
+
+    assert ws.sent_bytes == [b"\x00\x01\x02"]
+
+
+@pytest.mark.asyncio
+async def test_translate_event_yields_expected_tuples():
+    adapter = UltravoxRealtimeAdapter(api_key="fake")
+
+    async def collect(event):
+        return [item async for item in adapter._translate_event(event)]
+
+    user_transcript = await collect({
+        "type": "transcript",
+        "role": "user",
+        "text": "hello world",
+        "final": True,
+    })
+    assert user_transcript == [("transcript_input", "hello world")]
+
+    agent_transcript = await collect({
+        "type": "transcript",
+        "role": "agent",
+        "text": "hi!",
+    })
+    assert agent_transcript == [("transcript_output", "hi!")]
+
+    tool = await collect({
+        "type": "client_tool_invocation",
+        "invocationId": "call-1",
+        "toolName": "weather",
+        "parameters": {"city": "Rome"},
+    })
+    assert tool[0][0] == "function_call"
+    assert tool[0][1]["call_id"] == "call-1"
+    assert tool[0][1]["name"] == "weather"
+    assert json.loads(tool[0][1]["arguments"]) == {"city": "Rome"}
+
+
+def test_tool_params_to_ultravox_respects_required():
+    params = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "units": {"type": "string"}},
+        "required": ["city"],
+    }
+    out = _tool_params_to_ultravox(params)
+    names = {p["name"] for p in out}
+    assert names == {"city", "units"}
+    city = next(p for p in out if p["name"] == "city")
+    assert city["required"] is True
+    units = next(p for p in out if p["name"] == "units")
+    assert units["required"] is False
+
+
+def test_defaults_are_sane():
+    adapter = UltravoxRealtimeAdapter(api_key="fake")
+    assert adapter.sample_rate == DEFAULT_SAMPLE_RATE_HZ
+    assert adapter.model == "fixie-ai/ultravox"
+    assert adapter.language == "en"


### PR DESCRIPTION
## Summary

Four independent sub-streams built on top of Wave 1 core protocols (branch base: `feat/wave1-core-protocols`).

## H1 — Realtime S2S

Partial ports (~65-70%) from LiveKit Agents (Apache 2.0) — reshaped to Patter's simple realtime-adapter surface (`connect`/`send_audio`/`receive_events`/`close`), matching the existing `OpenAIRealtimeAdapter`. LiveKit's lifecycle/resume machinery is intentionally NOT ported — Patter handlers own session lifecycle.

- **Gemini Live** (`sdk/patter/providers/gemini_live.py`, `sdk-ts/src/providers/gemini-live.ts`) — lazy `google-genai` import; PCM16 mono; tool calling; VAD-driven barge-in.
  - LiveKit source: `livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py` (~1436 lines)
  - Adapted: ~480 lines Python + ~280 lines TS

- **Ultravox** (`sdk/patter/providers/ultravox_realtime.py`, `sdk-ts/src/providers/ultravox-realtime.ts`) — pure WebSocket (aiohttp / ws) + REST create-call.
  - LiveKit source: `livekit-plugins-ultravox/livekit/plugins/ultravox/realtime/realtime_model.py` (~1180 lines)
  - Adapted: ~310 lines Python + ~230 lines TS

- **Extras**: `getpatter[gemini-live]`, `getpatter[ultravox]`; `@google/genai` + `node-cron` optional in sdk-ts.

## H2 — Evals framework

New ~450-line custom module inspired by LiveKit's `evals/` structure (primitives there are LiveKit-specific and not portable).

- `sdk/patter/evals/`: `EvalCase`, `EvalSuite`, `EvalRunner`, `LLMJudge` (OpenAI-backed, injectable backend for tests), YAML/JSON suite loader.
- CLI: `patter eval run suite.yaml [--agent module:factory] [--output report.json]`.
- New extra: `getpatter[evals]`.

## H3 — OpenTelemetry tracing

New ~200-line opt-in module — **zero cost when disabled**.

- `sdk/patter/observability/tracing.py`: gated by `PATTER_OTEL_ENABLED=1`. Stable span names (`patter.stt`, `patter.llm`, `patter.tts`, `patter.tool`). Size/id attributes only — **never PII**.
- Instrumentation added in `handlers/stream_handler.py` (STT + TTS), `services/llm_loop.py` (LLM), `services/tool_executor.py` (tools).
- `docs/observability.md` with setup + troubleshooting.
- New extra: `getpatter[tracing]`.

## H4 — Scheduling wrapper

~180-line wrapper around battle-tested libraries.

- Python: `sdk/patter/scheduler.py` — `schedule_cron` / `schedule_once` / `schedule_interval` / `ScheduleHandle` on top of APScheduler (BSD).
- TS: `sdk-ts/src/scheduler.ts` — same API on top of node-cron (MIT) + `setTimeout`.
- New extra: `getpatter[scheduling]`.

## Attribution

- LiveKit Agents — Apache 2.0 (Gemini Live + Ultravox realtime adapters, evals structural inspiration)
- APScheduler — BSD 3-clause (Python scheduler backend)
- node-cron — MIT (TS scheduler backend)
- `@google/genai` — used as an optional runtime dep in TS; loaded lazily

Branch base SHA: `520b471` (Wave 1 infrastructure)

## Test plan

- [x] Python: `cd sdk && python3 -m pytest tests/ -x --tb=short` → **1265 passed, 1 skipped** (+32 new)
- [x] TypeScript: `cd sdk-ts && npx tsc --noEmit` → clean
- [x] TypeScript: `cd sdk-ts && npx vitest run` → **908 passed** (+23 new)
- [ ] Manual: `patter eval run examples/eval-suite.yaml` against a real agent
- [ ] Manual: set `PATTER_OTEL_ENABLED=1 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` and confirm spans appear in local collector
- [ ] Manual: real Gemini Live call with `google-genai>=1.55` installed
- [ ] Manual: real Ultravox call with `X-API-Key`

## Notes for reviewer

- No breaking changes. All new APIs are additive and all new deps are optional extras.
- Integration tests gated on `OPENAI_API_KEY` (LLMJudge) live under `tests/integration/` and skip cleanly.
- Tracing is purely additive — existing call flows are unchanged when `PATTER_OTEL_ENABLED` is unset (start_span yields None, never calls into OTel).

**Do not merge** — part of a coordinated multi-stream landing.