### PR TITLE
chore: make getpatter self-contained, bump 0.4.3

### DIFF
--- a/docs/dev-tools/dashboard.mdx
+++ b/docs/dev-tools/dashboard.mdx
@@ -29,7 +29,7 @@ Run the dashboard as a separate process — useful when using the SDK as a tool 
 
 <CodeGroup>
 ```bash Python
-pip install getpatter[local]
+pip install getpatter
 patter dashboard --port 8000
 ```
 

--- a/sdk-py/patter/__init__.py
+++ b/sdk-py/patter/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 from patter.client import Patter
 from patter.models import (

--- a/sdk-py/pyproject.toml
+++ b/sdk-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.4.2"
+version = "0.4.3"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }
@@ -27,6 +27,12 @@ requires-python = ">=3.11"
 dependencies = [
     "websockets>=13.0",
     "httpx>=0.27.0",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "twilio>=9.0.0",
+    "audioop-lts>=0.2.1; python_version>='3.13'",
+    "openai>=1.0.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.scripts]
@@ -39,14 +45,11 @@ Repository = "https://github.com/PatterAI/Patter"
 "Bug Tracker" = "https://github.com/PatterAI/Patter/issues"
 
 [project.optional-dependencies]
-local = [
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.30.0",
-    "twilio>=9.0.0",
-    "audioop-lts>=0.2.1; python_version>='3.13'",
-    "openai>=1.0.0",
-    "cryptography>=42.0.0",
-]
+# Kept as an empty alias for backwards compatibility: older guides and
+# templates documented `pip install getpatter[local]`. Those dependencies
+# are now part of the base install, so `getpatter[local]` is equivalent
+# to `getpatter`.
+local = []
 soniox = [
     "aiohttp>=3.10",
 ]

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Make `getpatter` self-contained on Python: move the six runtime dependencies (`fastapi`, `uvicorn[standard]`, `twilio`, `audioop-lts`, `openai`, `cryptography`) from the `[local]` extra into the base `dependencies` so `pip install getpatter` alone is enough to run the SDK end-to-end. The `[local]` extra is preserved as an empty alias so existing `pip install getpatter[local]` commands keep working.

The TypeScript package already ships `express` and `ws` as runtime dependencies, so no structural change is needed there beyond the version bump.

Bump version to 0.4.3 in `sdk-py/pyproject.toml`, `sdk-py/patter/__init__.py`, and `sdk-ts/package.json`. Also drop the now-redundant `[local]` marker from the dashboard docs install snippet.

Replaces #63 (opened from a branch that duplicated an already-merged rename commit).

## Impact

- `pip install getpatter` alone now pulls fastapi, uvicorn, twilio, openai, cryptography, and audioop-lts.
- Eight template repos already have PRs staged to drop `[local]` and target `^0.4.3` once this release is published to PyPI and npm.

## Release plan

After merge, publish `getpatter` 0.4.3 to PyPI and npm manually, then land the template PRs.

## Test plan

- [ ] `pip install .` from `sdk-py/` installs fastapi, uvicorn, twilio, openai, cryptography, audioop-lts automatically
- [ ] `pip install .[local]` still works (equivalent to plain install)
- [ ] `npm install` in `sdk-ts/` resolves with express and ws
- [ ] Existing unit/integration tests pass in both SDKs