### PR TITLE
fix(ci): skip optional-dep tests + fix E2E CallSid format (unblocks PR #52)

### DIFF
--- a/sdk-ts/tests/e2e/call-transfer.spec.ts
+++ b/sdk-ts/tests/e2e/call-transfer.spec.ts
@@ -8,7 +8,7 @@ test.describe("Call transfer", () => {
   }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/voice`, {
       form: {
-        CallSid: "CA_transfer_001",
+        CallSid: "CA0000000000000000000000000000a001",
         From: "+14155550001",
         To: "+15551234567",
       },
@@ -29,14 +29,14 @@ test.describe("Call transfer", () => {
   }) => {
     const resp1 = await request.post(`${BASE}/webhooks/twilio/voice`, {
       form: {
-        CallSid: "CA_transfer_unique_001",
+        CallSid: "CA0000000000000000000000000000b001",
         From: "+14155550001",
         To: "+15551234567",
       },
     });
     const resp2 = await request.post(`${BASE}/webhooks/twilio/voice`, {
       form: {
-        CallSid: "CA_transfer_unique_002",
+        CallSid: "CA0000000000000000000000000000b002",
         From: "+14155550002",
         To: "+15551234567",
       },
@@ -45,8 +45,8 @@ test.describe("Call transfer", () => {
     const body1 = await resp1.text();
     const body2 = await resp2.text();
 
-    expect(body1).toContain("CA_transfer_unique_001");
-    expect(body2).toContain("CA_transfer_unique_002");
+    expect(body1).toContain("CA0000000000000000000000000000b001");
+    expect(body2).toContain("CA0000000000000000000000000000b002");
     expect(body1).not.toEqual(body2);
   });
 

--- a/sdk-ts/tests/e2e/inbound-call.spec.ts
+++ b/sdk-ts/tests/e2e/inbound-call.spec.ts
@@ -61,7 +61,7 @@ test.describe("Inbound call scenario", () => {
   }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/voice`, {
       form: {
-        CallSid: "CA_e2e_inbound_001",
+        CallSid: "CA0000000000000000000000000000c001",
         From: "+14155551234",
         To: "+15551234567",
         Direction: "inbound",
@@ -76,7 +76,7 @@ test.describe("Inbound call scenario", () => {
     expect(body).toContain("<Response>");
     expect(body).toContain("<Connect>");
     expect(body).toContain("<Stream");
-    expect(body).toContain("wss://example.com/ws/stream/CA_e2e_inbound_001");
+    expect(body).toContain("wss://example.com/ws/stream/CA0000000000000000000000000000c001");
   });
 
   test("dashboard updates after simulated inbound call lifecycle", async ({
@@ -96,7 +96,7 @@ test.describe("Inbound call scenario", () => {
     // We verify the webhook endpoint is reachable and returns valid TwiML.
     const voiceResp = await request.post(`${BASE}/webhooks/twilio/voice`, {
       form: {
-        CallSid: "CA_e2e_inbound_002",
+        CallSid: "CA0000000000000000000000000000c002",
         From: "+14155559999",
         To: "+15551234567",
       },

--- a/sdk-ts/tests/e2e/machine-detection.spec.ts
+++ b/sdk-ts/tests/e2e/machine-detection.spec.ts
@@ -8,7 +8,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
   }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/amd`, {
       form: {
-        CallSid: "CA_e2e_amd_001",
+        CallSid: "CA0000000000000000000000000000e001",
         AnsweredBy: "human",
         AccountSid: "ACtest123456789",
       },
@@ -21,7 +21,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
   test("AMD webhook accepts machine_start detection", async ({ request }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/amd`, {
       form: {
-        CallSid: "CA_e2e_amd_002",
+        CallSid: "CA0000000000000000000000000000e002",
         AnsweredBy: "machine_start",
         AccountSid: "ACtest123456789",
       },
@@ -36,7 +36,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
     // With no voicemailMessage configured, no TwiML update is attempted.
     const response = await request.post(`${BASE}/webhooks/twilio/amd`, {
       form: {
-        CallSid: "CA_e2e_amd_003",
+        CallSid: "CA0000000000000000000000000000e003",
         AnsweredBy: "machine_end_beep",
         AccountSid: "ACtest123456789",
       },
@@ -50,7 +50,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
   }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/amd`, {
       form: {
-        CallSid: "CA_e2e_amd_004",
+        CallSid: "CA0000000000000000000000000000e004",
         AnsweredBy: "machine_end_silence",
         AccountSid: "ACtest123456789",
       },
@@ -62,7 +62,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
   test("AMD webhook accepts fax detection", async ({ request }) => {
     const response = await request.post(`${BASE}/webhooks/twilio/amd`, {
       form: {
-        CallSid: "CA_e2e_amd_005",
+        CallSid: "CA0000000000000000000000000000e005",
         AnsweredBy: "fax",
         AccountSid: "ACtest123456789",
       },
@@ -77,7 +77,7 @@ test.describe("Answering Machine Detection (AMD)", () => {
   }) => {
     // Fire AMD events
     await request.post(`${BASE}/webhooks/twilio/amd`, {
-      form: { CallSid: "CA_e2e_amd_stable", AnsweredBy: "human" },
+      form: { CallSid: "CA0000000000000000000000000000ef00", AnsweredBy: "human" },
     });
 
     // Navigate to dashboard — should load with key elements visible

--- a/sdk-ts/tests/e2e/recording.spec.ts
+++ b/sdk-ts/tests/e2e/recording.spec.ts
@@ -10,7 +10,7 @@ test.describe("Recording", () => {
       form: {
         RecordingSid: "RE_e2e_rec_001",
         RecordingUrl: "https://api.twilio.com/recordings/RE_e2e_rec_001",
-        CallSid: "CA_e2e_rec_call_001",
+        CallSid: "CA0000000000000000000000000000d001",
         RecordingDuration: "30",
       },
     });

--- a/sdk/tests/unit/test_deepfilternet_filter.py
+++ b/sdk/tests/unit/test_deepfilternet_filter.py
@@ -15,8 +15,11 @@ import sys
 import types
 from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
+
+# DeepFilterNet is an optional extra (`pip install getpatter[deepfilternet]`);
+# skip the whole module when numpy is absent on CI runners with base deps only.
+np = pytest.importorskip("numpy")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/tests/unit/test_silero_vad.py
+++ b/sdk/tests/unit/test_silero_vad.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 import math
 from typing import Iterable
 
-import numpy as np
 import pytest
 
-from patter.providers.base import VADEvent
-from patter.providers.silero_onnx import OnnxModel
-from patter.providers.silero_vad import SileroVAD, _VADOptions
+# Silero VAD is an optional extra (`pip install getpatter[silero]`); skip the
+# whole module gracefully when numpy is not installed on CI runners that only
+# install base deps.
+np = pytest.importorskip("numpy")
+
+from patter.providers.base import VADEvent  # noqa: E402
+from patter.providers.silero_onnx import OnnxModel  # noqa: E402
+from patter.providers.silero_vad import SileroVAD, _VADOptions  # noqa: E402
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
CI rosso su PR #52 (release develop→main):

**1. Python 3.11/3.12/3.13 fail at collection** — `test_silero_vad.py` e `test_deepfilternet_filter.py` importavano `numpy` al module scope, ma numpy è in extras opzionali (`[silero]`/`[deepfilternet]`). CI senza quegli extras non può neanche collezionare i test.

**2. E2E Playwright fail** — test posti CallSid `CA_transfer_001`, `CA_e2e_amd_001` che la nuova `validateTwilioSid()` (Wave 1 security fix) correttamente rigetta. Regex produzione: `^CA[0-9a-f]{32}$`.

## Fix
1. **`pytest.importorskip('numpy')`** all'inizio dei 2 test file (matcha il pattern già usato in `test_pcm_mixer.py` e `test_background_audio.py`)
2. **12 CallSid di test** aggiornati a placeholder hex-compliant 34-char, preservando unicità per-test

## Verifica locale
- `pytest tests/unit/test_silero_vad.py tests/unit/test_deepfilternet_filter.py` → 16 pass, 2 skip (integration)
- Collection pytest: 1454 test raccolti OK

## Impatto
Zero runtime behaviour change. Solo allineamento test harness al validator production.

Dopo merge: PR #52 dovrebbe girare verde, poi manual merge develop→main.