### PR TITLE
chore(ci): daily docs/feature-inventory drift check

### DIFF
--- a/.github/workflows/docs-feature-drift.yml
+++ b/.github/workflows/docs-feature-drift.yml
@@ -1,0 +1,112 @@
+name: Docs Feature Drift Check
+
+# Daily consistency check between:
+#   - the canonical feature inventory (patter_sdk_features.xlsx, stored in the
+#     patter-assets sibling repo)
+#   - the Mintlify documentation under docs/
+#   - the public SDK surface (sdk/patter/__init__.py + sdk-ts/src/index.ts)
+#
+# Opens or updates a single issue labelled `docs-drift` listing every mismatch.
+# If there is nothing to report, closes the issue (if open).
+
+on:
+  schedule:
+    # 03:00 UTC every day
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Patter repo
+        uses: actions/checkout@v5
+
+      - name: Checkout patter-assets (private, xlsx lives here)
+        uses: actions/checkout@v5
+        with:
+          repository: PatterAI/patter-assets
+          token: ${{ secrets.PATTER_ASSETS_TOKEN }}
+          path: patter-assets
+          # Soft-fail if the repo/secret isn't configured yet: the job falls
+          # back to a file path check and emits a warning.
+          continue-on-error: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install openpyxl==3.1.5
+
+      - name: Run drift check
+        id: drift
+        run: |
+          python scripts/check_feature_docs_drift.py \
+            --xlsx patter-assets/patter_sdk_features.xlsx \
+            --docs docs/ \
+            --py-init sdk/patter/__init__.py \
+            --ts-index sdk-ts/src/index.ts \
+            --output drift-report.md
+        continue-on-error: true
+
+      - name: Open or update docs-drift issue
+        if: steps.drift.outcome == 'failure'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('drift-report.md', 'utf8');
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'docs-drift',
+              state: 'open',
+            });
+            if (issues.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'docs-drift: feature inventory ↔ docs mismatch',
+                body,
+                labels: ['docs-drift', 'documentation'],
+              });
+            }
+
+      - name: Close docs-drift issue if clean
+        if: steps.drift.outcome == 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'docs-drift',
+              state: 'open',
+            });
+            for (const issue of issues) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Drift resolved — closing automatically.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/scripts/check_feature_docs_drift.py
+++ b/scripts/check_feature_docs_drift.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Docs feature drift checker.
+
+Cross-references:
+  1. The feature inventory (patter_sdk_features.xlsx) — source of truth for
+     what the SDK publicly ships.
+  2. The Mintlify documentation (docs/) — what the users can read about.
+  3. The SDK public surface (sdk/patter/__init__.py, sdk-ts/src/index.ts) —
+     what is actually exported from the code today.
+
+Exits with code 1 when drift exists (so the GitHub Action can open an issue);
+writes a Markdown report to --output.
+
+Usage:
+    python scripts/check_feature_docs_drift.py \\
+        --xlsx /path/to/patter_sdk_features.xlsx \\
+        --docs docs/ \\
+        --py-init sdk/patter/__init__.py \\
+        --ts-index sdk-ts/src/index.ts \\
+        --output drift-report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _load_inventory(xlsx_path: Path) -> list[dict[str, str]]:
+    """Read the feature inventory xlsx into a list of row dicts.
+
+    Returns empty list with a clear warning on the first line of the report
+    if the file is missing — the workflow falls back to a docs-only check
+    in that case.
+    """
+    try:
+        from openpyxl import load_workbook  # type: ignore[import-not-found]
+    except ModuleNotFoundError:
+        print("openpyxl not installed; cannot read xlsx", file=sys.stderr)
+        return []
+
+    if not xlsx_path.exists():
+        print(f"inventory file not found at {xlsx_path}", file=sys.stderr)
+        return []
+
+    wb = load_workbook(xlsx_path, read_only=True, data_only=True)
+    ws = wb.active
+    if ws is None:
+        return []
+    rows = list(ws.iter_rows(values_only=True))
+    if not rows:
+        return []
+    headers = [str(h or "").strip().lower() for h in rows[0]]
+    result: list[dict[str, str]] = []
+    for row in rows[1:]:
+        entry = {h: (str(v).strip() if v is not None else "") for h, v in zip(headers, row)}
+        if entry.get("feature_name"):
+            result.append(entry)
+    return result
+
+
+def _collect_docs_features(docs_dir: Path) -> set[str]:
+    """Collect feature identifiers from docs/ by inspecting mdx filenames.
+
+    Docs filenames are the canonical mapping key (e.g. silero_vad.mdx ->
+    ``silero_vad``). We accept both snake_case and kebab-case.
+    """
+    ids: set[str] = set()
+    for mdx in docs_dir.rglob("*.mdx"):
+        stem = mdx.stem.lower().replace("-", "_")
+        ids.add(stem)
+    return ids
+
+
+def _collect_sdk_exports(py_init: Path, ts_index: Path) -> set[str]:
+    """Parse public exports from both SDKs — best-effort regex-based."""
+    import re
+
+    ids: set[str] = set()
+
+    if py_init.exists():
+        text = py_init.read_text()
+        # __all__ entries
+        all_match = re.search(r"__all__\s*=\s*\[([^\]]+)\]", text, re.S)
+        if all_match:
+            for token in re.findall(r"['\"]([^'\"]+)['\"]", all_match.group(1)):
+                ids.add(token.lower())
+        # `from X import Y, Z` lines
+        for line in text.splitlines():
+            m = re.match(r"\s*from\s+\S+\s+import\s+(.+)", line)
+            if m:
+                for token in re.split(r"[,\s]+", m.group(1)):
+                    t = token.strip().rstrip(",").lower()
+                    if t and not t.startswith("_"):
+                        ids.add(t)
+
+    if ts_index.exists():
+        text = ts_index.read_text()
+        # export { Foo, Bar } / export class Foo / export function bar
+        for match in re.finditer(r"export\s+(?:class|function|const|interface|type)\s+(\w+)", text):
+            ids.add(match.group(1).lower())
+        for match in re.finditer(r"export\s*{\s*([^}]+)\s*}", text):
+            for token in re.split(r"[,\s]+", match.group(1)):
+                t = token.split(" as ")[0].strip().lower()
+                if t:
+                    ids.add(t)
+    return ids
+
+
+def _render_report(
+    inventory_missing_docs: list[dict[str, str]],
+    docs_missing_inventory: set[str],
+    exports_missing_inventory: set[str],
+    inventory_empty: bool,
+) -> str:
+    lines = ["# Docs feature drift report", ""]
+    if inventory_empty:
+        lines += [
+            "⚠️ **Feature inventory not found** — cannot enforce xlsx ↔ docs "
+            "parity. Check the `patter-assets` repo is reachable and the "
+            "workflow secret `PATTER_ASSETS_TOKEN` is configured.",
+            "",
+        ]
+    if inventory_missing_docs:
+        lines += [
+            "## Features in inventory but missing from docs",
+            "",
+            "| feature | status | sdk | ships_in_version |",
+            "|---------|--------|-----|------------------|",
+        ]
+        for row in inventory_missing_docs:
+            lines.append(
+                f"| {row.get('feature_name', '?')} | "
+                f"{row.get('status', '?')} | "
+                f"{row.get('sdk', '?')} | "
+                f"{row.get('ships_in_version', '?')} |"
+            )
+        lines.append("")
+    if docs_missing_inventory:
+        lines += [
+            "## Docs pages without matching inventory row",
+            "",
+            *[f"- `{name}`" for name in sorted(docs_missing_inventory)],
+            "",
+        ]
+    if exports_missing_inventory:
+        lines += [
+            "## Public SDK exports without matching inventory row",
+            "",
+            *[f"- `{name}`" for name in sorted(exports_missing_inventory)],
+            "",
+        ]
+    lines += [
+        "---",
+        "*Generated by `scripts/check_feature_docs_drift.py`. "
+        "Dispatch the `docs-sync` agent to resolve.*",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--xlsx", type=Path, required=True)
+    parser.add_argument("--docs", type=Path, required=True)
+    parser.add_argument("--py-init", type=Path, required=True)
+    parser.add_argument("--ts-index", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    inventory = _load_inventory(args.xlsx)
+    inventory_ids = {row.get("feature_name", "").lower() for row in inventory if row.get("feature_name")}
+    docs_ids = _collect_docs_features(args.docs)
+    export_ids = _collect_sdk_exports(args.py_init, args.ts_index)
+
+    # Inventory rows with docs_page empty OR feature_name not reachable by stem
+    inventory_missing_docs = [
+        row
+        for row in inventory
+        if row.get("feature_name", "").lower() not in docs_ids
+        and row.get("status") not in ("deprecated", "removed")
+    ]
+    docs_missing_inventory = {
+        name
+        for name in docs_ids
+        if name not in inventory_ids
+        and name not in {"index", "introduction", "quickstart", "changelog"}
+    }
+    # Heuristic: exports that look like features (>3 chars, not already standard)
+    standard = {"patter", "agent", "callcontrol", "patterror", "logger", "version"}
+    exports_missing_inventory = {
+        name
+        for name in export_ids
+        if name not in inventory_ids and len(name) > 3 and name not in standard
+    }
+
+    report = _render_report(
+        inventory_missing_docs,
+        docs_missing_inventory,
+        exports_missing_inventory,
+        inventory_empty=not inventory,
+    )
+    args.output.write_text(report)
+
+    drifted = bool(inventory_missing_docs or docs_missing_inventory)
+    print(report)
+    return 1 if drifted else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Automates the 'no feature without docs' invariant described in the new `documentation-best-practices` rule (local to `.claude/rules/`, gitignored).

- **Daily cron 03:00 UTC** (`.github/workflows/docs-feature-drift.yml`) cross-references the feature inventory (`patter-assets/patter_sdk_features.xlsx`) with the Mintlify docs and the public SDK surface.
- Opens or updates a single issue labelled `docs-drift` listing mismatches. Closes it automatically when clean.
- `scripts/check_feature_docs_drift.py` is the detection engine — pure openpyxl + filesystem scan, soft-fails when xlsx is unreachable.

## Companion changes (local to `.claude/`, not in this PR)

- `.claude/rules/documentation-best-practices.md` — plans mirror to `patter-assets/claude-code-plans/`, every shipped feature goes in the xlsx, docs-sync agent dispatched at ship-time.
- `.claude/agents/docs-sync.md` — extended to also sync the xlsx and accept dispatch from this workflow.

## Prerequisites

- Repo secret `PATTER_ASSETS_TOKEN` with read access to `PatterAI/patter-assets` (private). Without it the workflow emits a warning and still runs the docs\u2194code parity check.

## Test plan

- [x] Dry-run locally: `python3 scripts/check_feature_docs_drift.py ...` → produces a sensible report (baseline: xlsx is nearly empty so many SDK exports flagged for review — expected).
- [ ] Merge and watch the first scheduled run (or trigger via Actions \u2192 'Run workflow').