### PR TITLE
chore(security): redact real phone + pre-commit hardening

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,63 @@
+# Patter pre-commit hooks.
+# Adapted from https://github.com/mcp-use/mcp-use/blob/main/.pre-commit-config.yaml
+# (MIT-licensed reference project) for Patter's sdk/ (Python) + sdk-ts/ (TS) layout.
+#
+# Install locally:
+#   pip install pre-commit && pre-commit install
+# Run manually on the whole repo:
+#   pre-commit run --all-files
+
+repos:
+  # ── Python: ruff (lint + format) ─────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+        files: ^sdk/.*\.py$
+        types: [python]
+      - id: ruff-format
+        files: ^sdk/.*\.py$
+        types: [python]
+
+  # ── Hygiene (all files) ──────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: \.(ogg|onnx|png|jpg|jpeg|pdf|ico|lock)$
+      - id: end-of-file-fixer
+        exclude: \.(ogg|onnx|png|jpg|jpeg|pdf|ico|lock)$
+      - id: check-yaml
+        exclude: (package-lock\.json|pnpm-lock\.yaml)$
+      - id: check-json
+        exclude: (tsconfig.*\.json)$ # allow comments
+      - id: check-added-large-files
+        args: [--maxkb=3000] # 3MB cap (silero_vad.onnx is ~2.2MB)
+        exclude: \.(onnx|ogg)$ # vendored bundled assets
+      - id: debug-statements
+        files: ^sdk/.*\.py$
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  # ── Secret scan on every commit ──────────────────────────────────────────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+
+  # ── TypeScript: prettier + eslint via local npm scripts ──────────────────
+  - repo: local
+    hooks:
+      - id: ts-lint
+        name: TypeScript lint (tsc --noEmit)
+        entry: bash -c 'cd sdk-ts && npm run lint'
+        language: system
+        files: ^sdk-ts/.*\.(ts|tsx)$
+        pass_filenames: false
+
+default_language_version:
+  python: python3.11
+
+# The pre-push hook in .githooks/pre-push complements this with a full test run.

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -173,7 +173,7 @@ const phone = new Patter({
   twilioSid: process.env.TWILIO_SID,
   twilioToken: process.env.TWILIO_TOKEN,
   openaiKey: process.env.OPENAI_KEY,
-  phoneNumber: '+16592214527',
+  phoneNumber: '+15551234567',
   webhookUrl: 'your-domain.ngrok-free.dev',
 });
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -173,7 +173,7 @@ const phone = new Patter({
   twilioSid: process.env.TWILIO_SID,
   twilioToken: process.env.TWILIO_TOKEN,
   openaiKey: process.env.OPENAI_KEY,
-  phoneNumber: '+16592214527',
+  phoneNumber: '+15551234567',
   webhookUrl: 'your-domain.ngrok-free.dev',
 });
 


### PR DESCRIPTION
## Summary

Three defence layers against hardcoded secrets and PII leakage, inspired by the mcp-use reference project.

1. **Redact real phone number** from public READMEs. `+16592214527` (the real Twilio number visible in e2e call logs) → `+15551234567` (NANP 555 fictional range). The rest of the repo already used placeholder ranges.
2. **`.pre-commit-config.yaml`** adapted from mcp-use (MIT):
   - ruff lint + format on `sdk/*.py`
   - hygiene hooks (trailing-ws, EOF, check-yaml/json, large-files guard, debug-statements, `detect-private-key`, mixed-line-ending)
   - **gitleaks** secret-scan on every commit
   - `tsc --noEmit` on `sdk-ts/*.ts`
3. **CLAUDE.md + `.claude/hooks/scan-sensitive-on-write.sh` + `.claude/rules/security.md`** updates (not in this PR — `.claude/` and `CLAUDE.md` are gitignored by design). These add:
   - PostToolUse hook: blocks any Write/Edit containing high-confidence secrets (private keys, `sk-proj-*`, `sk-ant-*`, `AKIA*`, `ghp_*`, `xox*`, `AIza*`) and warns on possible hardcoded phone/email/SID/public-IP
   - Rule: placeholder table (555 NANP, example.com, `ACxxx...`, 169.254 for SSRF test context)
   - CLAUDE.md rules #8 (no hardcoded sensitive data) + #9 (plan-mode for non-trivial)

Existing `.githooks/pre-push` (full test + grep sweep) is the last-line defence — three layers total: PostToolUse hook → pre-commit → pre-push.

## .github / .githooks public?

Yes, both are standard for OSS:
- `.github/`: required public by GitHub (workflows, templates, CODEOWNERS) — mcp-use has 15+ workflows public
- `.githooks/`: convention for shared git hooks; our `pre-push` is 100% validator scripts, no secrets

## Test plan

- [x] hook self-tested: blocks `sk-proj-<50 chars>`, warns on `+14155559999`, clean on `+15551234567`
- [ ] install pre-commit locally: `pip install pre-commit && pre-commit install && pre-commit run --all-files`