### PR TITLE
fix(gemini-live): variable module name for optional @google/genai import

### DIFF
--- a/sdk-ts/src/providers/gemini-live.ts
+++ b/sdk-ts/src/providers/gemini-live.ts
@@ -73,7 +73,9 @@ export class GeminiLiveAdapter {
     let genaiModule: { GoogleGenAI: new (args: { apiKey: string; httpOptions?: Record<string, unknown> }) => unknown };
     try {
       // Lazy dynamic import — keeps @google/genai optional.
-      genaiModule = (await import('@google/genai')) as typeof genaiModule;
+      // Variable module name avoids TS2307 when the peer dep is not installed.
+      const modName = '@google/genai';
+      genaiModule = (await import(modName)) as typeof genaiModule;
     } catch (err) {
       throw new Error(
         "Gemini Live requires the '@google/genai' package. Install with: npm install @google/genai",


### PR DESCRIPTION
Post-merge fix: static import of '@google/genai' (optional peer dep) was triggering TS2307. Variable module name pattern preserves lazy runtime semantics without static check.

- tsc --noEmit: clean
- vitest: 1055/1055
- pytest: 1441/1441 (+13 skipped integration)