### PR TITLE
fix(ci): skip IVR + Krisp tests gracefully when extras missing (round 2)

### DIFF
--- a/sdk/tests/test_ivr.py
+++ b/sdk/tests/test_ivr.py
@@ -18,7 +18,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from patter.services.ivr import (
+# IVR loop detection requires sklearn (extras [ivr]). Several tests below
+# exercise TfidfLoopDetector (directly or via loop_detector=True). Skip the
+# whole module on CI runners without sklearn installed.
+pytest.importorskip("sklearn", reason="IVR tests require the 'ivr' extras (scikit-learn)")
+
+from patter.services.ivr import (  # noqa: E402
     DtmfEvent,
     IVRActivity,
     TfidfLoopDetector,

--- a/sdk/tests/unit/test_krisp_filter.py
+++ b/sdk/tests/unit/test_krisp_filter.py
@@ -16,6 +16,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# A few tests below import numpy locally to synthesise PCM frames; those tests
+# are skipped gracefully on CI runners without the optional extras installed.
+# Module-level importorskip makes the entire file skip cleanly when numpy
+# is absent, matching the pattern already used in test_pcm_mixer.py and
+# test_silero_vad.py.
+pytest.importorskip("numpy", reason="Krisp filter tests that synthesise PCM require numpy")
+
 
 # ---------------------------------------------------------------------------
 # Fake krisp_audio module fixture


### PR DESCRIPTION
Follow-up to #53. Second CI run on PR #52 caught 3 more failures:

- `tests/test_ivr.py::test_on_user_transcribed_ignored_before_start` → ImportError sklearn
- `tests/unit/test_krisp_filter.py::test_filter_process_delegates_to_krisp` → ModuleNotFoundError numpy
- `tests/unit/test_krisp_filter.py::test_filter_disable_passthrough` → ModuleNotFoundError numpy

Added `pytest.importorskip` at module level for both files. Matches existing pattern.

Locale: 25 passed, 1 skipped.