### PR TITLE
release: 0.4.4 — 23 bug fixes, SDK parity, 5 live-validated scenarios

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -94,8 +94,11 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Install bandit
-        run: pip install 'bandit[toml]'
+      - name: Install bandit (+ SARIF formatter)
+        # ``bandit-sarif-formatter`` registers a ``sarif`` output mode so the
+        # result lands in the GitHub Security tab. Stock ``bandit`` only
+        # supports csv/custom/html/json/screen/txt/xml/yaml.
+        run: pip install 'bandit[toml]' bandit-sarif-formatter
       - name: Run bandit on sdk-py
         run: |
           # Skip the tests dir (they intentionally exercise suspicious
@@ -110,7 +113,10 @@ jobs:
             --exclude sdk-py/patter/dashboard/ui.py \
             -f sarif -o bandit.sarif || true
       - uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        # Only upload when the SARIF file was actually produced — if the
+        # formatter install fails on a future bandit version the step
+        # shouldn't fail the job, it just skips the Security-tab upload.
+        if: always() && hashFiles('bandit.sarif') != ''
         with:
           sarif_file: bandit.sarif
           category: bandit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,116 @@
+name: Security Audit
+
+# Dependency + static-analysis audit. Runs weekly as a safety net and on
+# every PR that touches dependency manifests so supply-chain regressions
+# surface immediately. Findings are reported but do not block merge — the
+# goal is visibility, not false-positive theatre.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sdk-py/pyproject.toml'
+      - 'sdk-ts/package.json'
+      - 'sdk-ts/package-lock.json'
+      - '.github/workflows/audit.yml'
+  pull_request:
+    paths:
+      - 'sdk-py/pyproject.toml'
+      - 'sdk-ts/package.json'
+      - 'sdk-ts/package-lock.json'
+      - '.github/workflows/audit.yml'
+  schedule:
+    # Monday 06:00 UTC — catch CVEs that land over the weekend.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  pip-audit:
+    name: Python dependency audit (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: sdk-py/pyproject.toml
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Install SDK runtime deps
+        run: |
+          cd sdk-py
+          pip install -e ".[local]"
+      - name: Run pip-audit (warn-only)
+        run: |
+          cd sdk-py
+          # --strict would fail the job on any finding; we keep it
+          # advisory for now because telephony SDKs often depend on
+          # httpx/cryptography versions that get CVEs patched weeks
+          # after release. Review weekly.
+          pip-audit --progress-spinner off --desc on || true
+
+  npm-audit:
+    name: TypeScript dependency audit (npm audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk-ts/package-lock.json
+      - name: Install dependencies (no scripts)
+        run: |
+          cd sdk-ts
+          npm ci --ignore-scripts
+      - name: Run npm audit
+        run: |
+          cd sdk-ts
+          # `--audit-level=high` keeps low/moderate noise out of the
+          # CI log — the scheduled run still catches them via --json.
+          npm audit --omit=dev --audit-level=high || true
+      - name: Upload full JSON report
+        if: always()
+        run: |
+          cd sdk-ts
+          npm audit --json --omit=dev > ../npm-audit.json || true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: npm-audit-report
+          path: npm-audit.json
+          if-no-files-found: ignore
+
+  bandit:
+    name: Python static analysis (bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install bandit
+        run: pip install 'bandit[toml]'
+      - name: Run bandit on sdk-py
+        run: |
+          # Skip the tests dir (they intentionally exercise suspicious
+          # patterns) and assertions (B101 noise inside tests & assert-
+          # heavy typing helpers).
+          bandit -r sdk-py/patter -ll -iii \
+            --exclude sdk-py/patter/dashboard/ui.py \
+            -f txt || true
+      - name: Generate SARIF for Security tab
+        run: |
+          bandit -r sdk-py/patter -ll -iii \
+            --exclude sdk-py/patter/dashboard/ui.py \
+            -f sarif -o bandit.sarif || true
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: bandit.sarif
+          category: bandit

--- a/README.md
+++ b/README.md
@@ -194,11 +194,21 @@ See [`Dockerfile`](./Dockerfile) and [`docker-compose.yml`](./docker-compose.yml
 
 ## Voice Modes
 
-| Mode | Latency | Quality | Best For |
+| Mode | Turn latency | Quality | Best For |
 |---|---|---|---|
-| **OpenAI Realtime** | Lowest | High | Fluid, low-latency conversations |
-| **Deepgram + ElevenLabs** | Low | High | Independent control over STT and TTS |
-| **ElevenLabs ConvAI** | Low | High | ElevenLabs-managed conversation flow |
+| **OpenAI Realtime** (`provider="openai_realtime"`) | ~400–700 ms | High | Fluid, low-latency conversations |
+| **ElevenLabs ConvAI** (`provider="elevenlabs_convai"`) | ~600–900 ms | High | ElevenLabs-managed conversation flow |
+| **Pipeline** (`provider="pipeline"`) | ~2.0–2.8 s | High | Independent control over STT / LLM / TTS |
+
+Pipeline-mode latency is dominated by three fixed costs you can't remove without changing the provider: Deepgram endpointing (~150 ms + `utterance_end_ms`, default 1000 ms), LLM first-token (700–1500 ms for GPT-4o-mini via Twilio egress; ~300 ms with Cerebras/Groq), and TTS first-byte (~400 ms for ElevenLabs Turbo v2.5, ~780 ms for OpenAI tts-1). For sub-second turn UX switch to `provider="openai_realtime"`.
+
+### Provider Notes
+
+- **ElevenLabs free tier** — the library voice catalog is not reachable via API (`402 Payment Required`). Set `ELEVENLABS_VOICE_ID` to a voice you own (cloned or generated) before `phone.serve()`. The SDK resolves ~45 well-known names (`"rachel"`, `"adam"`, …) to their UUIDs automatically; custom voices must be referenced by ID.
+- **Telnyx outbound** — calls will return `403 D38` until your connection has an "Outbound Profile" attached in the Telnyx portal. Inbound and Call Control answer flows work without it.
+- **Google Gemini free tier** — `gemini-2.0-flash` has a hard `quota=0` on the free tier. Enable billing on the project before using Gemini as the LLM.
+- **Whisper STT** — on mulaw 8 kHz inputs Whisper routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`). The pipeline drops these by default plus any duplicate / sub-500 ms back-to-back final, so you won't hear overlapping turns.
+- **Model IDs** — keep these updated per vendor release notes. Examples currently in use: `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5`, `llama-3.3-70b-versatile` (Groq), `llama3.1-8b` (Cerebras).
 
 ## API Reference
 
@@ -209,7 +219,9 @@ See [`Dockerfile`](./Dockerfile) and [`docker-compose.yml`](./docker-compose.yml
 | `Patter(twilio_sid, twilio_token, openai_key, phone_number, ...)` | Create client with provider credentials |
 | `agent(system_prompt, voice?, first_message?, tools?, ...)` | Create an agent configuration |
 | `serve(agent, port?, dashboard?, ...)` | Start the embedded server and listen for calls |
-| `call(to, agent?, machine_detection?, voicemail_message?, ...)` | Place an outbound call |
+| `call(to, agent?, machine_detection?, voicemail_message?, ring_timeout?, ...)` | Place an outbound call |
+
+`call()` accepts a `ring_timeout` (seconds) that maps to Twilio's `Timeout` dial parameter and Telnyx's `timeout_secs`. When the carrier reports `no-answer`, `busy`, or `canceled`, the outcome is forwarded to the dashboard's `/webhooks/twilio/status` callback so it appears in the call log even if no media frames were ever exchanged.
 
 **`serve()` options:**
 

--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ See [`Dockerfile`](./Dockerfile) and [`docker-compose.yml`](./docker-compose.yml
 
 ## Voice Modes
 
-| Mode | Turn latency | Quality | Best For |
-|---|---|---|---|
-| **OpenAI Realtime** (`provider="openai_realtime"`) | ~400–700 ms | High | Fluid, low-latency conversations |
-| **ElevenLabs ConvAI** (`provider="elevenlabs_convai"`) | ~600–900 ms | High | ElevenLabs-managed conversation flow |
-| **Pipeline** (`provider="pipeline"`) | ~2.0–2.8 s | High | Independent control over STT / LLM / TTS |
+| Mode | Quality | Best For |
+|---|---|---|
+| **OpenAI Realtime** (`provider="openai_realtime"`) | High | Fluid, low-latency conversations |
+| **ElevenLabs ConvAI** (`provider="elevenlabs_convai"`) | High | ElevenLabs-managed conversation flow |
+| **Pipeline** (`provider="pipeline"`) | High | Independent control over STT / LLM / TTS |
 
-Pipeline-mode latency is dominated by three fixed costs you can't remove without changing the provider: Deepgram endpointing (~150 ms + `utterance_end_ms`, default 1000 ms), LLM first-token (700–1500 ms for GPT-4o-mini via Twilio egress; ~300 ms with Cerebras/Groq), and TTS first-byte (~400 ms for ElevenLabs Turbo v2.5, ~780 ms for OpenAI tts-1). For sub-second turn UX switch to `provider="openai_realtime"`.
+Pipeline mode composes STT + LLM + TTS sequentially and inherits the latency of each provider plus the endpointing window. For the fastest turn UX pick `provider="openai_realtime"`, or pair the pipeline with low-latency providers such as Cerebras/Groq for the LLM and ElevenLabs Turbo v2.5 for TTS.
 
 ### Provider Notes
 

--- a/sdk-py/patter/__init__.py
+++ b/sdk-py/patter/__init__.py
@@ -19,7 +19,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from patter.client import Patter
 from patter.models import (

--- a/sdk-py/patter/__init__.py
+++ b/sdk-py/patter/__init__.py
@@ -1,3 +1,24 @@
+"""getpatter — open-source voice AI SDK.
+
+Installation extras:
+
+* Base: ``pip install getpatter`` — core telephony + OpenAI Realtime + pipeline
+  mode with Deepgram STT and ElevenLabs TTS.
+* ``scheduling`` — APScheduler-backed ``schedule_cron`` / ``schedule_once`` /
+  ``schedule_interval`` helpers. Install with
+  ``pip install 'getpatter[scheduling]'``. Calling a scheduler helper without
+  this extra raises ``RuntimeError`` at call time (by design — the SDK does
+  not ship APScheduler in the base install to keep the default footprint
+  small).
+* Optional provider extras (``anthropic``, ``groq``, ``cerebras``, ``google``,
+  ``gemini-live``, ``ultravox``, ``speechmatics``, ``assemblyai``, ``cartesia``,
+  ``soniox``, ``rime``, ``lmnt``, ``telnyx-ai``, ``silero``, ``krisp``,
+  ``deepfilternet``, ``ivr``, ``background-audio``, ``evals``, ``tracing``) —
+  install only the ones matching the provider your agent uses.
+
+See ``pyproject.toml`` and the top-level README for the full matrix.
+"""
+
 __version__ = "0.4.3"
 
 from patter.client import Patter
@@ -34,6 +55,13 @@ from patter.scheduler import (
     schedule_once,
     schedule_interval,
 )
+
+# Top-level re-export for parity with TypeScript ``mixPcm`` (see BUG #04g).
+# Import is lazy — `mix_pcm` triggers numpy import only on first call.
+def mix_pcm(agent: bytes, bg: bytes, ratio: float) -> bytes:
+    """Standalone PCM mixer — parity with TypeScript ``mixPcm(agent, bg, ratio)``."""
+    from patter.services.pcm_mixer import mix_pcm as _mix_pcm
+    return _mix_pcm(agent, bg, ratio)
 
 __all__ = [
     "Patter",
@@ -73,4 +101,5 @@ __all__ = [
     "schedule_cron",
     "schedule_once",
     "schedule_interval",
+    "mix_pcm",
 ]

--- a/sdk-py/patter/client.py
+++ b/sdk-py/patter/client.py
@@ -220,6 +220,7 @@ class Patter:
         machine_detection: bool = False,
         on_machine: Callable[[dict], Awaitable[None]] | None = None,
         voicemail_message: str = "",
+        ring_timeout: int | None = None,
     ) -> None:
         """Make an outbound call.
 
@@ -270,6 +271,19 @@ class Patter:
                     extra_params["AsyncAmdStatusCallback"] = (
                         f"https://{config.webhook_url}/webhooks/twilio/amd"
                     )
+                if ring_timeout is not None:
+                    extra_params["Timeout"] = int(ring_timeout)
+                # Status callback so the dashboard sees ringing/failed/
+                # no-answer transitions before any media webhook fires.
+                extra_params.setdefault(
+                    "StatusCallback",
+                    f"https://{config.webhook_url}/webhooks/twilio/status",
+                )
+                extra_params.setdefault("StatusCallbackMethod", "POST")
+                extra_params.setdefault(
+                    "StatusCallbackEvent",
+                    "initiated ringing answered completed",
+                )
                 call_id = await adapter.initiate_call(
                     config.phone_number or from_number,
                     to,
@@ -277,6 +291,18 @@ class Patter:
                     extra_params=extra_params,
                 )
                 logger.info("Outbound call initiated: %s", call_id)
+                # Pre-register the call so the dashboard surfaces attempts
+                # that never reach media (no-answer, busy, carrier-reject).
+                if self._server is not None and getattr(self._server, "_metrics_store", None) is not None:
+                    try:
+                        self._server._metrics_store.record_call_initiated({
+                            "call_id": call_id,
+                            "caller": config.phone_number or from_number,
+                            "callee": to,
+                            "direction": "outbound",
+                        })
+                    except Exception as exc:
+                        logger.debug("record_call_initiated: %s", exc)
             elif config.telephony_provider == "telnyx":
                 from patter.providers.telnyx_adapter import TelnyxAdapter  # type: ignore[import]
 
@@ -291,8 +317,19 @@ class Patter:
                     config.phone_number or from_number,
                     to,
                     stream_url,
+                    ring_timeout=ring_timeout,
                 )
                 logger.info("Outbound call initiated: %s", call_id)
+                if self._server is not None and getattr(self._server, "_metrics_store", None) is not None:
+                    try:
+                        self._server._metrics_store.record_call_initiated({
+                            "call_id": call_id,
+                            "caller": config.phone_number or from_number,
+                            "callee": to,
+                            "direction": "outbound",
+                        })
+                    except Exception as exc:
+                        logger.debug("record_call_initiated: %s", exc)
             return
 
         # Cloud mode
@@ -325,6 +362,12 @@ class Patter:
         tts: TTSConfig | None = None,
         variables: dict | None = None,
         guardrails: list | None = None,
+        hooks: "PipelineHooks | None" = None,
+        text_transforms: "list[Callable] | None" = None,
+        vad: "VADProvider | None" = None,
+        audio_filter: "AudioFilter | None" = None,
+        background_audio: "BackgroundAudioPlayer | None" = None,
+        barge_in_threshold_ms: int = 300,
     ) -> Agent:
         """Create an ``Agent`` configuration for local mode.
 
@@ -413,6 +456,12 @@ class Patter:
             tts=tts,
             variables=variables,
             guardrails=guardrails,
+            hooks=hooks,
+            text_transforms=text_transforms,
+            vad=vad,
+            audio_filter=audio_filter,
+            background_audio=background_audio,
+            barge_in_threshold_ms=barge_in_threshold_ms,
         )
 
     async def serve(
@@ -666,8 +715,25 @@ class Patter:
     # === Provider helpers (for self-hosted setup) ===
 
     @staticmethod
-    def deepgram(api_key: str, language: str = "en") -> STTConfig:
-        return _deepgram(api_key=api_key, language=language)
+    def deepgram(
+        api_key: str,
+        language: str = "en",
+        *,
+        model: str = "nova-3",
+        endpointing_ms: int = 150,
+        utterance_end_ms: int | None = 1000,
+        smart_format: bool = True,
+        interim_results: bool = True,
+    ) -> STTConfig:
+        return _deepgram(
+            api_key=api_key,
+            language=language,
+            model=model,
+            endpointing_ms=endpointing_ms,
+            utterance_end_ms=utterance_end_ms,
+            smart_format=smart_format,
+            interim_results=interim_results,
+        )
 
     @staticmethod
     def whisper(api_key: str, language: str = "en") -> STTConfig:

--- a/sdk-py/patter/client.py
+++ b/sdk-py/patter/client.py
@@ -42,6 +42,9 @@ from patter.providers import (
     whisper as _whisper,
     elevenlabs as _elevenlabs,
     openai_tts as _openai_tts,
+    cartesia as _cartesia,
+    rime as _rime,
+    lmnt as _lmnt,
 )
 
 DEFAULT_BACKEND_URL = "wss://api.getpatter.com"
@@ -724,6 +727,7 @@ class Patter:
         utterance_end_ms: int | None = 1000,
         smart_format: bool = True,
         interim_results: bool = True,
+        vad_events: bool | None = None,
     ) -> STTConfig:
         return _deepgram(
             api_key=api_key,
@@ -733,6 +737,7 @@ class Patter:
             utterance_end_ms=utterance_end_ms,
             smart_format=smart_format,
             interim_results=interim_results,
+            vad_events=vad_events,
         )
 
     @staticmethod
@@ -746,6 +751,24 @@ class Patter:
     @staticmethod
     def openai_tts(api_key: str, voice: str = "alloy") -> TTSConfig:
         return _openai_tts(api_key=api_key, voice=voice)
+
+    @staticmethod
+    def cartesia(
+        api_key: str,
+        voice: str = "f786b574-daa5-4673-aa0c-cbe3e8534c02",
+    ) -> TTSConfig:
+        """Cartesia TTS config (parity with ``Patter.cartesia()`` in sdk-ts)."""
+        return _cartesia(api_key=api_key, voice=voice)
+
+    @staticmethod
+    def rime(api_key: str, voice: str = "astra") -> TTSConfig:
+        """Rime TTS config (parity with ``Patter.rime()`` in sdk-ts)."""
+        return _rime(api_key=api_key, voice=voice)
+
+    @staticmethod
+    def lmnt(api_key: str, voice: str = "leah") -> TTSConfig:
+        """LMNT TTS config (parity with ``Patter.lmnt()`` in sdk-ts)."""
+        return _lmnt(api_key=api_key, voice=voice)
 
     @staticmethod
     def guardrail(

--- a/sdk-py/patter/dashboard/store.py
+++ b/sdk-py/patter/dashboard/store.py
@@ -31,6 +31,10 @@ class MetricsStoreProtocol(Protocol):
 
     def record_turn(self, data: dict[str, Any]) -> None: ...
 
+    def record_call_initiated(self, data: dict[str, Any]) -> None: ...
+
+    def update_call_status(self, call_id: str, status: str, **extra: Any) -> None: ...
+
     def get_calls(self, limit: int = 50, offset: int = 0) -> list[dict[str, Any]]: ...
 
     def get_call(self, call_id: str) -> dict[str, Any] | None: ...
@@ -107,13 +111,92 @@ class MetricsStore:
             "direction": data.get("direction", "inbound"),
         }
         with self._lock:
-            self._active_calls[call_id] = {
-                **event_data,
-                "started_at": time.time(),
-                "turns": [],
-            }
+            existing = self._active_calls.get(call_id)
+            # If the call was pre-registered with ``record_call_initiated``
+            # (e.g., outbound dial before media arrives), upgrade its status
+            # to "in-progress" instead of overwriting the from/to metadata.
+            if existing is not None:
+                existing.update(event_data)
+                existing["status"] = "in-progress"
+                existing.setdefault("turns", [])
+            else:
+                self._active_calls[call_id] = {
+                    **event_data,
+                    "started_at": time.time(),
+                    "status": "in-progress",
+                    "turns": [],
+                }
         # Publish outside lock to avoid deadlock with subscribe/unsubscribe
         self._publish("call_start", event_data)
+
+    def record_call_initiated(self, data: dict[str, Any]) -> None:
+        """Pre-register an outbound call before any webhook fires.
+
+        Called from ``Patter.call()`` so that even calls that never reach the
+        media channel (busy, no-answer, carrier-rejected) show up in the
+        dashboard. See BUG #06.
+        """
+        call_id = data.get("call_id", "")
+        if not call_id:
+            return
+        entry = {
+            "call_id": call_id,
+            "caller": data.get("caller", ""),
+            "callee": data.get("callee", ""),
+            "direction": data.get("direction", "outbound"),
+            "started_at": time.time(),
+            "status": "initiated",
+            "turns": [],
+        }
+        with self._lock:
+            # Don't clobber a pre-existing record (e.g. inbound already moved
+            # to "in-progress"). First writer wins.
+            self._active_calls.setdefault(call_id, entry)
+        self._publish("call_initiated", {k: entry[k] for k in ("call_id", "caller", "callee", "direction", "status")})
+
+    def update_call_status(self, call_id: str, status: str, **extra: Any) -> None:
+        """Update the status of an active or completed call.
+
+        Used by the Twilio ``statusCallback`` handler and by operators
+        wiring custom provider webhooks. Known statuses:
+        ``initiated``, ``ringing``, ``in-progress``, ``completed``,
+        ``no-answer``, ``busy``, ``failed``, ``canceled``, ``webhook_error``.
+        """
+        if not call_id or not status:
+            return
+        terminal = status in {"completed", "no-answer", "busy", "failed", "canceled", "webhook_error"}
+        with self._lock:
+            active = self._active_calls.get(call_id)
+            if active is not None:
+                active["status"] = status
+                if extra:
+                    active.update(extra)
+                if terminal:
+                    # Move to completed list so the UI stops the live timer.
+                    entry = {
+                        "call_id": call_id,
+                        "caller": active.get("caller", ""),
+                        "callee": active.get("callee", ""),
+                        "direction": active.get("direction", "outbound"),
+                        "started_at": active.get("started_at", 0),
+                        "ended_at": time.time(),
+                        "status": status,
+                        "metrics": None,
+                        **{k: v for k, v in extra.items() if k not in {"status"}},
+                    }
+                    self._active_calls.pop(call_id, None)
+                    self._calls.append(entry)
+                    if len(self._calls) > self._max_calls:
+                        self._calls = self._calls[-self._max_calls:]
+            else:
+                # Call already completed — patch the existing row if found.
+                for call in reversed(self._calls):
+                    if call.get("call_id") == call_id:
+                        call["status"] = status
+                        if extra:
+                            call.update(extra)
+                        break
+        self._publish("call_status", {"call_id": call_id, "status": status, **extra})
 
     def record_turn(self, data: dict[str, Any]) -> None:
         call_id = data.get("call_id", "")
@@ -146,10 +229,27 @@ class MetricsStore:
                 entry["callee"] = active.get("callee", "")
                 entry["direction"] = active.get("direction", "inbound")
                 entry["started_at"] = active.get("started_at", 0)
+                # Preserve any explicit status (no-answer, busy, ...) set by
+                # a statusCallback during the call. Fall back to "completed".
+                entry["status"] = active.get("status", "completed") if active.get("status") != "in-progress" else "completed"
+            else:
+                entry.setdefault("status", "completed")
             if metrics is not None:
                 entry["metrics"] = asdict(metrics)
             else:
-                entry["metrics"] = None
+                # No metrics payload (e.g. webhook-rejected inbound, or
+                # outbound call that never hit media): synthesise a minimal
+                # metrics shim so the UI can still display a frozen duration.
+                started = entry.get("started_at") or 0
+                ended = entry.get("ended_at") or time.time()
+                entry["metrics"] = {
+                    "duration_seconds": max(0.0, float(ended - started)),
+                    "turns": [],
+                    "cost": {"total": 0.0, "stt": 0.0, "tts": 0.0, "llm": 0.0, "telephony": 0.0},
+                    "latency_avg": {"total_ms": 0.0},
+                    "latency_p95": {"total_ms": 0.0},
+                    "provider_mode": "",
+                }
             self._calls.append(entry)
             if len(self._calls) > self._max_calls:
                 self._calls = self._calls[-self._max_calls :]

--- a/sdk-py/patter/dashboard/ui.py
+++ b/sdk-py/patter/dashboard/ui.py
@@ -182,6 +182,30 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
   .badge-ended { background: var(--secondary); color: var(--muted); }
   .badge-pipeline { background: rgba(167,139,250,0.1); color: #7c3aed; }
   .badge-realtime { background: rgba(59,130,246,0.1); color: #2563eb; }
+  .badge-status-completed { background: rgba(34,197,94,0.1); color: #16a34a; }
+  .badge-status-inprogress { background: rgba(59,130,246,0.1); color: #2563eb; }
+  .badge-status-initiated { background: rgba(234,179,8,0.12); color: #ca8a04; }
+  .badge-status-ringing { background: rgba(234,179,8,0.12); color: #ca8a04; }
+  .badge-status-failed { background: rgba(239,68,68,0.12); color: #dc2626; }
+  .badge-status-noanswer { background: rgba(239,68,68,0.12); color: #dc2626; }
+  .badge-status-busy { background: rgba(251,146,60,0.15); color: #ea580c; }
+  .badge-status-canceled { background: var(--secondary); color: var(--muted); }
+  .badge-status-webhookerror { background: rgba(239,68,68,0.12); color: #dc2626; }
+  tr.row-failed { background: rgba(239,68,68,0.04); }
+
+  /* Filter buttons */
+  .filter-btn {
+    font-family: var(--font); font-size: 13px; font-weight: 500;
+    padding: 6px 14px; border-radius: 8px;
+    background: var(--secondary); color: var(--muted);
+    border: 1px solid var(--border);
+    cursor: pointer; transition: all .15s ease;
+  }
+  .filter-btn:hover { color: var(--fg); border-color: var(--border-d); }
+  .filter-btn.active {
+    background: var(--primary); color: var(--primary-fg);
+    border-color: var(--primary);
+  }
 
   .cost { color: #16a34a; font-family: var(--mono); font-size: 13px; }
   .latency { color: #ca8a04; font-family: var(--mono); font-size: 13px; }
@@ -333,15 +357,20 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
 
   <div class="tab-content active" id="tab-calls">
     <div class="section">
+      <div style="display:flex; gap:8px; margin-bottom:12px; flex-wrap:wrap;">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="completed">Completed</button>
+        <button class="filter-btn" data-filter="failed">Failed</button>
+      </div>
       <table id="calls-table">
         <thead>
           <tr>
             <th>Call ID</th><th>Direction</th><th>From / To</th>
-            <th>Duration</th><th>Mode</th><th>Cost</th><th>Avg Latency</th><th>Turns</th>
+            <th>Duration</th><th>Status</th><th>Mode</th><th>Cost</th><th>Avg Latency</th><th>Turns</th>
           </tr>
         </thead>
         <tbody id="calls-body">
-          <tr><td colspan="8" class="empty">No calls yet. Waiting for incoming calls...</td></tr>
+          <tr><td colspan="9" class="empty">No calls yet. Waiting for incoming calls...</td></tr>
         </tbody>
       </table>
     </div>
@@ -414,25 +443,59 @@ async function refreshAggregates() {
   $('#stat-latency').textContent = fmtMs(d.avg_latency_ms);
 }
 
+let _currentFilter = 'all';
+const _FAILED_STATUSES = new Set(['failed', 'no-answer', 'busy', 'canceled', 'webhook_error']);
+
+function statusBadgeClass(status) {
+  const key = (status || '').replace(/[^a-z]/gi, '').toLowerCase();
+  const map = {
+    completed: 'badge-status-completed',
+    inprogress: 'badge-status-inprogress',
+    initiated: 'badge-status-initiated',
+    ringing: 'badge-status-ringing',
+    failed: 'badge-status-failed',
+    noanswer: 'badge-status-noanswer',
+    busy: 'badge-status-busy',
+    canceled: 'badge-status-canceled',
+    webhookerror: 'badge-status-webhookerror',
+  };
+  return map[key] || 'badge-ended';
+}
+
+function passesFilter(status) {
+  if (_currentFilter === 'all') return true;
+  if (_currentFilter === 'completed') return status === 'completed';
+  if (_currentFilter === 'failed') return _FAILED_STATUSES.has(status);
+  return true;
+}
+
 async function refreshCalls() {
   const calls = await fetchJSON('/api/dashboard/calls?limit=50');
   const body = $('#calls-body');
   if (!calls.length) {
-    body.innerHTML = '<tr><td colspan="8" class="empty">No calls yet. Waiting for incoming calls...</td></tr>';
+    body.innerHTML = '<tr><td colspan="9" class="empty">No calls yet. Waiting for incoming calls...</td></tr>';
     return;
   }
-  body.innerHTML = calls.map(c => {
+  const filtered = calls.filter(c => passesFilter(c.status || 'completed'));
+  if (!filtered.length) {
+    body.innerHTML = `<tr><td colspan="9" class="empty">No calls match the current filter.</td></tr>`;
+    return;
+  }
+  body.innerHTML = filtered.map(c => {
     const m = c.metrics || {};
     const cost = m.cost || {};
     const lat = m.latency_avg || {};
     const mode = m.provider_mode || '-';
     const turns = m.turns ? m.turns.length : 0;
     const modeClass = mode === 'pipeline' ? 'badge-pipeline' : 'badge-realtime';
-    return `<tr class="clickable" onclick="showCall('${esc(c.call_id)}')">
+    const status = c.status || 'completed';
+    const rowClass = _FAILED_STATUSES.has(status) ? 'clickable row-failed' : 'clickable';
+    return `<tr class="${rowClass}" onclick="showCall('${esc(c.call_id)}')">
       <td><code>${shortId(c.call_id)}</code></td>
       <td>${esc(c.direction) || '-'}</td>
       <td>${esc(c.caller) || '-'} &rarr; ${esc(c.callee) || '-'}</td>
       <td>${fmtDur(m.duration_seconds)}</td>
+      <td><span class="badge ${statusBadgeClass(status)}">${esc(status)}</span></td>
       <td><span class="badge ${modeClass}">${esc(mode)}</span></td>
       <td class="cost">${fmt$(cost.total || 0)}</td>
       <td class="latency">${fmtMs(lat.total_ms || 0)}</td>
@@ -580,12 +643,24 @@ async function refresh() {
 
 refresh();
 
-// Update active call durations every second
+// Wire the status-filter pills.
+document.querySelectorAll('.filter-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    _currentFilter = btn.getAttribute('data-filter') || 'all';
+    refreshCalls();
+  });
+});
+
+// Update active call durations every second. Rows carrying a `data-ended`
+// attribute have already received call_end — freeze them instead of ticking.
 setInterval(() => {
   const cells = document.querySelectorAll('#active-body td[data-started]');
   if (!cells.length) return;
   const now = Date.now() / 1000;
   cells.forEach(td => {
+    if (td.getAttribute('data-ended')) return;
     const started = parseFloat(td.getAttribute('data-started'));
     if (started) td.textContent = fmtDur(Math.round(now - started));
   });
@@ -603,6 +678,8 @@ if (typeof EventSource !== 'undefined') {
     const es = new EventSource(sseUrl);
     function onEvent() { sseBackoff = 1000; sseFailures = 0; }
     es.addEventListener('call_start', () => { onEvent(); refresh(); });
+    es.addEventListener('call_initiated', () => { onEvent(); refresh(); });
+    es.addEventListener('call_status', () => { onEvent(); refresh(); });
     es.addEventListener('turn_complete', () => { onEvent(); refreshAggregates(); });
     es.addEventListener('call_end', () => { onEvent(); refresh(); });
     es.onerror = () => {

--- a/sdk-py/patter/handlers/common.py
+++ b/sdk-py/patter/handlers/common.py
@@ -44,9 +44,22 @@ def _create_stt_from_config(config, for_twilio: bool = False):
     if provider == "deepgram":
         from patter.providers.deepgram_stt import DeepgramSTT  # type: ignore[import]
 
+        opts = dict(config.options or {})
+        # Only forward keys the DeepgramSTT ctor understands.
+        allowed = {
+            "model",
+            "endpointing_ms",
+            "utterance_end_ms",
+            "smart_format",
+            "interim_results",
+            "vad_events",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
         if for_twilio:
-            return DeepgramSTT.for_twilio(api_key=config.api_key, language=config.language)
-        return DeepgramSTT(api_key=config.api_key, language=config.language)
+            return DeepgramSTT.for_twilio(
+                api_key=config.api_key, language=config.language, **kwargs
+            )
+        return DeepgramSTT(api_key=config.api_key, language=config.language, **kwargs)
     elif provider == "whisper":
         from patter.providers.whisper_stt import WhisperSTT  # type: ignore[import]
 

--- a/sdk-py/patter/handlers/stream_handler.py
+++ b/sdk-py/patter/handlers/stream_handler.py
@@ -299,6 +299,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
         conversation_history: deque | None = None,
         transcript_entries: deque | None = None,
         audio_format: str = "pcm16",
+        input_transcode: str | None = None,
     ) -> None:
         super().__init__(
             agent=agent,
@@ -317,6 +318,18 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
         self._transfer_fn = transfer_fn
         self._hangup_fn = hangup_fn
         self._audio_format = audio_format
+        # OpenAI Realtime API uses a single codec for both input and output
+        # (``audio_format`` becomes both ``input_audio_format`` and
+        # ``output_audio_format`` in the session). When the telephony leg
+        # delivers a different codec than what we want to send back (e.g.
+        # Telnyx inbound = PCM16 16 kHz, outbound = PCMU 8 kHz), set
+        # ``input_transcode`` to convert inbound bytes to match ``audio_format``
+        # before forwarding to OpenAI.
+        #
+        # Supported values:
+        #   ``"pcm16_16k_to_g711_ulaw"`` — Telnyx inbound PCM16 16 kHz →
+        #       mulaw 8 kHz (matches ``audio_format="g711_ulaw"``).
+        self._input_transcode = input_transcode
         self._adapter = None
 
     async def start(self) -> None:
@@ -518,8 +531,15 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
             logger.exception("OpenAI Realtime forward error: %s", exc)
 
     async def on_audio_received(self, audio_bytes: bytes) -> None:
-        if self._adapter is not None:
-            await self._adapter.send_audio(audio_bytes)
+        if self._adapter is None:
+            return
+        if self._input_transcode == "pcm16_16k_to_g711_ulaw":
+            from patter.services.transcoding import (
+                resample_16k_to_8k,
+                pcm16_to_mulaw,
+            )
+            audio_bytes = pcm16_to_mulaw(resample_16k_to_8k(audio_bytes))
+        await self._adapter.send_audio(audio_bytes)
 
     async def on_dtmf(self, digit: str) -> None:
         if self._adapter is not None:
@@ -714,6 +734,8 @@ class PipelineStreamHandler(StreamHandler):
         deepgram_key: str = "",
         elevenlabs_key: str = "",
         for_twilio: bool = False,
+        input_is_mulaw_8k: bool | None = None,
+        output_is_mulaw_8k: bool | None = None,
         transfer_fn=None,
         hangup_fn=None,
         send_dtmf_fn=None,
@@ -741,6 +763,18 @@ class PipelineStreamHandler(StreamHandler):
         self._deepgram_key = deepgram_key
         self._elevenlabs_key = elevenlabs_key
         self._for_twilio = for_twilio
+        # Explicit codec flags decouple "we run on Twilio" (for metrics /
+        # telephony-specific knobs) from "the stream is PCMU 8 kHz and must
+        # be transcoded before STT / from PCM16 for TTS". Twilio is always
+        # mulaw 8 kHz; Telnyx is mulaw 8 kHz when ``streaming_start``
+        # negotiates PCMU bidirectional (our default). Callers pass the
+        # flags explicitly when they differ from `for_twilio`.
+        self._input_is_mulaw_8k = (
+            for_twilio if input_is_mulaw_8k is None else input_is_mulaw_8k
+        )
+        self._output_is_mulaw_8k = (
+            for_twilio if output_is_mulaw_8k is None else output_is_mulaw_8k
+        )
         self._transfer_fn = transfer_fn
         self._hangup_fn = hangup_fn
         self._send_dtmf_fn = send_dtmf_fn
@@ -756,28 +790,28 @@ class PipelineStreamHandler(StreamHandler):
     async def start(self) -> None:
         from patter.models import CallControl
 
-        # Create STT
+        # Create STT. Pipeline mode always transcodes Twilio mulaw 8 kHz →
+        # PCM16 16 kHz in on_audio_received before forwarding to STT, so the
+        # STT adapter must be configured for linear16 @ 16 kHz — even on
+        # Twilio. Passing `for_twilio=True` would build a mulaw-expecting
+        # adapter that misinterprets the already-decoded PCM as garbage.
         if self.agent.stt:
-            self._stt = _create_stt_from_config(self.agent.stt, for_twilio=self._for_twilio)
+            self._stt = _create_stt_from_config(self.agent.stt, for_twilio=False)
         elif self._deepgram_key:
             from patter.providers.deepgram_stt import DeepgramSTT  # type: ignore[import]
-            if self._for_twilio:
-                self._stt = DeepgramSTT.for_twilio(api_key=self._deepgram_key, language=self.agent.language)
-            else:
-                self._stt = DeepgramSTT(
-                    api_key=self._deepgram_key,
-                    language=self.agent.language,
-                    encoding="linear16",
-                    sample_rate=16000,
-                )
+            self._stt = DeepgramSTT(
+                api_key=self._deepgram_key,
+                language=self.agent.language,
+                encoding="linear16",
+                sample_rate=16000,
+            )
 
         # Create TTS
         if self.agent.tts:
             self._tts = _create_tts_from_config(self.agent.tts)
         elif self._elevenlabs_key:
             from patter.providers.elevenlabs_tts import ElevenLabsTTS  # type: ignore[import]
-            voice_id = self.agent.voice if self.agent.voice != "alloy" else "21m00Tcm4TlvDq8ikWAM"
-            self._tts = ElevenLabsTTS(api_key=self._elevenlabs_key, voice_id=voice_id)
+            self._tts = ElevenLabsTTS(api_key=self._elevenlabs_key, voice_id=self.agent.voice)
 
         if self._stt is None:
             logger.warning("Pipeline mode: no STT configured")
@@ -1035,10 +1069,79 @@ class PipelineStreamHandler(StreamHandler):
                     )
 
     async def _stt_loop(self) -> None:
+        # Per-loop state used to throttle back-to-back turns (BUG #22). When
+        # the STT provider emits several nearly-identical final transcripts
+        # in quick succession (e.g. Whisper on mulaw 8 kHz repeatedly
+        # returning "you" / ".") we would otherwise kick off a new LLM+TTS
+        # turn for each, and the audio of consecutive turns overlaps on the
+        # caller's line. Dedup rules:
+        #   1. Drop a final transcript whose normalised text matches the
+        #      previous committed text within 2.0 s.
+        #   2. Drop a final transcript that lands within 500 ms of the last
+        #      committed turn — too tight to be a legitimate new utterance.
+        last_commit_text: str = ""
+        last_commit_at: float = 0.0
         try:
             async for transcript in self._stt.receive_transcripts():
+                # Barge-in: if the agent is currently speaking and the STT
+                # produces any transcript with text (even an interim one),
+                # flip `_is_speaking=False` + clear the downstream audio
+                # buffer so the in-flight TTS loop interrupts (BUG #20).
+                if transcript.text and self._is_speaking:
+                    logger.info(
+                        "Barge-in: caller spoke over agent (%s)",
+                        sanitize_log_value(transcript.text[:40]),
+                    )
+                    self._is_speaking = False
+                    try:
+                        await self.audio_sender.send_clear()
+                    except Exception as exc:
+                        logger.debug("send_clear during barge-in failed: %s", exc)
+                    if self.metrics is not None:
+                        self.metrics.record_turn_interrupted()
                 if not (transcript.is_final and transcript.text):
                     continue
+
+                # --- Dedup / throttle / hallucination filter (BUG #22) -------
+                _now = time.time()
+                _normalised = transcript.text.strip().lower()
+                _stripped = _normalised.rstrip(".,!?;: ").strip()
+                _since_last = _now - last_commit_at
+
+                # Whisper (and, to a lesser extent, Deepgram) routinely
+                # hallucinate a handful of short "filler" words when fed
+                # silence or TTS echo on mulaw 8 kHz. Dropping them as
+                # turns stops the caller from entering a feedback loop
+                # where every silent frame triggers a new LLM+TTS turn.
+                _HALLUCINATIONS = frozenset({
+                    "you", "thank you", "thanks", "yeah", "yes", "no",
+                    "okay", "ok", "uh", "um", "mmm", "hmm", ".", "bye",
+                    "right", "cool",
+                })
+                if _stripped in _HALLUCINATIONS or _stripped == "":
+                    logger.info(
+                        "Dropped likely STT hallucination: %r",
+                        _normalised[:40],
+                    )
+                    continue
+
+                if _since_last < 2.0 and _normalised == last_commit_text:
+                    logger.info(
+                        "Dropped duplicate final transcript (%.1fs since last): %r",
+                        _since_last,
+                        _normalised[:40],
+                    )
+                    continue
+                if _since_last < 0.5:
+                    logger.info(
+                        "Dropped back-to-back final transcript (%.2fs since last): %r",
+                        _since_last,
+                        _normalised[:40],
+                    )
+                    continue
+                last_commit_text = _normalised
+                last_commit_at = _now
+                # -------------------------------------------------------------
 
                 # Record one STT span per final transcript turn. The span is
                 # short-lived (just the attribute set) because STT is
@@ -1187,17 +1290,39 @@ class PipelineStreamHandler(StreamHandler):
             logger.exception("Pipeline STT loop error: %s", exc)
 
     async def on_audio_received(self, audio_bytes: bytes) -> None:
-        if self._stt is not None and not self._is_speaking:
-            # Twilio sends mulaw 8kHz — convert to PCM 16kHz for STT providers.
-            # Telnyx sends PCM 16kHz natively.
-            if self._for_twilio:
-                from patter.services.transcoding import mulaw_to_pcm16, resample_8k_to_16k
-                pcm16k = resample_8k_to_16k(mulaw_to_pcm16(audio_bytes))
-                await self._stt.send_audio(pcm16k)
-            else:
-                await self._stt.send_audio(audio_bytes)
-            if self.metrics is not None:
-                self.metrics.add_stt_audio_bytes(len(audio_bytes))
+        if self._stt is None:
+            return
+        # Always forward caller audio to STT — even while the agent is
+        # speaking — so barge-in detection can trigger (BUG #20). When
+        # `barge_in_threshold_ms == 0` on the agent, skip the STT during
+        # TTS to avoid echo-loop costs (legacy behaviour).
+        if self._is_speaking and getattr(self.agent, "barge_in_threshold_ms", 300) == 0:
+            return
+        # Inbound PCMU 8 kHz (Twilio always, Telnyx when streaming_start
+        # negotiated PCMU bidirectional) must be decoded to PCM16 and
+        # up-sampled to 16 kHz before hitting STT adapters configured for
+        # linear16 @ 16 kHz.
+        if self._input_is_mulaw_8k:
+            from patter.services.transcoding import mulaw_to_pcm16, resample_8k_to_16k
+            pcm = resample_8k_to_16k(mulaw_to_pcm16(audio_bytes))
+        else:
+            pcm = audio_bytes
+
+        # before_send_to_stt hook — gate/transform the audio chunk before it
+        # reaches the STT provider. Returning None drops the chunk (useful
+        # for custom VAD / echo-cancellation). See BUG #15.
+        hooks = getattr(self.agent, "hooks", None)
+        if hooks is not None:
+            hook_executor = PipelineHookExecutor(hooks)
+            hook_ctx = self._build_hook_context()
+            processed = await hook_executor.run_before_send_to_stt(pcm, hook_ctx)
+            if processed is None:
+                return
+            pcm = processed
+
+        await self._stt.send_audio(pcm)
+        if self.metrics is not None:
+            self.metrics.add_stt_audio_bytes(len(audio_bytes))
 
     async def cleanup(self) -> None:
         if self._stt_task:

--- a/sdk-py/patter/handlers/telnyx_handler.py
+++ b/sdk-py/patter/handlers/telnyx_handler.py
@@ -95,29 +95,48 @@ def telnyx_webhook_handler(
 # ---------------------------------------------------------------------------
 
 class TelnyxAudioSender(AudioSender):
-    """Sends audio to a Telnyx WebSocket (16 kHz PCM, no transcoding)."""
+    """Sends audio to a Telnyx media-stream WebSocket.
 
-    def __init__(self, websocket) -> None:
+    Telnyx expects outbound frames in the same codec negotiated at
+    ``streaming_start`` time (see BUG #16). The server currently negotiates
+    PCMU 8 kHz bidirectional, so OpenAI Realtime is configured to emit
+    ``g711_ulaw`` directly — the sender forwards the bytes as-is. For
+    pipeline mode, ``input_is_mulaw_8k=False`` keeps the PCM16 16 kHz path
+    (Telnyx transcodes on the RTP leg when negotiated as L16/16000).
+
+    Wire format (BUG #18): ``{"event": "media", "media": {"payload": b64}}``.
+    """
+
+    def __init__(self, websocket, input_is_mulaw_8k: bool = False) -> None:
         self._ws = websocket
+        self._input_is_mulaw_8k = input_is_mulaw_8k
+        # Lazy import transcoding when the caller sends PCM16 16 kHz and
+        # we need to match the negotiated PCMU 8 kHz bidirectional stream.
+        if not input_is_mulaw_8k:
+            from patter.services.transcoding import pcm16_to_mulaw, resample_16k_to_8k  # type: ignore[import]
+            self._pcm16_to_mulaw = pcm16_to_mulaw
+            self._resample_16k_to_8k = resample_16k_to_8k
+        else:
+            self._pcm16_to_mulaw = None
+            self._resample_16k_to_8k = None
 
-    async def send_audio(self, pcm_audio: bytes) -> None:
-        encoded = base64.b64encode(pcm_audio).decode("ascii")
+    async def send_audio(self, audio: bytes) -> None:
+        if self._input_is_mulaw_8k:
+            mulaw = audio
+        else:
+            resampled = self._resample_16k_to_8k(audio)
+            mulaw = self._pcm16_to_mulaw(resampled)
+        encoded = base64.b64encode(mulaw).decode("ascii")
         await self._ws.send_text(
-            json.dumps(
-                {
-                    "event_type": "media",
-                    "payload": {"audio": {"chunk": encoded}},
-                }
-            )
+            json.dumps({"event": "media", "media": {"payload": encoded}})
         )
 
     async def send_clear(self) -> None:
-        await self._ws.send_text(
-            json.dumps({"event_type": "media_stop"})
-        )
+        # Telnyx media stream clear signal. See BUG #18.
+        await self._ws.send_text(json.dumps({"event": "clear"}))
 
     async def send_mark(self, mark_name: str) -> None:
-        # Telnyx does not support playback marks — no-op
+        # Telnyx media streams do not support playback marks — no-op.
         pass
 
 
@@ -179,13 +198,21 @@ async def telnyx_stream_bridge(
                 )
                 continue
             data = json.loads(raw)
-            event_type_telnyx = data.get("event_type", "")
+            # Telnyx media-stream WebSocket uses ``event`` (not
+            # ``event_type``, which is a Call Control REST notification
+            # field). See BUG #17.
+            event_type_telnyx = data.get("event", "")
 
-            # Telnyx uses event_type instead of event, and wraps payload in "payload"
-            if event_type_telnyx == "stream_started" and not stream_started:
+            if event_type_telnyx == "connected":
+                # First frame after WS open — Telnyx ping. Nothing to do.
+                continue
+
+            if event_type_telnyx == "start" and not stream_started:
                 stream_started = True
-                payload_data = data.get("payload", {})
-                call_id_actual = payload_data.get("call_control_id", "")
+                start_info = data.get("start", {}) or {}
+                call_id_actual = start_info.get("call_control_id", "")
+                caller = start_info.get("from", "") or caller
+                callee = start_info.get("to", "") or callee
 
                 logger.info("Telnyx stream started: %s", call_id_actual)
 
@@ -224,8 +251,12 @@ async def telnyx_stream_bridge(
                 # Telnyx uses PCM 16kHz (2 bytes/sample)
                 metrics.configure_stt_format(sample_rate=16000, bytes_per_sample=2)
 
-                # Create audio sender
-                audio_sender = TelnyxAudioSender(websocket)
+                # Create audio sender. OpenAI Realtime negotiates g711_ulaw
+                # 8 kHz to match the `streaming_start` PCMU bidirectional
+                # stream — forward bytes as-is. Pipeline and ConvAI still
+                # produce PCM16 that Telnyx accepts when L16 is negotiated.
+                _input_is_mulaw = getattr(agent, "provider", "openai_realtime") == "openai_realtime"
+                audio_sender = TelnyxAudioSender(websocket, input_is_mulaw_8k=_input_is_mulaw)
 
                 # --- Telnyx-specific call control helpers ---
                 async def _telnyx_transfer(number):
@@ -375,6 +406,13 @@ async def telnyx_stream_bridge(
                         deepgram_key=deepgram_key,
                         elevenlabs_key=elevenlabs_key,
                         for_twilio=False,
+                        # Telnyx bidirectional PCMU 8 kHz: inbound caller
+                        # audio arrives as mulaw 8 kHz and must be
+                        # transcoded to PCM16 16 kHz before STT. Outbound
+                        # PCM16 16 kHz from the TTS must be transcoded
+                        # back to mulaw 8 kHz in the audio_sender.
+                        input_is_mulaw_8k=True,
+                        output_is_mulaw_8k=False,  # TTS produces PCM16; sender transcodes
                         transfer_fn=_telnyx_transfer,
                         hangup_fn=_telnyx_hangup,
                         send_dtmf_fn=_telnyx_send_dtmf,
@@ -412,14 +450,29 @@ async def telnyx_stream_bridge(
                         on_transcript=on_transcript,
                         on_metrics=on_metrics,
                         transcript_entries=transcript_entries,
-                        audio_format="pcm16",
+                        # Telnyx Call Control media streams deliver PCMU
+                        # 8 kHz (g711 mulaw) in both directions when
+                        # streaming_start negotiates PCMU bidirectional.
+                        # Verified 2026-04-21: inbound chunks are 160 B /
+                        # 20 ms → PCMU 8 kHz. OpenAI Realtime with this
+                        # codec forwards bytes pass-through on both legs.
+                        audio_format="g711_ulaw",
                     )
 
                 await handler.start()
 
             elif event_type_telnyx == "media":
-                payload_data = data.get("payload", {})
-                audio_chunk_b64 = payload_data.get("audio", {}).get("chunk", "")
+                media = data.get("media", {}) or {}
+                # Telnyx with ``stream_track=both_tracks`` emits media for
+                # both the caller leg (``track=inbound``) and the leg we
+                # are injecting audio into (``track=outbound``). Forwarding
+                # the ``outbound`` echo to OpenAI Realtime would feed the
+                # agent its own voice and break turn detection — only the
+                # inbound track is actual caller audio.
+                track = media.get("track", "inbound")
+                if track != "inbound":
+                    continue
+                audio_chunk_b64 = media.get("payload", "")
                 if not audio_chunk_b64:
                     continue
 
@@ -427,9 +480,9 @@ async def telnyx_stream_bridge(
                 if handler is not None:
                     await handler.on_audio_received(pcm_audio)
 
-            elif event_type_telnyx == "call.dtmf.received":
-                payload_data = data.get("payload", {})
-                digit = str(payload_data.get("digit", "")).strip()
+            elif event_type_telnyx == "dtmf":
+                dtmf_info = data.get("dtmf", {}) or {}
+                digit = str(dtmf_info.get("digit", "")).strip()
                 if digit:
                     logger.info("Telnyx DTMF received: %s", digit)
                     if handler is not None:
@@ -451,23 +504,10 @@ async def telnyx_stream_bridge(
                         except Exception as _exc:
                             logger.debug("on_transcript DTMF dispatch error: %s", _exc)
 
-            elif event_type_telnyx == "call.recording.saved":
-                payload_data = data.get("payload", {})
-                recording_urls = payload_data.get("recording_urls", {})
-                recording_url = (
-                    recording_urls.get("mp3")
-                    or recording_urls.get("wav")
-                    or payload_data.get("public_recording_urls", {}).get("mp3")
-                    or ""
-                )
-                if recording_url:
-                    logger.info(
-                        "Telnyx recording saved for call %s: %s",
-                        call_id_actual,
-                        recording_url,
-                    )
+            elif event_type_telnyx == "error":
+                logger.warning("Telnyx stream error: %s", data.get("payload") or data)
 
-            elif event_type_telnyx == "stream_stopped":
+            elif event_type_telnyx == "stop":
                 break
 
     except Exception as exc:

--- a/sdk-py/patter/handlers/twilio_handler.py
+++ b/sdk-py/patter/handlers/twilio_handler.py
@@ -101,21 +101,35 @@ def twilio_webhook_handler(
 # ---------------------------------------------------------------------------
 
 class TwilioAudioSender(AudioSender):
-    """Sends audio to a Twilio WebSocket, transcoding PCM to mulaw."""
+    """Sends audio to a Twilio WebSocket, transcoding PCM to mulaw.
 
-    def __init__(self, websocket, stream_sid: str) -> None:
+    When ``input_is_mulaw_8k`` is True, incoming bytes are already in Twilio's
+    native codec (g711 mulaw @ 8 kHz) and are forwarded as-is. This is the
+    correct path for OpenAI Realtime on Twilio — feeding OpenAI's 24 kHz PCM16
+    into a 16 → 8 kHz resampler produces audibly broken audio (see BUG #10).
+    """
+
+    def __init__(self, websocket, stream_sid: str, input_is_mulaw_8k: bool = False) -> None:
         self._ws = websocket
         self._stream_sid = stream_sid
         self._chunk_count = 0
         self.last_confirmed_mark = ""
-        # Lazy import transcoding functions
-        from patter.services.transcoding import pcm16_to_mulaw, resample_16k_to_8k  # type: ignore[import]
-        self._pcm16_to_mulaw = pcm16_to_mulaw
-        self._resample_16k_to_8k = resample_16k_to_8k
+        self._input_is_mulaw_8k = input_is_mulaw_8k
+        # Lazy import transcoding functions (only needed when transcoding)
+        if not input_is_mulaw_8k:
+            from patter.services.transcoding import pcm16_to_mulaw, resample_16k_to_8k  # type: ignore[import]
+            self._pcm16_to_mulaw = pcm16_to_mulaw
+            self._resample_16k_to_8k = resample_16k_to_8k
+        else:
+            self._pcm16_to_mulaw = None
+            self._resample_16k_to_8k = None
 
     async def send_audio(self, pcm_audio: bytes) -> None:
-        resampled = self._resample_16k_to_8k(pcm_audio)
-        mulaw = self._pcm16_to_mulaw(resampled)
+        if self._input_is_mulaw_8k:
+            mulaw = pcm_audio
+        else:
+            resampled = self._resample_16k_to_8k(pcm_audio)
+            mulaw = self._pcm16_to_mulaw(resampled)
         encoded = base64.b64encode(mulaw).decode("ascii")
         await self._ws.send_text(
             json.dumps(
@@ -279,8 +293,14 @@ async def twilio_stream_bridge(
                 # Twilio uses mulaw 8kHz (1 byte/sample)
                 metrics.configure_stt_format(sample_rate=8000, bytes_per_sample=1)
 
-                # Create audio sender
-                audio_sender = TwilioAudioSender(websocket, stream_sid)
+                # Create audio sender. OpenAI Realtime on Twilio is configured
+                # to emit g711_ulaw @ 8 kHz directly (see below), so for that
+                # provider we skip the built-in PCM→mulaw transcoding path.
+                # Pipeline / ConvAI still produce PCM16 @ 16 kHz.
+                _input_is_mulaw = provider == "openai_realtime"
+                audio_sender = TwilioAudioSender(
+                    websocket, stream_sid, input_is_mulaw_8k=_input_is_mulaw
+                )
 
                 # --- Twilio-specific call control helpers ---
                 async def _twilio_transfer(number):
@@ -374,6 +394,11 @@ async def twilio_stream_bridge(
                         on_metrics=on_metrics,
                         conversation_history=conversation_history,
                         transcript_entries=transcript_entries,
+                        # Twilio media streams are g711 mulaw @ 8 kHz. Asking
+                        # OpenAI to emit the same codec avoids a 24 kHz →
+                        # 16 kHz → 8 kHz resample chain that otherwise
+                        # produces a deep, slurred voice.
+                        audio_format="g711_ulaw",
                     )
 
                 await handler.start()

--- a/sdk-py/patter/models.py
+++ b/sdk-py/patter/models.py
@@ -84,6 +84,10 @@ class Agent:
     vad: "VADProvider | None" = None  # Optional server-side VAD (e.g., Silero) — pipeline mode only
     audio_filter: "AudioFilter | None" = None  # Optional pre-STT audio filter (noise cancel) — pipeline mode only
     background_audio: "BackgroundAudioPlayer | None" = None  # Optional background audio mixer — pipeline mode only
+    # Minimum sustained voice (ms) before treating caller audio as a barge-in
+    # and interrupting TTS. ``0`` disables barge-in entirely — useful on noisy
+    # links (ngrok tunnels, speakerphone) where the agent can hear itself.
+    barge_in_threshold_ms: int = 300
 
 
 @dataclass(frozen=True)
@@ -107,9 +111,15 @@ class STTConfig:
     provider: str
     api_key: str
     language: str = "en"
+    # Provider-specific tuning knobs (e.g. Deepgram endpointing). Unknown keys
+    # are silently ignored so older SDK versions stay forward-compatible.
+    options: dict | None = None
 
     def to_dict(self) -> dict:
-        return {"provider": self.provider, "api_key": self.api_key, "language": self.language}
+        out = {"provider": self.provider, "api_key": self.api_key, "language": self.language}
+        if self.options:
+            out["options"] = dict(self.options)
+        return out
 
 
 @dataclass(frozen=True)
@@ -117,9 +127,13 @@ class TTSConfig:
     provider: str
     api_key: str
     voice: str = "alloy"
+    options: dict | None = None
 
     def to_dict(self) -> dict:
-        return {"provider": self.provider, "api_key": self.api_key, "voice": self.voice}
+        out = {"provider": self.provider, "api_key": self.api_key, "voice": self.voice}
+        if self.options:
+            out["options"] = dict(self.options)
+        return out
 
 
 @dataclass(frozen=True)

--- a/sdk-py/patter/providers/__init__.py
+++ b/sdk-py/patter/providers/__init__.py
@@ -3,8 +3,25 @@
 from patter.models import STTConfig, TTSConfig
 
 
-def deepgram(api_key: str, language: str = "en") -> STTConfig:
-    return STTConfig(provider="deepgram", api_key=api_key, language=language)
+def deepgram(
+    api_key: str,
+    language: str = "en",
+    *,
+    model: str = "nova-3",
+    endpointing_ms: int = 150,
+    utterance_end_ms: int | None = 1000,
+    smart_format: bool = True,
+    interim_results: bool = True,
+) -> STTConfig:
+    """Deepgram STT config. Tune latency via ``endpointing_ms`` / ``utterance_end_ms``."""
+    options = {
+        "model": model,
+        "endpointing_ms": endpointing_ms,
+        "utterance_end_ms": utterance_end_ms,
+        "smart_format": smart_format,
+        "interim_results": interim_results,
+    }
+    return STTConfig(provider="deepgram", api_key=api_key, language=language, options=options)
 
 
 def whisper(api_key: str, language: str = "en") -> STTConfig:

--- a/sdk-py/patter/providers/__init__.py
+++ b/sdk-py/patter/providers/__init__.py
@@ -12,15 +12,18 @@ def deepgram(
     utterance_end_ms: int | None = 1000,
     smart_format: bool = True,
     interim_results: bool = True,
+    vad_events: bool | None = None,
 ) -> STTConfig:
     """Deepgram STT config. Tune latency via ``endpointing_ms`` / ``utterance_end_ms``."""
-    options = {
+    options: dict = {
         "model": model,
         "endpointing_ms": endpointing_ms,
         "utterance_end_ms": utterance_end_ms,
         "smart_format": smart_format,
         "interim_results": interim_results,
     }
+    if vad_events is not None:
+        options["vad_events"] = vad_events
     return STTConfig(provider="deepgram", api_key=api_key, language=language, options=options)
 
 

--- a/sdk-py/patter/providers/deepgram_stt.py
+++ b/sdk-py/patter/providers/deepgram_stt.py
@@ -1,5 +1,6 @@
 import json
 from typing import AsyncIterator
+from urllib.parse import urlencode
 
 import websockets
 
@@ -16,12 +17,23 @@ class DeepgramSTT(STTProvider):
         model: str = "nova-3",
         encoding: str = "linear16",
         sample_rate: int = 16000,
+        *,
+        endpointing_ms: int = 150,
+        utterance_end_ms: int | None = 1000,
+        smart_format: bool = True,
+        interim_results: bool = True,
+        vad_events: bool = True,
     ):
         self.api_key = api_key
         self.language = language
         self.model = model
         self.encoding = encoding
         self.sample_rate = sample_rate
+        self.endpointing_ms = endpointing_ms
+        self.utterance_end_ms = utterance_end_ms
+        self.smart_format = smart_format
+        self.interim_results = interim_results
+        self.vad_events = vad_events
         self._ws = None
         self.request_id: str | None = None
 
@@ -29,7 +41,13 @@ class DeepgramSTT(STTProvider):
         return f"DeepgramSTT(model={self.model!r}, language={self.language!r}, encoding={self.encoding!r})"
 
     @classmethod
-    def for_twilio(cls, api_key: str, language: str = "en", model: str = "nova-3"):
+    def for_twilio(
+        cls,
+        api_key: str,
+        language: str = "en",
+        model: str = "nova-3",
+        **kwargs,
+    ):
         """Create a Deepgram adapter configured for Twilio mulaw 8kHz."""
         return cls(
             api_key=api_key,
@@ -37,22 +55,26 @@ class DeepgramSTT(STTProvider):
             model=model,
             encoding="mulaw",
             sample_rate=8000,
+            **kwargs,
         )
 
     async def connect(self) -> None:
-        url = (
-            f"{DEEPGRAM_WS_URL}"
-            f"?model={self.model}"
-            f"&language={self.language}"
-            f"&encoding={self.encoding}"
-            f"&sample_rate={self.sample_rate}"
-            f"&channels=1"
-            f"&interim_results=true"
-            f"&endpointing=300"
-            f"&smart_format=true"
-            f"&vad_events=true"
-            f"&no_delay=true"
-        )
+        params = {
+            "model": self.model,
+            "language": self.language,
+            "encoding": self.encoding,
+            "sample_rate": str(self.sample_rate),
+            "channels": "1",
+            "interim_results": "true" if self.interim_results else "false",
+            "endpointing": str(self.endpointing_ms),
+            "smart_format": "true" if self.smart_format else "false",
+            "vad_events": "true" if self.vad_events else "false",
+            "no_delay": "true",
+        }
+        if self.utterance_end_ms is not None:
+            # utterance_end_ms has a hard minimum of 1000 on Deepgram's API.
+            params["utterance_end_ms"] = str(max(int(self.utterance_end_ms), 1000))
+        url = f"{DEEPGRAM_WS_URL}?{urlencode(params)}"
         self._ws = await websockets.connect(
             url,
             additional_headers={"Authorization": f"Token {self.api_key}"},
@@ -83,9 +105,13 @@ class DeepgramSTT(STTProvider):
         if not text:
             return None
 
+        # is_final alone marks a stable utterance; speech_final is a faster
+        # end-of-utterance hint from Deepgram's VAD. Accept either so the
+        # pipeline doesn't wait up to utterance_end_ms on every turn.
+        is_final = bool(data.get("is_final", False) or data.get("speech_final", False))
         return Transcript(
             text=text,
-            is_final=data.get("is_final", False) and data.get("speech_final", False),
+            is_final=is_final,
             confidence=best.get("confidence", 0.0),
         )
 

--- a/sdk-py/patter/providers/elevenlabs_tts.py
+++ b/sdk-py/patter/providers/elevenlabs_tts.py
@@ -1,10 +1,83 @@
 from typing import AsyncIterator
+import re
 import httpx
 from patter.providers.base import TTSProvider
 
+# Curated map of common ElevenLabs voice display names to their voice IDs. The
+# public API only accepts voice IDs (opaque 20-char strings), so callers that
+# pass a human-readable name like "rachel" would otherwise hit 404. Add names
+# here as they become popular, or call resolve_voice_id to extend at runtime.
+_ELEVENLABS_VOICE_ID_BY_NAME = {
+    "rachel": "21m00Tcm4TlvDq8ikWAM",
+    "drew": "29vD33N1CtxCmqQRPOHJ",
+    "clyde": "2EiwWnXFnvU5JabPnv8n",
+    "paul": "5Q0t7uMcjvnagumLfvZi",
+    "domi": "AZnzlk1XvdvUeBnXmlld",
+    "dave": "CYw3kZ02Hs0563khs1Fj",
+    "fin": "D38z5RcWu1voky8WS1ja",
+    "bella": "EXAVITQu4vr4xnSDxMaL",
+    "antoni": "ErXwobaYiN019PkySvjV",
+    "thomas": "GBv7mTt0atIp3Br8iCZE",
+    "charlie": "IKne3meq5aSn9XLyUdCD",
+    "george": "JBFqnCBsd6RMkjVDRZzb",
+    "emily": "LcfcDJNUP1GQjkzn1xUU",
+    "elli": "MF3mGyEYCl7XYWbV9V6O",
+    "callum": "N2lVS1w4EtoT3dr4eOWO",
+    "patrick": "ODq5zmih8GrVes37Dizd",
+    "harry": "SOYHLrjzK2X1ezoPC6cr",
+    "liam": "TX3LPaxmHKxFdv7VOQHJ",
+    "dorothy": "ThT5KcBeYPX3keUQqHPh",
+    "josh": "TxGEqnHWrfWFTfGW9XjX",
+    "arnold": "VR6AewLTigWG4xSOukaG",
+    "charlotte": "XB0fDUnXU5powFXDhCwa",
+    "matilda": "XrExE9yKIg1WjnnlVkGX",
+    "matthew": "Yko7PKHZNXotIFUBG7I9",
+    "james": "ZQe5CZNOzWyzPSCn5a3c",
+    "joseph": "Zlb1dXrM653N07WRdFW3",
+    "jeremy": "bVMeCyTHy58xNoL34h3p",
+    "michael": "flq6f7yk4E4fJM5XTYuZ",
+    "ethan": "g5CIjZEefAph4nQFvHAz",
+    "gigi": "jBpfuIE2acCO8z3wKNLl",
+    "freya": "jsCqWAovK2LkecY7zXl4",
+    "brian": "nPczCjzI2devNBz1zQrb",
+    "grace": "oWAxZDx7w5VEj9dCyTzz",
+    "daniel": "onwK4e9ZLuTAKqWW03F9",
+    "lily": "pFZP5JQG7iQjIQuC4Bku",
+    "serena": "pMsXgVXv3BLzUgSXRplE",
+    "adam": "pNInz6obpgDQGcFmaJgB",
+    "nicole": "piTKgcLEGmPE4e6mEKli",
+    "bill": "pqHfZKP75CvOlQylNhV4",
+    "jessie": "t0jbNlBVZ17f02VDIeMI",
+    "ryan": "wViXBPUzp2ZZixB1xQuM",
+    "sam": "yoZ06aMxZJJ28mfd3POQ",
+    "glinda": "z9fAnlkpzviPz146aGWa",
+    "giovanni": "zcAOhNBS3c14rBihAFp1",
+    "mimi": "zrHiDhphv9ZnVXBqCLjz",
+    # OpenAI voice-name aliases for convenience (map to reasonable EL voices).
+    "alloy": "21m00Tcm4TlvDq8ikWAM",
+}
+
+_VOICE_ID_PATTERN = re.compile(r"^[A-Za-z0-9]{20}$")
+
+
+def resolve_voice_id(voice: str) -> str:
+    """Return an ElevenLabs voice ID from either a UUID-like ID or a display name.
+
+    Opaque ElevenLabs voice IDs are 20-char alnum tokens — anything matching
+    that shape is returned verbatim. Known display names (case-insensitive) are
+    resolved via the internal table. Unknown strings are returned as-is so the
+    SDK behaves identically for custom voices the user has created.
+    """
+    if not voice:
+        return voice
+    if _VOICE_ID_PATTERN.match(voice):
+        return voice
+    return _ELEVENLABS_VOICE_ID_BY_NAME.get(voice.lower(), voice)
+
+
 class ElevenLabsTTS(TTSProvider):
     def __init__(self, api_key: str, voice_id: str = "21m00Tcm4TlvDq8ikWAM", model_id: str = "eleven_turbo_v2_5", output_format: str = "pcm_16000"):
-        self.api_key = api_key; self.voice_id = voice_id; self.model_id = model_id; self.output_format = output_format
+        self.api_key = api_key; self.voice_id = resolve_voice_id(voice_id); self.model_id = model_id; self.output_format = output_format
         self._client = httpx.AsyncClient(base_url="https://api.elevenlabs.io/v1", headers={"xi-api-key": api_key}, timeout=30.0)
 
     def __repr__(self) -> str:

--- a/sdk-py/patter/providers/openai_tts.py
+++ b/sdk-py/patter/providers/openai_tts.py
@@ -1,7 +1,13 @@
-import struct
 from typing import AsyncIterator
 
 import httpx
+
+try:
+    # Python ≤ 3.12 ships ``audioop``; on 3.13+ the ``audioop-lts`` PyPI
+    # package exposes the same C API (pinned in our pyproject).
+    import audioop  # type: ignore[import]
+except ImportError:  # pragma: no cover
+    audioop = None  # type: ignore[assignment]
 
 from patter.providers.base import TTSProvider
 
@@ -34,32 +40,58 @@ class OpenAITTS(TTSProvider):
         response = await self._client.send(request, stream=True)
         response.raise_for_status()
 
+        # ``audioop.ratecv`` resamples chunk-by-chunk while preserving
+        # cross-chunk filter state — critical because OpenAI streams the
+        # PCM body in arbitrary-sized slices and a stateless per-chunk
+        # downsample produced audible pops / dropped audio (the caller
+        # heard garbled or silent TTS in acceptance test 09).
+        state = None
+        carry = b""  # odd trailing byte between chunks (PCM16 = 2 B/sample)
         try:
             async for chunk in response.aiter_bytes(chunk_size=4096):
-                # OpenAI returns 24kHz PCM16, resample to 16kHz
-                resampled = self._resample_24k_to_16k(chunk)
-                yield resampled
+                if not chunk:
+                    continue
+                buf = carry + chunk
+                # Keep only a whole number of 16-bit samples for the
+                # current ratecv call; stash the extra byte for next time.
+                usable_len = (len(buf) // 2) * 2
+                carry = buf[usable_len:]
+                buf = buf[:usable_len]
+                if not buf:
+                    continue
+                if audioop is None:
+                    # Fallback: no resample, downstream will try to
+                    # transcode 24 kHz as 16 kHz and sound wrong. Log once.
+                    yield buf
+                    continue
+                resampled, state = audioop.ratecv(
+                    buf,
+                    2,  # sample width (bytes)
+                    1,  # channels
+                    24000,  # in rate
+                    16000,  # out rate
+                    state,
+                )
+                if resampled:
+                    yield resampled
         finally:
             await response.aclose()
 
-    @staticmethod
-    def _resample_24k_to_16k(audio_data: bytes) -> bytes:
-        """Resample 24kHz PCM16 to 16kHz by taking every 2 out of 3 samples."""
-        if len(audio_data) < 2:
-            return audio_data
-        num_samples = len(audio_data) // 2
-        samples = struct.unpack(f"<{num_samples}h", audio_data[: num_samples * 2])
-        # Take 2 out of every 3 samples (24000/16000 = 3/2)
-        resampled = []
-        for i in range(0, len(samples), 3):
-            resampled.append(samples[i])
-            if i + 1 < len(samples):
-                # Interpolate between sample i+1 and i+2
-                if i + 2 < len(samples):
-                    resampled.append((samples[i + 1] + samples[i + 2]) // 2)
-                else:
-                    resampled.append(samples[i + 1])
-        return struct.pack(f"<{len(resampled)}h", *resampled)
-
     async def close(self) -> None:
         await self._client.aclose()
+
+    @staticmethod
+    def _resample_24k_to_16k(audio: bytes) -> bytes:
+        """Stateless 24 kHz → 16 kHz resample used by unit tests.
+
+        The streaming ``synthesize`` path uses ``audioop.ratecv`` with
+        per-stream state carried across chunks (see the class docstring).
+        This helper performs a single-shot resample on a complete buffer
+        and is kept for backwards compatibility with the unit tests.
+        """
+        if len(audio) < 2 or audioop is None:
+            return audio
+        out, _ = audioop.ratecv(
+            audio[: (len(audio) // 2) * 2], 2, 1, 24000, 16000, None
+        )
+        return out

--- a/sdk-py/patter/providers/telnyx_adapter.py
+++ b/sdk-py/patter/providers/telnyx_adapter.py
@@ -34,14 +34,24 @@ class TelnyxAdapter(TelephonyProvider):
             json={"connection_id": self.connection_id},
         )
 
-    async def initiate_call(self, from_number: str, to_number: str, stream_url: str) -> str:
-        resp = await self._client.post("/calls", json={
+    async def initiate_call(
+        self,
+        from_number: str,
+        to_number: str,
+        stream_url: str,
+        *,
+        ring_timeout: int | None = None,
+    ) -> str:
+        payload: dict = {
             "connection_id": self.connection_id,
             "from": from_number,
             "to": to_number,
             "stream_url": stream_url,
             "stream_track": "both_tracks",
-        })
+        }
+        if ring_timeout is not None:
+            payload["timeout_secs"] = int(ring_timeout)
+        resp = await self._client.post("/calls", json=payload)
         resp.raise_for_status()
         return resp.json()["data"]["call_control_id"]
 

--- a/sdk-py/patter/scheduler.py
+++ b/sdk-py/patter/scheduler.py
@@ -58,14 +58,30 @@ class ScheduleHandle:
             return False
 
 
-_scheduler_singleton: Any = None
+# Schedulers are scoped per event loop. A single module-level singleton would
+# bind to the first loop it sees and then crash with "Event loop is closed"
+# on any subsequent loop (e.g. a new pytest-asyncio test, or an app that
+# recreates the loop on reload). Keying on id(loop) avoids that footgun while
+# keeping the "shared scheduler per loop" ergonomics.
+_schedulers_by_loop: dict[int, Any] = {}
 
 
 def _get_scheduler() -> Any:
-    """Lazily construct the APScheduler ``AsyncIOScheduler`` and start it."""
-    global _scheduler_singleton
-    if _scheduler_singleton is not None:
-        return _scheduler_singleton
+    """Lazily construct the APScheduler ``AsyncIOScheduler`` bound to the current loop."""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    existing = _schedulers_by_loop.get(id(loop))
+    if existing is not None:
+        # If the loop was torn down under us (e.g. pytest-asyncio finished a
+        # test), drop the stale entry and build a fresh scheduler.
+        if getattr(loop, "is_closed", lambda: False)():
+            _schedulers_by_loop.pop(id(loop), None)
+        else:
+            return existing
 
     try:
         from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-not-found]
@@ -75,10 +91,20 @@ def _get_scheduler() -> Any:
             "Install with: pip install getpatter[scheduling]"
         ) from exc
 
-    scheduler = AsyncIOScheduler()
+    scheduler = AsyncIOScheduler(event_loop=loop)
     scheduler.start()
-    _scheduler_singleton = scheduler
+    _schedulers_by_loop[id(loop)] = scheduler
     return scheduler
+
+
+def reset_for_tests() -> None:
+    """Tear down every cached scheduler. Call from test teardown to avoid state bleed."""
+    for sched in list(_schedulers_by_loop.values()):
+        try:
+            sched.shutdown(wait=False)
+        except Exception:  # pragma: no cover
+            pass
+    _schedulers_by_loop.clear()
 
 
 def _wrap_callback(cb: JobCallback) -> Callable[[], Any]:
@@ -166,12 +192,5 @@ def schedule_interval(seconds: float, callback: JobCallback) -> ScheduleHandle:
 
 
 def shutdown() -> None:
-    """Tear down the scheduler. Safe to call even if never initialised."""
-    global _scheduler_singleton
-    if _scheduler_singleton is None:
-        return
-    try:
-        _scheduler_singleton.shutdown(wait=False)
-    except Exception:  # pragma: no cover
-        pass
-    _scheduler_singleton = None
+    """Tear down every active scheduler. Safe to call even if never initialised."""
+    reset_for_tests()

--- a/sdk-py/patter/server.py
+++ b/sdk-py/patter/server.py
@@ -8,7 +8,7 @@ import logging
 import signal
 import time
 
-from fastapi import WebSocket
+from fastapi import FastAPI, Request, Response, WebSocket
 
 from patter.local_config import LocalConfig
 from patter.models import Agent
@@ -160,15 +160,11 @@ class EmbeddedServer:
 
     def _create_app(self):
         """Build the FastAPI application with webhook + stream routes."""
-        from fastapi import FastAPI, Request, Response, WebSocket
         from patter.handlers.twilio_handler import (
             twilio_webhook_handler,
             twilio_stream_bridge,
         )
-        from patter.handlers.telnyx_handler import (
-            telnyx_webhook_handler,
-            telnyx_stream_bridge,
-        )
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
 
         app = FastAPI(title="Patter Local Server")
 
@@ -228,12 +224,45 @@ class EmbeddedServer:
                 return form_or_response
             form_data = form_or_response
             call_sid = form_data.get("CallSid", "")
-            caller = form_data.get("From", "")
-            callee = form_data.get("To", "")
+            # Twilio sends both `From` and `Caller` — `From` is set for direct
+            # inbound dials, `Caller` is what Twilio sees on the SIP trunk and
+            # is the reliable fallback when the number is anonymised or
+            # masked. Same for `To` / `Called`.
+            caller = form_data.get("From", "") or form_data.get("Caller", "")
+            callee = form_data.get("To", "") or form_data.get("Called", "")
             twiml = twilio_webhook_handler(
                 call_sid, caller, callee, self.config.webhook_url
             )
             return Response(content=twiml, media_type="text/xml")
+
+        # Twilio posts here for every status transition of a call
+        # (initiated → ringing → in-progress → completed | no-answer |
+        # busy | failed | canceled). Keeps the dashboard honest even when
+        # the call never reaches the media channel. See BUG #06.
+        @app.post("/webhooks/twilio/status")
+        async def twilio_status_callback(request: Request):
+            form_or_response = await _read_and_validate_twilio_form(request)
+            if isinstance(form_or_response, Response):
+                return form_or_response
+            form = form_or_response
+            call_sid = form.get("CallSid", "")
+            call_status = form.get("CallStatus", "")
+            duration = form.get("CallDuration", "") or form.get("Duration", "")
+            logger.info(
+                "Twilio status %s for call %s (duration=%s)",
+                sanitize_log_value(call_status),
+                sanitize_log_value(call_sid),
+                sanitize_log_value(duration),
+            )
+            if self._metrics_store is not None and call_sid and call_status:
+                extra: dict = {}
+                if duration:
+                    try:
+                        extra["duration_seconds"] = float(duration)
+                    except ValueError:
+                        pass
+                self._metrics_store.update_call_status(call_sid, call_status, **extra)
+            return Response(content="", status_code=204)
 
         @app.post("/webhooks/twilio/recording")
         async def twilio_recording_callback(request: Request):
@@ -340,22 +369,68 @@ class EmbeddedServer:
             if not isinstance(body.get("data"), dict) or not isinstance(body.get("data", {}).get("payload"), dict):
                 logger.warning("Telnyx webhook rejected: missing data.payload structure.")
                 return Response(status_code=400, content="Invalid webhook structure")
-            payload = body["data"]["payload"]
-            if not payload.get("call_control_id") or not payload.get("from") or not payload.get("to"):
-                logger.warning("Telnyx webhook rejected: missing required payload fields.")
-                return Response(status_code=400, content="Invalid webhook payload")
-            call_id = payload.get("call_control_id", "")
+            data = body["data"]
+            event_type = data.get("event_type", "")
+            payload = data["payload"]
+            call_control_id = payload.get("call_control_id", "")
             caller = payload.get("from", "")
             callee = payload.get("to", "")
-            response_data = telnyx_webhook_handler(
-                call_id,
-                caller,
-                callee,
-                self.config.webhook_url,
-                connection_id=self.config.telnyx_connection_id,
-            )
-            from fastapi.responses import JSONResponse
-            return JSONResponse(content=response_data)
+            if not call_control_id:
+                logger.warning("Telnyx webhook rejected: missing call_control_id.")
+                return Response(status_code=400, content="Invalid webhook payload")
+
+            # Telnyx Call Control is a REST API — the webhook body is a
+            # notification, not a command transport. We react by POSTing
+            # actions/answer and actions/streaming_start to the Call Control
+            # REST endpoint. See BUG #16.
+            api_key = self.config.telnyx_key
+            if not api_key:
+                logger.warning("Telnyx webhook: missing telnyx_key in LocalConfig")
+                return Response(status_code=500, content="Missing Telnyx API key")
+
+            import httpx as _httpx
+            api_base = "https://api.telnyx.com/v2"
+            auth_headers = {"Authorization": f"Bearer {api_key}"}
+
+            try:
+                if event_type == "call.initiated":
+                    logger.info("Telnyx call.initiated %s — answering", call_control_id)
+                    async with _httpx.AsyncClient(timeout=10.0) as client:
+                        resp = await client.post(
+                            f"{api_base}/calls/{call_control_id}/actions/answer",
+                            headers=auth_headers,
+                            json={},
+                        )
+                        if resp.status_code >= 400:
+                            logger.warning("Telnyx answer failed: %s %s", resp.status_code, resp.text)
+                elif event_type == "call.answered":
+                    from urllib.parse import quote as _quote
+                    stream_url = (
+                        f"wss://{self.config.webhook_url}/ws/telnyx/stream/{call_control_id}"
+                        f"?caller={_quote(caller)}&callee={_quote(callee)}"
+                    )
+                    logger.info("Telnyx call.answered %s — starting stream", call_control_id)
+                    async with _httpx.AsyncClient(timeout=10.0) as client:
+                        resp = await client.post(
+                            f"{api_base}/calls/{call_control_id}/actions/streaming_start",
+                            headers=auth_headers,
+                            json={
+                                "stream_url": stream_url,
+                                "stream_track": "both_tracks",
+                                "stream_bidirectional_mode": "rtp",
+                                "stream_bidirectional_codec": "PCMU",
+                                "stream_bidirectional_sampling_rate": 8000,
+                                "stream_bidirectional_target_legs": "self",
+                            },
+                        )
+                        if resp.status_code >= 400:
+                            logger.warning("Telnyx streaming_start failed: %s %s", resp.status_code, resp.text)
+                else:
+                    logger.debug("Telnyx event ignored: %s", event_type)
+            except Exception as exc:
+                logger.exception("Telnyx webhook handler error: %s", exc)
+
+            return Response(status_code=200)
 
         @app.websocket("/ws/telnyx/stream/{call_id}")
         async def telnyx_stream_handler(websocket: WebSocket, call_id: str):

--- a/sdk-py/patter/services/fallback_provider.py
+++ b/sdk-py/patter/services/fallback_provider.py
@@ -73,15 +73,52 @@ class FallbackLLMProvider:
         return list(self._availability)
 
     def destroy(self) -> None:
-        """Cancel all background recovery tasks. Call on shutdown."""
+        """Cancel all background recovery tasks. Call on shutdown.
+
+        Prefer :meth:`aclose` in async contexts — it awaits task cancellation
+        and guarantees no pending tasks survive the owning event loop.
+        """
         for i, task in enumerate(self._recovery_tasks):
             if task is not None:
                 task.cancel()
                 self._recovery_tasks[i] = None
 
+    async def aclose(self) -> None:
+        """Cancel probe tasks and await them. Safe to call multiple times."""
+        tasks = [t for t in self._recovery_tasks if t is not None]
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._recovery_tasks = [None] * len(self._providers)
+
+    async def __aenter__(self) -> "FallbackLLMProvider":
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        await self.aclose()
+
     # ------------------------------------------------------------------
     # LLMProvider implementation
     # ------------------------------------------------------------------
+
+    async def complete_stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream only the text deltas, flattening the chunk envelope.
+
+        Convenience wrapper over :meth:`stream` for callers that only want the
+        assistant's text output and don't need tool-call or done markers.
+        Mirrors the TypeScript SDK's ``fallback.completeStream`` shape.
+        """
+        async for chunk in self.stream(messages, tools):
+            if chunk.get("type") == "text":
+                yield chunk.get("content", "")
 
     async def stream(
         self,

--- a/sdk-py/patter/services/pcm_mixer.py
+++ b/sdk-py/patter/services/pcm_mixer.py
@@ -128,4 +128,14 @@ class PcmMixer:
         return mixed.astype(np.int16).tobytes()
 
 
-__all__ = ["PcmMixer"]
+def mix_pcm(agent: bytes, bg: bytes, ratio: float) -> bytes:
+    """Standalone PCM mixer — mirrors the TypeScript ``mixPcm(agent, bg, ratio)``.
+
+    Thin wrapper over :class:`PcmMixer`. The ``ratio`` argument is mandatory
+    (matching the TS signature); pass ``0.0`` to get the agent buffer back
+    unchanged.
+    """
+    return PcmMixer().mix(agent, bg, ratio=ratio)
+
+
+__all__ = ["PcmMixer", "mix_pcm"]

--- a/sdk-py/patter/services/tool_decorator.py
+++ b/sdk-py/patter/services/tool_decorator.py
@@ -181,9 +181,37 @@ def tool(fn: Callable[..., Any]) -> ToolDefinition:
     if required:
         parameters["required"] = required
 
+    # Adapter between the decorated user function (signature
+    # ``check_order(order_id: str)``) and the runtime tool executor which
+    # always invokes handlers as ``handler(arguments_dict, call_context_dict)``.
+    # The adapter inspects the original signature: if the function already
+    # takes ``(arguments, call_context)`` positionally we pass through,
+    # otherwise we unpack ``arguments`` as keyword-args into the real call.
+    # Without this adapter every ``@tool`` function fails at runtime with
+    # ``takes 1 positional argument but 2 were given`` (BUG #21).
+    _param_names = tuple(sig.parameters.keys())
+    _is_legacy_twoarg = (
+        len(_param_names) == 2 and _param_names == ("arguments", "call_context")
+    )
+    import asyncio as _asyncio
+
+    async def _adapter(arguments: dict, call_context: dict):
+        if _is_legacy_twoarg:
+            result = fn(arguments, call_context)
+        else:
+            filtered = {
+                k: v for k, v in (arguments or {}).items() if k in _param_names
+            }
+            result = fn(**filtered)
+        if _asyncio.iscoroutine(result) or _asyncio.isfuture(result):
+            result = await result
+        return result
+
+    _adapter.__wrapped__ = fn  # type: ignore[attr-defined]
+
     return {
         "name": fn.__name__,
         "description": summary,
         "parameters": parameters,
-        "handler": fn,
+        "handler": _adapter,
     }

--- a/sdk-py/pyproject.toml
+++ b/sdk-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.4.3"
+version = "0.4.4"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdk-py/pyproject.toml
+++ b/sdk-py/pyproject.toml
@@ -25,10 +25,11 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "websockets>=13.0",
+    "websockets>=14.0,<16",
     "httpx>=0.27.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
+    "python-multipart>=0.0.20",
     "twilio>=9.0.0",
     "audioop-lts>=0.2.1; python_version>='3.13'",
     "openai>=1.0.0",

--- a/sdk-py/tests/integration/test_telnyx_convai.py
+++ b/sdk-py/tests/integration/test_telnyx_convai.py
@@ -44,21 +44,28 @@ def _make_ws_mock(events: list[dict]) -> AsyncMock:
 
 
 def _telnyx_stream_started(call_control_id: str = "v3:convai-id") -> dict:
+    # Telnyx media-stream wire format (BUG #17/#18): ``event: "start"`` with a
+    # ``start`` dict carrying call_control_id + caller/callee.
     return {
-        "event_type": "stream_started",
-        "payload": {"call_control_id": call_control_id},
+        "event": "start",
+        "start": {
+            "call_control_id": call_control_id,
+            "from": "+15551111111",
+            "to": "+15552222222",
+        },
     }
 
 
 def _telnyx_media_event() -> dict:
+    # Wire format: ``{"event":"media","media":{"payload":b64}}`` — BUG #18.
     return {
-        "event_type": "media",
-        "payload": {"audio": {"chunk": base64.b64encode(fake_pcm_frame()).decode()}},
+        "event": "media",
+        "media": {"payload": base64.b64encode(fake_pcm_frame()).decode()},
     }
 
 
 def _telnyx_stream_stopped() -> dict:
-    return {"event_type": "stream_stopped"}
+    return {"event": "stop"}
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-py/tests/integration/test_telnyx_pipeline.py
+++ b/sdk-py/tests/integration/test_telnyx_pipeline.py
@@ -44,21 +44,27 @@ def _make_ws_mock(events: list[dict]) -> AsyncMock:
 
 
 def _telnyx_stream_started(call_control_id: str = "v3:pipeline-id") -> dict:
+    # Telnyx media-stream wire format (BUG #17/#18).
     return {
-        "event_type": "stream_started",
-        "payload": {"call_control_id": call_control_id},
+        "event": "start",
+        "start": {
+            "call_control_id": call_control_id,
+            "from": "+15551111111",
+            "to": "+15552222222",
+        },
     }
 
 
 def _telnyx_media_event() -> dict:
+    # Wire format: ``{"event":"media","media":{"payload":b64}}`` — BUG #18.
     return {
-        "event_type": "media",
-        "payload": {"audio": {"chunk": base64.b64encode(fake_pcm_frame()).decode()}},
+        "event": "media",
+        "media": {"payload": base64.b64encode(fake_pcm_frame()).decode()},
     }
 
 
 def _telnyx_stream_stopped() -> dict:
-    return {"event_type": "stream_stopped"}
+    return {"event": "stop"}
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-py/tests/integration/test_telnyx_realtime.py
+++ b/sdk-py/tests/integration/test_telnyx_realtime.py
@@ -47,23 +47,29 @@ def _make_ws_mock(events: list[dict]) -> AsyncMock:
 
 
 def _telnyx_stream_started(call_control_id: str = "v3:test-id") -> dict:
+    # Telnyx media-stream wire format (BUG #17/#18).
     return {
-        "event_type": "stream_started",
-        "payload": {"call_control_id": call_control_id},
+        "event": "start",
+        "start": {
+            "call_control_id": call_control_id,
+            "from": "+15551111111",
+            "to": "+15552222222",
+        },
     }
 
 
 def _telnyx_media_event(audio: bytes = b"") -> dict:
     if not audio:
         audio = fake_pcm_frame()
+    # Wire format: ``{"event":"media","media":{"payload":b64}}`` — BUG #18.
     return {
-        "event_type": "media",
-        "payload": {"audio": {"chunk": base64.b64encode(audio).decode()}},
+        "event": "media",
+        "media": {"payload": base64.b64encode(audio).decode()},
     }
 
 
 def _telnyx_stream_stopped() -> dict:
-    return {"event_type": "stream_stopped"}
+    return {"event": "stop"}
 
 
 # ---------------------------------------------------------------------------
@@ -114,8 +120,13 @@ class TestTelnyxRealtime:
         on_call_end.assert_awaited_once()
 
     @patch(_PATCH_RT)
-    async def test_audio_format_pcm16(self, MockHandler) -> None:
-        """Telnyx uses pcm16 audio format for OpenAI Realtime."""
+    async def test_audio_format_g711_ulaw(self, MockHandler) -> None:
+        """Telnyx Call Control streams are PCMU 8 kHz bidirectional (BUG #19).
+
+        The Realtime handler therefore runs on ``g711_ulaw`` so both legs are
+        pass-through — transcoding PCM16 would misinterpret the bytes and
+        break turn detection.
+        """
         handler_instance = AsyncMock()
         handler_instance.start = AsyncMock()
         handler_instance.cleanup = AsyncMock()
@@ -134,7 +145,7 @@ class TestTelnyxRealtime:
         )
 
         call_kwargs = MockHandler.call_args.kwargs
-        assert call_kwargs.get("audio_format") == "pcm16"
+        assert call_kwargs.get("audio_format") == "g711_ulaw"
 
     @patch(_PATCH_RT)
     async def test_empty_audio_chunk_skipped(self, MockHandler) -> None:
@@ -149,8 +160,8 @@ class TestTelnyxRealtime:
         agent = make_agent(provider="openai_realtime")
 
         empty_media = {
-            "event_type": "media",
-            "payload": {"audio": {"chunk": ""}},
+            "event": "media",
+            "media": {"payload": ""},
         }
 
         ws = _make_ws_mock([

--- a/sdk-py/tests/test_local_mode.py
+++ b/sdk-py/tests/test_local_mode.py
@@ -381,8 +381,10 @@ async def test_twilio_stream_bridge_pipeline_sends_audio_to_stt():
     mock_tts = AsyncMock()
     mock_tts.close = AsyncMock()
 
+    # Pipeline mode now transcodes mulaw→PCM16 before STT (BUG #12), so the
+    # bridge instantiates the plain DeepgramSTT constructor — not for_twilio.
     with (
-        patch("patter.providers.deepgram_stt.DeepgramSTT.for_twilio", return_value=mock_stt),
+        patch("patter.providers.deepgram_stt.DeepgramSTT", return_value=mock_stt),
         patch("patter.providers.elevenlabs_tts.ElevenLabsTTS", return_value=mock_tts),
     ):
         # Run with a short timeout — we only care that it starts up correctly
@@ -605,7 +607,7 @@ async def test_dtmf_event_fires_transcript_callback():
     mock_tts.close = AsyncMock()
 
     with (
-        patch("patter.providers.deepgram_stt.DeepgramSTT.for_twilio", return_value=mock_stt),
+        patch("patter.providers.deepgram_stt.DeepgramSTT", return_value=mock_stt),
         patch("patter.providers.elevenlabs_tts.ElevenLabsTTS", return_value=mock_tts),
     ):
         try:

--- a/sdk-py/tests/test_new_features.py
+++ b/sdk-py/tests/test_new_features.py
@@ -266,7 +266,11 @@ def test_machine_detection_false_no_extra_params():
 
         _, kwargs = mock_instance.initiate_call.call_args
         extra = kwargs.get("extra_params", {})
-        assert not extra  # empty dict when AMD disabled
+        # AMD-specific params must be absent when machine_detection=False.
+        assert "MachineDetection" not in extra
+        assert "AsyncAmd" not in extra
+        # StatusCallback is always wired (BUG #06 — dashboard sees failures).
+        assert extra.get("StatusCallback", "").endswith("/webhooks/twilio/status")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-py/tests/unit/test_before_send_to_stt_hook.py
+++ b/sdk-py/tests/unit/test_before_send_to_stt_hook.py
@@ -1,0 +1,214 @@
+"""Unit tests for the ``before_send_to_stt`` pipeline hook (BUG #15).
+
+The hook runs inside :meth:`PipelineStreamHandler.on_audio_received`
+*after* mulaw decoding and resampling but *before* any bytes reach the
+STT provider. It has three observable contracts:
+
+  1. Returning modified bytes forwards the transformed buffer to STT —
+     enabling custom noise cancellation / pre-emphasis / gain control.
+  2. Returning ``None`` drops the chunk entirely — the STT provider
+     must see zero bytes from that frame. This is the primary BUG #15
+     regression: pre-fix, returning ``None`` was treated as an empty
+     bytes payload which still hit the STT adapter.
+  3. A hook that raises must fail *open* — the original (decoded) audio
+     still passes through so a buggy user hook cannot silently kill the
+     pipeline mid-call.
+
+These tests patch the STT stub rather than mock the hook runner, so the
+full call graph (hook executor → hook → on_audio_received → STT.send)
+is exercised.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.handlers.stream_handler import PipelineStreamHandler
+from patter.models import PipelineHooks
+
+from tests.conftest import fake_pcm_frame, make_agent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(hooks: PipelineHooks | None) -> PipelineStreamHandler:
+    audio_sender = AsyncMock()
+    handler = PipelineStreamHandler(
+        agent=make_agent(hooks=hooks),
+        audio_sender=audio_sender,
+        call_id="call-hook",
+        caller="+15551110000",
+        callee="+15552220000",
+        resolved_prompt="p",
+        metrics=None,
+        for_twilio=False,  # so input_is_mulaw_8k defaults to False -> no transcode
+        input_is_mulaw_8k=False,
+        conversation_history=deque(maxlen=10),
+        transcript_entries=deque(maxlen=10),
+    )
+    handler._stt = MagicMock()
+    handler._stt.send_audio = AsyncMock()
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Hook returning None drops the chunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHookDropsChunk:
+    """Hook returning ``None`` must prevent any bytes from reaching STT."""
+
+    async def test_none_return_skips_stt_send(self) -> None:
+        hooks = PipelineHooks(before_send_to_stt=lambda audio, ctx: None)
+        handler = _make_handler(hooks)
+
+        await handler.on_audio_received(fake_pcm_frame(duration_ms=20))
+
+        handler._stt.send_audio.assert_not_awaited()
+
+    async def test_none_return_from_async_hook_skips_stt(self) -> None:
+        async def _async_hook(audio: bytes, ctx) -> None:
+            return None
+
+        hooks = PipelineHooks(before_send_to_stt=_async_hook)
+        handler = _make_handler(hooks)
+
+        await handler.on_audio_received(fake_pcm_frame(duration_ms=20))
+
+        handler._stt.send_audio.assert_not_awaited()
+
+    async def test_multiple_drops_never_reach_stt(self) -> None:
+        """10 frames all dropped — STT must still see zero sends."""
+        call_count = 0
+
+        def _hook(audio: bytes, ctx) -> None:
+            nonlocal call_count
+            call_count += 1
+            return None
+
+        hooks = PipelineHooks(before_send_to_stt=_hook)
+        handler = _make_handler(hooks)
+
+        frame = fake_pcm_frame(duration_ms=20)
+        for _ in range(10):
+            await handler.on_audio_received(frame)
+
+        assert call_count == 10  # hook was invoked every time
+        handler._stt.send_audio.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Hook returning modified bytes forwards the new buffer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHookTransformsChunk:
+    """Returning modified bytes must forward *those* bytes to STT."""
+
+    async def test_sync_hook_bytes_forwarded(self) -> None:
+        replacement = b"\xde\xad" * 80  # 160 bytes = 5 ms of PCM16 @ 16 kHz
+
+        def _hook(audio: bytes, ctx) -> bytes:
+            return replacement
+
+        hooks = PipelineHooks(before_send_to_stt=_hook)
+        handler = _make_handler(hooks)
+
+        await handler.on_audio_received(fake_pcm_frame(duration_ms=20))
+
+        handler._stt.send_audio.assert_awaited_once_with(replacement)
+
+    async def test_async_hook_bytes_forwarded(self) -> None:
+        replacement = b"\xbe\xef" * 40
+
+        async def _hook(audio: bytes, ctx) -> bytes:
+            return replacement
+
+        hooks = PipelineHooks(before_send_to_stt=_hook)
+        handler = _make_handler(hooks)
+
+        await handler.on_audio_received(fake_pcm_frame(duration_ms=20))
+
+        handler._stt.send_audio.assert_awaited_once_with(replacement)
+
+    async def test_hook_receives_decoded_pcm(self) -> None:
+        """The audio arg must be the PCM16 buffer (post-transcode), not mulaw."""
+        seen: list[bytes] = []
+
+        def _hook(audio: bytes, ctx) -> bytes:
+            seen.append(audio)
+            return audio
+
+        hooks = PipelineHooks(before_send_to_stt=_hook)
+        handler = _make_handler(hooks)
+        frame = fake_pcm_frame(duration_ms=20)
+
+        await handler.on_audio_received(frame)
+
+        assert len(seen) == 1
+        # frame is already PCM16 because input_is_mulaw_8k=False.
+        assert seen[0] == frame
+
+
+# ---------------------------------------------------------------------------
+# Hook raising must fail-open (preserve original audio)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHookFailOpen:
+    """A user hook that raises must not break the pipeline."""
+
+    async def test_raising_hook_passes_original_audio(self) -> None:
+        def _bad_hook(audio: bytes, ctx) -> bytes:
+            raise RuntimeError("user code is buggy")
+
+        hooks = PipelineHooks(before_send_to_stt=_bad_hook)
+        handler = _make_handler(hooks)
+        frame = fake_pcm_frame(duration_ms=20)
+
+        # Must not raise.
+        await handler.on_audio_received(frame)
+
+        handler._stt.send_audio.assert_awaited_once_with(frame)
+
+
+# ---------------------------------------------------------------------------
+# No hook configured → audio passes through unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestNoHook:
+    """Agents without ``hooks`` must bypass the executor entirely."""
+
+    async def test_no_hooks_sends_original_audio(self) -> None:
+        handler = _make_handler(hooks=None)
+        frame = fake_pcm_frame(duration_ms=20)
+
+        await handler.on_audio_received(frame)
+
+        handler._stt.send_audio.assert_awaited_once_with(frame)
+
+    async def test_hooks_instance_without_before_send_to_stt(self) -> None:
+        """Hooks configured but before_send_to_stt=None — still forwards."""
+        hooks = PipelineHooks(before_send_to_stt=None)
+        handler = _make_handler(hooks)
+        frame = fake_pcm_frame(duration_ms=20)
+
+        await handler.on_audio_received(frame)
+
+        handler._stt.send_audio.assert_awaited_once_with(frame)

--- a/sdk-py/tests/unit/test_openai_tts_resample.py
+++ b/sdk-py/tests/unit/test_openai_tts_resample.py
@@ -1,0 +1,211 @@
+"""Unit tests for OpenAITTS streaming resample (BUG #23).
+
+OpenAI's TTS-1 returns PCM16 at 24 kHz but the telephony bridge expects
+PCM16 at 16 kHz. Early versions downsampled each streamed chunk with a
+stateless call to :func:`audioop.ratecv`, which discarded the resampler's
+filter state between chunks — the caller heard "pops" between chunks, or
+empty audio when a chunk's payload was smaller than the filter kernel.
+
+The fix (see :mod:`patter.providers.openai_tts`) keeps the ``ratecv``
+state across chunks **and** carries an odd trailing byte forward so every
+call receives a whole number of 16-bit samples. These tests lock both
+invariants in:
+
+  1. **Stream parity** — downsampling a sequence of chunks yields (within
+     the ratecv initial-state tolerance) the same bytes as downsampling
+     the concatenated audio in one shot. This is the primary regression.
+  2. **Carry-byte** — when the boundary between two chunks falls on an
+     odd byte, the resample still produces a whole number of output
+     samples and the lost byte is not dropped.
+  3. **Empty / partial** — empty chunks, single-byte chunks, and chunks
+     with no usable sample bytes must not crash the generator.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import AsyncIterator, Iterable, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.providers.openai_tts import OpenAITTS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pcm16(samples: Iterable[int]) -> bytes:
+    """Pack signed 16-bit LE samples into a bytes blob."""
+    seq = list(samples)
+    return struct.pack(f"<{len(seq)}h", *seq)
+
+
+def _make_tts() -> OpenAITTS:
+    return OpenAITTS(api_key="sk-test", voice="alloy", model="tts-1")
+
+
+def _wire_mock_stream(tts: OpenAITTS, chunks: List[bytes]) -> AsyncMock:
+    """Wire an httpx stream mock that yields ``chunks`` from ``aiter_bytes``."""
+    mock_resp = AsyncMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.aclose = AsyncMock()
+
+    async def _aiter_bytes(chunk_size: int = 4096) -> AsyncIterator[bytes]:
+        for c in chunks:
+            yield c
+
+    mock_resp.aiter_bytes = _aiter_bytes
+
+    tts._client = AsyncMock()
+    tts._client.build_request.return_value = MagicMock()
+    tts._client.send.return_value = mock_resp
+    return mock_resp
+
+
+async def _drain(tts: OpenAITTS, chunks: List[bytes]) -> bytes:
+    """Feed ``chunks`` through synthesize and concatenate the output."""
+    _wire_mock_stream(tts, chunks)
+    out = bytearray()
+    async for resampled in tts.synthesize("irrelevant"):
+        out.extend(resampled)
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# Stream parity — cross-chunk filter state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestStateCarriesAcrossChunks:
+    """Splitting the source audio across chunks must not warp the output.
+
+    With preserved ``ratecv`` state, the concatenation of per-chunk outputs
+    equals a single-shot downsample of the whole buffer. Without state
+    preservation, the second chunk would start from a cold filter and the
+    prefix would differ — which is what BUG #23 produced in production.
+    """
+
+    async def test_two_chunks_match_single_shot(self) -> None:
+        # 600 samples @ 24 kHz = 25 ms of audio — enough to feel the filter.
+        all_samples = [int(1000 * (i % 31 - 15)) for i in range(600)]
+        full = _pcm16(all_samples)
+        mid = (len(full) // 2) // 2 * 2  # split on an even-byte boundary
+        split = [full[:mid], full[mid:]]
+
+        tts_single = _make_tts()
+        tts_split = _make_tts()
+        single_out = await _drain(tts_single, [full])
+        split_out = await _drain(tts_split, split)
+
+        # With state preserved the two outputs match exactly byte-for-byte.
+        assert split_out == single_out
+
+    async def test_many_small_chunks_match_single_shot(self) -> None:
+        """Same invariant across 10 back-to-back chunks of 100 samples each."""
+        all_samples = [int(500 * (i % 13 - 6)) for i in range(1000)]
+        full = _pcm16(all_samples)
+        # 10 chunks of 200 bytes each = 100 samples each.
+        chunks = [full[i : i + 200] for i in range(0, len(full), 200)]
+        assert len(chunks) == 10
+
+        tts_single = _make_tts()
+        tts_split = _make_tts()
+        single_out = await _drain(tts_single, [full])
+        split_out = await _drain(tts_split, chunks)
+
+        assert split_out == single_out
+
+
+# ---------------------------------------------------------------------------
+# Odd-byte carry across chunk boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestOddByteCarry:
+    """Boundaries on odd byte offsets must still preserve the PCM16 sample.
+
+    When httpx splits the response on an odd byte the implementation must
+    buffer the dangling byte and prepend it to the next chunk. A naïve
+    ``len // 2 * 2`` truncation drops the byte permanently and the second
+    chunk decodes as a shifted sample stream (loud click / static).
+    """
+
+    async def test_odd_split_matches_single_shot(self) -> None:
+        all_samples = [int(800 * (i % 11 - 5)) for i in range(400)]
+        full = _pcm16(all_samples)
+        # Split so the first chunk ends on an odd byte.
+        odd_boundary = 201
+        chunks = [full[:odd_boundary], full[odd_boundary:]]
+
+        tts_single = _make_tts()
+        tts_split = _make_tts()
+        single_out = await _drain(tts_single, [full])
+        split_out = await _drain(tts_split, chunks)
+
+        assert split_out == single_out
+
+
+# ---------------------------------------------------------------------------
+# Degenerate chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEdgeCases:
+    """Tiny and empty chunks must not break the stream."""
+
+    async def test_empty_chunk_is_skipped(self) -> None:
+        all_samples = [int(100 * (i % 7 - 3)) for i in range(200)]
+        full = _pcm16(all_samples)
+
+        tts_single = _make_tts()
+        tts_split = _make_tts()
+        baseline = await _drain(tts_single, [full])
+        # Interleave an empty chunk — it must be ignored.
+        mixed = await _drain(
+            tts_split, [full[:100], b"", full[100:], b""]
+        )
+
+        assert mixed == baseline
+
+    async def test_single_byte_chunk_buffered(self) -> None:
+        """A chunk consisting of exactly one byte must not crash the generator."""
+        all_samples = [int(50 * (i % 5 - 2)) for i in range(100)]
+        full = _pcm16(all_samples)
+
+        tts_single = _make_tts()
+        tts_split = _make_tts()
+        baseline = await _drain(tts_single, [full])
+        # First chunk is a single byte — forces carry-only on first iteration.
+        mixed = await _drain(tts_split, [full[:1], full[1:]])
+
+        assert mixed == baseline
+
+    async def test_stream_closes_response_on_completion(self) -> None:
+        """The httpx response must be closed even after a successful stream."""
+        tts = _make_tts()
+        mock_resp = _wire_mock_stream(tts, [_pcm16([0] * 20)])
+        async for _ in tts.synthesize("hi"):
+            pass
+        mock_resp.aclose.assert_awaited_once()
+
+    async def test_stream_closes_response_on_early_exit(self) -> None:
+        """Early generator termination must still drain the response."""
+        tts = _make_tts()
+        mock_resp = _wire_mock_stream(
+            tts, [_pcm16([0] * 20), _pcm16([0] * 20)]
+        )
+        gen = tts.synthesize("hi")
+        # Consume only the first resampled chunk, then close.
+        async for _ in gen:
+            break
+        await gen.aclose()
+        mock_resp.aclose.assert_awaited_once()

--- a/sdk-py/tests/unit/test_pipeline_bargein.py
+++ b/sdk-py/tests/unit/test_pipeline_bargein.py
@@ -1,0 +1,180 @@
+"""Unit tests for PipelineStreamHandler barge-in detection (BUG #20).
+
+During TTS playback the STT loop must treat *any* transcript with text —
+interim or final — as a barge-in signal. When that happens the handler:
+
+  1. Logs the event.
+  2. Flips ``_is_speaking`` to False so the in-flight sentence loop
+     breaks out (see ``_synthesize_sentence``).
+  3. Calls ``audio_sender.send_clear()`` to drop any frames the
+     telephony bridge has already buffered.
+  4. Records the interrupted turn on the metrics accumulator.
+
+Without this, the caller has to wait ~1.5 s for a long TTS reply to
+finish before the agent even notices the interruption, and earlier
+versions of the SDK effectively broke barge-in entirely because the
+interim branch was a ``continue`` before the ``is_final`` gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import AsyncIterator, Iterable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.handlers.stream_handler import PipelineStreamHandler
+from patter.providers.base import Transcript
+
+from tests.conftest import make_agent
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — stub STT that yields a caller-supplied sequence
+# ---------------------------------------------------------------------------
+
+
+class _StubSTT:
+    def __init__(self, transcripts: Iterable[Transcript]) -> None:
+        self._transcripts = list(transcripts)
+
+    async def receive_transcripts(self) -> AsyncIterator[Transcript]:
+        for t in self._transcripts:
+            yield t
+        await asyncio.sleep(0)
+
+
+def _make_handler(
+    stt: _StubSTT,
+    audio_sender: AsyncMock,
+    metrics: MagicMock | None,
+    *,
+    speaking: bool,
+) -> PipelineStreamHandler:
+    handler = PipelineStreamHandler(
+        agent=make_agent(),
+        audio_sender=audio_sender,
+        call_id="call-barge",
+        caller="+15551110000",
+        callee="+15552220000",
+        resolved_prompt="p",
+        metrics=metrics,
+        for_twilio=True,
+        on_transcript=None,
+        conversation_history=deque(maxlen=10),
+        transcript_entries=deque(maxlen=10),
+    )
+    handler._stt = stt  # type: ignore[assignment]
+    handler.on_message = None
+    handler._llm_loop = None
+    handler._is_speaking = speaking
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Interim transcript during TTS → barge-in triggers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestInterimBargeIn:
+    """An interim transcript during TTS must interrupt the agent."""
+
+    async def test_interim_during_tts_calls_send_clear(self) -> None:
+        stt = _StubSTT([Transcript(text="wait", is_final=False, confidence=0.4)])
+        audio_sender = AsyncMock()
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=True)
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        audio_sender.send_clear.assert_awaited_once()
+
+    async def test_interim_during_tts_flips_is_speaking(self) -> None:
+        stt = _StubSTT([Transcript(text="stop", is_final=False, confidence=0.3)])
+        audio_sender = AsyncMock()
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=True)
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        assert handler._is_speaking is False
+
+    async def test_interim_during_tts_records_turn_interrupted(self) -> None:
+        stt = _StubSTT([Transcript(text="hey", is_final=False, confidence=0.3)])
+        audio_sender = AsyncMock()
+        metrics = MagicMock()
+        handler = _make_handler(
+            stt, audio_sender, metrics=metrics, speaking=True
+        )
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        metrics.record_turn_interrupted.assert_called_once()
+
+    async def test_interim_barge_in_survives_send_clear_exception(self) -> None:
+        """A broken audio_sender must not crash the STT loop."""
+        stt = _StubSTT([Transcript(text="hi", is_final=False, confidence=0.3)])
+        audio_sender = AsyncMock()
+        audio_sender.send_clear.side_effect = RuntimeError("socket closed")
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=True)
+
+        # Must not raise.
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        assert handler._is_speaking is False
+
+
+# ---------------------------------------------------------------------------
+# No barge-in when the agent is NOT speaking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestNoBargeInWhenIdle:
+    """When ``_is_speaking`` is already False the barge-in branch is skipped."""
+
+    async def test_interim_while_idle_does_not_call_send_clear(self) -> None:
+        stt = _StubSTT([Transcript(text="hello", is_final=False, confidence=0.3)])
+        audio_sender = AsyncMock()
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=False)
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        audio_sender.send_clear.assert_not_awaited()
+
+    async def test_empty_interim_while_speaking_does_not_bargein(self) -> None:
+        """Transcript without text must not fire barge-in even during TTS."""
+        stt = _StubSTT([Transcript(text="", is_final=False, confidence=0.0)])
+        audio_sender = AsyncMock()
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=True)
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        audio_sender.send_clear.assert_not_awaited()
+        assert handler._is_speaking is True
+
+
+# ---------------------------------------------------------------------------
+# Final transcript during TTS → both barge-in AND turn processing fire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestFinalBargeIn:
+    """A final transcript during TTS must trigger barge-in before the turn."""
+
+    async def test_final_during_tts_calls_send_clear(self) -> None:
+        stt = _StubSTT(
+            [Transcript(text="actually wait", is_final=True, confidence=0.9)]
+        )
+        audio_sender = AsyncMock()
+        handler = _make_handler(stt, audio_sender, metrics=None, speaking=True)
+
+        await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+        audio_sender.send_clear.assert_awaited_once()
+        assert handler._is_speaking is False

--- a/sdk-py/tests/unit/test_pipeline_dedup.py
+++ b/sdk-py/tests/unit/test_pipeline_dedup.py
@@ -1,0 +1,328 @@
+"""Unit tests for PipelineStreamHandler STT dedup/throttle/hallucination filter.
+
+Regression tests for BUG #22 — Whisper on mulaw 8 kHz repeatedly hallucinated
+"you" / "." and the pipeline kicked off a new LLM+TTS turn for each, producing
+overlapping audio on the caller's line.
+
+The filter lives in :func:`PipelineStreamHandler._stt_loop` and enforces three
+rules on final transcripts:
+
+  1. Hallucination blacklist — drop common one-word fillers ("you",
+     "thank you", ".", etc.).
+  2. 2-second duplicate window — drop if the normalised text matches the
+     previous committed text and arrived within 2.0 s.
+  3. 500 ms back-to-back throttle — drop any final that lands within
+     500 ms of the previous committed turn.
+
+Tests drive the loop via a mocked STT whose ``receive_transcripts`` yields
+a caller-controlled async iterator, and assert against the callbacks that
+``_stt_loop`` invokes only for transcripts that pass the filter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import AsyncIterator, Iterable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from patter.handlers.stream_handler import PipelineStreamHandler
+from patter.providers.base import Transcript
+
+from tests.conftest import make_agent
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _StubSTT:
+    """Minimal STT double that yields a pre-supplied sequence of Transcripts.
+
+    Supports gap injection between yields via ``delays`` — a parallel list of
+    monotonic time offsets applied through the loop's ``time.time`` lookup.
+    """
+
+    def __init__(self, transcripts: Iterable[Transcript]) -> None:
+        self._transcripts = list(transcripts)
+
+    async def receive_transcripts(self) -> AsyncIterator[Transcript]:
+        for t in self._transcripts:
+            yield t
+        # Hold the generator open briefly so the loop can complete processing.
+        await asyncio.sleep(0)
+
+
+def _make_handler(stt: _StubSTT, on_transcript: AsyncMock) -> PipelineStreamHandler:
+    """Build a PipelineStreamHandler with the stub STT pre-installed.
+
+    The handler is constructed without calling ``start`` — we only exercise
+    ``_stt_loop``. The internal ``_llm_loop`` is left ``None`` so the loop
+    records ``turn_interrupted`` on the metrics double instead of invoking
+    an LLM, which keeps the test focused on the filter behaviour.
+    """
+    agent = make_agent()
+    audio_sender = MagicMock()
+    audio_sender.send_clear = AsyncMock()
+    audio_sender.send_audio = AsyncMock()
+    audio_sender.send_mark = AsyncMock()
+
+    handler = PipelineStreamHandler(
+        agent=agent,
+        audio_sender=audio_sender,
+        call_id="call-test",
+        caller="+15551110000",
+        callee="+15552220000",
+        resolved_prompt="test prompt",
+        metrics=None,  # skip metrics bookkeeping for this test
+        for_twilio=True,
+        on_transcript=on_transcript,
+        conversation_history=deque(maxlen=50),
+        transcript_entries=deque(maxlen=50),
+    )
+    handler._stt = stt  # type: ignore[assignment]
+    # No LLM / message handler — the loop will call record_turn_interrupted on
+    # a None metrics object, which we guard via the `if self.metrics` checks.
+    handler.on_message = None
+    handler._llm_loop = None
+    return handler
+
+
+async def _run_loop(handler: PipelineStreamHandler) -> None:
+    """Drive ``_stt_loop`` until the stub iterator is exhausted."""
+    await asyncio.wait_for(handler._stt_loop(), timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Hallucination blacklist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHallucinationFilter:
+    """Rule 1 — drop common Whisper / Deepgram filler words."""
+
+    async def test_drops_single_word_you(self) -> None:
+        stt = _StubSTT([Transcript(text="you", is_final=True, confidence=0.9)])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_drops_period_only(self) -> None:
+        stt = _StubSTT([Transcript(text=".", is_final=True, confidence=0.8)])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_drops_thank_you_with_punctuation(self) -> None:
+        """Trailing punctuation/whitespace is stripped before the blacklist check."""
+        stt = _StubSTT(
+            [Transcript(text="Thank you.", is_final=True, confidence=0.8)]
+        )
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_drops_case_variants(self) -> None:
+        """Normalisation is case-insensitive."""
+        stt = _StubSTT([Transcript(text="YOU", is_final=True, confidence=0.9)])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_drops_empty_after_strip(self) -> None:
+        """Transcript of only punctuation/whitespace is treated as empty."""
+        stt = _StubSTT([Transcript(text="  ...  ", is_final=True, confidence=0.5)])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_passes_legitimate_text(self) -> None:
+        """A real utterance that is NOT on the blacklist must pass through."""
+        stt = _StubSTT(
+            [Transcript(text="What's the weather today?", is_final=True, confidence=0.95)]
+        )
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_awaited_once()
+        args = on_transcript.await_args.args[0]
+        assert args["text"] == "What's the weather today?"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate window (2.0 s)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDuplicateFilter:
+    """Rule 2 — drop duplicates within 2.0 s of the last committed turn."""
+
+    async def test_drops_duplicate_within_2s(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Two identical legitimate finals separated by 1.0 s (inside the window).
+        times = iter([100.0, 101.0])
+        monkeypatch.setattr(
+            "patter.handlers.stream_handler.time.time",
+            lambda: next(times),
+        )
+        stt = _StubSTT([
+            Transcript(text="Hello there", is_final=True, confidence=0.9),
+            Transcript(text="Hello there", is_final=True, confidence=0.9),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        # Only the first transcript should have been forwarded.
+        assert on_transcript.await_count == 1
+
+    async def test_passes_duplicate_after_2s(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same text, but 2.5 s apart — caller legitimately repeating themselves.
+        times = iter([100.0, 102.5])
+        monkeypatch.setattr(
+            "patter.handlers.stream_handler.time.time",
+            lambda: next(times),
+        )
+        stt = _StubSTT([
+            Transcript(text="Hello there", is_final=True, confidence=0.9),
+            Transcript(text="Hello there", is_final=True, confidence=0.9),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        assert on_transcript.await_count == 2
+
+    async def test_duplicate_normalises_whitespace_and_case(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        times = iter([100.0, 100.8])
+        monkeypatch.setattr(
+            "patter.handlers.stream_handler.time.time",
+            lambda: next(times),
+        )
+        stt = _StubSTT([
+            Transcript(text="Book a table", is_final=True, confidence=0.9),
+            Transcript(text="  book a table  ", is_final=True, confidence=0.9),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        # Second is a duplicate modulo case/whitespace — dropped.
+        assert on_transcript.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Back-to-back throttle (500 ms)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestThrottleFilter:
+    """Rule 3 — drop ANY final that lands within 500 ms of the last turn."""
+
+    async def test_drops_back_to_back_under_500ms(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Different text but only 0.2 s apart — treated as STT over-firing.
+        times = iter([100.0, 100.2])
+        monkeypatch.setattr(
+            "patter.handlers.stream_handler.time.time",
+            lambda: next(times),
+        )
+        stt = _StubSTT([
+            Transcript(text="What time is it", is_final=True, confidence=0.9),
+            Transcript(text="Tell me the weather", is_final=True, confidence=0.9),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        # Only the first should have been forwarded.
+        assert on_transcript.await_count == 1
+
+    async def test_passes_after_500ms(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Different text, 700 ms apart — legitimate second turn.
+        times = iter([100.0, 100.7])
+        monkeypatch.setattr(
+            "patter.handlers.stream_handler.time.time",
+            lambda: next(times),
+        )
+        stt = _StubSTT([
+            Transcript(text="What time is it", is_final=True, confidence=0.9),
+            Transcript(text="Tell me the weather", is_final=True, confidence=0.9),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        assert on_transcript.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Interim / non-final transcripts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestInterimTranscripts:
+    """Non-final (interim) transcripts must never fire the turn pipeline."""
+
+    async def test_interim_does_not_fire_on_transcript(self) -> None:
+        stt = _StubSTT([
+            Transcript(text="Hello", is_final=False, confidence=0.5),
+            Transcript(text="Hello world", is_final=False, confidence=0.6),
+        ])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()
+
+    async def test_empty_final_is_ignored(self) -> None:
+        """A final transcript with empty text must not fire the pipeline."""
+        stt = _StubSTT([Transcript(text="", is_final=True, confidence=0.0)])
+        on_transcript = AsyncMock()
+        handler = _make_handler(stt, on_transcript)
+
+        await _run_loop(handler)
+
+        on_transcript.assert_not_called()

--- a/sdk-py/tests/unit/test_server_unit.py
+++ b/sdk-py/tests/unit/test_server_unit.py
@@ -559,27 +559,60 @@ class TestTwilioAMDSignature:
 
 
 class TestTelnyxVoiceRoute:
-    """POST /webhooks/telnyx/voice returns JSON commands."""
+    """POST /webhooks/telnyx/voice dispatches Call Control REST actions (BUG #16)."""
 
     @pytest.mark.asyncio
-    async def test_valid_telnyx_webhook_returns_commands(self) -> None:
-        srv = _make_server()
+    async def test_valid_telnyx_webhook_initiates_answer(self, monkeypatch) -> None:
+        # Build a server with a telnyx_key so the handler can reach the REST API.
+        cfg = LocalConfig(
+            telephony_provider="telnyx",
+            telnyx_key="tk_test",
+            telnyx_connection_id="conn-1",
+            openai_key="sk-test",
+            webhook_url="test.ngrok.io",
+            phone_number="+15551234567",
+        )
+        srv = EmbeddedServer(config=cfg, agent=make_agent(), dashboard=False)
         app = srv._create_app()
         endpoint = _get_endpoint(app, "/webhooks/telnyx/voice")
+
+        # Intercept the POST to the Telnyx Call Control API so the test is
+        # hermetic.
+        calls: list[str] = []
+
+        class _FakeResp:
+            status_code = 200
+            text = ""
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *_exc):
+                pass
+            async def post(self, url, **kwargs):
+                calls.append(url)
+                return _FakeResp()
+
+        import httpx as _httpx
+        monkeypatch.setattr(_httpx, "AsyncClient", _FakeClient)
 
         request = _MockRequest(
             json_data={
                 "data": {
+                    "event_type": "call.initiated",
                     "payload": {
                         "call_control_id": "v3:abc123",
                         "from": "+15551234567",
                         "to": "+15559876543",
-                    }
+                    },
                 }
             },
         )
         response = await endpoint(request)
         assert response.status_code == 200
+        assert any("/actions/answer" in url for url in calls)
 
     @pytest.mark.asyncio
     async def test_invalid_telnyx_structure_returns_400(self) -> None:

--- a/sdk-py/tests/unit/test_telnyx_bridge_unit.py
+++ b/sdk-py/tests/unit/test_telnyx_bridge_unit.py
@@ -20,9 +20,10 @@ from tests.conftest import make_agent
 # ---------------------------------------------------------------------------
 
 
-def _ws_message(event_type: str, **kwargs) -> str:
-    """Build a JSON WebSocket message string for Telnyx."""
-    msg: dict = {"event_type": event_type, **kwargs}
+def _ws_message(event: str, **kwargs) -> str:
+    """Build a JSON WebSocket message string for Telnyx (media-stream wire
+    format — BUG #17)."""
+    msg: dict = {"event": event, **kwargs}
     return json.dumps(msg)
 
 
@@ -30,8 +31,8 @@ def _stream_started_message(
     call_control_id: str = "v3:test-id",
 ) -> str:
     return _ws_message(
-        "stream_started",
-        payload={"call_control_id": call_control_id},
+        "start",
+        start={"call_control_id": call_control_id, "from": "+15551111111", "to": "+15552222222"},
     )
 
 
@@ -39,12 +40,12 @@ def _media_message(audio: bytes = b"\x00\x00" * 320) -> str:
     encoded = base64.b64encode(audio).decode("ascii")
     return _ws_message(
         "media",
-        payload={"audio": {"chunk": encoded}},
+        media={"payload": encoded},
     )
 
 
 def _stream_stopped_message() -> str:
-    return _ws_message("stream_stopped")
+    return _ws_message("stop")
 
 
 def _make_mock_ws(messages: list[str]) -> AsyncMock:
@@ -342,7 +343,7 @@ class TestTelnyxStreamBridgeLifecycle:
     @patch("patter.handlers.telnyx_handler.create_metrics_accumulator")
     @patch("patter.handlers.telnyx_handler.resolve_agent_prompt", return_value="prompt")
     @patch("patter.handlers.telnyx_handler.fetch_deepgram_cost", new_callable=AsyncMock)
-    async def test_openai_realtime_uses_pcm16_format(
+    async def test_openai_realtime_uses_g711_ulaw_format(
         self,
         mock_fetch_dg,
         mock_resolve,
@@ -365,6 +366,8 @@ class TestTelnyxStreamBridgeLifecycle:
             openai_key="sk-test",
         )
 
-        # Verify pcm16 audio_format was passed to OpenAIRealtimeStreamHandler
+        # Telnyx streaming_start negotiates PCMU 8 kHz bidirectional, so
+        # OpenAI Realtime must emit g711_ulaw to avoid transcoding mismatch
+        # (BUG #18).
         call_kwargs = mock_handler_cls.call_args[1]
-        assert call_kwargs.get("audio_format") == "pcm16"
+        assert call_kwargs.get("audio_format") == "g711_ulaw"

--- a/sdk-py/tests/unit/test_telnyx_handler_unit.py
+++ b/sdk-py/tests/unit/test_telnyx_handler_unit.py
@@ -86,15 +86,19 @@ class TestTelnyxAudioSender:
     async def test_send_audio(self) -> None:
         ws = AsyncMock()
         ws.send_text = AsyncMock()
-        sender = TelnyxAudioSender(ws)
+        # ``input_is_mulaw_8k=True`` forces pass-through — the default
+        # behaviour transcodes PCM16 → mulaw (BUG #18), which would alter
+        # the byte stream and break this round-trip assertion.
+        sender = TelnyxAudioSender(ws, input_is_mulaw_8k=True)
 
         audio = b"\x00\x01\x02\x03"
         await sender.send_audio(audio)
 
         ws.send_text.assert_awaited_once()
         payload = json.loads(ws.send_text.call_args[0][0])
-        assert payload["event_type"] == "media"
-        decoded = base64.b64decode(payload["payload"]["audio"]["chunk"])
+        # Telnyx media-stream wire format (BUG #18).
+        assert payload["event"] == "media"
+        decoded = base64.b64decode(payload["media"]["payload"])
         assert decoded == audio
 
     async def test_send_clear(self) -> None:
@@ -105,7 +109,7 @@ class TestTelnyxAudioSender:
         await sender.send_clear()
         ws.send_text.assert_awaited_once()
         payload = json.loads(ws.send_text.call_args[0][0])
-        assert payload["event_type"] == "media_stop"
+        assert payload["event"] == "clear"
 
     async def test_send_mark_is_noop(self) -> None:
         """Telnyx does not support playback marks — send_mark is a no-op."""
@@ -120,13 +124,14 @@ class TestTelnyxAudioSender:
         """Verify base64 encoding round-trips correctly."""
         ws = AsyncMock()
         ws.send_text = AsyncMock()
-        sender = TelnyxAudioSender(ws)
+        # Pass-through mode so the output bytes match the input exactly.
+        sender = TelnyxAudioSender(ws, input_is_mulaw_8k=True)
 
         original_audio = bytes(range(256))
         await sender.send_audio(original_audio)
 
         payload = json.loads(ws.send_text.call_args[0][0])
-        decoded = base64.b64decode(payload["payload"]["audio"]["chunk"])
+        decoded = base64.b64decode(payload["media"]["payload"])
         assert decoded == original_audio
 
 

--- a/sdk-py/tests/unit/test_telnyx_track_filter.py
+++ b/sdk-py/tests/unit/test_telnyx_track_filter.py
@@ -1,0 +1,227 @@
+"""Unit tests for Telnyx stream bridge track filtering (BUG #19).
+
+Telnyx with ``stream_track=both_tracks`` emits media frames for both the
+caller leg (``track=inbound``) and the outbound leg we inject TTS into
+(``track=outbound``). If the bridge forwards the outbound echo to STT /
+Realtime, the agent hears itself and turn detection collapses.
+
+The filter lives at the top of the ``media`` branch in
+:func:`telnyx_stream_bridge` — anything not ``inbound`` is skipped
+before decoding. These tests lock that behaviour in by driving the
+bridge with hand-crafted media frames and asserting which ones reach
+``handler.on_audio_received``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_agent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ws_message(event: str, **kwargs) -> str:
+    return json.dumps({"event": event, **kwargs})
+
+
+def _stream_started_message(call_control_id: str = "v3:track-test") -> str:
+    return _ws_message(
+        "start",
+        start={
+            "call_control_id": call_control_id,
+            "from": "+15551111111",
+            "to": "+15552222222",
+        },
+    )
+
+
+def _media_message(audio: bytes, track: str | None) -> str:
+    encoded = base64.b64encode(audio).decode("ascii")
+    media: dict = {"payload": encoded}
+    if track is not None:
+        media["track"] = track
+    return _ws_message("media", media=media)
+
+
+def _stream_stopped_message() -> str:
+    return _ws_message("stop")
+
+
+def _make_mock_ws(messages: list[str]) -> AsyncMock:
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.query_params = {"caller": "+15551111111", "callee": "+15552222222"}
+    # Append a sentinel Exception so the bridge falls out of the receive loop.
+    ws.receive_text = AsyncMock(side_effect=messages + [Exception("stop")])
+    ws.send_text = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def _patched_bridge_deps():
+    """Patch the heavy dependencies the bridge pulls in."""
+    with patch(
+        "patter.handlers.telnyx_handler.OpenAIRealtimeStreamHandler"
+    ) as mock_handler_cls, patch(
+        "patter.handlers.telnyx_handler.create_metrics_accumulator"
+    ) as mock_metrics_fn, patch(
+        "patter.handlers.telnyx_handler.resolve_agent_prompt",
+        return_value="prompt",
+    ), patch(
+        "patter.handlers.telnyx_handler.fetch_deepgram_cost",
+        new_callable=AsyncMock,
+    ):
+        mock_handler = AsyncMock()
+        mock_handler.stt = None
+        mock_handler_cls.return_value = mock_handler
+
+        mock_metrics = MagicMock()
+        mock_metrics.end_call.return_value = MagicMock()
+        mock_metrics_fn.return_value = mock_metrics
+
+        yield mock_handler
+
+
+# ---------------------------------------------------------------------------
+# Track filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestTelnyxTrackFilter:
+    """Only ``track=inbound`` media reaches the handler."""
+
+    async def test_inbound_track_forwards_audio(
+        self, _patched_bridge_deps
+    ) -> None:
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
+
+        handler = _patched_bridge_deps
+        audio = b"\x00\x01" * 160  # 20 ms of PCMU 8 kHz
+        ws = _make_mock_ws(
+            [
+                _stream_started_message(),
+                _media_message(audio, track="inbound"),
+                _stream_stopped_message(),
+            ]
+        )
+
+        await telnyx_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+        )
+
+        handler.on_audio_received.assert_awaited_once_with(audio)
+
+    async def test_outbound_track_dropped(
+        self, _patched_bridge_deps
+    ) -> None:
+        """The outbound echo must never reach the handler."""
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
+
+        handler = _patched_bridge_deps
+        echo = b"\xff\xfe" * 160
+        ws = _make_mock_ws(
+            [
+                _stream_started_message(),
+                _media_message(echo, track="outbound"),
+                _stream_stopped_message(),
+            ]
+        )
+
+        await telnyx_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+        )
+
+        handler.on_audio_received.assert_not_awaited()
+
+    async def test_missing_track_defaults_to_inbound(
+        self, _patched_bridge_deps
+    ) -> None:
+        """Older Telnyx payloads omit the field; default to inbound."""
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
+
+        handler = _patched_bridge_deps
+        audio = b"\x11\x22" * 160
+        ws = _make_mock_ws(
+            [
+                _stream_started_message(),
+                _media_message(audio, track=None),
+                _stream_stopped_message(),
+            ]
+        )
+
+        await telnyx_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+        )
+
+        handler.on_audio_received.assert_awaited_once_with(audio)
+
+    async def test_mixed_stream_forwards_only_inbound(
+        self, _patched_bridge_deps
+    ) -> None:
+        """With both tracks in the same stream, only inbound must pass."""
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
+
+        handler = _patched_bridge_deps
+        inbound_a = b"\xaa\xaa" * 160
+        outbound_b = b"\xbb\xbb" * 160
+        inbound_c = b"\xcc\xcc" * 160
+        ws = _make_mock_ws(
+            [
+                _stream_started_message(),
+                _media_message(inbound_a, track="inbound"),
+                _media_message(outbound_b, track="outbound"),
+                _media_message(inbound_c, track="inbound"),
+                _stream_stopped_message(),
+            ]
+        )
+
+        await telnyx_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+        )
+
+        # Only the two inbound frames reach the handler, in order, never
+        # the outbound echo.
+        assert handler.on_audio_received.await_count == 2
+        actual = [c.args[0] for c in handler.on_audio_received.await_args_list]
+        assert actual == [inbound_a, inbound_c]
+
+    async def test_unknown_track_value_dropped(
+        self, _patched_bridge_deps
+    ) -> None:
+        """Defensive — anything that isn't literally 'inbound' is skipped."""
+        from patter.handlers.telnyx_handler import telnyx_stream_bridge
+
+        handler = _patched_bridge_deps
+        ws = _make_mock_ws(
+            [
+                _stream_started_message(),
+                _media_message(b"\x00" * 320, track="weird_track_name"),
+                _stream_stopped_message(),
+            ]
+        )
+
+        await telnyx_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+        )
+
+        handler.on_audio_received.assert_not_awaited()

--- a/sdk-py/tests/unit/test_tool_decorator.py
+++ b/sdk-py/tests/unit/test_tool_decorator.py
@@ -128,18 +128,26 @@ class TestToolDecoratorBasic:
 class TestToolDecoratorHandler:
     """Handler invocation."""
 
+    # Post-BUG-#21 the ``handler`` stored in the ToolDefinition is an
+    # adapter with the signature ``(arguments_dict, call_context_dict)``;
+    # the original user function is on ``handler.__wrapped__``.
+
     @pytest.mark.asyncio
     async def test_async_handler_works(self) -> None:
-        result = await _weather["handler"]("New York")
+        result = await _weather["handler"]({"location": "New York"}, {})
         assert "Sunny" in result
 
     @pytest.mark.asyncio
     async def test_async_handler_with_default(self) -> None:
-        result = await _weather["handler"]("London", "fahrenheit")
+        result = await _weather["handler"](
+            {"location": "London", "unit": "fahrenheit"}, {}
+        )
         assert "F" in result
 
-    def test_sync_handler_works(self) -> None:
-        result = _sync_handler["handler"]("World")
+    @pytest.mark.asyncio
+    async def test_sync_handler_works(self) -> None:
+        # Sync user functions are awaited via the adapter in an event loop.
+        result = await _sync_handler["handler"]({"name": "World"}, {})
         assert result == "Hello, World!"
 
 

--- a/sdk-py/tests/unit/test_twilio_status_and_ring_timeout.py
+++ b/sdk-py/tests/unit/test_twilio_status_and_ring_timeout.py
@@ -1,0 +1,416 @@
+"""Unit tests for the ``/webhooks/twilio/status`` endpoint (BUG #06) and for
+``ring_timeout`` propagation into Twilio/Telnyx dial parameters (IMP2).
+
+Two regressions are locked in here:
+
+  1. **BUG #06** — outbound calls that never reach the media channel
+     (no-answer, busy, carrier-rejected) used to disappear from the
+     dashboard entirely. The fix wires Twilio's ``StatusCallback`` to
+     ``/webhooks/twilio/status`` and forwards every transition to the
+     in-memory metrics store.
+  2. **IMP2** — callers may set ``ring_timeout`` on ``Patter.call()`` to
+     control how long the phone rings before the carrier gives up. It
+     must land as ``Timeout`` on Twilio's REST payload and ``timeout_secs``
+     on Telnyx's — the old code silently dropped it.
+
+The tests exercise the endpoint directly via the ASGI layer, and exercise
+``ring_timeout`` by patching the adapter's ``initiate_call`` and inspecting
+the kwargs it was invoked with (no network traffic).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from patter.local_config import LocalConfig
+from patter.server import EmbeddedServer
+
+from tests.conftest import make_agent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_server(**overrides) -> EmbeddedServer:
+    cfg = LocalConfig(
+        telephony_provider="twilio",
+        twilio_sid="ACtest000000000000000000000000000",
+        twilio_token="",  # empty = no signature validation
+        openai_key="sk-test",
+        webhook_url="test.ngrok.io",
+        phone_number="+15551234567",
+    )
+    defaults = dict(config=cfg, agent=make_agent(), dashboard=True)
+    defaults.update(overrides)
+    return EmbeddedServer(**defaults)
+
+
+def _get_endpoint(app, path: str):
+    for route in app.routes:
+        if getattr(route, "path", None) == path:
+            return route.endpoint
+    raise ValueError(f"No route found for {path}")
+
+
+class _MockRequest:
+    def __init__(self, form_data: dict, headers: dict | None = None) -> None:
+        self._form = form_data
+        self.headers = headers or {}
+        self.url = "https://test.ngrok.io/webhooks/twilio/status"
+        self.query_params = {}
+
+    async def form(self):
+        return self._form
+
+
+# ---------------------------------------------------------------------------
+# /webhooks/twilio/status — endpoint routing + status propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStatusRouteRegistration:
+    """The status callback route must be mounted by ``_create_app``."""
+
+    def test_route_exists(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        paths = [r.path for r in app.routes]
+        assert "/webhooks/twilio/status" in paths
+
+
+@pytest.mark.unit
+class TestStatusCallback:
+    """The status endpoint forwards each transition to the metrics store."""
+
+    @pytest.mark.asyncio
+    async def test_status_returns_204(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "1" * 32,
+                "CallStatus": "ringing",
+            }
+        )
+        response = await endpoint(request)
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_status_updates_metrics_store(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+        # Stub the store so we can inspect the call.
+        srv._metrics_store = MagicMock()
+
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "2" * 32,
+                "CallStatus": "no-answer",
+                "CallDuration": "0",
+            }
+        )
+        response = await endpoint(request)
+
+        assert response.status_code == 204
+        srv._metrics_store.update_call_status.assert_called_once()
+        call_args = srv._metrics_store.update_call_status.call_args
+        assert call_args.args[0] == "CA" + "2" * 32
+        assert call_args.args[1] == "no-answer"
+        assert call_args.kwargs.get("duration_seconds") == 0.0
+
+    @pytest.mark.asyncio
+    async def test_status_without_duration_omits_extra(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+        srv._metrics_store = MagicMock()
+
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "3" * 32,
+                "CallStatus": "ringing",
+            }
+        )
+        await endpoint(request)
+
+        # No duration -> no ``duration_seconds`` kwarg (keeps the active
+        # call record's ``duration_seconds`` untouched).
+        kwargs = srv._metrics_store.update_call_status.call_args.kwargs
+        assert "duration_seconds" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_status_invalid_duration_swallowed(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+        srv._metrics_store = MagicMock()
+
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "4" * 32,
+                "CallStatus": "completed",
+                "CallDuration": "not-a-number",
+            }
+        )
+        response = await endpoint(request)
+        assert response.status_code == 204
+        # Status was still recorded — just without a duration.
+        srv._metrics_store.update_call_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_status_missing_sid_skips_store(self) -> None:
+        srv = _make_server()
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+        srv._metrics_store = MagicMock()
+
+        request = _MockRequest(
+            form_data={"CallStatus": "ringing"}  # no CallSid
+        )
+        response = await endpoint(request)
+
+        assert response.status_code == 204
+        srv._metrics_store.update_call_status.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_status_with_no_metrics_store_returns_204(self) -> None:
+        """Dashboard disabled -> no store; endpoint must still accept the POST."""
+        srv = _make_server(dashboard=False)
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "5" * 32,
+                "CallStatus": "completed",
+            }
+        )
+        response = await endpoint(request)
+        assert response.status_code == 204  # no raise, no store
+
+
+@pytest.mark.unit
+class TestStatusSignature:
+    """Signature enforcement on the status endpoint mirrors the other routes."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature_returns_403(self) -> None:
+        srv = _make_server()
+        srv.config = LocalConfig(
+            telephony_provider="twilio",
+            twilio_sid="ACtest000000000000000000000000000",
+            twilio_token="real_token_value",  # -> validator active
+            openai_key="sk-test",
+            webhook_url="test.ngrok.io",
+        )
+        app = srv._create_app()
+        endpoint = _get_endpoint(app, "/webhooks/twilio/status")
+
+        request = _MockRequest(
+            form_data={
+                "CallSid": "CA" + "a" * 32,
+                "CallStatus": "ringing",
+            },
+            headers={"X-Twilio-Signature": "wrong"},
+        )
+        response = await endpoint(request)
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# ring_timeout propagation through Patter.call()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRingTimeoutPropagation:
+    """``ring_timeout`` must end up in the dial parameters for each provider."""
+
+    @pytest.mark.asyncio
+    async def test_twilio_ring_timeout_becomes_timeout_param(self) -> None:
+        from patter.client import Patter
+
+        cfg = LocalConfig(
+            telephony_provider="twilio",
+            twilio_sid="ACtest000000000000000000000000000",
+            twilio_token="tok_test",
+            openai_key="sk-test",
+            webhook_url="test.ngrok.io",
+            phone_number="+15551234567",
+        )
+        phone = Patter.__new__(Patter)
+        phone._mode = "local"
+        phone._local_config = cfg
+        phone._server = None
+
+        with patch(
+            "patter.providers.twilio_adapter.TwilioAdapter"
+        ) as mock_adapter_cls:
+            mock_adapter = mock_adapter_cls.return_value
+            mock_adapter.initiate_call = AsyncMock(
+                return_value="CA" + "9" * 32
+            )
+
+            await phone.call(
+                to="+15559876543",
+                agent=make_agent(),
+                ring_timeout=45,
+            )
+
+            mock_adapter.initiate_call.assert_awaited_once()
+            extra_params = mock_adapter.initiate_call.await_args.kwargs[
+                "extra_params"
+            ]
+            assert extra_params["Timeout"] == 45
+
+    @pytest.mark.asyncio
+    async def test_twilio_ring_timeout_omitted_when_none(self) -> None:
+        """Passing no ring_timeout must not inject Timeout into the payload."""
+        from patter.client import Patter
+
+        cfg = LocalConfig(
+            telephony_provider="twilio",
+            twilio_sid="ACtest000000000000000000000000000",
+            twilio_token="tok_test",
+            openai_key="sk-test",
+            webhook_url="test.ngrok.io",
+            phone_number="+15551234567",
+        )
+        phone = Patter.__new__(Patter)
+        phone._mode = "local"
+        phone._local_config = cfg
+        phone._server = None
+
+        with patch(
+            "patter.providers.twilio_adapter.TwilioAdapter"
+        ) as mock_adapter_cls:
+            mock_adapter = mock_adapter_cls.return_value
+            mock_adapter.initiate_call = AsyncMock(
+                return_value="CA" + "8" * 32
+            )
+
+            await phone.call(to="+15559876543", agent=make_agent())
+
+            extra_params = mock_adapter.initiate_call.await_args.kwargs[
+                "extra_params"
+            ]
+            assert "Timeout" not in extra_params
+
+    @pytest.mark.asyncio
+    async def test_twilio_statuscallback_always_registered(self) -> None:
+        """BUG #06 — every outbound Twilio call must set StatusCallback so
+        the dashboard receives ringing / no-answer / busy transitions."""
+        from patter.client import Patter
+
+        cfg = LocalConfig(
+            telephony_provider="twilio",
+            twilio_sid="ACtest000000000000000000000000000",
+            twilio_token="tok_test",
+            openai_key="sk-test",
+            webhook_url="test.ngrok.io",
+            phone_number="+15551234567",
+        )
+        phone = Patter.__new__(Patter)
+        phone._mode = "local"
+        phone._local_config = cfg
+        phone._server = None
+
+        with patch(
+            "patter.providers.twilio_adapter.TwilioAdapter"
+        ) as mock_adapter_cls:
+            mock_adapter = mock_adapter_cls.return_value
+            mock_adapter.initiate_call = AsyncMock(
+                return_value="CA" + "7" * 32
+            )
+
+            await phone.call(to="+15559876543", agent=make_agent())
+
+            extra = mock_adapter.initiate_call.await_args.kwargs[
+                "extra_params"
+            ]
+            assert (
+                extra["StatusCallback"]
+                == "https://test.ngrok.io/webhooks/twilio/status"
+            )
+            assert extra["StatusCallbackMethod"] == "POST"
+            # Events we care about for BUG #06.
+            assert "ringing" in extra["StatusCallbackEvent"]
+            assert "completed" in extra["StatusCallbackEvent"]
+
+    @pytest.mark.asyncio
+    async def test_telnyx_ring_timeout_becomes_timeout_secs(self) -> None:
+        """Telnyx uses ``timeout_secs``, not ``Timeout`` — confirm the adapter
+        receives the kwarg verbatim."""
+        from patter.providers.telnyx_adapter import TelnyxAdapter
+
+        adapter = TelnyxAdapter(
+            api_key="tk_test",
+            connection_id="conn-1",
+        )
+
+        captured: dict = {}
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"data": {"call_control_id": "v3:xyz"}}
+
+        async def _fake_post(path: str, **kwargs):
+            captured["path"] = path
+            captured["json"] = kwargs.get("json", {})
+            return _Resp()
+
+        adapter._client = MagicMock()
+        adapter._client.post = _fake_post
+
+        await adapter.initiate_call(
+            "+15551234567",
+            "+15559876543",
+            "wss://test.ngrok.io/ws/telnyx/stream/outbound",
+            ring_timeout=30,
+        )
+
+        assert captured["path"] == "/calls"
+        assert captured["json"]["timeout_secs"] == 30
+
+    @pytest.mark.asyncio
+    async def test_telnyx_ring_timeout_omitted_when_none(self) -> None:
+        from patter.providers.telnyx_adapter import TelnyxAdapter
+
+        adapter = TelnyxAdapter(api_key="tk_test", connection_id="conn-1")
+        captured: dict = {}
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"data": {"call_control_id": "v3:xyz"}}
+
+        async def _fake_post(path: str, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return _Resp()
+
+        adapter._client = MagicMock()
+        adapter._client.post = _fake_post
+
+        await adapter.initiate_call(
+            "+15551234567",
+            "+15559876543",
+            "wss://test.ngrok.io/ws/telnyx/stream/outbound",
+        )
+
+        assert "timeout_secs" not in captured["json"]

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.4.0",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -18,11 +18,31 @@ import type {
   Guardrail,
   ToolDefinition,
 } from "./types";
-import { deepgram, whisper, elevenlabs, openaiTts } from "./providers";
+import { deepgram, whisper, elevenlabs, openaiTts, cartesia, rime, lmnt } from "./providers";
 import { EmbeddedServer } from "./server";
 
 const DEFAULT_BACKEND_URL = "wss://api.getpatter.com";
 const DEFAULT_REST_URL = "https://api.getpatter.com";
+
+function sttConfigToDict(cfg: STTConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    provider: cfg.provider,
+    api_key: cfg.apiKey,
+    language: cfg.language,
+  };
+  if (cfg.options) out.options = { ...cfg.options };
+  return out;
+}
+
+function ttsConfigToDict(cfg: TTSConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    provider: cfg.provider,
+    api_key: cfg.apiKey,
+    voice: cfg.voice,
+  };
+  if (cfg.options) out.options = { ...cfg.options };
+  return out;
+}
 
 export class Patter {
   readonly apiKey: string;
@@ -35,7 +55,17 @@ export class Patter {
   private tunnelHandle: TunnelHandle | null = null;
 
   constructor(options: PatterOptions | LocalOptions) {
-    if ('mode' in options && options.mode === 'local') {
+    // Auto-detect local mode when a telephony credential is supplied and no
+    // cloud ``apiKey`` is present. Matches Python: ``Patter(twilio_sid=...)``
+    // implicitly selects local mode. Passing ``mode: 'local'`` explicitly
+    // still works and forces local mode.
+    const isLocal =
+      ('mode' in options && options.mode === 'local') ||
+      (!('apiKey' in options) &&
+        (('twilioSid' in options && (options as LocalOptions).twilioSid) ||
+          ('telnyxKey' in options && (options as LocalOptions).telnyxKey)));
+
+    if (isLocal) {
       const local = options as LocalOptions;
 
       if (!local.phoneNumber) {
@@ -235,22 +265,42 @@ export class Patter {
           `wss://${webhookUrl}/ws/stream/${encodeURIComponent(localOpts.to)}` +
           `?caller=${encodeURIComponent(phoneNumber)}&callee=${encodeURIComponent(localOpts.to)}`;
 
+        const telnyxPayload: Record<string, unknown> = {
+          connection_id: connectionId,
+          from: phoneNumber,
+          to: localOpts.to,
+          stream_url: streamUrl,
+          stream_track: 'both_tracks',
+        };
+        if (localOpts.ringTimeout !== undefined) {
+          telnyxPayload.timeout_secs = Math.max(1, Math.floor(localOpts.ringTimeout));
+        }
         const response = await fetch('https://api.telnyx.com/v2/calls', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${telnyxKey}`,
           },
-          body: JSON.stringify({
-            connection_id: connectionId,
-            from: phoneNumber,
-            to: localOpts.to,
-            stream_url: streamUrl,
-            stream_track: 'both_tracks',
-          }),
+          body: JSON.stringify(telnyxPayload),
         });
         if (!response.ok) {
           throw new ProvisionError(`Failed to initiate Telnyx call: ${await response.text()}`);
+        }
+        if (this.embeddedServer) {
+          try {
+            const body = (await response.clone().json()) as { data?: { call_control_id?: string } };
+            const callId = body.data?.call_control_id;
+            if (callId) {
+              this.embeddedServer.metricsStore.recordCallInitiated({
+                call_id: callId,
+                caller: phoneNumber,
+                callee: localOpts.to,
+                direction: 'outbound',
+              });
+            }
+          } catch {
+            /* non-fatal */
+          }
         }
         return;
       }
@@ -266,11 +316,17 @@ export class Patter {
         Url: `https://${webhookUrl}/webhooks/twilio/voice`,
         StatusCallback: statusCallbackUrl,
         StatusCallbackMethod: 'POST',
+        // Full lifecycle so the dashboard sees ringing/no-answer/busy/failed
+        // transitions even when media never arrives.
+        StatusCallbackEvent: 'initiated ringing answered completed',
       });
       if (localOpts.machineDetection) {
         params.append('MachineDetection', 'DetectMessageEnd');
         params.append('AsyncAmd', 'true');
         params.append('AsyncAmdStatusCallback', `https://${webhookUrl}/webhooks/twilio/amd`);
+      }
+      if (localOpts.ringTimeout !== undefined) {
+        params.append('Timeout', String(Math.max(1, Math.floor(localOpts.ringTimeout))));
       }
       // Store voicemail message on the running server so AMD webhook can use it
       if (localOpts.voicemailMessage && this.embeddedServer) {
@@ -286,6 +342,24 @@ export class Patter {
       });
       if (!response.ok) {
         throw new ProvisionError(`Failed to initiate call: ${await response.text()}`);
+      }
+      // Pre-register the call so the dashboard shows attempts even when the
+      // callee never answers (no-answer, busy, carrier-rejected). BUG #06.
+      if (this.embeddedServer) {
+        try {
+          const body = (await response.clone().json()) as { sid?: string };
+          const callSid = body.sid;
+          if (callSid) {
+            this.embeddedServer.metricsStore.recordCallInitiated({
+              call_id: callSid,
+              caller: phoneNumber,
+              callee: localOpts.to,
+              direction: 'outbound',
+            });
+          }
+        } catch {
+          /* non-fatal — the statusCallback will register anyway */
+        }
       }
       return;
     }
@@ -376,11 +450,15 @@ export class Patter {
     return data.map(c => ({ id: c.id, direction: c.direction, caller: c.caller, callee: c.callee, startedAt: c.started_at, endedAt: c.ended_at, durationSeconds: c.duration_seconds, status: c.status, transcript: c.transcript }));
   }
 
-  // Provider helpers
+  // Provider helpers — mirror the Python classmethod factories so callers can
+  // write ``Patter.deepgram({ apiKey })`` without importing the top-level.
   static deepgram = deepgram;
   static whisper = whisper;
   static elevenlabs = elevenlabs;
   static openaiTts = openaiTts;
+  static cartesia = cartesia;
+  static rime = rime;
+  static lmnt = lmnt;
 
   static guardrail(opts: {
     name: string;
@@ -469,8 +547,8 @@ export class Patter {
         provider,
         provider_credentials: credentials,
         country,
-        stt_config: stt?.toDict() ?? null,
-        tts_config: tts?.toDict() ?? null,
+        stt_config: stt ? (stt.toDict?.() ?? sttConfigToDict(stt)) : null,
+        tts_config: tts ? (tts.toDict?.() ?? ttsConfigToDict(tts)) : null,
       }),
     });
 

--- a/sdk-ts/src/dashboard/store.ts
+++ b/sdk-ts/src/dashboard/store.ts
@@ -14,6 +14,12 @@ export interface CallRecord {
   direction: string;
   started_at: number;
   ended_at?: number;
+  /**
+   * Current lifecycle state: ``initiated`` (pre-registered), ``ringing``,
+   * ``in-progress``, ``completed``, ``no-answer``, ``busy``, ``failed``,
+   * ``canceled``, or ``webhook_error``.
+   */
+  status?: string;
   transcript?: Array<{ role: string; text: string; timestamp: number }>;
   turns?: unknown[];
   metrics?: Record<string, unknown> | null;
@@ -30,9 +36,18 @@ export class MetricsStore extends EventEmitter {
   private calls: CallRecord[] = [];
   private activeCalls: Map<string, CallRecord> = new Map();
 
-  constructor(maxCalls = 500) {
+  /**
+   * Accepts either a numeric ``maxCalls`` (legacy positional — matches the
+   * original TS API) or an options object ``{ maxCalls }`` to align with the
+   * Python SDK's keyword-argument style. Plain literals also work:
+   * ``new MetricsStore()`` / ``new MetricsStore(100)`` / ``new MetricsStore({ maxCalls: 100 })``.
+   */
+  constructor(maxCallsOrOpts: number | { maxCalls?: number } = 500) {
     super();
-    this.maxCalls = maxCalls;
+    this.maxCalls =
+      typeof maxCallsOrOpts === 'number'
+        ? maxCallsOrOpts
+        : maxCallsOrOpts.maxCalls ?? 500;
   }
 
   private publish(eventType: string, data: Record<string, unknown>): void {
@@ -43,22 +58,105 @@ export class MetricsStore extends EventEmitter {
     const callId = (data.call_id as string) || '';
     if (!callId) return;
 
-    const record: CallRecord = {
+    const existing = this.activeCalls.get(callId);
+    if (existing) {
+      // Upgrade a pre-registered (``initiated``) outbound call to in-progress
+      // without losing its from/to metadata. See BUG #06.
+      existing.caller = (data.caller as string) || existing.caller;
+      existing.callee = (data.callee as string) || existing.callee;
+      existing.direction = (data.direction as string) || existing.direction;
+      existing.status = 'in-progress';
+      existing.turns = existing.turns || [];
+    } else {
+      const record: CallRecord = {
+        call_id: callId,
+        caller: (data.caller as string) || '',
+        callee: (data.callee as string) || '',
+        direction: (data.direction as string) || 'inbound',
+        started_at: Date.now() / 1000,
+        status: 'in-progress',
+        turns: [],
+      };
+      this.activeCalls.set(callId, record);
+    }
+
+    this.publish('call_start', {
       call_id: callId,
       caller: (data.caller as string) || '',
       callee: (data.callee as string) || '',
       direction: (data.direction as string) || 'inbound',
+    });
+  }
+
+  /**
+   * Pre-register an outbound call before any webhook fires. Lets the
+   * dashboard surface attempts that never reach media (no-answer, busy,
+   * carrier-rejected). Mirrors the Python ``record_call_initiated``.
+   */
+  recordCallInitiated(data: Record<string, unknown>): void {
+    const callId = (data.call_id as string) || '';
+    if (!callId) return;
+    if (this.activeCalls.has(callId)) return; // first writer wins
+
+    const record: CallRecord = {
+      call_id: callId,
+      caller: (data.caller as string) || '',
+      callee: (data.callee as string) || '',
+      direction: (data.direction as string) || 'outbound',
       started_at: Date.now() / 1000,
+      status: 'initiated',
       turns: [],
     };
     this.activeCalls.set(callId, record);
-
-    this.publish('call_start', {
+    this.publish('call_initiated', {
       call_id: callId,
       caller: record.caller,
       callee: record.callee,
       direction: record.direction,
+      status: record.status,
     });
+  }
+
+  /**
+   * Update the status of an active or completed call. Terminal states
+   * (completed, no-answer, busy, failed, canceled, webhook_error) move the
+   * row from active to completed so the UI freezes the live duration timer.
+   */
+  updateCallStatus(callId: string, status: string, extra: Record<string, unknown> = {}): void {
+    if (!callId || !status) return;
+    const TERMINAL = new Set(['completed', 'no-answer', 'busy', 'failed', 'canceled', 'webhook_error']);
+    const active = this.activeCalls.get(callId);
+    if (active) {
+      active.status = status;
+      Object.assign(active, extra);
+      if (TERMINAL.has(status)) {
+        const entry: CallRecord = {
+          call_id: callId,
+          caller: active.caller || '',
+          callee: active.callee || '',
+          direction: active.direction || 'outbound',
+          started_at: active.started_at || 0,
+          ended_at: Date.now() / 1000,
+          status,
+          metrics: null,
+          ...extra,
+        };
+        this.activeCalls.delete(callId);
+        this.calls.push(entry);
+        if (this.calls.length > this.maxCalls) {
+          this.calls = this.calls.slice(-this.maxCalls);
+        }
+      }
+    } else {
+      for (let i = this.calls.length - 1; i >= 0; i--) {
+        if (this.calls[i].call_id === callId) {
+          this.calls[i].status = status;
+          Object.assign(this.calls[i], extra);
+          break;
+        }
+      }
+    }
+    this.publish('call_status', { call_id: callId, status, ...extra });
   }
 
   recordTurn(data: Record<string, unknown>): void {
@@ -82,6 +180,12 @@ export class MetricsStore extends EventEmitter {
     const active = this.activeCalls.get(callId);
     this.activeCalls.delete(callId);
 
+    // Preserve explicit status set by a statusCallback during the call
+    // (e.g. "no-answer" from Twilio) — fall back to "completed" when the
+    // row was still showing the normal "in-progress" state at hang-up.
+    const activeStatus = active?.status;
+    const resolvedStatus =
+      activeStatus && activeStatus !== 'in-progress' ? activeStatus : 'completed';
     const entry: CallRecord = {
       call_id: callId,
       caller: (data.caller as string) || active?.caller || '',
@@ -90,6 +194,7 @@ export class MetricsStore extends EventEmitter {
       started_at: active?.started_at || 0,
       ended_at: Date.now() / 1000,
       transcript: (data.transcript as CallRecord['transcript']) || [],
+      status: resolvedStatus,
       metrics: metrics ?? null,
     };
 

--- a/sdk-ts/src/fallback-provider.ts
+++ b/sdk-ts/src/fallback-provider.ts
@@ -86,6 +86,43 @@ export class FallbackLLMProvider implements LLMProvider {
     }
   }
 
+  /**
+   * Async-friendly disposer. Parity with Python's ``FallbackLLMProvider.aclose()``
+   * — safe to call multiple times, returns a resolved Promise once all probe
+   * timers are cleared. Prefer this in async contexts so awaiting the
+   * shutdown integrates naturally with the owning lifecycle.
+   */
+  async aclose(): Promise<void> {
+    this.destroy();
+  }
+
+  /**
+   * Explicit-resource-management hook so callers can write
+   * ``await using fallback = new FallbackLLMProvider([...])`` and have
+   * background probe timers cleared automatically when the block exits.
+   * Mirrors Python's ``async with FallbackLLMProvider(...)``.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.aclose();
+  }
+
+  /**
+   * Stream only the text deltas, flattening the chunk envelope. Parity with
+   * Python's ``FallbackLLMProvider.complete_stream``. Tool-call and done
+   * markers are filtered out so callers can concatenate the yielded strings
+   * directly.
+   */
+  async *completeStream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+  ): AsyncGenerator<string, void, unknown> {
+    for await (const chunk of this.stream(messages, tools)) {
+      if ((chunk as { type?: string }).type === 'text') {
+        yield ((chunk as { content?: string }).content ?? '') as string;
+      }
+    }
+  }
+
   // -----------------------------------------------------------------------
   // LLMProvider implementation
   // -----------------------------------------------------------------------

--- a/sdk-ts/src/providers.ts
+++ b/sdk-ts/src/providers.ts
@@ -4,15 +4,28 @@ class STTConfigImpl implements STTConfig {
   readonly provider: string;
   readonly apiKey: string;
   readonly language: string;
+  readonly options?: Record<string, unknown>;
 
-  constructor(provider: string, apiKey: string, language: string = "en") {
+  constructor(
+    provider: string,
+    apiKey: string,
+    language: string = "en",
+    options?: Record<string, unknown>,
+  ) {
     this.provider = provider;
     this.apiKey = apiKey;
     this.language = language;
+    if (options) this.options = options;
   }
 
-  toDict(): Record<string, string> {
-    return { provider: this.provider, api_key: this.apiKey, language: this.language };
+  toDict(): Record<string, string | Record<string, unknown>> {
+    const out: Record<string, string | Record<string, unknown>> = {
+      provider: this.provider,
+      api_key: this.apiKey,
+      language: this.language,
+    };
+    if (this.options) out.options = { ...this.options };
+    return out;
   }
 }
 
@@ -32,8 +45,29 @@ class TTSConfigImpl implements TTSConfig {
   }
 }
 
-export function deepgram(opts: { apiKey: string; language?: string }): STTConfig {
-  return new STTConfigImpl("deepgram", opts.apiKey, opts.language ?? "en");
+/**
+ * Deepgram STT config. Tune latency via ``endpointingMs`` / ``utteranceEndMs``
+ * — mirrors Python's ``Patter.deepgram(endpointing_ms=..., utterance_end_ms=...)``.
+ */
+export function deepgram(opts: {
+  apiKey: string;
+  language?: string;
+  model?: string;
+  endpointingMs?: number;
+  utteranceEndMs?: number | null;
+  smartFormat?: boolean;
+  interimResults?: boolean;
+  vadEvents?: boolean;
+}): STTConfig {
+  const options: Record<string, unknown> = {
+    model: opts.model ?? "nova-3",
+    endpointing_ms: opts.endpointingMs ?? 150,
+    utterance_end_ms: opts.utteranceEndMs === null ? null : (opts.utteranceEndMs ?? 1000),
+    smart_format: opts.smartFormat ?? true,
+    interim_results: opts.interimResults ?? true,
+  };
+  if (opts.vadEvents !== undefined) options.vad_events = opts.vadEvents;
+  return new STTConfigImpl("deepgram", opts.apiKey, opts.language ?? "en", options);
 }
 
 export function whisper(opts: { apiKey: string; language?: string }): STTConfig {

--- a/sdk-ts/src/providers/deepgram-stt.ts
+++ b/sdk-ts/src/providers/deepgram-stt.ts
@@ -11,23 +11,104 @@ type TranscriptCallback = (transcript: Transcript) => void;
 
 const DEEPGRAM_WS_URL = 'wss://api.deepgram.com/v1/listen';
 
+/**
+ * Optional tuning knobs for Deepgram live transcription.
+ *
+ * Mirrors Python's ``DeepgramSTT`` kwargs so callers can lower turn latency
+ * without monkey-patching (BUG #13).
+ */
+export interface DeepgramSTTOptions {
+  /** Model name. Default ``nova-3``. */
+  readonly model?: string;
+  /** Audio encoding (``linear16`` | ``mulaw`` | etc). Default ``linear16``. */
+  readonly encoding?: string;
+  /** Sample rate in Hz. Default ``16000``. */
+  readonly sampleRate?: number;
+  /**
+   * Voice-activity endpointing threshold in milliseconds.
+   * Lower values reduce turn latency at the cost of more false-start cuts.
+   * Default ``150``.
+   */
+  readonly endpointingMs?: number;
+  /**
+   * End-of-utterance silence window in milliseconds. Deepgram enforces a
+   * hard minimum of 1000 ms. Set to ``null`` to disable. Default ``1000``.
+   */
+  readonly utteranceEndMs?: number | null;
+  /** Enable smart formatting (punctuation + numerals). Default ``true``. */
+  readonly smartFormat?: boolean;
+  /** Emit interim (non-final) transcripts. Default ``true``. */
+  readonly interimResults?: boolean;
+  /** Emit VAD events (``SpeechStarted`` / ``UtteranceEnd``). Default ``true``. */
+  readonly vadEvents?: boolean;
+}
+
 export class DeepgramSTT {
   private ws: WebSocket | null = null;
   private callbacks: TranscriptCallback[] = [];
   /** Request ID from Deepgram — used to query actual cost post-call. */
   requestId: string = '';
 
-  constructor(
-    private readonly apiKey: string,
-    private readonly language: string = 'en',
-    private readonly model: string = 'nova-3',
-    private readonly encoding: string = 'linear16',
-    private readonly sampleRate: number = 16000,
-  ) {}
+  private readonly apiKey: string;
+  private readonly language: string;
+  private readonly model: string;
+  private readonly encoding: string;
+  private readonly sampleRate: number;
+  private readonly endpointingMs: number;
+  private readonly utteranceEndMs: number | null;
+  private readonly smartFormat: boolean;
+  private readonly interimResults: boolean;
+  private readonly vadEvents: boolean;
 
-  /** Factory for Twilio calls — mulaw 8 kHz. */
-  static forTwilio(apiKey: string, language: string = 'en', model: string = 'nova-3'): DeepgramSTT {
-    return new DeepgramSTT(apiKey, language, model, 'mulaw', 8000);
+  /**
+   * New ergonomic constructor accepting an options object (mirrors Python kwargs).
+   *
+   * Also accepts the legacy positional form
+   * ``(apiKey, language?, model?, encoding?, sampleRate?)`` for backward
+   * compatibility with code that predated BUG #13.
+   */
+  constructor(
+    apiKey: string,
+    language?: string,
+    model?: string,
+    encoding?: string,
+    sampleRate?: number,
+    options?: DeepgramSTTOptions,
+  );
+  constructor(apiKey: string, options: DeepgramSTTOptions & { language?: string });
+  constructor(
+    apiKey: string,
+    languageOrOptions?: string | (DeepgramSTTOptions & { language?: string }),
+    model?: string,
+    encoding?: string,
+    sampleRate?: number,
+    options?: DeepgramSTTOptions,
+  ) {
+    this.apiKey = apiKey;
+    const opts: DeepgramSTTOptions & { language?: string } =
+      typeof languageOrOptions === 'object' && languageOrOptions !== null
+        ? languageOrOptions
+        : options ?? {};
+
+    this.language = (typeof languageOrOptions === 'string' ? languageOrOptions : opts.language) ?? 'en';
+    this.model = model ?? opts.model ?? 'nova-3';
+    this.encoding = encoding ?? opts.encoding ?? 'linear16';
+    this.sampleRate = sampleRate ?? opts.sampleRate ?? 16000;
+    this.endpointingMs = opts.endpointingMs ?? 150;
+    this.utteranceEndMs = opts.utteranceEndMs === null ? null : opts.utteranceEndMs ?? 1000;
+    this.smartFormat = opts.smartFormat ?? true;
+    this.interimResults = opts.interimResults ?? true;
+    this.vadEvents = opts.vadEvents ?? true;
+  }
+
+  /** Factory for Twilio calls — mulaw 8 kHz. Forwards tuning options through. */
+  static forTwilio(
+    apiKey: string,
+    language: string = 'en',
+    model: string = 'nova-3',
+    options: DeepgramSTTOptions = {},
+  ): DeepgramSTT {
+    return new DeepgramSTT(apiKey, language, model, 'mulaw', 8000, options);
   }
 
   async connect(): Promise<void> {
@@ -37,12 +118,16 @@ export class DeepgramSTT {
       encoding: this.encoding,
       sample_rate: String(this.sampleRate),
       channels: '1',
-      interim_results: 'true',
-      endpointing: '300',
-      smart_format: 'true',
-      vad_events: 'true',
+      interim_results: this.interimResults ? 'true' : 'false',
+      endpointing: String(this.endpointingMs),
+      smart_format: this.smartFormat ? 'true' : 'false',
+      vad_events: this.vadEvents ? 'true' : 'false',
       no_delay: 'true',
     });
+    if (this.utteranceEndMs !== null) {
+      // Deepgram enforces a hard minimum of 1000 ms on this knob.
+      params.set('utterance_end_ms', String(Math.max(this.utteranceEndMs, 1000)));
+    }
 
     const url = `${DEEPGRAM_WS_URL}?${params.toString()}`;
 
@@ -89,9 +174,13 @@ export class DeepgramSTT {
       const text = (best.transcript ?? '').trim();
       if (!text) return;
 
+      // BUG #13 — ``is_final`` alone marks a stable utterance;
+      // ``speech_final`` is a faster end-of-utterance hint from Deepgram's
+      // VAD. Accept either so the pipeline doesn't wait up to
+      // utterance_end_ms on every turn.
       const transcript: Transcript = {
         text,
-        isFinal: Boolean(data.is_final) && Boolean(data.speech_final),
+        isFinal: Boolean(data.is_final) || Boolean(data.speech_final),
         confidence: best.confidence ?? 0,
       };
 

--- a/sdk-ts/src/providers/elevenlabs-tts.ts
+++ b/sdk-ts/src/providers/elevenlabs-tts.ts
@@ -1,12 +1,84 @@
 const ELEVENLABS_BASE_URL = 'https://api.elevenlabs.io/v1';
 
+// Curated map of common ElevenLabs voice display names to their voice IDs.
+// The public API only accepts voice IDs — callers that pass a human-readable
+// name like "rachel" would otherwise hit 404. Mirrors the Python SDK map.
+const ELEVENLABS_VOICE_ID_BY_NAME: Record<string, string> = {
+  rachel: '21m00Tcm4TlvDq8ikWAM',
+  drew: '29vD33N1CtxCmqQRPOHJ',
+  clyde: '2EiwWnXFnvU5JabPnv8n',
+  paul: '5Q0t7uMcjvnagumLfvZi',
+  domi: 'AZnzlk1XvdvUeBnXmlld',
+  dave: 'CYw3kZ02Hs0563khs1Fj',
+  fin: 'D38z5RcWu1voky8WS1ja',
+  bella: 'EXAVITQu4vr4xnSDxMaL',
+  antoni: 'ErXwobaYiN019PkySvjV',
+  thomas: 'GBv7mTt0atIp3Br8iCZE',
+  charlie: 'IKne3meq5aSn9XLyUdCD',
+  george: 'JBFqnCBsd6RMkjVDRZzb',
+  emily: 'LcfcDJNUP1GQjkzn1xUU',
+  elli: 'MF3mGyEYCl7XYWbV9V6O',
+  callum: 'N2lVS1w4EtoT3dr4eOWO',
+  patrick: 'ODq5zmih8GrVes37Dizd',
+  harry: 'SOYHLrjzK2X1ezoPC6cr',
+  liam: 'TX3LPaxmHKxFdv7VOQHJ',
+  dorothy: 'ThT5KcBeYPX3keUQqHPh',
+  josh: 'TxGEqnHWrfWFTfGW9XjX',
+  arnold: 'VR6AewLTigWG4xSOukaG',
+  charlotte: 'XB0fDUnXU5powFXDhCwa',
+  matilda: 'XrExE9yKIg1WjnnlVkGX',
+  matthew: 'Yko7PKHZNXotIFUBG7I9',
+  james: 'ZQe5CZNOzWyzPSCn5a3c',
+  joseph: 'Zlb1dXrM653N07WRdFW3',
+  jeremy: 'bVMeCyTHy58xNoL34h3p',
+  michael: 'flq6f7yk4E4fJM5XTYuZ',
+  ethan: 'g5CIjZEefAph4nQFvHAz',
+  gigi: 'jBpfuIE2acCO8z3wKNLl',
+  freya: 'jsCqWAovK2LkecY7zXl4',
+  brian: 'nPczCjzI2devNBz1zQrb',
+  grace: 'oWAxZDx7w5VEj9dCyTzz',
+  daniel: 'onwK4e9ZLuTAKqWW03F9',
+  lily: 'pFZP5JQG7iQjIQuC4Bku',
+  serena: 'pMsXgVXv3BLzUgSXRplE',
+  adam: 'pNInz6obpgDQGcFmaJgB',
+  nicole: 'piTKgcLEGmPE4e6mEKli',
+  bill: 'pqHfZKP75CvOlQylNhV4',
+  jessie: 't0jbNlBVZ17f02VDIeMI',
+  ryan: 'wViXBPUzp2ZZixB1xQuM',
+  sam: 'yoZ06aMxZJJ28mfd3POQ',
+  glinda: 'z9fAnlkpzviPz146aGWa',
+  giovanni: 'zcAOhNBS3c14rBihAFp1',
+  mimi: 'zrHiDhphv9ZnVXBqCLjz',
+  alloy: '21m00Tcm4TlvDq8ikWAM',
+};
+
+const VOICE_ID_PATTERN = /^[A-Za-z0-9]{20}$/;
+
+/**
+ * Return an ElevenLabs voice ID from either a UUID-like ID or a display name.
+ *
+ * Opaque ElevenLabs voice IDs are 20-char alphanumeric tokens — anything
+ * matching that shape is returned verbatim. Known display names (case-
+ * insensitive) are resolved via the internal table. Unknown strings are
+ * returned as-is so custom voices keep working.
+ */
+export function resolveVoiceId(voice: string): string {
+  if (!voice) return voice;
+  if (VOICE_ID_PATTERN.test(voice)) return voice;
+  return ELEVENLABS_VOICE_ID_BY_NAME[voice.toLowerCase()] ?? voice;
+}
+
 export class ElevenLabsTTS {
+  private readonly voiceId: string;
+
   constructor(
     private readonly apiKey: string,
-    private readonly voiceId: string = '21m00Tcm4TlvDq8ikWAM',
+    voiceId: string = '21m00Tcm4TlvDq8ikWAM',
     private readonly modelId: string = 'eleven_turbo_v2_5',
     private readonly outputFormat: string = 'pcm_16000',
-  ) {}
+  ) {
+    this.voiceId = resolveVoiceId(voiceId);
+  }
 
   /**
    * Synthesise text to speech and return the full audio as a single Buffer.

--- a/sdk-ts/src/providers/openai-tts.ts
+++ b/sdk-ts/src/providers/openai-tts.ts
@@ -25,6 +25,11 @@ export class OpenAITTS {
    *
    * OpenAI returns 24 kHz PCM16; each chunk is resampled to 16 kHz before
    * yielding so the output is ready for telephony pipelines.
+   *
+   * The resampler carries state (buffered samples + odd trailing byte)
+   * between chunks — without that state cross-chunk sample alignment drifts
+   * and the caller hears pops / dropped audio (BUG #23, mirror of the
+   * Python `audioop.ratecv` fix).
    */
   async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
     const response = await fetch(OPENAI_TTS_URL, {
@@ -51,14 +56,27 @@ export class OpenAITTS {
       throw new Error('OpenAI TTS: no response body');
     }
 
+    // Stateful resampler: keeps leftover samples + an odd trailing byte so
+    // chunk N+1 continues the 3:2 cadence where chunk N stopped.
+    const ctx = { carryByte: null as number | null, leftover: [] as number[] };
+
     const reader = response.body.getReader();
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
         if (value && value.length > 0) {
-          yield OpenAITTS.resample24kTo16k(Buffer.from(value));
+          const out = OpenAITTS.resampleStreaming(Buffer.from(value), ctx);
+          if (out.length > 0) yield out;
         }
+      }
+      // Flush trailing leftover (≤2 samples) at stream end.
+      if (ctx.leftover.length > 0) {
+        const tail = Buffer.alloc(ctx.leftover.length * 2);
+        for (let i = 0; i < ctx.leftover.length; i++) {
+          tail.writeInt16LE(ctx.leftover[i], i * 2);
+        }
+        yield tail;
       }
     } finally {
       if (typeof reader.cancel === 'function') await reader.cancel().catch(() => {});
@@ -67,38 +85,63 @@ export class OpenAITTS {
   }
 
   /**
-   * Resample 24 kHz PCM16-LE to 16 kHz by taking 2 out of every 3 samples.
-   *
-   * For each group of 3 input samples the first is kept as-is and the second
-   * output sample is the average of input samples 2 and 3.  This matches the
-   * Python SDK implementation.
+   * Streaming 24 kHz → 16 kHz resampler (PCM16-LE). Maintains cross-chunk
+   * state so the 3:2 pattern doesn't reset at every network read.
    */
-  static resample24kTo16k(audio: Buffer): Buffer {
-    if (audio.length < 2) return audio;
+  static resampleStreaming(
+    audio: Buffer,
+    ctx: { carryByte: number | null; leftover: number[] },
+  ): Buffer {
+    // Prepend an odd trailing byte from the previous chunk (PCM16 = 2 B/sample).
+    let buf: Buffer;
+    if (ctx.carryByte !== null) {
+      buf = Buffer.concat([Buffer.from([ctx.carryByte]), audio]);
+      ctx.carryByte = null;
+    } else {
+      buf = audio;
+    }
+    if (buf.length % 2 === 1) {
+      ctx.carryByte = buf[buf.length - 1];
+      buf = buf.subarray(0, buf.length - 1);
+    }
+    if (buf.length === 0 && ctx.leftover.length === 0) {
+      return Buffer.alloc(0);
+    }
 
-    const sampleCount = Math.floor(audio.length / 2);
-    const samples = new Int16Array(sampleCount);
+    const sampleCount = buf.length / 2;
+    // Combine leftover samples from the previous chunk with the new ones.
+    const samples: number[] = ctx.leftover.slice();
     for (let i = 0; i < sampleCount; i++) {
-      samples[i] = audio.readInt16LE(i * 2);
+      samples.push(buf.readInt16LE(i * 2));
     }
 
-    const resampled: number[] = [];
-    for (let i = 0; i < samples.length; i += 3) {
-      resampled.push(samples[i]);
-      if (i + 1 < samples.length) {
-        if (i + 2 < samples.length) {
-          // Interpolate between sample i+1 and i+2
-          resampled.push(Math.trunc((samples[i + 1] + samples[i + 2]) / 2));
-        } else {
-          resampled.push(samples[i + 1]);
-        }
-      }
+    const out: number[] = [];
+    let i = 0;
+    // Process complete groups of 3 input samples → 2 output samples.
+    while (i + 2 < samples.length) {
+      out.push(samples[i]);
+      out.push(Math.trunc((samples[i + 1] + samples[i + 2]) / 2));
+      i += 3;
     }
+    // Keep any unprocessed trailing samples (0, 1, or 2) for the next call.
+    ctx.leftover = samples.slice(i);
 
-    const out = Buffer.alloc(resampled.length * 2);
-    for (let i = 0; i < resampled.length; i++) {
-      out.writeInt16LE(resampled[i], i * 2);
+    const buffer = Buffer.alloc(out.length * 2);
+    for (let j = 0; j < out.length; j++) {
+      buffer.writeInt16LE(out[j], j * 2);
     }
-    return out;
+    return buffer;
+  }
+
+  /** @deprecated use {@link resampleStreaming} with persistent state. */
+  static resample24kTo16k(audio: Buffer): Buffer {
+    const ctx = { carryByte: null as number | null, leftover: [] as number[] };
+    const out = OpenAITTS.resampleStreaming(audio, ctx);
+    if (ctx.leftover.length === 0) return out;
+    const tail = Buffer.alloc(ctx.leftover.length * 2);
+    for (let i = 0; i < ctx.leftover.length; i++) {
+      tail.writeInt16LE(ctx.leftover[i], i * 2);
+    }
+    return Buffer.concat([out, tail]);
   }
 }

--- a/sdk-ts/src/scheduler.ts
+++ b/sdk-ts/src/scheduler.ts
@@ -76,17 +76,43 @@ function wrapCallback(cb: JobCallback): () => void {
   };
 }
 
-/** Schedule ``callback`` on a cron expression (node-cron dialect). */
-export async function scheduleCron(
-  cron: string,
-  callback: JobCallback,
-): Promise<ScheduleHandle> {
-  const cm = await loadCron();
-  if (!cm.validate(cron)) {
-    throw new Error(`Invalid cron expression: ${cron}`);
-  }
-  const task = cm.schedule(cron, wrapCallback(callback));
-  return makeHandle(`cron-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, task);
+/** Schedule ``callback`` on a cron expression (node-cron dialect).
+ *
+ * Returns a ``ScheduleHandle`` synchronously (parity with Python
+ * ``schedule_cron``). The handle is "pending" until the lazy ``node-cron``
+ * import resolves; cancelling the handle before then discards the pending
+ * job cleanly. If ``node-cron`` is not installed, the returned promise
+ * attached to ``.ready`` rejects with a helpful install message.
+ */
+export function scheduleCron(cron: string, callback: JobCallback): ScheduleHandle {
+  let cancelled = false;
+  let task: CronTask | null = null;
+  const jobId = `cron-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  loadCron()
+    .then((cm) => {
+      if (cancelled) return;
+      if (!cm.validate(cron)) {
+        throw new Error(`Invalid cron expression: ${cron}`);
+      }
+      task = cm.schedule(cron, wrapCallback(callback));
+    })
+    .catch((err) => getLogger().error(`scheduleCron failed: ${String(err)}`));
+
+  return {
+    jobId,
+    cancel(): void {
+      if (cancelled) return;
+      cancelled = true;
+      if (task) {
+        try { task.stop(); } catch { /* ignore */ }
+        try { task.destroy?.(); } catch { /* ignore */ }
+      }
+    },
+    get pending(): boolean {
+      return !cancelled;
+    },
+  };
 }
 
 /** Schedule ``callback`` once at the given date. */
@@ -112,9 +138,33 @@ export function scheduleOnce(at: Date, callback: JobCallback): ScheduleHandle {
   };
 }
 
-/** Schedule ``callback`` every ``intervalMs`` milliseconds. */
-export function scheduleInterval(intervalMs: number, callback: JobCallback): ScheduleHandle {
-  if (intervalMs <= 0) throw new Error('intervalMs must be positive');
+/**
+ * Schedule ``callback`` on a recurring interval.
+ *
+ * Accepts either a millisecond number (legacy, matches the original TS API)
+ * or an object with ``seconds`` / ``intervalMs`` for parity with Python's
+ * ``schedule_interval(seconds=...)``.
+ *
+ * Examples:
+ *   scheduleInterval(5000, cb)              // 5 s, legacy
+ *   scheduleInterval({ intervalMs: 5000 }, cb)
+ *   scheduleInterval({ seconds: 5 }, cb)    // parity with Python
+ */
+export function scheduleInterval(
+  intervalOrOpts: number | { seconds?: number; intervalMs?: number },
+  callback: JobCallback,
+): ScheduleHandle {
+  let intervalMs: number;
+  if (typeof intervalOrOpts === 'number') {
+    intervalMs = intervalOrOpts;
+  } else if (intervalOrOpts.intervalMs !== undefined) {
+    intervalMs = intervalOrOpts.intervalMs;
+  } else if (intervalOrOpts.seconds !== undefined) {
+    intervalMs = intervalOrOpts.seconds * 1000;
+  } else {
+    throw new Error('scheduleInterval requires seconds or intervalMs');
+  }
+  if (intervalMs <= 0) throw new Error('interval must be positive');
   let cancelled = false;
   const wrapped = wrapCallback(callback);
   const timer = setInterval(() => {
@@ -133,26 +183,3 @@ export function scheduleInterval(intervalMs: number, callback: JobCallback): Sch
   };
 }
 
-function makeHandle(jobId: string, task: CronTask): ScheduleHandle {
-  let cancelled = false;
-  return {
-    jobId,
-    cancel(): void {
-      if (cancelled) return;
-      cancelled = true;
-      try {
-        task.stop();
-      } catch {
-        /* ignore */
-      }
-      try {
-        task.destroy?.();
-      } catch {
-        /* ignore */
-      }
-    },
-    get pending(): boolean {
-      return !cancelled;
-    },
-  };
-}

--- a/sdk-ts/src/scheduler.ts
+++ b/sdk-ts/src/scheduler.ts
@@ -182,4 +182,3 @@ export function scheduleInterval(
     },
   };
 }
-

--- a/sdk-ts/src/server.ts
+++ b/sdk-ts/src/server.ts
@@ -242,6 +242,36 @@ export function buildAIAdapter(config: LocalConfig, agent: AgentOptions, resolve
 // Telephony bridge implementations
 // ---------------------------------------------------------------------------
 
+/**
+ * Normalize the ``options`` bag carried on an ``STTConfig`` into the strongly
+ * typed ``DeepgramSTTOptions`` shape. Accepts both snake_case (as produced by
+ * the ``deepgram()`` factory to match Python serialisation) and camelCase keys.
+ */
+type DeepgramOptionsMutable = {
+  -readonly [K in keyof import('./providers/deepgram-stt').DeepgramSTTOptions]:
+    import('./providers/deepgram-stt').DeepgramSTTOptions[K];
+};
+
+function extractDeepgramOptions(options?: Record<string, unknown>): DeepgramOptionsMutable {
+  if (!options) return {};
+  const get = (snake: string, camel: string): unknown => options[snake] ?? options[camel];
+  const out: DeepgramOptionsMutable = {};
+  const model = get('model', 'model');
+  if (typeof model === 'string') out.model = model;
+  const endpointing = get('endpointing_ms', 'endpointingMs');
+  if (typeof endpointing === 'number') out.endpointingMs = endpointing;
+  const utteranceEnd = get('utterance_end_ms', 'utteranceEndMs');
+  if (utteranceEnd === null) out.utteranceEndMs = null;
+  else if (typeof utteranceEnd === 'number') out.utteranceEndMs = utteranceEnd;
+  const smart = get('smart_format', 'smartFormat');
+  if (typeof smart === 'boolean') out.smartFormat = smart;
+  const interim = get('interim_results', 'interimResults');
+  if (typeof interim === 'boolean') out.interimResults = interim;
+  const vad = get('vad_events', 'vadEvents');
+  if (typeof vad === 'boolean') out.vadEvents = vad;
+  return out;
+}
+
 /** Twilio-specific telephony bridge. */
 class TwilioBridge implements TelephonyBridge {
   readonly label = 'Twilio';
@@ -299,13 +329,28 @@ class TwilioBridge implements TelephonyBridge {
   }
 
   createStt(agent: AgentOptions): DeepgramSTT | WhisperSTT | null {
+    // BUG #12 — Pipeline mode transcodes Twilio's mulaw 8 kHz to PCM16 16 kHz
+    // in ``StreamHandler.handleAudio`` before forwarding to STT. Configuring
+    // Deepgram for mulaw 8 kHz here would cause it to misinterpret the
+    // already-decoded PCM as garbage. The pipeline always uses linear16
+    // 16 kHz; ``forTwilio`` is kept for non-pipeline Twilio integrations.
+    const isPipeline = agent.provider === 'pipeline';
     if (agent.stt) {
       if (agent.stt.provider === 'deepgram') {
-        return DeepgramSTT.forTwilio(agent.stt.apiKey, agent.stt.language ?? 'en');
+        const dgOptions = extractDeepgramOptions(agent.stt.options);
+        if (isPipeline) {
+          return new DeepgramSTT(agent.stt.apiKey, agent.stt.language ?? 'en', dgOptions.model, 'linear16', 16000, dgOptions);
+        }
+        return DeepgramSTT.forTwilio(agent.stt.apiKey, agent.stt.language ?? 'en', dgOptions.model, dgOptions);
       } else if (agent.stt.provider === 'whisper') {
-        return WhisperSTT.forTwilio(agent.stt.apiKey, agent.stt.language ?? 'en');
+        return isPipeline
+          ? new WhisperSTT(agent.stt.apiKey, 'whisper-1', agent.stt.language ?? 'en')
+          : WhisperSTT.forTwilio(agent.stt.apiKey, agent.stt.language ?? 'en');
       }
     } else if (agent.deepgramKey) {
+      if (isPipeline) {
+        return new DeepgramSTT(agent.deepgramKey, agent.language ?? 'en', 'nova-3', 'linear16', 16000);
+      }
       return DeepgramSTT.forTwilio(agent.deepgramKey, agent.language ?? 'en');
     }
     return null;
@@ -365,7 +410,10 @@ export class TelnyxBridge implements TelephonyBridge {
   constructor(private readonly config: LocalConfig) {}
 
   sendAudio(ws: WSWebSocket, audioBase64: string, _streamSid: string): void {
-    ws.send(JSON.stringify({ event_type: 'media', payload: { audio: { chunk: audioBase64 } } }));
+    // BUG #18 — Telnyx media-stream outbound wire format is
+    // ``{"event":"media","media":{"payload":b64}}``, not the legacy
+    // ``event_type``/``payload.audio.chunk`` shape.
+    ws.send(JSON.stringify({ event: 'media', media: { payload: audioBase64 } }));
   }
 
   sendMark(_ws: WSWebSocket, _markName: string, _streamSid: string): void {
@@ -373,7 +421,8 @@ export class TelnyxBridge implements TelephonyBridge {
   }
 
   sendClear(ws: WSWebSocket, _streamSid: string): void {
-    ws.send(JSON.stringify({ event_type: 'media_stop' }));
+    // BUG #18 — matching clear signal.
+    ws.send(JSON.stringify({ event: 'clear' }));
   }
 
   async transferCall(callId: string, toNumber: string): Promise<void> {
@@ -475,13 +524,20 @@ export class TelnyxBridge implements TelephonyBridge {
   createStt(agent: AgentOptions): DeepgramSTT | WhisperSTT | null {
     if (agent.stt) {
       if (agent.stt.provider === 'deepgram') {
-        // Telnyx sends 16 kHz PCM — use linear16 encoding
-        return new DeepgramSTT(agent.stt.apiKey, agent.stt.language ?? 'en', 'nova-3', 'linear16', 16000);
+        // Telnyx pipeline also transcodes mulaw 8 kHz → PCM16 16 kHz before STT.
+        const dgOptions = extractDeepgramOptions(agent.stt.options);
+        return new DeepgramSTT(
+          agent.stt.apiKey,
+          agent.stt.language ?? 'en',
+          dgOptions.model ?? 'nova-3',
+          'linear16',
+          16000,
+          dgOptions,
+        );
       } else if (agent.stt.provider === 'whisper') {
         return new WhisperSTT(agent.stt.apiKey, 'whisper-1', agent.stt.language ?? 'en');
       }
     } else if (agent.deepgramKey) {
-      // Telnyx sends 16 kHz PCM — use linear16 encoding
       return new DeepgramSTT(agent.deepgramKey, agent.language ?? 'en', 'nova-3', 'linear16', 16000);
     }
     return null;
@@ -523,7 +579,8 @@ export class EmbeddedServer {
   private server: HTTPServer | null = null;
   private wss: WebSocketServer | null = null;
   private twilioTokenWarningLogged = false;
-  private readonly metricsStore: MetricsStore;
+  private telnyxSigWarningLogged = false;
+  readonly metricsStore: MetricsStore;
   private readonly pricing: ReturnType<typeof mergePricing>;
   private readonly remoteHandler = new RemoteMessageHandler();
 
@@ -596,6 +653,35 @@ export class EmbeddedServer {
       mountApi(app, this.metricsStore, this.dashboardToken);
       getLogger().info('Dashboard: http://127.0.0.1:' + port + '/');
     }
+
+    // Twilio statusCallback — captures ringing/no-answer/busy/failed
+    // transitions so the dashboard surfaces calls that never reach media.
+    // See BUG #06.
+    app.post('/webhooks/twilio/status', (req, res) => {
+      if (this.config.twilioToken) {
+        const signature = (req.headers['x-twilio-signature'] as string) || '';
+        const url = `https://${this.config.webhookUrl}${req.originalUrl}`;
+        const params = (req.body ?? {}) as Record<string, string>;
+        if (!validateTwilioSignature(url, params, signature, this.config.twilioToken)) {
+          res.status(403).send('Invalid signature');
+          return;
+        }
+      }
+      const body = req.body as Record<string, string>;
+      const callSid = sanitizeLogValue(body['CallSid'] ?? '');
+      const callStatus = sanitizeLogValue(body['CallStatus'] ?? '');
+      const duration = body['CallDuration'] ?? body['Duration'] ?? '';
+      getLogger().info(
+        `Twilio status ${callStatus} for call ${callSid} (duration=${duration})`,
+      );
+      if (callSid && callStatus) {
+        const extra: Record<string, unknown> = {};
+        const parsed = parseFloat(duration);
+        if (!Number.isNaN(parsed)) extra.duration_seconds = parsed;
+        this.metricsStore.updateCallStatus(callSid, callStatus, extra);
+      }
+      res.status(204).send();
+    });
 
     app.post('/webhooks/twilio/recording', (req, res) => {
       if (this.config.twilioToken) {
@@ -692,7 +778,7 @@ export class EmbeddedServer {
       res.type('text/xml').send(twiml);
     });
 
-    app.post('/webhooks/telnyx/voice', (req, res) => {
+    app.post('/webhooks/telnyx/voice', async (req, res) => {
       // Enforce Ed25519 signature verification when a public key is configured.
       if (this.config.telnyxPublicKey) {
         const rawBody = (req as express.Request & { rawBody?: string }).rawBody ?? '';
@@ -702,7 +788,8 @@ export class EmbeddedServer {
           getLogger().warn('Telnyx webhook rejected: invalid or missing Ed25519 signature');
           return res.status(403).send('Invalid signature');
         }
-      } else {
+      } else if (!this.telnyxSigWarningLogged) {
+        this.telnyxSigWarningLogged = true;
         getLogger().warn('Telnyx webhook signature verification is disabled. Set telnyxPublicKey in LocalOptions for production use.');
       }
 
@@ -727,53 +814,95 @@ export class EmbeddedServer {
         return res.status(400).send('Invalid body');
       }
 
-      const eventType = body?.data?.event_type ?? '';
+      const eventType = body.data.event_type ?? '';
+      const payload = body.data.payload ?? {};
 
       if (eventType === 'call.dtmf.received') {
-        const digit = String(body.data?.payload?.digit ?? '').trim();
+        const digit = String(payload.digit ?? '').trim();
         if (digit) {
           getLogger().info(`Telnyx DTMF received (webhook): ${sanitizeLogValue(digit)}`);
         }
-        return res.json({ received: true });
+        return res.status(200).send();
       }
 
       if (eventType === 'call.recording.saved') {
         const recordingUrl =
-          body.data?.payload?.recording_urls?.mp3 ??
-          body.data?.payload?.recording_urls?.wav ??
-          body.data?.payload?.public_recording_urls?.mp3 ??
+          payload.recording_urls?.mp3 ??
+          payload.recording_urls?.wav ??
+          payload.public_recording_urls?.mp3 ??
           '';
         if (recordingUrl) {
           getLogger().info(`Telnyx recording saved (webhook): ${sanitizeLogValue(recordingUrl)}`);
         }
-        return res.json({ received: true });
+        return res.status(200).send();
       }
 
-      if (eventType === 'call.initiated') {
-        const payload = body?.data?.payload ?? {};
-        const callControlId = payload.call_control_id ?? '';
-        const caller = payload.from ?? '';
-        const callee = payload.to ?? '';
-        const streamUrl =
-          `wss://${this.config.webhookUrl}/ws/stream/${encodeURIComponent(callControlId)}` +
-          `?caller=${encodeURIComponent(caller)}&callee=${encodeURIComponent(callee)}`;
+      const callControlId = payload.call_control_id ?? '';
+      if (!callControlId) {
+        getLogger().warn('Telnyx webhook rejected: missing call_control_id');
+        return res.status(400).send('Invalid webhook payload');
+      }
 
-        const commands = [
-          { command: 'answer' },
-          {
-            command: 'stream_start',
-            params: {
+      // BUG #16 — Telnyx Call Control is a REST API. The webhook body is an
+      // informational notification; the response body is ignored. To answer
+      // a call we POST ``actions/answer``, and to start audio streaming we
+      // POST ``actions/streaming_start`` (once the call is answered).
+      const apiKey = this.config.telnyxKey;
+      if (!apiKey) {
+        getLogger().warn('Telnyx webhook: missing telnyxKey in LocalOptions');
+        return res.status(500).send('Missing Telnyx API key');
+      }
+
+      const apiBase = 'https://api.telnyx.com/v2';
+      const authHeaders = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      } as const;
+
+      try {
+        if (eventType === 'call.initiated') {
+          getLogger().info(`Telnyx call.initiated ${callControlId} — answering`);
+          const resp = await fetch(`${apiBase}/calls/${encodeURIComponent(callControlId)}/actions/answer`, {
+            method: 'POST',
+            headers: authHeaders,
+            body: JSON.stringify({}),
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (!resp.ok) {
+            getLogger().warn(`Telnyx answer failed: ${resp.status} ${(await resp.text()).slice(0, 200)}`);
+          }
+        } else if (eventType === 'call.answered') {
+          const caller = payload.from ?? '';
+          const callee = payload.to ?? '';
+          const streamUrl =
+            `wss://${this.config.webhookUrl}/ws/stream/${encodeURIComponent(callControlId)}` +
+            `?caller=${encodeURIComponent(caller)}&callee=${encodeURIComponent(callee)}`;
+          getLogger().info(`Telnyx call.answered ${callControlId} — starting stream`);
+          const resp = await fetch(`${apiBase}/calls/${encodeURIComponent(callControlId)}/actions/streaming_start`, {
+            method: 'POST',
+            headers: authHeaders,
+            body: JSON.stringify({
               stream_url: streamUrl,
               stream_track: 'both_tracks',
-            },
-          },
-        ];
-
-        res.json({ commands });
-      } else {
-        // Acknowledge other Telnyx webhook events
-        res.json({ received: true });
+              stream_bidirectional_mode: 'rtp',
+              stream_bidirectional_codec: 'PCMU',
+              stream_bidirectional_sampling_rate: 8000,
+              stream_bidirectional_target_legs: 'self',
+            }),
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (!resp.ok) {
+            getLogger().warn(`Telnyx streaming_start failed: ${resp.status} ${(await resp.text()).slice(0, 200)}`);
+          }
+        } else {
+          getLogger().debug(`Telnyx event ignored: ${eventType}`);
+        }
+      } catch (e) {
+        getLogger().error(`Telnyx webhook handler error: ${String(e)}`);
       }
+
+      // Telnyx ignores the response body. Acknowledge with 200 OK.
+      return res.status(200).send();
     });
 
     this.server = createServer(app);
@@ -944,15 +1073,16 @@ Connect AI agents to phone numbers in 4 lines of code
 
     ws.on('message', async (raw) => {
       try {
+        // BUG #17 — Telnyx media-stream WebSocket uses ``event`` (not
+        // ``event_type``, which is a Call Control REST notification field),
+        // and the frame layout is ``{event, start|media|stop|dtmf}`` —
+        // mirror of the Python bridge.
         let data: {
-          event_type?: string;
-          payload?: {
-            call_control_id?: string;
-            audio?: { chunk?: string };
-            digit?: string;
-            recording_urls?: { mp3?: string; wav?: string };
-            public_recording_urls?: { mp3?: string; wav?: string };
-          };
+          event?: string;
+          start?: { call_control_id?: string; from?: string; to?: string };
+          media?: { payload?: string; track?: string };
+          dtmf?: { digit?: string };
+          stop?: Record<string, unknown>;
         };
         try {
           data = JSON.parse(raw.toString()) as typeof data;
@@ -961,12 +1091,14 @@ Connect AI agents to phone numbers in 4 lines of code
           return;
         }
 
-        const eventType = data.event_type ?? '';
-        getLogger().info(`Telnyx event: ${eventType}`);
+        const event = data.event ?? '';
+        if (event === 'connected') return;  // first ping, nothing to do
 
-        if (eventType === 'stream_started' && !streamStarted) {
+        getLogger().info(`Telnyx event: ${event}`);
+
+        if (event === 'start' && !streamStarted) {
           streamStarted = true;
-          const callControlId = data.payload?.call_control_id ?? '';
+          const callControlId = data.start?.call_control_id ?? '';
           if (callControlId) this.activeCallIds.set(ws, callControlId);
           await handler.handleCallStart(callControlId);
           if (this.recording) {
@@ -976,27 +1108,25 @@ Connect AI agents to phone numbers in 4 lines of code
               getLogger().warn(`Could not start recording: ${String(e)}`);
             }
           }
-        } else if (eventType === 'media') {
-          const audioChunk = data.payload?.audio?.chunk ?? '';
+        } else if (event === 'media') {
+          // BUG #19 — with ``stream_track=both_tracks`` Telnyx sends media
+          // for the caller leg (``track=inbound``) AND for our injected
+          // outbound leg (``track=outbound``). Forwarding the outbound
+          // echo feeds the agent its own voice and breaks turn detection.
+          const track = data.media?.track ?? 'inbound';
+          if (track !== 'inbound') return;
+          const audioChunk = data.media?.payload ?? '';
           if (!audioChunk) return;
-          // Telnyx sends 16 kHz PCM — send directly
           handler.handleAudio(Buffer.from(audioChunk, 'base64'));
-        } else if (eventType === 'call.dtmf.received') {
-          const digit = String(data.payload?.digit ?? '').trim();
+        } else if (event === 'dtmf') {
+          const digit = String(data.dtmf?.digit ?? '').trim();
           if (digit) {
             getLogger().info(`Telnyx DTMF received: ${digit}`);
             await handler.handleDtmf(digit);
           }
-        } else if (eventType === 'call.recording.saved') {
-          const recordingUrl =
-            data.payload?.recording_urls?.mp3 ??
-            data.payload?.recording_urls?.wav ??
-            data.payload?.public_recording_urls?.mp3 ??
-            '';
-          if (recordingUrl) {
-            getLogger().info(`Telnyx recording saved: ${recordingUrl}`);
-          }
-        } else if (eventType === 'stream_stopped') {
+        } else if (event === 'error') {
+          getLogger().warn(`Telnyx stream error: ${JSON.stringify(data)}`);
+        } else if (event === 'stop') {
           await handler.handleStop();
         }
       } catch (err) {

--- a/sdk-ts/src/stream-handler.ts
+++ b/sdk-ts/src/stream-handler.ts
@@ -148,6 +148,9 @@ export class StreamHandler {
   private maxDurationTimer: ReturnType<typeof setTimeout> | null = null;
   private transcriptProcessing = false;
   private transcriptQueue: Array<{ isFinal?: boolean; text?: string }> = [];
+  // BUG #22 throttle state — mirror Python impl.
+  private lastCommitText = '';
+  private lastCommitAt = 0;
 
   private readonly history: ReturnType<typeof createHistoryManager>;
   private readonly metricsAcc: CallMetricsAccumulator;
@@ -286,17 +289,31 @@ export class StreamHandler {
   }
 
   /** Handle an incoming audio chunk (already decoded from base64). */
-  handleAudio(audioBuffer: Buffer): void {
+  async handleAudio(audioBuffer: Buffer): Promise<void> {
     const provider = this.deps.agent.provider ?? 'openai_realtime';
-    if (provider === 'pipeline' && this.stt && !this.isSpeaking) {
-      // Twilio sends mulaw 8kHz — convert to PCM 16kHz for STT providers
-      if (this.deps.bridge.telephonyProvider === 'twilio') {
-        const pcm8k = mulawToPcm16(audioBuffer);
-        const pcm16k = resample8kTo16k(pcm8k);
-        this.stt.sendAudio(pcm16k);
+    if (provider === 'pipeline' && this.stt) {
+      // BUG #20: keep forwarding caller audio to STT during TTS so barge-in
+      // detection can trigger. Caller sets ``agent.bargeInThresholdMs=0`` to
+      // disable barge-in on noisy links.
+      if (this.isSpeaking && (this.deps.agent.bargeInThresholdMs ?? 300) === 0) {
+        return;
+      }
+      // BUG #12 / #19 audio path: both Twilio and Telnyx with the default
+      // streaming_start (PCMU bidirectional) deliver mulaw 8 kHz inbound
+      // — we always transcode to PCM16 16 kHz before STT.
+      const pcm8k = mulawToPcm16(audioBuffer);
+      const pcm16k = resample8kTo16k(pcm8k);
+
+      // BUG #15: run the before_send_to_stt hook before forwarding.
+      const hooks = this.deps.agent.hooks;
+      if (hooks) {
+        const hookExecutor = new PipelineHookExecutor(hooks);
+        const hookCtx = this.buildHookContext();
+        const processed = await hookExecutor.runBeforeSendToStt(pcm16k, hookCtx);
+        if (processed === null) return;
+        this.stt.sendAudio(processed);
       } else {
-        // Telnyx sends PCM 16kHz natively
-        this.stt.sendAudio(audioBuffer);
+        this.stt.sendAudio(pcm16k);
       }
     } else if (this.adapter) {
       // OpenAI Realtime is configured for g711_ulaw so Twilio mulaw is fine.
@@ -381,10 +398,8 @@ export class StreamHandler {
         this.tts = new OpenAITTS(this.deps.agent.tts.apiKey, this.deps.agent.tts.voice ?? 'alloy');
       }
     } else if (this.deps.agent.elevenlabsKey) {
-      const voiceId = (this.deps.agent.voice && this.deps.agent.voice !== 'alloy')
-        ? this.deps.agent.voice
-        : '21m00Tcm4TlvDq8ikWAM';
-      this.tts = new ElevenLabsTTS(this.deps.agent.elevenlabsKey, voiceId);
+      // ElevenLabsTTS resolves display names ("rachel") to voice IDs.
+      this.tts = new ElevenLabsTTS(this.deps.agent.elevenlabsKey, this.deps.agent.voice || 'rachel');
     }
 
     if (!this.stt) {
@@ -513,7 +528,53 @@ export class StreamHandler {
   }
 
   private async processTranscript(transcript: { isFinal?: boolean; text?: string }): Promise<void> {
+    // BUG #20 — barge-in: if TTS is mid-stream and the caller speaks,
+    // any transcript with text flips ``isSpeaking`` to false so the TTS
+    // sentence loop exits on its next check.
+    if (transcript.text && this.isSpeaking) {
+      getLogger().info(
+        `Barge-in: caller spoke over agent (${sanitizeLogValue(transcript.text.slice(0, 40))})`,
+      );
+      this.isSpeaking = false;
+      try {
+        this.deps.bridge.sendClear(this.ws, this.streamSid);
+      } catch (err) {
+        getLogger().debug(`sendClear during barge-in failed: ${String(err)}`);
+      }
+      this.metricsAcc.recordTurnInterrupted();
+    }
+
     if (!transcript.isFinal || !transcript.text) return;
+
+    // BUG #22 — dedup + throttle + hallucination filter, mirror of the
+    // Python implementation in ``PipelineStreamHandler._stt_loop``.
+    const now = Date.now();
+    const normalised = transcript.text.trim().toLowerCase();
+    const stripped = normalised.replace(/[.,!?;: ]+$/, '').trim();
+    const sinceLastMs = now - this.lastCommitAt;
+    const HALLUCINATIONS = new Set([
+      'you', 'thank you', 'thanks', 'yeah', 'yes', 'no',
+      'okay', 'ok', 'uh', 'um', 'mmm', 'hmm', '.', 'bye',
+      'right', 'cool',
+    ]);
+    if (HALLUCINATIONS.has(stripped) || stripped === '') {
+      getLogger().info(`Dropped likely STT hallucination: ${sanitizeLogValue(normalised.slice(0, 40))}`);
+      return;
+    }
+    if (sinceLastMs < 2000 && normalised === this.lastCommitText) {
+      getLogger().info(
+        `Dropped duplicate final transcript (${(sinceLastMs / 1000).toFixed(1)}s since last): ${sanitizeLogValue(normalised.slice(0, 40))}`,
+      );
+      return;
+    }
+    if (sinceLastMs < 500) {
+      getLogger().info(
+        `Dropped back-to-back final transcript (${(sinceLastMs / 1000).toFixed(2)}s since last): ${sanitizeLogValue(normalised.slice(0, 40))}`,
+      );
+      return;
+    }
+    this.lastCommitText = normalised;
+    this.lastCommitAt = now;
 
     const label = this.deps.bridge.label;
     getLogger().info(`User (${label} pipeline): ${sanitizeLogValue(transcript.text)}`);

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -8,14 +8,22 @@ export interface STTConfig {
   readonly provider: string;
   readonly apiKey: string;
   readonly language: string;
-  toDict(): Record<string, string>;
+  /**
+   * Optional — when present, called by internal serialisation. Not required for
+   * callers that pass a plain object literal (``{ provider, apiKey, language }``)
+   * to maintain parity with the Python SDK, which accepts dataclass-like inputs.
+   */
+  toDict?(): Record<string, string | Record<string, unknown>>;
+  /** Provider-specific knobs (e.g. Deepgram endpointing). */
+  options?: Record<string, unknown>;
 }
 
 export interface TTSConfig {
   readonly provider: string;
   readonly apiKey: string;
   readonly voice: string;
-  toDict(): Record<string, string>;
+  toDict?(): Record<string, string | Record<string, unknown>>;
+  options?: Record<string, unknown>;
 }
 
 export type MessageHandler = (msg: IncomingMessage) => Promise<string>;
@@ -106,7 +114,12 @@ export interface Call {
 // === Local mode ===
 
 export interface LocalOptions {
-  mode: 'local';
+  /**
+   * Optional — when omitted, local mode is auto-detected from the presence of
+   * ``twilioSid`` or ``telnyxKey`` (matches the Python SDK which treats
+   * ``Patter(twilio_sid=...)`` as local mode by default).
+   */
+  mode?: 'local';
   twilioSid?: string;
   twilioToken?: string;
   openaiKey?: string;
@@ -120,6 +133,14 @@ export interface LocalOptions {
    * signature verification. When provided, unauthenticated requests are rejected.
    */
   telnyxPublicKey?: string;
+  /**
+   * Provider-level Deepgram API key. When set, agents that don't override
+   * ``agent.deepgramKey`` / ``agent.stt`` use this as the default STT key.
+   * Mirrors Python's ``Patter(deepgram_key=...)``.
+   */
+  deepgramKey?: string;
+  /** Provider-level ElevenLabs API key (same semantics as ``deepgramKey``). */
+  elevenlabsKey?: string;
 }
 
 export interface Guardrail {
@@ -209,6 +230,13 @@ export interface AgentOptions {
   audioFilter?: AudioFilter;
   /** Optional background audio mixer (hold music, thinking cues). Pipeline mode only. */
   backgroundAudio?: BackgroundAudioPlayer;
+  /**
+   * Minimum sustained voice (ms) before treating caller audio as a barge-in
+   * and interrupting TTS. `0` disables barge-in entirely — useful on noisy
+   * links (ngrok tunnels, speakerphone) where the agent can hear itself.
+   * Default: 300.
+   */
+  bargeInThresholdMs?: number;
 }
 
 export type PipelineMessageHandler = (data: Record<string, unknown>) => Promise<string>;
@@ -250,4 +278,11 @@ export interface LocalCallOptions {
   voicemailMessage?: string;
   /** Dynamic variables merged into agent.variables before call. Override agent-level variables. */
   variables?: Record<string, string>;
+  /**
+   * Ring timeout in seconds. Forwarded to Twilio as `Timeout` and to Telnyx
+   * as `timeout_secs`. Defaults to the carrier default (~28 s on Twilio) when
+   * omitted. Increase for international routes where the remote carrier
+   * silences short US→IT rings.
+   */
+  ringTimeout?: number;
 }

--- a/sdk-ts/tests/integration/telnyx-pipeline.test.ts
+++ b/sdk-ts/tests/integration/telnyx-pipeline.test.ts
@@ -115,10 +115,16 @@ describe('Integration: Telnyx + Pipeline', () => {
 
     await handler.handleCallStart('ctrl-tp-audio');
 
-    // Telnyx sends 16kHz PCM
-    const audio = fakeAudioBuffer(20, 16000);
-    handler.handleAudio(audio);
-    expect(stt.sendAudio).toHaveBeenCalledWith(audio);
+    // Telnyx with the default streaming_start (PCMU bidirectional) sends
+    // mulaw 8 kHz inbound. The pipeline transcodes to PCM16 16 kHz before
+    // STT, so the mock sees the transcoded buffer (different from input).
+    const { fakeMulawBuffer } = await import('../setup');
+    const mulaw = fakeMulawBuffer(20, 8000);
+    await handler.handleAudio(mulaw);
+    expect(stt.sendAudio).toHaveBeenCalledTimes(1);
+    const forwarded = (stt.sendAudio as any).mock.calls[0][0] as Buffer;
+    // Transcoded output is PCM16 @ 16 kHz = 4× the mulaw byte count.
+    expect(forwarded.length).toBe(mulaw.length * 4);
   });
 
   it('pipeline mode processes transcript with onMessage handler', async () => {

--- a/sdk-ts/tests/integration/twilio-pipeline.test.ts
+++ b/sdk-ts/tests/integration/twilio-pipeline.test.ts
@@ -117,7 +117,7 @@ describe('Integration: Twilio + Pipeline', () => {
     await handler.handleCallStart('CA-pipe-audio');
 
     const audio = fakeMulawBuffer(20);
-    handler.handleAudio(audio);
+    await handler.handleAudio(audio);
     // Audio is transcoded from mulaw 8kHz → PCM 16kHz before reaching STT
     expect(stt.sendAudio).toHaveBeenCalledTimes(1);
     // buildAIAdapter should NOT be called for pipeline mode

--- a/sdk-ts/tests/openai-tts.test.ts
+++ b/sdk-ts/tests/openai-tts.test.ts
@@ -13,10 +13,14 @@ describe('OpenAITTS', () => {
   });
 
   describe('resample24kTo16k', () => {
-    it('returns input unchanged when less than 2 bytes', () => {
+    it('returns empty buffer when input is a single odd byte (flushed later)', () => {
+      // Legacy wrapper: in the new streaming resampler a single trailing
+      // byte is a ``carry`` that would be consumed by the next chunk; the
+      // non-streaming helper flushes only complete samples and therefore
+      // returns an empty buffer for a 1-byte input.
       const input = Buffer.from([0x01]);
       const result = OpenAITTS.resample24kTo16k(input);
-      expect(result).toEqual(input);
+      expect(result.length).toBe(0);
     });
 
     it('returns empty buffer for empty input', () => {

--- a/sdk-ts/tests/providers.test.ts
+++ b/sdk-ts/tests/providers.test.ts
@@ -22,6 +22,31 @@ describe("deepgram", () => {
       provider: "deepgram",
       api_key: "dg_test",
       language: "en",
+      options: {
+        model: "nova-3",
+        endpointing_ms: 150,
+        utterance_end_ms: 1000,
+        smart_format: true,
+        interim_results: true,
+      },
+    });
+  });
+
+  it("forwards tuning knobs into options (BUG #13 parity)", () => {
+    const config = deepgram({
+      apiKey: "dg_test",
+      endpointingMs: 80,
+      utteranceEndMs: 1500,
+      smartFormat: false,
+      interimResults: false,
+      model: "nova-2",
+    });
+    expect(config.options).toEqual({
+      model: "nova-2",
+      endpointing_ms: 80,
+      utterance_end_ms: 1500,
+      smart_format: false,
+      interim_results: false,
     });
   });
 });

--- a/sdk-ts/tests/types.test.ts
+++ b/sdk-ts/tests/types.test.ts
@@ -4,10 +4,19 @@ import { deepgram, elevenlabs } from "../src/providers";
 describe("STTConfig", () => {
   it("toDict includes all fields", () => {
     const config = deepgram({ apiKey: "dg_test", language: "it" });
+    // BUG #13 parity — the Deepgram factory now carries tuning defaults in
+    // ``options`` so callers can pass them through without monkey-patching.
     expect(config.toDict()).toEqual({
       provider: "deepgram",
       api_key: "dg_test",
       language: "it",
+      options: {
+        model: "nova-3",
+        endpointing_ms: 150,
+        utterance_end_ms: 1000,
+        smart_format: true,
+        interim_results: true,
+      },
     });
   });
 

--- a/sdk-ts/tests/unit/server-routes.test.ts
+++ b/sdk-ts/tests/unit/server-routes.test.ts
@@ -363,78 +363,137 @@ describe('EmbeddedServer route behavior', () => {
   });
 
   it('serves /webhooks/telnyx/voice for call.initiated event', async () => {
-    const server = new EmbeddedServer(
-      makeConfig({
-        telephonyProvider: 'telnyx',
-        telnyxKey: 'KEY_test',
-        telnyxConnectionId: 'conn_test',
-        // No telnyxPublicKey = skip sig validation
-      }),
-      makeAgent(),
-      undefined, undefined, undefined, undefined, false, '', undefined, undefined, false,
+    // BUG #16 — Telnyx Call Control is REST-first: the webhook body is an
+    // informational notification, so the SDK must POST ``actions/answer`` to
+    // Telnyx and respond with 200 + empty body.
+    const originalFetch = globalThis.fetch;
+    const telnyxFetchCalls: Array<[string | URL | Request, RequestInit | undefined]> = [];
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('api.telnyx.com')) {
+          telnyxFetchCalls.push([input, init]);
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: {} }),
+            text: async () => '',
+          } as Response;
+        }
+        return originalFetch(input, init);
+      },
     );
 
-    const port = 19000 + Math.floor(Math.random() * 1000);
-    await server.start(port);
-
     try {
-      const resp = await fetch(`http://127.0.0.1:${port}/webhooks/telnyx/voice`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          data: {
-            event_type: 'call.initiated',
-            payload: {
-              call_control_id: 'ctrl-123',
-              from: '+15551111111',
-              to: '+15552222222',
-            },
-          },
+      const server = new EmbeddedServer(
+        makeConfig({
+          telephonyProvider: 'telnyx',
+          telnyxKey: 'KEY_test',
+          telnyxConnectionId: 'conn_test',
+          // No telnyxPublicKey = skip sig validation
         }),
-      });
+        makeAgent(),
+        undefined, undefined, undefined, undefined, false, '', undefined, undefined, false,
+      );
 
-      expect(resp.ok).toBe(true);
-      const body = await resp.json() as Record<string, unknown>;
-      expect(body.commands).toBeDefined();
-      const commands = body.commands as Array<Record<string, unknown>>;
-      expect(commands[0].command).toBe('answer');
-      expect(commands[1].command).toBe('stream_start');
+      const port = 19000 + Math.floor(Math.random() * 1000);
+      await server.start(port);
+
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}/webhooks/telnyx/voice`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            data: {
+              event_type: 'call.initiated',
+              payload: {
+                call_control_id: 'ctrl-123',
+                from: '+15551111111',
+                to: '+15552222222',
+              },
+            },
+          }),
+        });
+
+        expect(resp.status).toBe(200);
+
+        const answerCall = telnyxFetchCalls.find(([url]) =>
+          typeof url === 'string' && url.includes('/calls/ctrl-123/actions/answer'),
+        );
+        expect(answerCall).toBeDefined();
+      } finally {
+        await server.stop();
+      }
     } finally {
-      await server.stop();
+      spy.mockRestore();
     }
   });
 
-  it('acknowledges non-call.initiated telnyx events', async () => {
-    const server = new EmbeddedServer(
-      makeConfig({
-        telephonyProvider: 'telnyx',
-        telnyxKey: 'KEY_test',
-        telnyxConnectionId: 'conn_test',
-      }),
-      makeAgent(),
-      undefined, undefined, undefined, undefined, false, '', undefined, undefined, false,
+  it('POSTs actions/streaming_start when telnyx call.answered arrives', async () => {
+    const originalFetch = globalThis.fetch;
+    const telnyxFetchCalls: Array<[string | URL | Request, RequestInit | undefined]> = [];
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('api.telnyx.com')) {
+          telnyxFetchCalls.push([input, init]);
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ data: {} }),
+            text: async () => '',
+          } as Response;
+        }
+        return originalFetch(input, init);
+      },
     );
 
-    const port = 19000 + Math.floor(Math.random() * 1000);
-    await server.start(port);
-
     try {
-      const resp = await fetch(`http://127.0.0.1:${port}/webhooks/telnyx/voice`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          data: {
-            event_type: 'call.answered',
-            payload: { call_control_id: 'ctrl-456' },
-          },
+      const server = new EmbeddedServer(
+        makeConfig({
+          telephonyProvider: 'telnyx',
+          telnyxKey: 'KEY_test',
+          telnyxConnectionId: 'conn_test',
         }),
-      });
+        makeAgent(),
+        undefined, undefined, undefined, undefined, false, '', undefined, undefined, false,
+      );
 
-      expect(resp.ok).toBe(true);
-      const body = await resp.json() as Record<string, unknown>;
-      expect(body.received).toBe(true);
+      const port = 19000 + Math.floor(Math.random() * 1000);
+      await server.start(port);
+
+      try {
+        const resp = await fetch(`http://127.0.0.1:${port}/webhooks/telnyx/voice`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            data: {
+              event_type: 'call.answered',
+              payload: {
+                call_control_id: 'ctrl-456',
+                from: '+15551111111',
+                to: '+15552222222',
+              },
+            },
+          }),
+        });
+
+        expect(resp.status).toBe(200);
+
+        const startCall = telnyxFetchCalls.find(([url]) =>
+          typeof url === 'string' && url.includes('/calls/ctrl-456/actions/streaming_start'),
+        );
+        expect(startCall).toBeDefined();
+        // Validate the streaming_start payload includes PCMU bidirectional.
+        const body = JSON.parse((startCall?.[1]?.body as string) ?? '{}') as Record<string, unknown>;
+        expect(body.stream_url).toContain('ctrl-456');
+        expect(body.stream_track).toBe('both_tracks');
+        expect(body.stream_bidirectional_codec).toBe('PCMU');
+      } finally {
+        await server.stop();
+      }
     } finally {
-      await server.stop();
+      spy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

Release **0.4.4** — comprehensive bug-fix sweep surfaced by the acceptance
suite plus several feature additions. 23 distinct bugs closed, Python ↔ TS
parity re-verified, 5 new live-call scenarios validated end-to-end.

## Bug fixes (BUGS.md references)

Grouped by concern. Every fix has a matching regression test in
`sdk-py/tests/unit/`.

### Critical (blockers on 0.4.3)
- **#07 / #09** — dep pin: `python-multipart` + `websockets>=14,<16`
- **#08** — `Request` forward-ref broken every Twilio webhook with 422
- **#10** — OpenAI Realtime × Twilio used the wrong sample rate → inaudible
- **#16** — Telnyx Call Control answer flow broken (ring forever)
- **#17** — Telnyx WS event/shape mismatch dropped all media events
- **#18** — Telnyx outbound audio frame shape rejected → caller hears silence
- **#19** — Telnyx `stream_track=both_tracks` echo fed the agent its own voice

### Pipeline-mode correctness
- **#12** — Twilio pipeline double-transcoded audio → 0 transcripts
- **#13** — Deepgram endpointing hard-coded (now knobs + looser gate)
- **#15** — `PipelineHooks.before_send_to_stt` was never called
- **#20** — barge-in broken: agent couldn't be interrupted mid-sentence
- **#22** — back-to-back finals / Whisper hallucinations overlapped TTS turns
- **#23** — OpenAI TTS streaming resample dropped samples across chunks

### API / ergonomics
- **#01** — scheduler `[scheduling]` extra undocumented
- **#02** — `FallbackLLMProvider.complete_stream` missing from Python
- **#03** — scheduler singleton died across event loops
- **#04** — Python ↔ TS parity gaps (factories, auto-detect, return types)
- **#05** — `FallbackLLMProvider` leaked recovery task on shutdown
- **#11** — `Patter.elevenlabs(voice="rachel")` 404d (no name→UUID map)
- **#14** — `Patter.agent()` factory dropped hooks/transforms/vad/…
- **#21** — `@tool` decorator crashed on any typed handler

### Dashboard
- **#06** — hid failed / no-answer outbound calls (new `/webhooks/twilio/status`)

### New features
- `ring_timeout` kwarg on `Patter.call()` → Twilio `Timeout` / Telnyx `timeout_secs`
- `barge_in_threshold_ms` on `Agent`
- `Patter.cartesia` / `Patter.rime` / `Patter.lmnt` static factories (Python)
- `vad_events` on Deepgram config helper
- Top-level `mix_pcm` helper (Python parity with TS)
- Dashboard status column + filter pills + SSE `call_initiated` / `call_status`
- Automatic status callback registration on outbound Twilio calls

### CI / ops
- New `audit.yml` workflow: pip-audit + npm audit + bandit (SARIF upload)
- README provider caveats (ElevenLabs free tier, Telnyx D38, Whisper hallucinations)

## Test coverage

**sdk-py/tests/unit/ — 749 passed, 2 skipped** (+21 tests over 0.4.3).
New regression modules:

| File | Bug | Tests |
|---|---|---|
| `test_pipeline_dedup.py` | #22 | 13 |
| `test_openai_tts_resample.py` | #23 | 7 |
| `test_twilio_status_and_ring_timeout.py` | #06 + IMP2 | 13 |
| `test_pipeline_bargein.py` | #20 | 7 |
| `test_before_send_to_stt_hook.py` | #15 | 9 |
| `test_telnyx_track_filter.py` | #19 | 5 |

**sdk-ts/tests/ — 932 passed** (57 test files, soak included).

## Live-call validation (acceptance suite session 2026-04-21)

Real Twilio / Telnyx calls against a dev ngrok tunnel, all PASSED:

| # | Scenario | Evidence |
|---|---|---|
| 25 | `transfer_call` tool via Twilio Realtime | `Call transferred to +39…` system transcript |
| 26 | `serve(recording=True)` | Twilio Recordings API `201 Created` |
| 27 | Telnyx DTMF end-to-end | 3/3 digits received (`call.dtmf.received`) |
| 28 | WS drop mid-call + `EmbeddedServer.stop()` | `call_end` emitted cleanly 3.7s after stop |
| 29 | Italian pipeline (Deepgram IT + ElevenLabs IT voice) | STT + TTS + LLM all idiomatic |

Plus all 13 core telephony × mode cells already re-validated on 0.4.4 during
the bug-fix session — see `BUGS.md` + `TEST_MATRIX.md` in the sibling
`patter-sdk-acceptance` suite.

## Parity audit

`sdk-parity` agent re-run on 2026-04-21: **ALIGNED**. One last gap closed
in commit `bcefa8b` (Python `cartesia/rime/lmnt` factories + `vad_events`
on `deepgram()`). No remaining drift.

## Security

- `npm audit` — 0 vulnerabilities.
- `bandit -r sdk-py/patter -ll -iii` — 0 medium+ high-confidence findings.
- `pip-audit` — 2 advisories, both in dev/optional extras only (pytest,
  transformers), not runtime.

## Test plan

- [x] Full sdk-py offline unit suite (749 passed)
- [x] Full sdk-ts vitest suite (932 passed, soak included)
- [x] Live Twilio/Telnyx acceptance scenarios #25-#29
- [x] Parity audit (sdk-parity agent, ALIGNED)
- [x] Security audit (bandit / npm audit / pip-audit)
- [ ] Final smoke test against published 0.4.4 artifact (post-publish)