### PR TITLE
release: 0.5.1 — first-class llm= selector + 5 LLM providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.1 (2026-04-22)
+
+### Added
+- **First-class `llm=` selector on `phone.agent()`** — pick any of 5 LLM providers the same way you pick STT/TTS.
+  - `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM` — all instance-based with env-var fallback.
+  - Namespaced imports: `from getpatter.llm import openai, anthropic, groq, cerebras, google` (Python) / `import * as anthropic from "getpatter/llm/anthropic"` (TypeScript).
+  - Flat imports: `from getpatter import AnthropicLLM, GroqLLM, ...` / `import { AnthropicLLM, GroqLLM, ... } from "getpatter"`.
+- Tool calling works across all 5 providers — each adapter normalizes to Patter's unified `{type: "text" | "tool_call" | "done"}` chunk protocol.
+- `GoogleLLM` reads `GEMINI_API_KEY` preferred, falls back to `GOOGLE_API_KEY`.
+
+### Unchanged (no break from 0.5.0)
+- `on_message` / `onMessage` callback still works for custom LLM logic. Mutually exclusive with `llm=` (conflict raises at `serve()` time).
+- When no `llm=` and no `on_message` but `OPENAI_API_KEY` is set, the default OpenAI LLM loop keeps running.
+
 ## 0.5.0 (2026-04-22)
 
 Patter 0.5.0 ships an instance-based API. Every provider — carriers, engines, STT, TTS, tunnels — is a typed class that reads its credentials from environment variables by default. The result is a four-line quickstart:

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -84,20 +84,23 @@ agent = phone.agent(
 **Pipeline mode (full control)** — you pick each stage:
 
 ```python
-from getpatter import DeepgramSTT, ElevenLabsTTS
+from getpatter import DeepgramSTT, AnthropicLLM, ElevenLabsTTS
 
 agent = phone.agent(
-    stt=DeepgramSTT(),          # speech → text
-    tts=ElevenLabsTTS(),        # text → speech
+    stt=DeepgramSTT(),           # speech → text
+    llm=AnthropicLLM(),          # text → text (ANTHROPIC_API_KEY from env)
+    tts=ElevenLabsTTS(),         # text → speech
     system_prompt="...",
 )
-await phone.serve(agent, on_message=my_llm_handler)  # your LLM in on_message
+await phone.serve(agent)
 ```
+
+Want fully custom LLM logic (multi-model routing, local models, an internal gateway)? Drop `llm=` and pass an async `on_message` callback to `serve()` instead. `llm=` and `on_message` are mutually exclusive.
 
 Three independent stages — swap any of them for a different vendor or local model:
 
 - **STT (Speech-to-Text)** — transcribes caller audio in real time. Providers: `DeepgramSTT`, `WhisperSTT`, `CartesiaSTT`, `SonioxSTT`, `SpeechmaticsSTT` (Python-only), `AssemblyAISTT`. See [STT](/python-sdk/stt).
-- **LLM (Large Language Model)** — generates the reply. Today you plug this via `on_message`; any Python/TS client works (OpenAI, Anthropic, Groq, a local `llama.cpp`, etc.). A first-class `llm=` selector is planned for 0.6. See [LLM](/python-sdk/llm).
+- **LLM (Large Language Model)** — generates the reply. Pass a class instance via `llm=`: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. For anything else, use `on_message`. See [LLM](/python-sdk/llm).
 - **TTS (Text-to-Speech)** — synthesizes the reply audio. Providers: `ElevenLabsTTS`, `OpenAITTS`, `CartesiaTTS`, `RimeTTS`, `LMNTTTS`. See [TTS](/python-sdk/tts).
 
 Pick engine mode when you want minimum code. Pick pipeline mode when you need a specific LLM, a custom voice, or fine-grained control over latency / costs.

--- a/docs/python-sdk/agents.mdx
+++ b/docs/python-sdk/agents.mdx
@@ -34,27 +34,32 @@ agent = phone.agent(
 )
 ```
 
-To use pipeline mode (STT + your own LLM via `on_message` + TTS):
+To use pipeline mode (pick STT, LLM, TTS independently):
 
 ```python
-from getpatter import DeepgramSTT, ElevenLabsTTS
+from getpatter import DeepgramSTT, AnthropicLLM, ElevenLabsTTS
 
 agent = phone.agent(
     stt=DeepgramSTT(endpointing_ms=80),        # DEEPGRAM_API_KEY from env
+    llm=AnthropicLLM(),                        # ANTHROPIC_API_KEY from env
     tts=ElevenLabsTTS(voice_id="rachel"),      # ELEVENLABS_API_KEY from env
     system_prompt="You are a helpful assistant.",
     first_message="Hi!",
 )
 ```
 
+Available LLM providers: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. See [LLM](/python-sdk/llm) for the full reference. For fully custom logic (multi-model routing, local models), drop `llm=` and pass an `on_message` callback to `serve()` instead — `llm=` and `on_message` are mutually exclusive.
+
 The same pipeline using namespaced imports:
 
 ```python
 from getpatter.stt import deepgram
+from getpatter.llm import anthropic
 from getpatter.tts import elevenlabs
 
 agent = phone.agent(
     stt=deepgram.STT(endpointing_ms=80),
+    llm=anthropic.LLM(),
     tts=elevenlabs.TTS(voice_id="rachel"),
     system_prompt="You are a helpful assistant.",
 )
@@ -67,6 +72,7 @@ agent = phone.agent(
 | `system_prompt` | `str` | *required* | Instructions that define the agent's behavior. |
 | `engine` | `OpenAIRealtime \| ElevenLabsConvAI \| None` | `None` → OpenAI Realtime | End-to-end engine. See [Engines](/python-sdk/engines). Omit for pipeline mode. |
 | `stt` | `STTProvider \| None` | `None` | STT instance for pipeline mode (`DeepgramSTT()`, `CartesiaSTT()`, ...). See [STT](/python-sdk/stt). |
+| `llm` | `LLMProvider \| None` | `None` | LLM instance for pipeline mode (`AnthropicLLM()`, `GroqLLM()`, ...). Mutually exclusive with `on_message` on `serve()`. Ignored when `engine` is set. See [LLM](/python-sdk/llm). |
 | `tts` | `TTSProvider \| None` | `None` | TTS instance for pipeline mode (`ElevenLabsTTS()`, `RimeTTS()`, ...). See [TTS](/python-sdk/tts). |
 | `voice` | `str` | `"alloy"` | Voice name. Usually inferred from the engine or TTS instance. |
 | `model` | `str` | `"gpt-4o-mini-realtime-preview"` | Model ID for OpenAI Realtime. Usually inferred from the engine. |
@@ -164,7 +170,7 @@ Voice is usually inferred from the engine or TTS instance — e.g. `OpenAIRealti
 ## Engine vs Pipeline Mode
 
 ```python
-from getpatter import OpenAIRealtime, ElevenLabsConvAI, DeepgramSTT, ElevenLabsTTS
+from getpatter import OpenAIRealtime, ElevenLabsConvAI, DeepgramSTT, AnthropicLLM, ElevenLabsTTS
 
 # OpenAI Realtime (default engine) — end-to-end
 agent = phone.agent(
@@ -178,9 +184,10 @@ agent = phone.agent(
     system_prompt="...",
 )
 
-# Pipeline — custom STT + TTS + on_message LLM
+# Pipeline — pick STT, LLM, TTS independently
 agent = phone.agent(
     stt=DeepgramSTT(),
+    llm=AnthropicLLM(),
     tts=ElevenLabsTTS(voice_id="rachel"),
     system_prompt="...",
 )

--- a/docs/python-sdk/llm.mdx
+++ b/docs/python-sdk/llm.mdx
@@ -1,36 +1,36 @@
 ---
 title: "LLM"
-description: "Voice AI modes and language model providers."
+description: "Pick an LLM provider the same way you pick STT and TTS."
 icon: "brain"
 ---
 
 # LLM (Voice Mode)
 
-Patter supports two high-level voice AI architectures:
+Patter supports two voice architectures:
 
 | Mode | How to enable | When to use |
 |------|---------------|-------------|
-| **Engine (end-to-end)** | `phone.agent(engine=OpenAIRealtime(...))` or `engine=ElevenLabsConvAI(...)` | Lowest-latency speech-to-speech. The engine handles STT + LLM + TTS in a single provider. |
-| **Pipeline** | `phone.agent(stt=..., tts=...)` (omit `engine=`) | Full control. Plug a streaming STT, your own LLM, and a streaming TTS. |
+| **Engine (speech-to-speech)** | `phone.agent(engine=OpenAIRealtime(...))` or `engine=ElevenLabsConvAI(...)` | Lowest-latency speech-to-speech. A single provider handles STT + LLM + TTS. |
+| **Pipeline (STT + LLM + TTS)** | `phone.agent(stt=..., llm=..., tts=...)` (omit `engine=`) | Full control. Mix and match providers per stage. |
 
-See [Engines](/python-sdk/engines) for the reference on engine classes. This page focuses on the LLM step.
+See [Engines](/python-sdk/engines) for engine-mode reference. This page focuses on the `llm=` selector in pipeline mode.
 
-## Engine mode
+## Pipeline mode
 
-Engine mode collapses STT, LLM, and TTS into a single streaming connection with the provider.
-
-### OpenAI Realtime (default)
+Compose the three stages independently. Each provider reads its credentials from the environment by default.
 
 ```python
 import asyncio
-from getpatter import Patter, Twilio, OpenAIRealtime
+from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS
 
-phone = Patter(carrier=Twilio(), phone_number="+15550001234")   # TWILIO_* from env
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
 
 agent = phone.agent(
-    engine=OpenAIRealtime(voice="nova"),                        # OPENAI_API_KEY from env
+    stt=DeepgramSTT(),                    # DEEPGRAM_API_KEY
+    llm=AnthropicLLM(),                   # ANTHROPIC_API_KEY
+    tts=ElevenLabsTTS(voice_id="rachel"), # ELEVENLABS_API_KEY
     system_prompt="You are a helpful assistant.",
-    first_message="Hello!",
+    first_message="Hi!",
 )
 
 async def main():
@@ -39,29 +39,107 @@ async def main():
 asyncio.run(main())
 ```
 
-**Voices:** `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
-**Env var:** `OPENAI_API_KEY`
+Tool calling works across every provider — each adapter normalizes its vendor-specific streaming format to Patter's unified `{type: "text" | "tool_call" | "done"}` chunk protocol, so your tools are defined once and run everywhere.
 
-### ElevenLabs ConvAI
+<Note>
+`llm=` and `on_message` are **mutually exclusive**. Pass one or the other on `serve()` — passing both raises a clear error at `serve()` time. When `engine=` is set, `llm=` is ignored (with a one-time warning in the logs). If neither `llm=` nor `on_message` is passed and `OPENAI_API_KEY` is set, Patter auto-constructs the default OpenAI LLM loop — existing 0.5.0 code still works.
+</Note>
 
-Uses a Conversational AI agent configured in the ElevenLabs dashboard.
+## Supported LLM providers
+
+| Flat import | Namespaced import | Env var | Install extra |
+|---|---|---|---|
+| `OpenAILLM` | `getpatter.llm.openai.LLM` | `OPENAI_API_KEY` | included |
+| `AnthropicLLM` | `getpatter.llm.anthropic.LLM` | `ANTHROPIC_API_KEY` | `getpatter[anthropic]` |
+| `GroqLLM` | `getpatter.llm.groq.LLM` | `GROQ_API_KEY` | `getpatter[groq]` |
+| `CerebrasLLM` | `getpatter.llm.cerebras.LLM` | `CEREBRAS_API_KEY` | `getpatter[cerebras]` |
+| `GoogleLLM` | `getpatter.llm.google.LLM` | `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) | `getpatter[google]` |
+
+All classes accept `api_key: str | None = None` and fall back to the listed env var when it is omitted.
+
+### OpenAILLM
+
+OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-4o-mini"`. For other OpenAI-compatible endpoints use the dedicated wrappers (`GroqLLM`, `CerebrasLLM`) — they subclass `OpenAILLMProvider` with the right `base_url`.
 
 ```python
-from getpatter import Patter, Twilio, ElevenLabsConvAI
+from getpatter import OpenAILLM                    # flat
+from getpatter.llm import openai                   # namespaced
 
-phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+llm = OpenAILLM()                                   # reads OPENAI_API_KEY
+llm = openai.LLM(api_key="sk-...", model="gpt-4o-mini")
+```
 
-agent = phone.agent(
-    engine=ElevenLabsConvAI(agent_id="agent_abc123"),           # ELEVENLABS_API_KEY + ELEVENLABS_AGENT_ID from env
-    system_prompt="You are a warm and friendly concierge.",
+### AnthropicLLM
+
+Anthropic Messages API with native streaming and `tool_use` blocks, normalised to Patter's chunk protocol. Default model `"claude-3-5-sonnet-20241022"`, default `max_tokens=1024` (Anthropic requires an explicit cap on every request).
+
+```python
+from getpatter import AnthropicLLM                 # flat
+from getpatter.llm import anthropic                # namespaced
+
+llm = AnthropicLLM()                                # reads ANTHROPIC_API_KEY
+llm = anthropic.LLM(
+    api_key="sk-ant-...",
+    model="claude-3-5-sonnet-20241022",
+    max_tokens=2048,
 )
 ```
 
-**Env vars:** `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`
+Install: `pip install 'getpatter[anthropic]'`.
 
-## Pipeline mode
+### GroqLLM
 
-Omit `engine=` and pass `stt=` + `tts=` instead. Patter wires them together automatically. For the LLM step, provide an `on_message` callback — you can run any model you like inside.
+Hardware-accelerated Llama inference via Groq's OpenAI-compatible Chat Completions API at `https://api.groq.com/openai/v1`. Default model `"llama-3.3-70b-versatile"`.
+
+```python
+from getpatter import GroqLLM                      # flat
+from getpatter.llm import groq                     # namespaced
+
+llm = GroqLLM()                                     # reads GROQ_API_KEY
+llm = groq.LLM(api_key="gsk_...", model="llama-3.3-70b-versatile")
+```
+
+Install: `pip install 'getpatter[groq]'`.
+
+### CerebrasLLM
+
+Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"llama3.1-8b"`. Supports optional msgpack + gzip payload compression (enabled by default) to reduce time-to-first-token on large prompts — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization).
+
+```python
+from getpatter import CerebrasLLM                  # flat
+from getpatter.llm import cerebras                 # namespaced
+
+llm = CerebrasLLM()                                 # reads CEREBRAS_API_KEY
+llm = cerebras.LLM(
+    api_key="csk-...",
+    model="llama3.1-8b",
+    gzip_compression=True,                          # defaults to True
+    msgpack_encoding=True,                          # defaults to True
+)
+```
+
+Install: `pip install 'getpatter[cerebras]'`.
+
+### GoogleLLM
+
+Google Gemini via the `google-genai` SDK. Supports the Gemini Developer API (API key) and Vertex AI (GCP project + location). Default model `"gemini-2.5-flash"`.
+
+```python
+from getpatter import GoogleLLM                    # flat
+from getpatter.llm import google                   # namespaced
+
+llm = GoogleLLM()                                   # reads GEMINI_API_KEY, falls back to GOOGLE_API_KEY
+llm = google.LLM(api_key="AIza...", model="gemini-2.5-flash")
+
+# Vertex AI
+llm = google.LLM(vertexai=True, project="my-gcp-project", location="us-central1")
+```
+
+Install: `pip install 'getpatter[google]'`.
+
+## Custom LLM via `on_message`
+
+For cases the five built-in providers don't cover — multi-model routing, local `llama.cpp`, an internal gateway, caching layers — drop `llm=` and plug an async `on_message` callback instead:
 
 ```python
 import asyncio
@@ -70,14 +148,13 @@ from getpatter import Patter, Twilio, DeepgramSTT, ElevenLabsTTS
 phone = Patter(carrier=Twilio(), phone_number="+15550001234")
 
 agent = phone.agent(
-    stt=DeepgramSTT(endpointing_ms=80),          # DEEPGRAM_API_KEY from env
-    tts=ElevenLabsTTS(voice_id="rachel"),        # ELEVENLABS_API_KEY from env
+    stt=DeepgramSTT(),
+    tts=ElevenLabsTTS(voice_id="rachel"),
     system_prompt="You are a helpful assistant.",
-    first_message="Hi!",
 )
 
 async def handle_message(event) -> str:
-    # Drop in OpenAI, Anthropic, Groq, a local llama.cpp, whatever.
+    # Route to any model you like — local llama.cpp, a private gateway, etc.
     return f"You said: {event['text']}. How can I help?"
 
 async def main():
@@ -86,36 +163,15 @@ async def main():
 asyncio.run(main())
 ```
 
-### Built-in LLM adapters
+<Warning>
+`on_message` and `llm=` cannot be used together. Combining them raises a clear error at `serve()` time — pick one.
+</Warning>
 
-The following adapters live in `getpatter.providers` and are safe to call directly from `on_message`:
-
-| Provider | Module | Install extra |
-|----------|--------|---------------|
-| Anthropic | `getpatter.providers.anthropic_llm` | `getpatter[anthropic]` |
-| Google Gemini | `getpatter.providers.google_llm` | `getpatter[google]` |
-| Groq | `getpatter.providers.groq_llm` | `getpatter[groq]` |
-| Cerebras | `getpatter.providers.cerebras_llm` | `getpatter[cerebras]` |
-| Ultravox (realtime) | `getpatter.providers.ultravox_realtime` | `getpatter[ultravox]` |
-
-<Note>
-A first-class `llm=AnthropicLLM(...)` parameter is planned for Patter 0.6 — once it lands you will be able to plug LLMs the same way you plug STT and TTS today. Until then, the LLM step of pipeline mode flows through `on_message`.
-</Note>
-
-## Comparison
-
-| Feature | `engine=OpenAIRealtime()` | `engine=ElevenLabsConvAI()` | Pipeline (`stt=`/`tts=`) |
-|---------|---------------------------|------------------------------|---------------------------|
-| Latency | Lowest | Low | Medium |
-| Voice quality | Good | Best | Configurable |
-| Custom LLM | No | No | Yes (via `on_message`) |
-| Required env vars | `OPENAI_API_KEY` | `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID` | STT + TTS provider keys |
-
-## What's Next
+## What's next
 
 <CardGroup cols={2}>
-  <Card title="Engines" icon="bolt" href="/python-sdk/engines">Engine class reference.</Card>
   <Card title="STT" icon="microphone" href="/python-sdk/stt">STT providers for pipeline mode.</Card>
   <Card title="TTS" icon="volume" href="/python-sdk/tts">TTS providers for pipeline mode.</Card>
-  <Card title="Tools" icon="wrench" href="/python-sdk/tools">Function calling.</Card>
+  <Card title="Tools" icon="wrench" href="/python-sdk/tools">Function calling (works across every LLM).</Card>
+  <Card title="Engines" icon="bolt" href="/python-sdk/engines">Speech-to-speech engines (OpenAI Realtime, ElevenLabs ConvAI).</Card>
 </CardGroup>

--- a/docs/python-sdk/quickstart.mdx
+++ b/docs/python-sdk/quickstart.mdx
@@ -126,22 +126,23 @@ await phone.serve(agent, tunnel=True)
 
 `ElevenLabsConvAI()` reads `ELEVENLABS_API_KEY` and `ELEVENLABS_AGENT_ID` from the environment.
 
-For the STT + LLM + TTS pipeline mode, pass `stt=` and `tts=` to `agent()`:
+For the STT + LLM + TTS pipeline mode, pick each stage independently:
 
 ```python
-from getpatter import Patter, Twilio
-from getpatter.stt import deepgram
-from getpatter.tts import elevenlabs
+from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS
 
 phone = Patter(carrier=Twilio(), phone_number="+15550001234")
 agent = phone.agent(
-    stt=deepgram.STT(),        # reads DEEPGRAM_API_KEY
-    tts=elevenlabs.TTS(),      # reads ELEVENLABS_API_KEY
+    stt=DeepgramSTT(),                    # reads DEEPGRAM_API_KEY
+    llm=AnthropicLLM(),                   # reads ANTHROPIC_API_KEY
+    tts=ElevenLabsTTS(voice_id="rachel"), # reads ELEVENLABS_API_KEY
     system_prompt="You are a helpful assistant.",
     first_message="Hello!",
 )
 await phone.serve(agent, tunnel=True)
 ```
+
+Swap `AnthropicLLM()` for `OpenAILLM()`, `GroqLLM()`, `CerebrasLLM()`, or `GoogleLLM()` — tool calling works across all five. Need fully custom LLM logic? Drop `llm=` and pass `on_message=handler` to `serve()` instead.
 
 ---
 

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -6,7 +6,7 @@ icon: "terminal"
 
 # API Reference
 
-Complete reference for the `getpatter` Python SDK (v0.5.0).
+Complete reference for the `getpatter` Python SDK (v0.5.1).
 
 ## Patter
 
@@ -43,6 +43,7 @@ def agent(
     system_prompt: str,
     engine: OpenAIRealtime | ElevenLabsConvAI | None = None,
     stt: STTProvider | None = None,
+    llm: LLMProvider | None = None,
     tts: TTSProvider | None = None,
     voice: str = "alloy",
     model: str = "gpt-4o-mini-realtime-preview",
@@ -67,6 +68,7 @@ Pass `engine=OpenAIRealtime(...)` or `engine=ElevenLabsConvAI(...)` for end-to-e
 | `system_prompt` | `str` | *required* | Agent instructions. |
 | `engine` | `OpenAIRealtime \| ElevenLabsConvAI \| None` | `None` | End-to-end voice runtime. Omit for pipeline mode. |
 | `stt` | `STTProvider \| None` | `None` | STT instance for pipeline mode (e.g. `DeepgramSTT()`). |
+| `llm` | `LLMProvider \| None` | `None` | LLM provider instance for pipeline mode (e.g. `AnthropicLLM()`). Mutually exclusive with `on_message` on `serve()`. Ignored when `engine` is set. |
 | `tts` | `TTSProvider \| None` | `None` | TTS instance for pipeline mode (e.g. `ElevenLabsTTS()`). |
 | `voice` | `str` | `"alloy"` | TTS voice name (when engine doesn't carry it). |
 | `model` | `str` | `"gpt-4o-mini-realtime-preview"` | AI model ID (when engine doesn't carry it). |
@@ -232,6 +234,19 @@ All classes accept `api_key: str | None = None` and fall back to the provider's 
 
 ---
 
+## LLM providers
+
+```python
+from getpatter import OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM   # flat
+from getpatter.llm import openai, anthropic, groq, cerebras, google              # namespaced
+```
+
+All classes accept `api_key: str | None = None` and fall back to the provider's standard env var (`GoogleLLM` prefers `GEMINI_API_KEY`, falls back to `GOOGLE_API_KEY`). See the [LLM page](/python-sdk/llm) for full constructor signatures and tool-calling semantics.
+
+Pass an instance via `phone.agent(llm=...)` for pipeline mode. `llm=` is mutually exclusive with `on_message` on `serve()` and is ignored when `engine=` is set.
+
+---
+
 ## Tunnels
 
 ```python
@@ -393,6 +408,9 @@ from getpatter import (
     # TTS classes
     ElevenLabsTTS, OpenAITTS, CartesiaTTS, RimeTTS, LMNTTTS,
 
+    # LLM classes
+    OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM,
+
     # Public primitives
     Tool, Guardrail, tool, guardrail,
 
@@ -418,5 +436,6 @@ from getpatter.carriers import twilio, telnyx
 from getpatter.engines import openai, elevenlabs
 from getpatter.stt import deepgram, whisper, cartesia, assemblyai, soniox, speechmatics
 from getpatter.tts import elevenlabs, openai, cartesia, rime, lmnt
+from getpatter.llm import openai, anthropic, groq, cerebras, google
 from getpatter.tunnels import CloudflareTunnel, Static, Ngrok
 ```

--- a/docs/typescript-sdk/agents.mdx
+++ b/docs/typescript-sdk/agents.mdx
@@ -36,29 +36,34 @@ const agent = phone.agent({
 });
 ```
 
-Pipeline mode (STT + your own LLM via `onMessage` + TTS):
+Pipeline mode (pick STT, LLM, TTS independently):
 
 ```typescript
-import { Patter, Twilio, DeepgramSTT, ElevenLabsTTS } from "getpatter";
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
 
 const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
 
 const agent = phone.agent({
   stt: new DeepgramSTT({ endpointingMs: 80 }),           // DEEPGRAM_API_KEY from env
+  llm: new AnthropicLLM(),                               // ANTHROPIC_API_KEY from env
   tts: new ElevenLabsTTS({ voiceId: "rachel" }),         // ELEVENLABS_API_KEY from env
   systemPrompt: "You are a helpful assistant.",
   firstMessage: "Hi!",
 });
 ```
 
+Available LLM providers: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. See [LLM](/typescript-sdk/llm) for the full reference. For fully custom logic (multi-model routing, local models), drop `llm` and pass an `onMessage` callback to `serve()` instead — `llm` and `onMessage` are mutually exclusive.
+
 The same pipeline using namespaced imports:
 
 ```typescript
 import * as deepgram from "getpatter/stt/deepgram";
+import * as anthropic from "getpatter/llm/anthropic";
 import * as elevenlabs from "getpatter/tts/elevenlabs";
 
 const agent = phone.agent({
   stt: new deepgram.STT({ endpointingMs: 80 }),
+  llm: new anthropic.LLM(),
   tts: new elevenlabs.TTS({ voiceId: "rachel" }),
   systemPrompt: "You are a helpful assistant.",
 });
@@ -71,6 +76,7 @@ const agent = phone.agent({
 | `systemPrompt` | `string` | Yes | — | Instructions that define the agent's persona and behavior. |
 | `engine` | `OpenAIRealtime \| ElevenLabsConvAI` | No | defaults to `OpenAIRealtime` | End-to-end engine. See [Engines](/typescript-sdk/engines). Omit for pipeline mode. |
 | `stt` | `STTProvider` | No | — | STT instance for pipeline mode (`new DeepgramSTT()`, `new CartesiaSTT()`, ...). |
+| `llm` | `LLMProvider` | No | — | LLM instance for pipeline mode (`new AnthropicLLM()`, `new GroqLLM()`, ...). Mutually exclusive with `onMessage` on `serve()`. Ignored when `engine` is set. See [LLM](/typescript-sdk/llm). |
 | `tts` | `TTSProvider` | No | — | TTS instance for pipeline mode (`new ElevenLabsTTS()`, `new RimeTTS()`, ...). |
 | `voice` | `string` | No | Provider default | Voice ID. Usually inferred from the engine or TTS instance. |
 | `model` | `string` | No | `"gpt-4o-mini-realtime-preview"` | Model ID for OpenAI Realtime. Usually inferred from the engine. |
@@ -122,7 +128,7 @@ You do not need to define these in your `tools` array. The AI model can invoke t
 ## Engine vs Pipeline Mode
 
 ```typescript
-import { OpenAIRealtime, ElevenLabsConvAI, DeepgramSTT, ElevenLabsTTS } from "getpatter";
+import { OpenAIRealtime, ElevenLabsConvAI, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
 
 // OpenAI Realtime — end-to-end
 const agent = phone.agent({
@@ -136,9 +142,10 @@ const agent = phone.agent({
   systemPrompt: "...",
 });
 
-// Pipeline — custom STT + TTS + onMessage LLM
+// Pipeline — pick STT, LLM, TTS independently
 const agent = phone.agent({
   stt: new DeepgramSTT(),
+  llm: new AnthropicLLM(),
   tts: new ElevenLabsTTS({ voiceId: "rachel" }),
   systemPrompt: "...",
 });

--- a/docs/typescript-sdk/llm.mdx
+++ b/docs/typescript-sdk/llm.mdx
@@ -1,64 +1,130 @@
 ---
 title: "LLM"
-description: "Voice AI modes and language model providers."
+description: "Pick an LLM provider the same way you pick STT and TTS."
 icon: "brain"
 ---
 
 # LLM (Voice Mode)
 
-Patter supports two high-level voice AI architectures:
+Patter supports two voice architectures:
 
 | Mode | How to enable | When to use |
 |------|---------------|-------------|
-| **Engine (end-to-end)** | `phone.agent({ engine: new OpenAIRealtime(...) })` or `engine: new ElevenLabsConvAI(...)` | Lowest-latency speech-to-speech. The engine handles STT + LLM + TTS in a single provider. |
-| **Pipeline** | `phone.agent({ stt: ..., tts: ... })` (omit `engine`) | Full control. Plug a streaming STT, your own LLM, and a streaming TTS. |
+| **Engine (speech-to-speech)** | `phone.agent({ engine: new OpenAIRealtime(...) })` or `engine: new ElevenLabsConvAI(...)` | Lowest-latency speech-to-speech. A single provider handles STT + LLM + TTS. |
+| **Pipeline (STT + LLM + TTS)** | `phone.agent({ stt, llm, tts })` (omit `engine`) | Full control. Mix and match providers per stage. |
 
-See [Engines](/typescript-sdk/engines) for the reference on engine classes. This page focuses on the LLM step.
+See [Engines](/typescript-sdk/engines) for engine-mode reference. This page focuses on the `llm` selector in pipeline mode.
 
-## Engine mode
+## Pipeline mode
 
-Engine mode collapses STT, LLM, and TTS into a single streaming connection with the provider.
-
-### OpenAI Realtime (default)
+Compose the three stages independently. Each provider reads its credentials from the environment by default.
 
 ```typescript
 // npx tsx example.ts
-import { Patter, Twilio, OpenAIRealtime } from "getpatter";
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
 
 const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
 
 const agent = phone.agent({
-  engine: new OpenAIRealtime({ voice: "alloy" }),           // OPENAI_API_KEY from env
+  stt: new DeepgramSTT(),                       // DEEPGRAM_API_KEY
+  llm: new AnthropicLLM(),                      // ANTHROPIC_API_KEY
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }), // ELEVENLABS_API_KEY
   systemPrompt: "You are a helpful assistant.",
-  firstMessage: "Hello!",
+  firstMessage: "Hi!",
 });
 
 await phone.serve({ agent });
 ```
 
-**Voices:** `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`
-**Env var:** `OPENAI_API_KEY`
+Tool calling works across every provider — each adapter normalizes its vendor-specific streaming format to Patter's unified `{ type: "text" | "tool_call" | "done" }` chunk protocol, so your tools are defined once and run everywhere.
 
-### ElevenLabs ConvAI
+<Note>
+`llm` and `onMessage` are **mutually exclusive**. Pass one or the other on `serve()` — passing both raises a clear error at `serve()` time. When `engine` is set, `llm` is ignored (with a one-time warning in the logs). If neither `llm` nor `onMessage` is passed and `OPENAI_API_KEY` is set, Patter auto-constructs the default OpenAI LLM loop — existing 0.5.0 code still works.
+</Note>
 
-Uses a Conversational AI agent configured in the ElevenLabs dashboard.
+## Supported LLM providers
+
+| Flat import | Namespaced import | Env var | Install |
+|---|---|---|---|
+| `OpenAILLM` | `getpatter/llm/openai` → `LLM` | `OPENAI_API_KEY` | included |
+| `AnthropicLLM` | `getpatter/llm/anthropic` → `LLM` | `ANTHROPIC_API_KEY` | included |
+| `GroqLLM` | `getpatter/llm/groq` → `LLM` | `GROQ_API_KEY` | included |
+| `CerebrasLLM` | `getpatter/llm/cerebras` → `LLM` | `CEREBRAS_API_KEY` | included |
+| `GoogleLLM` | `getpatter/llm/google` → `LLM` | `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) | included |
+
+All classes accept an options object with `apiKey?: string` and fall back to the listed env var when it is omitted.
+
+### OpenAILLM
+
+OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-4o-mini"`.
 
 ```typescript
-import { Patter, Twilio, ElevenLabsConvAI } from "getpatter";
+import { OpenAILLM } from "getpatter";                    // flat
+import * as openai from "getpatter/llm/openai";           // namespaced
 
-const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const llm = new OpenAILLM();                              // reads OPENAI_API_KEY
+const llm2 = new openai.LLM({ apiKey: "sk-...", model: "gpt-4o-mini" });
+```
 
-const agent = phone.agent({
-  engine: new ElevenLabsConvAI({ agentId: "agent_abc123" }),   // ELEVENLABS_API_KEY + ELEVENLABS_AGENT_ID from env
-  systemPrompt: "You are a warm and friendly concierge.",
+### AnthropicLLM
+
+Anthropic Messages API with native streaming and `tool_use` blocks, normalised to Patter's chunk protocol. Default model `"claude-3-5-sonnet-20241022"`. Pass `maxTokens` to override the default token cap.
+
+```typescript
+import { AnthropicLLM } from "getpatter";                 // flat
+import * as anthropic from "getpatter/llm/anthropic";     // namespaced
+
+const llm = new AnthropicLLM();                           // reads ANTHROPIC_API_KEY
+const llm2 = new anthropic.LLM({
+  apiKey: "sk-ant-...",
+  model: "claude-3-5-sonnet-20241022",
+  maxTokens: 2048,
 });
 ```
 
-**Env vars:** `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID`
+### GroqLLM
 
-## Pipeline mode
+Hardware-accelerated Llama inference via Groq's OpenAI-compatible Chat Completions API at `https://api.groq.com/openai/v1`. Default model `"llama-3.3-70b-versatile"`.
 
-Omit `engine` and pass `stt` + `tts` instead. Patter wires them together automatically. For the LLM step, provide an `onMessage` callback — you can run any model you like inside.
+```typescript
+import { GroqLLM } from "getpatter";                      // flat
+import * as groq from "getpatter/llm/groq";               // namespaced
+
+const llm = new GroqLLM();                                // reads GROQ_API_KEY
+const llm2 = new groq.LLM({ apiKey: "gsk_...", model: "llama-3.3-70b-versatile" });
+```
+
+### CerebrasLLM
+
+Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"llama3.1-8b"`. Supports optional gzip request-body compression via `gzipCompression: true` to reduce time-to-first-token on large prompts — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization).
+
+```typescript
+import { CerebrasLLM } from "getpatter";                  // flat
+import * as cerebras from "getpatter/llm/cerebras";       // namespaced
+
+const llm = new CerebrasLLM();                            // reads CEREBRAS_API_KEY
+const llm2 = new cerebras.LLM({
+  apiKey: "csk-...",
+  model: "llama3.1-8b",
+  gzipCompression: true,
+});
+```
+
+### GoogleLLM
+
+Google Gemini via the Developer API (streaming SSE). Default model `"gemini-2.5-flash"`.
+
+```typescript
+import { GoogleLLM } from "getpatter";                    // flat
+import * as google from "getpatter/llm/google";           // namespaced
+
+const llm = new GoogleLLM();                              // reads GEMINI_API_KEY, falls back to GOOGLE_API_KEY
+const llm2 = new google.LLM({ apiKey: "AIza...", model: "gemini-2.5-flash" });
+```
+
+## Custom LLM via `onMessage`
+
+For cases the five built-in providers don't cover — multi-model routing, local inference, an internal gateway, caching layers — drop `llm` and plug an async `onMessage` callback instead:
 
 ```typescript
 // npx tsx example.ts
@@ -67,51 +133,29 @@ import { Patter, Twilio, DeepgramSTT, ElevenLabsTTS } from "getpatter";
 const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
 
 const agent = phone.agent({
-  stt: new DeepgramSTT({ endpointingMs: 80 }),          // DEEPGRAM_API_KEY from env
-  tts: new ElevenLabsTTS({ voiceId: "rachel" }),        // ELEVENLABS_API_KEY from env
+  stt: new DeepgramSTT(),
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }),
   systemPrompt: "You are a helpful assistant.",
-  firstMessage: "Hi!",
 });
 
 await phone.serve({
   agent,
   onMessage: async ({ text }) => {
-    // Drop in OpenAI, Anthropic, Groq, a local llama.cpp, whatever.
+    // Route to any model you like — local inference, a private gateway, etc.
     return `You said: ${text}. How can I help?`;
   },
 });
 ```
 
-### Built-in LLM adapters
+<Warning>
+`onMessage` and `llm` cannot be used together. Combining them raises a clear error at `serve()` time — pick one.
+</Warning>
 
-Built-in LLM adapters live inside `getpatter` and can be called from `onMessage`:
-
-| Provider | Notes |
-|----------|-------|
-| Anthropic | `anthropic-llm.ts` |
-| Google Gemini | `google-llm.ts` (Gemini Live also available via `gemini-live.ts`) |
-| Groq | `groq-llm.ts` |
-| Cerebras | `cerebras-llm.ts` |
-| Ultravox (realtime) | `ultravox-realtime.ts` |
-
-<Note>
-A first-class `llm: new AnthropicLLM(...)` parameter is planned for Patter 0.6 — once it lands you will be able to plug LLMs the same way you plug STT and TTS today. Until then, the LLM step of pipeline mode flows through `onMessage`.
-</Note>
-
-## Comparison
-
-| Feature | `engine: OpenAIRealtime` | `engine: ElevenLabsConvAI` | Pipeline (`stt` / `tts`) |
-|---------|--------------------------|-----------------------------|---------------------------|
-| Latency | Lowest | Low | Medium |
-| Voice quality | High | Very high | Depends on TTS |
-| Custom LLM | No | No | Yes (via `onMessage`) |
-| Function calling | Yes | Limited | Yes |
-
-## What's Next
+## What's next
 
 <CardGroup cols={2}>
-  <Card title="Engines" icon="bolt" href="/typescript-sdk/engines">Engine class reference.</Card>
   <Card title="STT" icon="microphone" href="/typescript-sdk/stt">STT providers for pipeline mode.</Card>
   <Card title="TTS" icon="volume" href="/typescript-sdk/tts">TTS providers for pipeline mode.</Card>
-  <Card title="Tools" icon="wrench" href="/typescript-sdk/tools">Function calling.</Card>
+  <Card title="Tools" icon="wrench" href="/typescript-sdk/tools">Function calling (works across every LLM).</Card>
+  <Card title="Engines" icon="bolt" href="/typescript-sdk/engines">Speech-to-speech engines (OpenAI Realtime, ElevenLabs ConvAI).</Card>
 </CardGroup>

--- a/docs/typescript-sdk/quickstart.mdx
+++ b/docs/typescript-sdk/quickstart.mdx
@@ -126,20 +126,23 @@ await phone.serve({ agent, tunnel: true });
 
 `new ElevenLabsConvAI()` reads `ELEVENLABS_API_KEY` and `ELEVENLABS_AGENT_ID` from the environment.
 
-For the STT + LLM + TTS pipeline mode, pass `stt` and `tts` to `agent()`:
+For the STT + LLM + TTS pipeline mode, pick each stage independently:
 
 ```typescript
-import { Patter, Twilio, DeepgramSTT, ElevenLabsTTS } from "getpatter";
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
 
 const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
 const agent = phone.agent({
-  stt: new DeepgramSTT(),        // reads DEEPGRAM_API_KEY
-  tts: new ElevenLabsTTS(),      // reads ELEVENLABS_API_KEY
+  stt: new DeepgramSTT(),                         // reads DEEPGRAM_API_KEY
+  llm: new AnthropicLLM(),                        // reads ANTHROPIC_API_KEY
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }),  // reads ELEVENLABS_API_KEY
   systemPrompt: "You are a helpful assistant.",
   firstMessage: "Hello!",
 });
 await phone.serve({ agent, tunnel: true });
 ```
+
+Swap `new AnthropicLLM()` for `new OpenAILLM()`, `new GroqLLM()`, `new CerebrasLLM()`, or `new GoogleLLM()` — tool calling works across all five. Need fully custom LLM logic? Drop `llm` and pass `onMessage` to `serve()` instead.
 
 ---
 

--- a/docs/typescript-sdk/reference.mdx
+++ b/docs/typescript-sdk/reference.mdx
@@ -131,6 +131,21 @@ Each class accepts an options object with `apiKey?: string` and falls back to th
 
 ---
 
+## LLM classes
+
+```typescript
+import { OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM } from "getpatter";
+import * as openai from "getpatter/llm/openai";
+import * as anthropic from "getpatter/llm/anthropic";
+import * as groq from "getpatter/llm/groq";
+import * as cerebras from "getpatter/llm/cerebras";
+import * as google from "getpatter/llm/google";
+```
+
+Each class accepts an options object with `apiKey?: string` and falls back to the provider's standard env var (`GoogleLLM` prefers `GEMINI_API_KEY`, falls back to `GOOGLE_API_KEY`). Pass an instance via `phone.agent({ llm })` for pipeline mode. `llm` is mutually exclusive with `onMessage` on `serve()` and is ignored when `engine` is set. See the [LLM page](/typescript-sdk/llm) for full constructor signatures.
+
+---
+
 ## Tunnels
 
 ```typescript
@@ -190,6 +205,7 @@ interface AgentOptions {
   systemPrompt: string;
   engine?: OpenAIRealtime | ElevenLabsConvAI;
   stt?: STTProvider;
+  llm?: LLMProvider;
   tts?: TTSProvider;
   voice?: string;
   model?: string;
@@ -327,6 +343,9 @@ export {
   // TTS classes
   ElevenLabsTTS, OpenAITTS, CartesiaTTS, RimeTTS, LMNTTTS,
 
+  // LLM classes
+  OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM,
+
   // Tunnels
   CloudflareTunnel, StaticTunnel,
 
@@ -348,5 +367,10 @@ import * as elevenlabs from "getpatter/engines/elevenlabs";
 import * as deepgram from "getpatter/stt/deepgram";
 import * as whisper from "getpatter/stt/whisper";
 import * as cartesia from "getpatter/stt/cartesia";
+import * as openaiLlm from "getpatter/llm/openai";
+import * as anthropicLlm from "getpatter/llm/anthropic";
+import * as groqLlm from "getpatter/llm/groq";
+import * as cerebrasLlm from "getpatter/llm/cerebras";
+import * as googleLlm from "getpatter/llm/google";
 // etc.
 ```

--- a/sdk-py/README.md
+++ b/sdk-py/README.md
@@ -57,7 +57,8 @@ await phone.serve(agent, tunnel=True)
 | Tool calling | `agent(tools=[Tool(...)])` | Agent calls external APIs mid-conversation |
 | Custom STT + TTS | `agent(stt=DeepgramSTT(), tts=ElevenLabsTTS())` | Bring your own voice providers |
 | Dynamic variables | `agent(variables={...})` | Personalize prompts per caller |
-| Custom LLM (any model) | `serve(on_message=handler)` | Claude, Mistral, LLaMA, etc. |
+| Pluggable LLM | `agent(llm=AnthropicLLM())` | 5 built-in providers: OpenAI, Anthropic, Groq, Cerebras, Google |
+| Custom LLM (any model) | `serve(on_message=handler)` | Route to anything — local llama.cpp, internal gateways, etc. |
 | Call recording | `serve(recording=True)` | Record all calls |
 | Call transfer | `transfer_call` (auto-injected) | Transfer to a human |
 | Voicemail drop | `call(voicemail_message="...")` | Play message on voicemail |
@@ -81,6 +82,10 @@ Every provider reads its credentials from the environment by default. Pass `api_
 | `SONIOX_API_KEY` | `getpatter.stt.soniox.STT` |
 | `SPEECHMATICS_API_KEY` | `getpatter.stt.speechmatics.STT` |
 | `ASSEMBLYAI_API_KEY` | `getpatter.stt.assemblyai.STT` |
+| `ANTHROPIC_API_KEY` | `AnthropicLLM` / `getpatter.llm.anthropic.LLM` |
+| `GROQ_API_KEY` | `GroqLLM` / `getpatter.llm.groq.LLM` |
+| `CEREBRAS_API_KEY` | `CerebrasLLM` / `getpatter.llm.cerebras.LLM` |
+| `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | `GoogleLLM` / `getpatter.llm.google.LLM` |
 
 ```bash
 cp .env.example .env
@@ -233,6 +238,23 @@ agent = phone.agent(
 )
 await phone.serve(agent, tunnel=True)
 ```
+
+### Pipeline mode — pick STT, LLM, TTS independently
+
+```python
+from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+agent = phone.agent(
+    stt=DeepgramSTT(),                     # reads DEEPGRAM_API_KEY
+    llm=AnthropicLLM(),                    # reads ANTHROPIC_API_KEY
+    tts=ElevenLabsTTS(voice_id="rachel"),  # reads ELEVENLABS_API_KEY
+    system_prompt="You are a helpful voice assistant.",
+)
+await phone.serve(agent, tunnel=True)
+```
+
+Available LLM providers: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. For fully custom logic, drop `llm=` and pass an `on_message` callback to `serve()` instead.
 
 ### Tool calling
 

--- a/sdk-py/getpatter/__init__.py
+++ b/sdk-py/getpatter/__init__.py
@@ -19,7 +19,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.4.4"
+__version__ = "0.5.1"
 
 from getpatter.client import Patter
 from getpatter.models import (
@@ -69,6 +69,13 @@ from getpatter.tts.openai import TTS as OpenAITTS
 from getpatter.tts.cartesia import TTS as CartesiaTTS
 from getpatter.tts.rime import TTS as RimeTTS
 from getpatter.tts.lmnt import TTS as LMNTTTS
+
+# LLM flat aliases — parity with sdk-ts/src/index.ts and mirror of STT/TTS layout.
+from getpatter.llm.openai import LLM as OpenAILLM
+from getpatter.llm.anthropic import LLM as AnthropicLLM
+from getpatter.llm.groq import LLM as GroqLLM
+from getpatter.llm.cerebras import LLM as CerebrasLLM
+from getpatter.llm.google import LLM as GoogleLLM
 
 # Tunnel flat aliases.
 from getpatter.tunnels import CloudflareTunnel, Ngrok, Static as StaticTunnel
@@ -136,6 +143,11 @@ __all__ = [
     "CartesiaTTS",
     "RimeTTS",
     "LMNTTTS",
+    "OpenAILLM",
+    "AnthropicLLM",
+    "GroqLLM",
+    "CerebrasLLM",
+    "GoogleLLM",
     "CloudflareTunnel",
     "Ngrok",
     "StaticTunnel",

--- a/sdk-py/getpatter/client.py
+++ b/sdk-py/getpatter/client.py
@@ -41,6 +41,7 @@ from getpatter.exceptions import PatterConnectionError, ProvisionError
 from getpatter.models import Agent, Guardrail, IncomingMessage, STTConfig, TTSConfig
 from getpatter.local_config import LocalConfig
 from getpatter.providers.base import STTProvider, TTSProvider
+from getpatter.services.llm_loop import LLMProvider
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
     from getpatter.carriers.twilio import Carrier as TwilioCarrier
@@ -485,6 +486,7 @@ class Patter:
         background_audio: "BackgroundAudioPlayer | None" = None,
         barge_in_threshold_ms: int = 300,
         engine: Any = None,
+        llm: "LLMProvider | None" = None,
     ) -> Agent:
         """Create an ``Agent`` configuration for local mode.
 
@@ -514,10 +516,24 @@ class Patter:
                 replaced before TTS.
             engine: ``OpenAIRealtime(...)`` or ``ElevenLabsConvAI(...)``.
         """
+        # --- Validate llm= (runtime-checkable Protocol) ---
+        if llm is not None and not isinstance(llm, LLMProvider):
+            raise TypeError(
+                "llm must be an LLMProvider instance (e.g. AnthropicLLM(api_key=...)) "
+                f"or None; got {type(llm).__name__}"
+            )
+
         # --- Engine dispatch ---
         openai_engine_key: str = ""
         elevenlabs_engine_key: str = ""
         if engine is not None:
+            # Engine mode handles the LLM internally — `llm=` is ignored.
+            # Emit a one-time warning so the user knows.
+            if llm is not None:
+                logger.warning(
+                    "llm= ignored when engine= is set (the engine handles the "
+                    "LLM internally)."
+                )
             engine_kind, engine_fields = self._unpack_engine(engine)
             provider = engine_kind
             # Engine-supplied voice/model win over the method defaults, but we
@@ -531,7 +547,7 @@ class Patter:
                 openai_engine_key = engine_fields.get("api_key", "")
             elif engine_kind == "elevenlabs_convai":
                 elevenlabs_engine_key = engine_fields.get("api_key", "")
-        elif stt is not None or tts is not None:
+        elif stt is not None or tts is not None or llm is not None:
             provider = "pipeline"
         else:
             provider = "openai_realtime"
@@ -617,6 +633,7 @@ class Patter:
             audio_filter=audio_filter,
             background_audio=background_audio,
             barge_in_threshold_ms=barge_in_threshold_ms,
+            llm=llm,
         )
 
     @staticmethod
@@ -737,6 +754,11 @@ class Patter:
             raise TypeError(
                 f"agent must be an Agent instance, got {type(agent).__name__}. "
                 "Use phone.agent() to create one."
+            )
+        if agent.llm is not None and on_message is not None:
+            raise ValueError(
+                "Cannot pass both `llm=` on the agent and `on_message=` on serve(). "
+                "Pick one — `llm=` for built-in LLMs, `on_message=` for custom logic."
             )
         if not isinstance(port, int) or isinstance(port, bool) or port < 1 or port > 65535:
             raise ValueError(

--- a/sdk-py/getpatter/handlers/stream_handler.py
+++ b/sdk-py/getpatter/handlers/stream_handler.py
@@ -847,8 +847,21 @@ class PipelineStreamHandler(StreamHandler):
             except (ValueError, TypeError):
                 pass
 
-        # Built-in LLM loop
-        if self.on_message is None and self._openai_key:
+        # Built-in LLM loop. Three paths:
+        #   1. `agent.llm` set + `on_message` set → ValueError (caught early
+        #      in serve(), but we re-assert here for belt-and-braces).
+        #   2. `agent.llm` set → use the user-supplied LLMProvider; openai_key
+        #      is not required.
+        #   3. Otherwise fall back to the legacy OpenAI default (requires
+        #      `openai_key`).
+        agent_llm = getattr(self.agent, "llm", None)
+        if agent_llm is not None and self.on_message is not None:
+            raise ValueError(
+                "Cannot pass both `llm=` on the agent and `on_message=` on serve(). "
+                "Pick one — `llm=` for built-in LLMs, `on_message=` for custom logic."
+            )
+
+        if self.on_message is None and (agent_llm is not None or self._openai_key):
             from getpatter.services.llm_loop import LLMLoop
             from getpatter.services.tool_executor import ToolExecutor
 
@@ -862,6 +875,7 @@ class PipelineStreamHandler(StreamHandler):
                 system_prompt=self.resolved_prompt,
                 tools=self.agent.tools,
                 tool_executor=tool_executor,
+                llm_provider=agent_llm,
             )
 
         # Create remote message handler once if on_message is a remote URL

--- a/sdk-py/getpatter/handlers/stream_handler.py
+++ b/sdk-py/getpatter/handlers/stream_handler.py
@@ -133,7 +133,7 @@ def apply_call_overrides(agent, overrides: dict):
         base = {k: v for k, v in asdict(agent).items() if k not in fields}
         base.update(fields)
         agent = _Agent(**base)
-        logger.info("Per-call config overrides applied: %s", list(fields.keys()))
+        logger.debug("Per-call config overrides applied: %s", list(fields.keys()))
     return agent
 
 
@@ -356,7 +356,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
             audio_format=self._audio_format,
         )
         await self._adapter.connect()
-        logger.info("OpenAI Realtime connected")
+        logger.debug("OpenAI Realtime connected")
 
         if self.agent.first_message:
             await self._adapter.send_text(self.agent.first_message)
@@ -379,7 +379,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
                     await self.audio_sender.send_mark(f"audio_{id(ev_data)}")
 
                 elif ev_type == "transcript_input":
-                    logger.info("User: %s", sanitize_log_value(ev_data))
+                    logger.debug("User: %s", sanitize_log_value(ev_data))
                     if self.metrics is not None:
                         self.metrics.start_turn()
                         self.metrics.record_stt_complete(ev_data)
@@ -464,7 +464,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
                                 json.dumps({"error": "Invalid phone number format", "status": "rejected"}),
                             )
                             continue
-                        logger.info(
+                        logger.debug(
                             "Transferring call to %s", mask_phone_number(transfer_number)
                         )
                         await self._adapter.send_function_result(
@@ -487,7 +487,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
                         raw_args = func_data.get("arguments", "{}")
                         args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
                         reason = args.get("reason", "conversation_complete")
-                        logger.info("Ending call: %s", reason)
+                        logger.debug("Ending call: %s", reason)
                         await self._adapter.send_function_result(
                             func_data["call_id"],
                             json.dumps({"status": "ending", "reason": reason}),
@@ -616,7 +616,7 @@ class ElevenLabsConvAIStreamHandler(StreamHandler):
             first_message=self.agent.first_message,
         )
         await self._adapter.connect()
-        logger.info("ElevenLabs ConvAI connected")
+        logger.debug("ElevenLabs ConvAI connected")
 
         self._background_task = asyncio.create_task(self._forward_events())
 
@@ -632,7 +632,7 @@ class ElevenLabsConvAIStreamHandler(StreamHandler):
                     await self.audio_sender.send_audio(ev_data)
 
                 elif ev_type == "transcript_input":
-                    logger.info("User: %s", sanitize_log_value(ev_data))
+                    logger.debug("User: %s", sanitize_log_value(ev_data))
                     if self.metrics is not None:
                         self.metrics.start_turn()
                         self.metrics.record_stt_complete(ev_data)
@@ -821,7 +821,7 @@ class PipelineStreamHandler(StreamHandler):
         if self._stt is not None:
             await self._stt.connect()
 
-        logger.info("Pipeline mode: STT + TTS connected")
+        logger.debug("Pipeline mode: STT + TTS connected")
 
         # Play first_message if configured and no on_message handler
         if self.agent.first_message and self.on_message is None and self._tts is not None:
@@ -1102,7 +1102,7 @@ class PipelineStreamHandler(StreamHandler):
                 # flip `_is_speaking=False` + clear the downstream audio
                 # buffer so the in-flight TTS loop interrupts (BUG #20).
                 if transcript.text and self._is_speaking:
-                    logger.info(
+                    logger.debug(
                         "Barge-in: caller spoke over agent (%s)",
                         sanitize_log_value(transcript.text[:40]),
                     )
@@ -1133,21 +1133,21 @@ class PipelineStreamHandler(StreamHandler):
                     "right", "cool",
                 })
                 if _stripped in _HALLUCINATIONS or _stripped == "":
-                    logger.info(
+                    logger.debug(
                         "Dropped likely STT hallucination: %r",
                         _normalised[:40],
                     )
                     continue
 
                 if _since_last < 2.0 and _normalised == last_commit_text:
-                    logger.info(
+                    logger.debug(
                         "Dropped duplicate final transcript (%.1fs since last): %r",
                         _since_last,
                         _normalised[:40],
                     )
                     continue
                 if _since_last < 0.5:
-                    logger.info(
+                    logger.debug(
                         "Dropped back-to-back final transcript (%.2fs since last): %r",
                         _since_last,
                         _normalised[:40],
@@ -1170,7 +1170,7 @@ class PipelineStreamHandler(StreamHandler):
                 ):
                     pass
 
-                logger.info("User: %s", sanitize_log_value(transcript.text))
+                logger.debug("User: %s", sanitize_log_value(transcript.text))
 
                 if self.metrics is not None:
                     self.metrics.start_turn()
@@ -1199,7 +1199,7 @@ class PipelineStreamHandler(StreamHandler):
                     transcript.text, hook_ctx
                 )
                 if filtered_text is None:
-                    logger.info("afterTranscribe hook vetoed turn")
+                    logger.debug("afterTranscribe hook vetoed turn")
                     if self.metrics is not None:
                         self.metrics.record_turn_interrupted()
                     continue
@@ -1395,6 +1395,6 @@ async def fetch_deepgram_cost(metrics, stt, deepgram_key: str) -> None:
                             usd = req_resp.json().get("response", {}).get("details", {}).get("usd", None)
                             if usd is not None:
                                 metrics.set_actual_stt_cost(float(usd))
-                                logger.info("Deepgram actual cost: $%s", usd)
+                                logger.debug("Deepgram actual cost: $%s", usd)
     except Exception as exc:
         logger.debug("Could not fetch Deepgram request cost: %s", exc)

--- a/sdk-py/getpatter/handlers/telnyx_handler.py
+++ b/sdk-py/getpatter/handlers/telnyx_handler.py
@@ -214,7 +214,18 @@ async def telnyx_stream_bridge(
                 caller = start_info.get("from", "") or caller
                 callee = start_info.get("to", "") or callee
 
-                logger.info("Telnyx stream started: %s", call_id_actual)
+                # Single INFO line per call-start — full context in one place.
+                _mode = (
+                    f"engine={getattr(agent.engine, 'kind', 'unknown')}"
+                    if getattr(agent, 'engine', None) is not None
+                    else "pipeline"
+                    if (getattr(agent, 'stt', None) is not None and getattr(agent, 'tts', None) is not None)
+                    else f"engine={getattr(agent, 'provider', 'unknown')}"
+                )
+                logger.info(
+                    "Call started: %s (Telnyx, %s, %s → %s)",
+                    call_id_actual, _mode, caller or '?', callee or '?',
+                )
 
                 # Fire on_call_start callback — may return per-call config overrides
                 _call_overrides = None
@@ -280,7 +291,7 @@ async def telnyx_stream_bridge(
                                 json={"to": number},
                                 timeout=10.0,
                             )
-                        logger.info(
+                        logger.debug(
                             "Telnyx call transferred to %s", mask_phone_number(number)
                         )
 
@@ -294,7 +305,7 @@ async def telnyx_stream_bridge(
                                 json={},
                                 timeout=10.0,
                             )
-                        logger.info("Telnyx call hung up")
+                        logger.debug("Telnyx call hung up")
 
                 async def _telnyx_send_dtmf(digits: str, delay_ms: int = 300) -> None:
                     """Send DTMF digits via the Telnyx Call Control API.
@@ -335,7 +346,7 @@ async def telnyx_stream_bridge(
                             )
                             if idx < len(filtered) - 1 and delay_ms > 0:
                                 await asyncio.sleep(delay_ms / 1000)
-                    logger.info(
+                    logger.debug(
                         "Telnyx DTMF sent (%d digits, delay=%dms)",
                         len(filtered),
                         delay_ms,
@@ -361,7 +372,7 @@ async def telnyx_stream_bridge(
                                 resp.text[:200],
                             )
                         else:
-                            logger.info("Telnyx recording started")
+                            logger.debug("Telnyx recording started")
 
                 async def _telnyx_stop_recording() -> None:
                     """Stop recording the call via Telnyx Call Control API."""
@@ -383,7 +394,7 @@ async def telnyx_stream_bridge(
                                 resp.text[:200],
                             )
                         else:
-                            logger.info("Telnyx recording stopped")
+                            logger.debug("Telnyx recording stopped")
 
                 # Kick off recording if requested
                 if recording:
@@ -484,7 +495,7 @@ async def telnyx_stream_bridge(
                 dtmf_info = data.get("dtmf", {}) or {}
                 digit = str(dtmf_info.get("digit", "")).strip()
                 if digit:
-                    logger.info("Telnyx DTMF received: %s", digit)
+                    logger.debug("Telnyx DTMF received: %s", digit)
                     if handler is not None:
                         try:
                             on_dtmf = getattr(handler, "on_dtmf", None)
@@ -550,7 +561,7 @@ async def telnyx_stream_bridge(
                         total_cost = cost.get("amount")
                         if total_cost is not None:
                             metrics.set_actual_telephony_cost(abs(float(total_cost)))
-                            logger.info("Telnyx actual cost: $%s", abs(float(total_cost)))
+                            logger.debug("Telnyx actual cost: $%s", abs(float(total_cost)))
             except Exception as exc:
                 logger.debug("Could not fetch Telnyx call cost: %s", exc)
 
@@ -579,4 +590,16 @@ async def telnyx_stream_bridge(
                 )
             except Exception as exc:
                 logger.exception("on_call_end error: %s", exc)
-        logger.info("Telnyx call ended")
+
+        # Single INFO line per call-end — duration, turns, cost, latency.
+        if call_metrics is not None:
+            _dur = getattr(call_metrics, 'duration_seconds', 0) or 0
+            _turns = len(getattr(call_metrics, 'turns', []) or [])
+            _cost = getattr(getattr(call_metrics, 'cost', None), 'total', 0) or 0
+            _p95 = getattr(getattr(call_metrics, 'latency_p95', None), 'total_ms', 0) or 0
+            logger.info(
+                "Call ended: %s (%.1fs, %d turns, cost=$%.4f, p95=%dms)",
+                call_id_actual, _dur, _turns, _cost, round(_p95),
+            )
+        else:
+            logger.info("Call ended: %s", call_id_actual)

--- a/sdk-py/getpatter/handlers/twilio_handler.py
+++ b/sdk-py/getpatter/handlers/twilio_handler.py
@@ -234,9 +234,20 @@ async def twilio_stream_bridge(
                 call_sid_actual = start_data.get("callSid", "")
                 custom_params: dict = start_data.get("customParameters", {})
 
-                logger.info("Call started: %s", call_sid_actual)
+                # Single INFO line per call-start — full context in one place.
+                _mode = (
+                    f"engine={getattr(agent, 'provider', 'unknown')}"
+                    if getattr(agent, 'engine', None) is None
+                    else f"engine={getattr(agent.engine, 'kind', 'unknown')}"
+                )
+                if getattr(agent, 'stt', None) is not None and getattr(agent, 'tts', None) is not None and getattr(agent, 'engine', None) is None:
+                    _mode = "pipeline"
+                logger.info(
+                    "Call started: %s (Twilio, %s, %s → %s)",
+                    call_sid_actual, _mode, caller or '?', callee or '?',
+                )
                 if custom_params:
-                    logger.info("Custom params: %s", custom_params)
+                    logger.debug("Custom params: %s", custom_params)
 
                 # Fire on_call_start callback — may return per-call config overrides
                 _call_overrides = None
@@ -273,7 +284,7 @@ async def twilio_stream_bridge(
                                     f"https://api.twilio.com/2010-04-01/Accounts/{twilio_sid}/Calls/{call_sid_actual}/Recordings.json",
                                     auth=(twilio_sid, twilio_token),
                                 )
-                            logger.info("Recording started for %s", call_sid_actual)
+                            logger.debug("Recording started for %s", call_sid_actual)
                         except Exception as _exc:
                             logger.warning("Could not start recording: %s", _exc)
 
@@ -322,7 +333,7 @@ async def twilio_stream_bridge(
                                 auth=(twilio_sid, twilio_token),
                                 data={"Twiml": twiml},
                             )
-                        logger.info(
+                        logger.debug(
                             "Call transferred to %s", mask_phone_number(number)
                         )
 
@@ -338,7 +349,7 @@ async def twilio_stream_bridge(
                                 auth=(twilio_sid, twilio_token),
                                 data={"Status": "completed"},
                             )
-                        logger.info("Call hung up")
+                        logger.debug("Call hung up")
 
                 # Create the appropriate stream handler
                 if provider == "pipeline":
@@ -418,7 +429,7 @@ async def twilio_stream_bridge(
 
             elif event == "dtmf":
                 digit = data.get("dtmf", {}).get("digit", "")
-                logger.info("DTMF: %s", digit)
+                logger.debug("DTMF: %s", digit)
                 if handler is not None:
                     await handler.on_dtmf(digit)
                 if on_transcript:
@@ -462,7 +473,7 @@ async def twilio_stream_bridge(
                         if price is not None:
                             # Twilio returns price as negative string (e.g. "-0.0085")
                             metrics.set_actual_telephony_cost(abs(float(price)))
-                            logger.info("Twilio actual cost: $%s", abs(float(price)))
+                            logger.debug("Twilio actual cost: $%s", abs(float(price)))
             except Exception as exc:
                 logger.debug("Could not fetch Twilio call cost: %s", exc)
 
@@ -491,4 +502,16 @@ async def twilio_stream_bridge(
                 )
             except Exception as exc:
                 logger.exception("on_call_end error: %s", exc)
-        logger.info("Call ended")
+
+        # Single INFO line per call-end — duration, turns, cost, latency.
+        if call_metrics is not None:
+            _dur = getattr(call_metrics, 'duration_seconds', 0) or 0
+            _turns = len(getattr(call_metrics, 'turns', []) or [])
+            _cost = getattr(getattr(call_metrics, 'cost', None), 'total', 0) or 0
+            _p95 = getattr(getattr(call_metrics, 'latency_p95', None), 'total_ms', 0) or 0
+            logger.info(
+                "Call ended: %s (%.1fs, %d turns, cost=$%.4f, p95=%dms)",
+                call_sid_actual, _dur, _turns, _cost, round(_p95),
+            )
+        else:
+            logger.info("Call ended: %s", call_sid_actual)

--- a/sdk-py/getpatter/llm/__init__.py
+++ b/sdk-py/getpatter/llm/__init__.py
@@ -1,0 +1,23 @@
+"""Namespaced LLM adapters for Patter pipeline mode.
+
+Each submodule exposes a thin ``LLM`` subclass of the corresponding provider
+adapter with:
+
+* An environment-variable fallback on ``api_key``.
+* A clear error message when credentials are missing.
+
+Usage::
+
+    from getpatter.llm import anthropic
+    llm = anthropic.LLM()  # reads ANTHROPIC_API_KEY
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "openai",
+    "anthropic",
+    "groq",
+    "cerebras",
+    "google",
+]

--- a/sdk-py/getpatter/llm/anthropic.py
+++ b/sdk-py/getpatter/llm/anthropic.py
@@ -1,0 +1,36 @@
+"""Anthropic Claude LLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.providers.anthropic_llm import AnthropicLLMProvider as _AnthropicLLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_AnthropicLLM):
+    """Anthropic Claude LLM provider (Messages API, streaming).
+
+    Example::
+
+        from getpatter.llm import anthropic
+
+        llm = anthropic.LLM()                         # reads ANTHROPIC_API_KEY
+        llm = anthropic.LLM(api_key="sk-ant-...", model="claude-3-5-sonnet-20241022")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "claude-3-5-sonnet-20241022",
+        **kwargs,
+    ) -> None:
+        key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not key:
+            raise ValueError(
+                "Anthropic LLM requires an api_key. Pass api_key='sk-ant-...' or "
+                "set ANTHROPIC_API_KEY in the environment."
+            )
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/sdk-py/getpatter/llm/cerebras.py
+++ b/sdk-py/getpatter/llm/cerebras.py
@@ -1,0 +1,36 @@
+"""Cerebras LLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.providers.cerebras_llm import CerebrasLLMProvider as _CerebrasLLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_CerebrasLLM):
+    """Cerebras LLM provider (OpenAI-compatible Inference API).
+
+    Example::
+
+        from getpatter.llm import cerebras
+
+        llm = cerebras.LLM()                          # reads CEREBRAS_API_KEY
+        llm = cerebras.LLM(api_key="csk-...", model="llama3.1-8b")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "llama3.1-8b",
+        **kwargs,
+    ) -> None:
+        key = api_key or os.environ.get("CEREBRAS_API_KEY")
+        if not key:
+            raise ValueError(
+                "Cerebras LLM requires an api_key. Pass api_key='csk-...' or "
+                "set CEREBRAS_API_KEY in the environment."
+            )
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/sdk-py/getpatter/llm/google.py
+++ b/sdk-py/getpatter/llm/google.py
@@ -1,0 +1,42 @@
+"""Google Gemini LLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.providers.google_llm import GoogleLLMProvider as _GoogleLLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_GoogleLLM):
+    """Google Gemini LLM provider (``google-genai`` SDK).
+
+    Example::
+
+        from getpatter.llm import google
+
+        llm = google.LLM()                            # reads GEMINI_API_KEY or GOOGLE_API_KEY
+        llm = google.LLM(api_key="AIza...", model="gemini-2.5-flash")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "gemini-2.5-flash",
+        **kwargs,
+    ) -> None:
+        # Prefer ``GEMINI_API_KEY`` (more specific), fall back to
+        # ``GOOGLE_API_KEY`` for parity with the underlying provider adapter.
+        key = (
+            api_key
+            or os.environ.get("GEMINI_API_KEY")
+            or os.environ.get("GOOGLE_API_KEY")
+        )
+        if not key and not kwargs.get("vertexai"):
+            raise ValueError(
+                "Google Gemini LLM requires an api_key. Pass api_key='AIza...' or "
+                "set GEMINI_API_KEY (or GOOGLE_API_KEY) in the environment."
+            )
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/sdk-py/getpatter/llm/groq.py
+++ b/sdk-py/getpatter/llm/groq.py
@@ -1,0 +1,36 @@
+"""Groq LLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.providers.groq_llm import GroqLLMProvider as _GroqLLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_GroqLLM):
+    """Groq LLM provider (OpenAI-compatible Chat Completions).
+
+    Example::
+
+        from getpatter.llm import groq
+
+        llm = groq.LLM()                              # reads GROQ_API_KEY
+        llm = groq.LLM(api_key="gsk_...", model="llama-3.3-70b-versatile")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "llama-3.3-70b-versatile",
+        **kwargs,
+    ) -> None:
+        key = api_key or os.environ.get("GROQ_API_KEY")
+        if not key:
+            raise ValueError(
+                "Groq LLM requires an api_key. Pass api_key='gsk_...' or "
+                "set GROQ_API_KEY in the environment."
+            )
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/sdk-py/getpatter/llm/openai.py
+++ b/sdk-py/getpatter/llm/openai.py
@@ -1,0 +1,36 @@
+"""OpenAI LLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.services.llm_loop import OpenAILLMProvider as _OpenAILLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_OpenAILLM):
+    """OpenAI Chat Completions LLM provider.
+
+    Example::
+
+        from getpatter.llm import openai
+
+        llm = openai.LLM()                            # reads OPENAI_API_KEY
+        llm = openai.LLM(api_key="sk-...", model="gpt-4o-mini")
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        **kwargs,
+    ) -> None:
+        key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not key:
+            raise ValueError(
+                "OpenAI LLM requires an api_key. Pass api_key='sk-...' or "
+                "set OPENAI_API_KEY in the environment."
+            )
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/sdk-py/getpatter/models.py
+++ b/sdk-py/getpatter/models.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from getpatter.providers.base import AudioFilter, BackgroundAudioPlayer, VADProvider
+    from getpatter.services.llm_loop import LLMProvider
 
 logger = logging.getLogger("patter")
 
@@ -84,6 +85,7 @@ class Agent:
     vad: "VADProvider | None" = None  # Optional server-side VAD (e.g., Silero) — pipeline mode only
     audio_filter: "AudioFilter | None" = None  # Optional pre-STT audio filter (noise cancel) — pipeline mode only
     background_audio: "BackgroundAudioPlayer | None" = None  # Optional background audio mixer — pipeline mode only
+    llm: "LLMProvider | None" = None  # Optional built-in LLM provider for pipeline mode (e.g., AnthropicLLM())
     # Minimum sustained voice (ms) before treating caller audio as a barge-in
     # and interrupting TTS. ``0`` disables barge-in entirely — useful on noisy
     # links (ngrok tunnels, speakerphone) where the agent can hear itself.

--- a/sdk-py/pyproject.toml
+++ b/sdk-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.5.0"
+version = "0.5.1"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdk-py/tests/unit/test_llm_api.py
+++ b/sdk-py/tests/unit/test_llm_api.py
@@ -1,0 +1,251 @@
+"""Unit tests for the public LLM API — Phase 2 of v0.5.1.
+
+Covers:
+
+* Per-provider wrapper instantiation (explicit key, env fallback, missing key).
+* ``phone.agent(llm=...)`` wiring — happy path, type validation, engine-mode
+  warning.
+* ``LLMLoop`` accepting a pre-built ``LLMProvider``.
+* ``phone.serve()`` conflict check between ``agent.llm`` and ``on_message``.
+* Flat re-export parity (``from getpatter import OpenAILLM, ...``).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from getpatter import (
+    AnthropicLLM,
+    CerebrasLLM,
+    DeepgramSTT,
+    ElevenLabsTTS,
+    GoogleLLM,
+    GroqLLM,
+    OpenAIRealtime,
+    OpenAILLM,
+    Twilio,
+)
+from getpatter.client import Patter
+from getpatter.services.llm_loop import LLMLoop, LLMProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _local_phone() -> Patter:
+    """Build a default local-mode Patter instance for tests."""
+    return Patter(
+        carrier=Twilio(
+            account_sid="ACtest000000000000000000000000000", auth_token="tok"
+        ),
+        phone_number="+15550001234",
+        webhook_url="abc.ngrok.io",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-provider instantiation
+# ---------------------------------------------------------------------------
+
+
+PROVIDER_CASES = [
+    pytest.param(OpenAILLM, "OPENAI_API_KEY", {}, id="openai"),
+    pytest.param(AnthropicLLM, "ANTHROPIC_API_KEY", {}, id="anthropic"),
+    pytest.param(GroqLLM, "GROQ_API_KEY", {}, id="groq"),
+    pytest.param(
+        CerebrasLLM,
+        "CEREBRAS_API_KEY",
+        {"gzip_compression": False, "msgpack_encoding": False},
+        id="cerebras",
+    ),
+]
+
+
+@pytest.mark.unit
+class TestProviderWrappers:
+    """Each LLM wrapper resolves api_key, env fallback, and raises clearly."""
+
+    @pytest.mark.parametrize("cls,env_var,extra", PROVIDER_CASES)
+    def test_explicit_api_key(self, cls, env_var, extra, monkeypatch) -> None:
+        # Ensure the env var is *not* what drives the test.
+        monkeypatch.delenv(env_var, raising=False)
+        llm = cls(api_key="explicit-key", **extra)
+        assert isinstance(llm, LLMProvider)
+
+    @pytest.mark.parametrize("cls,env_var,extra", PROVIDER_CASES)
+    def test_env_fallback(self, cls, env_var, extra, monkeypatch) -> None:
+        monkeypatch.setenv(env_var, "env-key")
+        llm = cls(**extra)
+        assert isinstance(llm, LLMProvider)
+
+    @pytest.mark.parametrize("cls,env_var,extra", PROVIDER_CASES)
+    def test_missing_key_raises(self, cls, env_var, extra, monkeypatch) -> None:
+        monkeypatch.delenv(env_var, raising=False)
+        with pytest.raises(ValueError, match=env_var):
+            cls(**extra)
+
+    # Google reads either GEMINI_API_KEY or GOOGLE_API_KEY; cover both plus
+    # the missing-both case.
+
+    def test_google_explicit_api_key(self, monkeypatch) -> None:
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        llm = GoogleLLM(api_key="AIza-explicit")
+        assert isinstance(llm, LLMProvider)
+
+    def test_google_env_fallback_gemini(self, monkeypatch) -> None:
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-gemini")
+        llm = GoogleLLM()
+        assert isinstance(llm, LLMProvider)
+
+    def test_google_env_fallback_google(self, monkeypatch) -> None:
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIza-google")
+        llm = GoogleLLM()
+        assert isinstance(llm, LLMProvider)
+
+    def test_google_missing_both_raises(self, monkeypatch) -> None:
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            GoogleLLM()
+
+
+# ---------------------------------------------------------------------------
+# phone.agent(llm=...)
+# ---------------------------------------------------------------------------
+
+
+class _DummyLLM:
+    """Minimal LLMProvider implementation for wiring tests (no network)."""
+
+    async def stream(self, messages, tools=None):
+        # Satisfy the Protocol; never actually invoked in these tests.
+        if False:  # pragma: no cover
+            yield {"type": "done"}
+
+
+@pytest.mark.unit
+class TestAgentLLM:
+    """phone.agent(llm=...) stores the provider and validates its type."""
+
+    def test_stores_llm_on_agent(self) -> None:
+        phone = _local_phone()
+        llm = _DummyLLM()
+        agent = phone.agent(
+            system_prompt="hi",
+            stt=DeepgramSTT(api_key="dg"),
+            tts=ElevenLabsTTS(api_key="el"),
+            llm=llm,
+        )
+        assert agent.llm is llm
+        # `llm=` implies pipeline mode.
+        assert agent.provider == "pipeline"
+
+    def test_rejects_non_llm_provider(self) -> None:
+        phone = _local_phone()
+        with pytest.raises(TypeError, match="LLMProvider"):
+            phone.agent(system_prompt="hi", llm="not-an-llm")
+
+    def test_engine_plus_llm_warns(self, caplog) -> None:
+        phone = _local_phone()
+        engine = OpenAIRealtime(api_key="sk-test")
+        llm = _DummyLLM()
+        with caplog.at_level(logging.WARNING, logger="patter"):
+            agent = phone.agent(
+                system_prompt="hi",
+                engine=engine,
+                llm=llm,
+            )
+        # Engine mode wins — provider stays realtime.
+        assert agent.provider == "openai_realtime"
+        assert agent.llm is llm  # stored, but ignored by the engine-mode path.
+        assert any(
+            "llm= ignored" in rec.message for rec in caplog.records
+        ), f"expected warning, got {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# LLMLoop accepts injected provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLLMLoopInjection:
+    """LLMLoop accepts a pre-built ``LLMProvider`` via ``llm_provider=``."""
+
+    def test_injected_provider_used(self) -> None:
+        dummy = _DummyLLM()
+        loop = LLMLoop(
+            openai_key="",  # not used when llm_provider is supplied
+            model="ignored",
+            system_prompt="sys",
+            llm_provider=dummy,
+        )
+        assert loop._provider is dummy
+
+    def test_default_openai_path_still_works(self) -> None:
+        # No llm_provider → constructs the default OpenAILLMProvider using the
+        # provided openai_key. This must not raise at construction time.
+        loop = LLMLoop(
+            openai_key="sk-test",
+            model="gpt-4o-mini",
+            system_prompt="sys",
+        )
+        # We don't care about the exact type, only that a provider exists.
+        assert loop._provider is not None
+
+
+# ---------------------------------------------------------------------------
+# serve() conflict — agent.llm + on_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestServeConflict:
+    """phone.serve() raises when both agent.llm and on_message are set."""
+
+    async def test_llm_plus_on_message_raises(self) -> None:
+        phone = _local_phone()
+        llm = _DummyLLM()
+        agent = phone.agent(
+            system_prompt="hi",
+            stt=DeepgramSTT(api_key="dg"),
+            tts=ElevenLabsTTS(api_key="el"),
+            llm=llm,
+        )
+
+        async def handler(msg):  # pragma: no cover — should never run
+            return "ok"
+
+        with pytest.raises(ValueError, match="both"):
+            await phone.serve(agent, on_message=handler)
+
+
+# ---------------------------------------------------------------------------
+# Flat re-export parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFlatReExports:
+    """The flat ``from getpatter import *LLM`` aliases resolve correctly."""
+
+    def test_flat_aliases_match_namespaced(self) -> None:
+        from getpatter.llm.openai import LLM as ns_openai
+        from getpatter.llm.anthropic import LLM as ns_anthropic
+        from getpatter.llm.groq import LLM as ns_groq
+        from getpatter.llm.cerebras import LLM as ns_cerebras
+        from getpatter.llm.google import LLM as ns_google
+
+        assert OpenAILLM is ns_openai
+        assert AnthropicLLM is ns_anthropic
+        assert GroqLLM is ns_groq
+        assert CerebrasLLM is ns_cerebras
+        assert GoogleLLM is ns_google

--- a/sdk-py/tests/unit/test_llm_api.py
+++ b/sdk-py/tests/unit/test_llm_api.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 from unittest.mock import AsyncMock
 
@@ -30,6 +31,24 @@ from getpatter import (
 )
 from getpatter.client import Patter
 from getpatter.services.llm_loop import LLMLoop, LLMProvider
+
+
+# Optional-extras availability — these tests construct adapter instances whose
+# underlying providers import the vendor SDK lazily at class construction time.
+# On the base CI matrix (no optional extras) those imports fail; skip
+# parametrized entries that need a missing package. The all-extras CI job
+# installs everything and exercises every branch.
+_ANTHROPIC_AVAILABLE = importlib.util.find_spec("anthropic") is not None
+_GOOGLE_GENAI_AVAILABLE = importlib.util.find_spec("google.genai") is not None
+
+_skip_if_no_anthropic = pytest.mark.skipif(
+    not _ANTHROPIC_AVAILABLE,
+    reason="anthropic package not installed — run with getpatter[anthropic]",
+)
+_skip_if_no_google = pytest.mark.skipif(
+    not _GOOGLE_GENAI_AVAILABLE,
+    reason="google-genai package not installed — run with getpatter[google]",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +74,10 @@ def _local_phone() -> Patter:
 
 PROVIDER_CASES = [
     pytest.param(OpenAILLM, "OPENAI_API_KEY", {}, id="openai"),
-    pytest.param(AnthropicLLM, "ANTHROPIC_API_KEY", {}, id="anthropic"),
+    pytest.param(
+        AnthropicLLM, "ANTHROPIC_API_KEY", {}, id="anthropic",
+        marks=_skip_if_no_anthropic,
+    ),
     pytest.param(GroqLLM, "GROQ_API_KEY", {}, id="groq"),
     pytest.param(
         CerebrasLLM,
@@ -90,20 +112,23 @@ class TestProviderWrappers:
             cls(**extra)
 
     # Google reads either GEMINI_API_KEY or GOOGLE_API_KEY; cover both plus
-    # the missing-both case.
+    # the missing-both case. Requires the optional ``google`` extra.
 
+    @_skip_if_no_google
     def test_google_explicit_api_key(self, monkeypatch) -> None:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         llm = GoogleLLM(api_key="AIza-explicit")
         assert isinstance(llm, LLMProvider)
 
+    @_skip_if_no_google
     def test_google_env_fallback_gemini(self, monkeypatch) -> None:
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         monkeypatch.setenv("GEMINI_API_KEY", "AIza-gemini")
         llm = GoogleLLM()
         assert isinstance(llm, LLMProvider)
 
+    @_skip_if_no_google
     def test_google_env_fallback_google(self, monkeypatch) -> None:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_API_KEY", "AIza-google")

--- a/sdk-py/tests/unit/test_llm_api.py
+++ b/sdk-py/tests/unit/test_llm_api.py
@@ -38,8 +38,18 @@ from getpatter.services.llm_loop import LLMLoop, LLMProvider
 # On the base CI matrix (no optional extras) those imports fail; skip
 # parametrized entries that need a missing package. The all-extras CI job
 # installs everything and exercises every branch.
-_ANTHROPIC_AVAILABLE = importlib.util.find_spec("anthropic") is not None
-_GOOGLE_GENAI_AVAILABLE = importlib.util.find_spec("google.genai") is not None
+#
+# ``find_spec`` for a dotted child path raises ``ModuleNotFoundError`` when the
+# parent doesn't exist (instead of returning None), so we catch it.
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+_ANTHROPIC_AVAILABLE = _has_module("anthropic")
+_GOOGLE_GENAI_AVAILABLE = _has_module("google.genai")
 
 _skip_if_no_anthropic = pytest.mark.skipif(
     not _ANTHROPIC_AVAILABLE,

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -57,7 +57,8 @@ await phone.serve({ agent, tunnel: true });
 | Tool calling | `agent({ tools: [tool(...)] })` | Agent calls external APIs mid-conversation |
 | Custom STT + TTS | `agent({ stt: new DeepgramSTT(), tts: new ElevenLabsTTS() })` | Bring your own voice providers |
 | Dynamic variables | `agent({ variables: {...} })` | Personalize prompts per caller |
-| Custom LLM (any model) | `serve({ onMessage })` | Claude, Mistral, LLaMA, etc. |
+| Pluggable LLM | `agent({ llm: new AnthropicLLM() })` | 5 built-in providers: OpenAI, Anthropic, Groq, Cerebras, Google |
+| Custom LLM (any model) | `serve({ onMessage })` | Route to anything — local inference, internal gateways, etc. |
 | Call recording | `serve({ recording: true })` | Record all calls |
 | Call transfer | `transfer_call` (auto-injected) | Transfer to a human |
 | Voicemail drop | `call({ voicemailMessage: "..." })` | Play message on voicemail |
@@ -80,6 +81,10 @@ Every provider reads its credentials from the environment by default. Pass `apiK
 | `LMNT_API_KEY` | `LMNTTTS` |
 | `SONIOX_API_KEY` | `SonioxSTT` |
 | `ASSEMBLYAI_API_KEY` | `AssemblyAISTT` |
+| `ANTHROPIC_API_KEY` | `AnthropicLLM` |
+| `GROQ_API_KEY` | `GroqLLM` |
+| `CEREBRAS_API_KEY` | `CerebrasLLM` |
+| `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | `GoogleLLM` |
 
 ```bash
 cp .env.example .env
@@ -180,6 +185,8 @@ import {
   DeepgramSTT, WhisperSTT, CartesiaSTT, SonioxSTT, AssemblyAISTT,
   // TTS
   ElevenLabsTTS, OpenAITTS, CartesiaTTS, RimeTTS, LMNTTTS,
+  // LLM
+  OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM,
   // Tunnels
   CloudflareTunnel, StaticTunnel,
   // Primitives
@@ -224,6 +231,23 @@ const agent = phone.agent({
 });
 await phone.serve({ agent, tunnel: true });
 ```
+
+### Pipeline mode — pick STT, LLM, TTS independently
+
+```typescript
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const agent = phone.agent({
+  stt: new DeepgramSTT(),                         // reads DEEPGRAM_API_KEY
+  llm: new AnthropicLLM(),                        // reads ANTHROPIC_API_KEY
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }),  // reads ELEVENLABS_API_KEY
+  systemPrompt: "You are a helpful voice assistant.",
+});
+await phone.serve({ agent, tunnel: true });
+```
+
+Available LLM providers: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. For fully custom logic, drop `llm` and pass an `onMessage` callback to `serve()` instead.
 
 ### Tool calling
 

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -22,6 +22,7 @@ import { Carrier as TelnyxCarrier } from "./carriers/telnyx";
 import { Realtime as OpenAIRealtime } from "./engines/openai";
 import { ConvAI as ElevenLabsConvAI } from "./engines/elevenlabs";
 import { CloudflareTunnel, Static as StaticTunnel } from "./tunnels";
+import { getLogger } from "./logger";
 
 const DEFAULT_BACKEND_URL = "wss://api.getpatter.com";
 const DEFAULT_REST_URL = "https://api.getpatter.com";
@@ -174,6 +175,28 @@ export class Patter {
       const valid = ['openai_realtime', 'elevenlabs_convai', 'pipeline'];
       if (!valid.includes(working.provider)) {
         throw new Error(`provider must be one of: ${valid.join(', ')}. Got: '${working.provider}'`);
+      }
+    }
+
+    // Validate llm — must implement the LLMProvider interface (duck-typed on
+    // ``.stream`` being a function).  Surface a clear error if the caller
+    // passed a plain object literal by mistake.
+    if (working.llm !== undefined) {
+      const llm = working.llm as { stream?: unknown };
+      if (!llm || typeof llm.stream !== 'function') {
+        throw new Error(
+          "`llm` must be an LLMProvider instance (e.g. new AnthropicLLM()). " +
+            "Got a value without a `.stream` method.",
+        );
+      }
+      // engine + llm: engine path owns LLM selection (realtime model is the
+      // LLM). Warn once and keep the agent working — don't throw.
+      if (working.engine) {
+        getLogger().warn(
+          "agent({ engine, llm }): `llm` is ignored when `engine` is set — " +
+            "realtime/ConvAI engines run their own model. Remove `llm` or " +
+            "switch to pipeline mode (stt + tts + llm) to silence this warning.",
+        );
       }
     }
 

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -168,6 +168,15 @@ export class Patter {
           "Unknown engine. Expected OpenAIRealtime or ElevenLabsConvAI instance.",
         );
       }
+    } else if (
+      !working.provider &&
+      (working.stt !== undefined || working.tts !== undefined || working.llm !== undefined)
+    ) {
+      // Parity with sdk-py: when the caller supplies any pipeline-mode piece
+      // (stt / tts / llm) without an explicit engine or provider, derive
+      // ``provider = "pipeline"`` so metrics, logs, and the ``Call started``
+      // mode-label are accurate.
+      working = { ...working, provider: 'pipeline' };
     }
 
     // Validate provider

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -94,6 +94,18 @@ export type { RimeTTSOptions } from "./tts/rime";
 export { TTS as LMNTTTS } from "./tts/lmnt";
 export type { LMNTTTSOptions } from "./tts/lmnt";
 
+// New namespaced LLM classes (Phase 2 of the v0.5.x API refactor).
+export { LLM as OpenAILLM } from "./llm/openai";
+export type { OpenAILLMOptions } from "./llm/openai";
+export { LLM as AnthropicLLM } from "./llm/anthropic";
+export type { AnthropicLLMOptions } from "./llm/anthropic";
+export { LLM as GroqLLM } from "./llm/groq";
+export type { GroqLLMOptions } from "./llm/groq";
+export { LLM as CerebrasLLM } from "./llm/cerebras";
+export type { CerebrasLLMOptions } from "./llm/cerebras";
+export { LLM as GoogleLLM } from "./llm/google";
+export type { GoogleLLMOptions } from "./llm/google";
+
 // Telephony carriers.
 export { Carrier as Twilio } from "./carriers/twilio";
 export type { TwilioCarrierOptions } from "./carriers/twilio";

--- a/sdk-ts/src/llm/anthropic.ts
+++ b/sdk-ts/src/llm/anthropic.ts
@@ -1,0 +1,46 @@
+/** Anthropic Claude LLM for Patter pipeline mode. */
+import { AnthropicLLMProvider as _AnthropicLLM } from "../providers/anthropic-llm";
+
+export interface AnthropicLLMOptions {
+  /** API key. Falls back to ANTHROPIC_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Anthropic Messages API model id (e.g. ``"claude-3-5-sonnet-20241022"``). */
+  model?: string;
+  /** Maximum number of tokens to sample. Defaults to the adapter default. */
+  maxTokens?: number;
+  /** Sampling temperature. */
+  temperature?: number;
+  /** Override the Messages API base URL (rarely needed). */
+  baseUrl?: string;
+  /** ``anthropic-version`` header override. */
+  anthropicVersion?: string;
+}
+
+/**
+ * Anthropic Claude LLM provider (Messages API, streaming).
+ *
+ * @example
+ * ```ts
+ * import * as anthropic from "getpatter/llm/anthropic";
+ * const llm = new anthropic.LLM();                                   // reads ANTHROPIC_API_KEY
+ * const llm = new anthropic.LLM({ apiKey: "sk-ant-...", model: "claude-3-5-sonnet-20241022" });
+ * ```
+ */
+export class LLM extends _AnthropicLLM {
+  constructor(opts: AnthropicLLMOptions = {}) {
+    const key = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Anthropic LLM requires an apiKey. Pass { apiKey: 'sk-ant-...' } or set ANTHROPIC_API_KEY.",
+      );
+    }
+    super({
+      apiKey: key,
+      model: opts.model,
+      maxTokens: opts.maxTokens,
+      temperature: opts.temperature,
+      baseUrl: opts.baseUrl,
+      anthropicVersion: opts.anthropicVersion,
+    });
+  }
+}

--- a/sdk-ts/src/llm/cerebras.ts
+++ b/sdk-ts/src/llm/cerebras.ts
@@ -1,0 +1,40 @@
+/** Cerebras LLM for Patter pipeline mode. */
+import { CerebrasLLMProvider as _CerebrasLLM } from "../providers/cerebras-llm";
+
+export interface CerebrasLLMOptions {
+  /** API key. Falls back to CEREBRAS_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Model id (e.g. ``"llama3.1-8b"``). */
+  model?: string;
+  /** Override the OpenAI-compatible base URL (rarely needed). */
+  baseUrl?: string;
+  /** Gzip request payloads for faster TTFT on large prompts. */
+  gzipCompression?: boolean;
+}
+
+/**
+ * Cerebras LLM provider (OpenAI-compatible Inference API, streaming).
+ *
+ * @example
+ * ```ts
+ * import * as cerebras from "getpatter/llm/cerebras";
+ * const llm = new cerebras.LLM();                              // reads CEREBRAS_API_KEY
+ * const llm = new cerebras.LLM({ apiKey: "csk-...", model: "llama3.1-8b" });
+ * ```
+ */
+export class LLM extends _CerebrasLLM {
+  constructor(opts: CerebrasLLMOptions = {}) {
+    const key = opts.apiKey ?? process.env.CEREBRAS_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Cerebras LLM requires an apiKey. Pass { apiKey: 'csk-...' } or set CEREBRAS_API_KEY.",
+      );
+    }
+    super({
+      apiKey: key,
+      model: opts.model,
+      baseUrl: opts.baseUrl,
+      gzipCompression: opts.gzipCompression,
+    });
+  }
+}

--- a/sdk-ts/src/llm/google.ts
+++ b/sdk-ts/src/llm/google.ts
@@ -1,0 +1,49 @@
+/** Google Gemini LLM for Patter pipeline mode. */
+import { GoogleLLMProvider as _GoogleLLM } from "../providers/google-llm";
+
+export interface GoogleLLMOptions {
+  /**
+   * API key. Falls back to ``GEMINI_API_KEY`` first, then ``GOOGLE_API_KEY``.
+   * (Google's CLI tooling uses ``GEMINI_API_KEY``; ``GOOGLE_API_KEY`` is the
+   * legacy/alt name accepted for parity with other SDKs.)
+   */
+  apiKey?: string;
+  /** Model id (e.g. ``"gemini-2.5-flash"``). */
+  model?: string;
+  /** Override the Generative Language API base URL (rarely needed). */
+  baseUrl?: string;
+  /** Sampling temperature. */
+  temperature?: number;
+  /** Maximum output tokens. */
+  maxOutputTokens?: number;
+}
+
+/**
+ * Google Gemini LLM provider (Developer API, streaming SSE).
+ *
+ * @example
+ * ```ts
+ * import * as google from "getpatter/llm/google";
+ * const llm = new google.LLM();                                 // reads GEMINI_API_KEY or GOOGLE_API_KEY
+ * const llm = new google.LLM({ apiKey: "AIza...", model: "gemini-2.5-flash" });
+ * ```
+ */
+export class LLM extends _GoogleLLM {
+  constructor(opts: GoogleLLMOptions = {}) {
+    const key =
+      opts.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Google LLM requires an apiKey. Pass { apiKey: 'AIza...' } or set " +
+          "GEMINI_API_KEY (or GOOGLE_API_KEY).",
+      );
+    }
+    super({
+      apiKey: key,
+      model: opts.model,
+      baseUrl: opts.baseUrl,
+      temperature: opts.temperature,
+      maxOutputTokens: opts.maxOutputTokens,
+    });
+  }
+}

--- a/sdk-ts/src/llm/groq.ts
+++ b/sdk-ts/src/llm/groq.ts
@@ -1,0 +1,37 @@
+/** Groq LLM for Patter pipeline mode. */
+import { GroqLLMProvider as _GroqLLM } from "../providers/groq-llm";
+
+export interface GroqLLMOptions {
+  /** API key. Falls back to GROQ_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Model id (e.g. ``"llama-3.3-70b-versatile"``). */
+  model?: string;
+  /** Override the OpenAI-compatible base URL (rarely needed). */
+  baseUrl?: string;
+}
+
+/**
+ * Groq LLM provider (OpenAI-compatible Chat Completions, streaming).
+ *
+ * @example
+ * ```ts
+ * import * as groq from "getpatter/llm/groq";
+ * const llm = new groq.LLM();                                // reads GROQ_API_KEY
+ * const llm = new groq.LLM({ apiKey: "gsk_...", model: "llama-3.3-70b-versatile" });
+ * ```
+ */
+export class LLM extends _GroqLLM {
+  constructor(opts: GroqLLMOptions = {}) {
+    const key = opts.apiKey ?? process.env.GROQ_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Groq LLM requires an apiKey. Pass { apiKey: 'gsk_...' } or set GROQ_API_KEY.",
+      );
+    }
+    super({
+      apiKey: key,
+      model: opts.model,
+      baseUrl: opts.baseUrl,
+    });
+  }
+}

--- a/sdk-ts/src/llm/openai.ts
+++ b/sdk-ts/src/llm/openai.ts
@@ -1,0 +1,31 @@
+/** OpenAI LLM for Patter pipeline mode. */
+import { OpenAILLMProvider as _OpenAILLM } from "../llm-loop";
+
+export interface OpenAILLMOptions {
+  /** API key. Falls back to OPENAI_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Chat Completions model id. Defaults to ``"gpt-4o-mini"``. */
+  model?: string;
+}
+
+/**
+ * OpenAI Chat Completions LLM provider.
+ *
+ * @example
+ * ```ts
+ * import * as openai from "getpatter/llm/openai";
+ * const llm = new openai.LLM();                           // reads OPENAI_API_KEY
+ * const llm = new openai.LLM({ apiKey: "sk-...", model: "gpt-4o-mini" });
+ * ```
+ */
+export class LLM extends _OpenAILLM {
+  constructor(opts: OpenAILLMOptions = {}) {
+    const key = opts.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!key) {
+      throw new Error(
+        "OpenAI LLM requires an apiKey. Pass { apiKey: 'sk-...' } or set OPENAI_API_KEY.",
+      );
+    }
+    super(key, opts.model ?? "gpt-4o-mini");
+  }
+}

--- a/sdk-ts/src/stream-handler.ts
+++ b/sdk-ts/src/stream-handler.ts
@@ -184,7 +184,7 @@ export class StreamHandler {
       pricing: deps.pricing,
     });
 
-    getLogger().info(`WebSocket connection opened (${deps.bridge.label})`);
+    getLogger().debug(`WebSocket connection opened (${deps.bridge.label})`);
   }
 
   // ---------------------------------------------------------------------------
@@ -207,10 +207,17 @@ export class StreamHandler {
     if (customParams.caller && !this.caller) this.caller = customParams.caller;
     if (customParams.callee && !this.callee) this.callee = customParams.callee;
 
-    getLogger().info(`Call started: ${callId}`);
+    // Single INFO line per call-start — full context in one place.
+    const mode =
+      this.deps.agent.engine
+        ? `engine=${(this.deps.agent.engine as { kind?: string }).kind ?? 'unknown'}`
+        : 'pipeline';
+    getLogger().info(
+      `Call started: ${callId} (${this.deps.bridge.label}, ${mode}, ${sanitizeLogValue(this.caller || '?')} → ${sanitizeLogValue(this.callee || '?')})`,
+    );
 
     if (Object.keys(customParams).length > 0) {
-      getLogger().info(`Custom params: ${sanitizeLogValue(JSON.stringify(customParams))}`);
+      getLogger().debug(`Custom params: ${sanitizeLogValue(JSON.stringify(customParams))}`);
     }
 
     this.deps.metricsStore.recordCallStart({
@@ -262,7 +269,7 @@ export class StreamHandler {
             },
           });
           if (recResp.ok) {
-            getLogger().info(`Recording started for ${callId}`);
+            getLogger().debug(`Recording started for ${callId}`);
           } else {
             getLogger().warn(`could not start recording: ${await recResp.text()}`);
           }
@@ -336,7 +343,7 @@ export class StreamHandler {
 
   /** Handle a DTMF keypress event (Twilio only). */
   async handleDtmf(digit: string): Promise<void> {
-    getLogger().info(`DTMF: ${digit}`);
+    getLogger().debug(`DTMF: ${digit}`);
     if (this.adapter instanceof OpenAIRealtimeAdapter) {
       await this.adapter.sendText(`The user pressed key ${digit} on their phone keypad.`);
     }
@@ -399,15 +406,15 @@ export class StreamHandler {
     this.tts = await createTTS(this.deps.agent);
 
     if (!this.stt) {
-      getLogger().info(`Pipeline mode (${label}): no STT configured`);
+      getLogger().debug(`Pipeline mode (${label}): no STT configured`);
     }
     if (!this.tts) {
-      getLogger().info(`Pipeline mode (${label}): no TTS configured`);
+      getLogger().debug(`Pipeline mode (${label}): no TTS configured`);
     }
 
     try {
       if (this.stt) await this.stt.connect();
-      getLogger().info(`Pipeline mode (${label}): STT + TTS connected`);
+      getLogger().debug(`Pipeline mode (${label}): STT + TTS connected`);
     } catch (e) {
       getLogger().error(`Pipeline connect FAILED (${label}):`, e);
       try { await this.deps.bridge.endCall(this.callId, this.ws); } catch { /* best effort */ }
@@ -453,7 +460,7 @@ export class StreamHandler {
         this.deps.agent.llm,
       );
       const llmLabel = this.deps.agent.llm.constructor?.name ?? 'custom';
-      getLogger().info(`Built-in LLM loop active (pipeline, ${label}, llm=${llmLabel})`);
+      getLogger().debug(`Built-in LLM loop active (pipeline, ${label}, llm=${llmLabel})`);
     } else if (!this.deps.onMessage && this.deps.config.openaiKey) {
       let llmModel = this.deps.agent.model || 'gpt-4o-mini';
       if (llmModel.includes('realtime')) llmModel = 'gpt-4o-mini';
@@ -463,7 +470,7 @@ export class StreamHandler {
         resolvedPrompt,
         this.deps.agent.tools as ToolDefinition[] | undefined,
       );
-      getLogger().info(`Built-in LLM loop active (pipeline, ${label})`);
+      getLogger().debug(`Built-in LLM loop active (pipeline, ${label})`);
     }
 
     if (this.stt) {
@@ -545,7 +552,7 @@ export class StreamHandler {
     // any transcript with text flips ``isSpeaking`` to false so the TTS
     // sentence loop exits on its next check.
     if (transcript.text && this.isSpeaking) {
-      getLogger().info(
+      getLogger().debug(
         `Barge-in: caller spoke over agent (${sanitizeLogValue(transcript.text.slice(0, 40))})`,
       );
       this.isSpeaking = false;
@@ -571,17 +578,17 @@ export class StreamHandler {
       'right', 'cool',
     ]);
     if (HALLUCINATIONS.has(stripped) || stripped === '') {
-      getLogger().info(`Dropped likely STT hallucination: ${sanitizeLogValue(normalised.slice(0, 40))}`);
+      getLogger().debug(`Dropped likely STT hallucination: ${sanitizeLogValue(normalised.slice(0, 40))}`);
       return;
     }
     if (sinceLastMs < 2000 && normalised === this.lastCommitText) {
-      getLogger().info(
+      getLogger().debug(
         `Dropped duplicate final transcript (${(sinceLastMs / 1000).toFixed(1)}s since last): ${sanitizeLogValue(normalised.slice(0, 40))}`,
       );
       return;
     }
     if (sinceLastMs < 500) {
-      getLogger().info(
+      getLogger().debug(
         `Dropped back-to-back final transcript (${(sinceLastMs / 1000).toFixed(2)}s since last): ${sanitizeLogValue(normalised.slice(0, 40))}`,
       );
       return;
@@ -590,7 +597,7 @@ export class StreamHandler {
     this.lastCommitAt = now;
 
     const label = this.deps.bridge.label;
-    getLogger().info(`User (${label} pipeline): ${sanitizeLogValue(transcript.text)}`);
+    getLogger().debug(`User (${label} pipeline): ${sanitizeLogValue(transcript.text)}`);
 
     this.metricsAcc.startTurn();
     this.metricsAcc.recordSttComplete(transcript.text);
@@ -609,7 +616,7 @@ export class StreamHandler {
     const hookCtx = this.buildHookContext();
     const filteredTranscript = await hookExecutor.runAfterTranscribe(transcript.text, hookCtx);
     if (filteredTranscript === null) {
-      getLogger().info(`afterTranscribe hook vetoed turn (${label})`);
+      getLogger().debug(`afterTranscribe hook vetoed turn (${label})`);
       this.metricsAcc.recordTurnInterrupted();
       return;
     }
@@ -723,7 +730,7 @@ export class StreamHandler {
     if (!this.llmLoop) {
       const guard = checkGuardrails(responseText, this.deps.agent.guardrails);
       if (guard) {
-        getLogger().info(`Guardrail '${guard.name}' triggered (pipeline)`);
+        getLogger().debug(`Guardrail '${guard.name}' triggered (pipeline)`);
         responseText = guard.replacement ?? "I'm sorry, I can't respond to that.";
       }
 
@@ -805,7 +812,7 @@ export class StreamHandler {
 
     try {
       await this.adapter.connect();
-      getLogger().info(`AI adapter connected (${label})`);
+      getLogger().debug(`AI adapter connected (${label})`);
     } catch (e) {
       getLogger().error(`AI adapter connect FAILED (${label}):`, e);
       // Hang up the telephony call so it doesn't stay connected billing
@@ -856,7 +863,7 @@ export class StreamHandler {
       this.deps.bridge.sendMark(this.ws, `audio_${this.chunkCount}`, this.streamSid);
     } else if (type === 'transcript_input') {
       const inputText = eventData as string;
-      getLogger().info(`User (${this.deps.bridge.label}): ${sanitizeLogValue(inputText)}`);
+      getLogger().debug(`User (${this.deps.bridge.label}): ${sanitizeLogValue(inputText)}`);
       this.history.push({ role: 'user', text: inputText, timestamp: Date.now() });
       // Start a new turn when user finishes speaking (Realtime mode)
       this.metricsAcc.startTurn();
@@ -875,7 +882,7 @@ export class StreamHandler {
       if (outputText) {
         const triggered = checkGuardrails(outputText, this.deps.agent.guardrails);
         if (triggered) {
-          getLogger().info(`Guardrail '${triggered.name}' triggered`);
+          getLogger().debug(`Guardrail '${triggered.name}' triggered`);
           if (this.adapter instanceof OpenAIRealtimeAdapter) {
             this.adapter.cancelResponse();
             await this.adapter.sendText(triggered.replacement ?? "I'm sorry, I can't respond to that.");
@@ -943,7 +950,7 @@ export class StreamHandler {
         await adapter.sendFunctionResult(fc.call_id, JSON.stringify({ error: 'Invalid phone number format', status: 'rejected' }));
         return;
       }
-      getLogger().info(`Transferring call to ${transferTo}`);
+      getLogger().debug(`Transferring call to ${transferTo}`);
       await adapter.sendFunctionResult(fc.call_id, JSON.stringify({ status: 'transferring', to: transferTo }));
       await this.deps.bridge.transferCall(this.callId, transferTo);
       if (this.deps.onTranscript) {
@@ -960,7 +967,7 @@ export class StreamHandler {
         endArgs = {};
       }
       const reason = endArgs.reason ?? 'conversation_complete';
-      getLogger().info(`Ending call (${this.deps.bridge.label}): ${reason}`);
+      getLogger().debug(`Ending call (${this.deps.bridge.label}): ${reason}`);
       await adapter.sendFunctionResult(fc.call_id, JSON.stringify({ status: 'ending', reason }));
       await this.deps.bridge.endCall(this.callId, this.ws);
       if (this.deps.onTranscript) {
@@ -1018,6 +1025,14 @@ export class StreamHandler {
       transcript: [...this.history.entries],
       metrics: finalMetrics as unknown as Record<string, unknown>,
     };
+
+    // Single INFO line per call-end — duration, turns, cost, latency.
+    const cost = (finalMetrics.cost as { total?: number } | undefined)?.total ?? 0;
+    const latencyP95 = (finalMetrics.latency_p95 as { total_ms?: number } | undefined)?.total_ms ?? 0;
+    getLogger().info(
+      `Call ended: ${this.callId} (${finalMetrics.duration_seconds.toFixed(1)}s, ` +
+        `${finalMetrics.turns.length} turns, cost=$${cost.toFixed(4)}, p95=${Math.round(latencyP95)}ms)`,
+    );
     this.deps.metricsStore.recordCallEnd(
       callEndData,
       finalMetrics as unknown as Record<string, unknown>,
@@ -1063,7 +1078,7 @@ async function queryDeepgramCost(
           const usd = reqData.response?.details?.usd;
           if (usd != null) {
             metricsAcc.setActualSttCost(usd);
-            getLogger().info(`Deepgram actual cost: $${usd}`);
+            getLogger().debug(`Deepgram actual cost: $${usd}`);
           }
         }
       }

--- a/sdk-ts/src/stream-handler.ts
+++ b/sdk-ts/src/stream-handler.ts
@@ -436,8 +436,25 @@ export class StreamHandler {
       }
     }
 
-    // Create LLM loop for pipeline mode when no onMessage handler provided
-    if (!this.deps.onMessage && this.deps.config.openaiKey) {
+    // Create LLM loop for pipeline mode when no onMessage handler provided.
+    // Precedence: user-supplied ``agent.llm`` > OpenAI default (from openaiKey).
+    if (this.deps.agent.llm) {
+      if (this.deps.onMessage) {
+        throw new Error(
+          "Cannot pass both agent({ llm }) and serve({ onMessage }). Pick one — " +
+            "`llm` for built-in LLMs, `onMessage` for custom logic.",
+        );
+      }
+      this.llmLoop = new LLMLoop(
+        '', // apiKey unused when llmProvider is supplied
+        '', // model unused when llmProvider is supplied
+        resolvedPrompt,
+        this.deps.agent.tools as ToolDefinition[] | undefined,
+        this.deps.agent.llm,
+      );
+      const llmLabel = this.deps.agent.llm.constructor?.name ?? 'custom';
+      getLogger().info(`Built-in LLM loop active (pipeline, ${label}, llm=${llmLabel})`);
+    } else if (!this.deps.onMessage && this.deps.config.openaiKey) {
       let llmModel = this.deps.agent.model || 'gpt-4o-mini';
       if (llmModel.includes('realtime')) llmModel = 'gpt-4o-mini';
       this.llmLoop = new LLMLoop(

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -5,6 +5,7 @@ import type { ConvAI } from "./engines/elevenlabs";
 import type { CloudflareTunnel, Static as StaticTunnel } from "./tunnels";
 import type { Tool as ToolInstance } from "./public-api";
 import type { STTAdapter, TTSAdapter } from "./provider-factory";
+import type { LLMProvider } from "./llm-loop";
 
 export interface IncomingMessage {
   readonly text: string;
@@ -241,6 +242,13 @@ export interface AgentOptions {
   stt?: STTAdapter;
   /** Pre-instantiated TTS adapter (e.g. ``new ElevenLabsTTS({ apiKey })``). */
   tts?: TTSAdapter;
+  /**
+   * Pipeline-mode LLM provider (e.g. ``new AnthropicLLM()``). When set, the
+   * built-in LLM loop uses this provider instead of the OpenAI default.
+   * Mutually exclusive with ``onMessage`` passed to ``serve()``. Ignored
+   * when ``engine`` is set (realtime mode bypasses the pipeline LLM).
+   */
+  llm?: LLMProvider;
   /** Dynamic variables for ``{placeholder}`` substitution in systemPrompt at call time. */
   variables?: Record<string, string>;
   /** Output guardrails — ``Guardrail`` class instances from ``getpatter``. */

--- a/sdk-ts/tests/unit/llm-api.test.ts
+++ b/sdk-ts/tests/unit/llm-api.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Unit tests for the Phase 2 v0.5.1 LLM namespace API:
+ *  - `llm/openai`, `llm/anthropic`, `llm/groq`, `llm/cerebras`, `llm/google`
+ *  - `phone.agent({ llm })` selector on the client
+ *  - `LLMLoop` accepts an injected `llmProvider` instance
+ *  - `serve({ onMessage })` conflicts with `agent({ llm })`
+ *  - Flat re-exports from `getpatter` index
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import * as openaiLlm from "../../src/llm/openai";
+import * as anthropicLlm from "../../src/llm/anthropic";
+import * as groqLlm from "../../src/llm/groq";
+import * as cerebrasLlm from "../../src/llm/cerebras";
+import * as googleLlm from "../../src/llm/google";
+
+import * as flat from "../../src/index";
+import { LLMLoop } from "../../src/llm-loop";
+import type { LLMProvider, LLMChunk } from "../../src/llm-loop";
+import { setLogger, getLogger } from "../../src/logger";
+import type { Logger } from "../../src/logger";
+import { Patter } from "../../src/client";
+import { Twilio } from "../../src/index";
+
+// ---------------------------------------------------------------------------
+// Env var snapshot — restore after each test so nothing leaks between cases.
+// ---------------------------------------------------------------------------
+
+const TRACKED_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GROQ_API_KEY",
+  "CEREBRAS_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+] as const;
+
+let envSnapshot: Record<string, string | undefined>;
+
+beforeEach(() => {
+  envSnapshot = {};
+  for (const k of TRACKED_ENV_KEYS) {
+    envSnapshot[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of TRACKED_ENV_KEYS) {
+    const v = envSnapshot[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Per-provider instantiation
+// ---------------------------------------------------------------------------
+
+describe("llm/openai", () => {
+  it("LLM accepts explicit apiKey", () => {
+    const llm = new openaiLlm.LLM({ apiKey: "sk-test" });
+    expect(llm).toBeDefined();
+    expect(typeof llm.stream).toBe("function");
+  });
+
+  it("LLM reads OPENAI_API_KEY env", () => {
+    process.env.OPENAI_API_KEY = "sk-env";
+    expect(new openaiLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM throws with a message mentioning OPENAI_API_KEY when no key is available", () => {
+    expect(() => new openaiLlm.LLM()).toThrow(/OPENAI_API_KEY/);
+  });
+
+  it("LLM accepts an optional model override", () => {
+    expect(new openaiLlm.LLM({ apiKey: "sk-x", model: "gpt-4o" })).toBeDefined();
+  });
+});
+
+describe("llm/anthropic", () => {
+  it("LLM accepts explicit apiKey", () => {
+    const llm = new anthropicLlm.LLM({ apiKey: "sk-ant-test" });
+    expect(llm).toBeDefined();
+    expect(typeof llm.stream).toBe("function");
+  });
+
+  it("LLM reads ANTHROPIC_API_KEY env", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-env";
+    expect(new anthropicLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM throws with a message mentioning ANTHROPIC_API_KEY when no key is available", () => {
+    expect(() => new anthropicLlm.LLM()).toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it("LLM accepts a model override", () => {
+    expect(
+      new anthropicLlm.LLM({ apiKey: "sk-ant-x", model: "claude-3-5-sonnet-20241022" }),
+    ).toBeDefined();
+  });
+});
+
+describe("llm/groq", () => {
+  it("LLM accepts explicit apiKey", () => {
+    const llm = new groqLlm.LLM({ apiKey: "gsk_test" });
+    expect(llm).toBeDefined();
+    expect(typeof llm.stream).toBe("function");
+  });
+
+  it("LLM reads GROQ_API_KEY env", () => {
+    process.env.GROQ_API_KEY = "gsk_env";
+    expect(new groqLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM throws with a message mentioning GROQ_API_KEY when no key is available", () => {
+    expect(() => new groqLlm.LLM()).toThrow(/GROQ_API_KEY/);
+  });
+});
+
+describe("llm/cerebras", () => {
+  it("LLM accepts explicit apiKey", () => {
+    const llm = new cerebrasLlm.LLM({ apiKey: "csk-test" });
+    expect(llm).toBeDefined();
+    expect(typeof llm.stream).toBe("function");
+  });
+
+  it("LLM reads CEREBRAS_API_KEY env", () => {
+    process.env.CEREBRAS_API_KEY = "csk-env";
+    expect(new cerebrasLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM throws with a message mentioning CEREBRAS_API_KEY when no key is available", () => {
+    expect(() => new cerebrasLlm.LLM()).toThrow(/CEREBRAS_API_KEY/);
+  });
+});
+
+describe("llm/google", () => {
+  it("LLM accepts explicit apiKey", () => {
+    const llm = new googleLlm.LLM({ apiKey: "AIza-explicit" });
+    expect(llm).toBeDefined();
+    expect(typeof llm.stream).toBe("function");
+  });
+
+  it("LLM reads GEMINI_API_KEY first", () => {
+    process.env.GEMINI_API_KEY = "AIza-gemini";
+    process.env.GOOGLE_API_KEY = "AIza-google";
+    // Both are present; constructor picks GEMINI_API_KEY.  We can't introspect
+    // the stored key (it's private), so just assert construction succeeds and
+    // verify precedence in the GOOGLE_API_KEY-only fallback case below.
+    expect(new googleLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM falls back to GOOGLE_API_KEY when GEMINI_API_KEY is unset", () => {
+    process.env.GOOGLE_API_KEY = "AIza-google-only";
+    expect(new googleLlm.LLM()).toBeDefined();
+  });
+
+  it("LLM throws mentioning both GEMINI_API_KEY and GOOGLE_API_KEY when neither is set", () => {
+    expect(() => new googleLlm.LLM()).toThrow(/GEMINI_API_KEY/);
+    expect(() => new googleLlm.LLM()).toThrow(/GOOGLE_API_KEY/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// phone.agent({ llm })
+// ---------------------------------------------------------------------------
+
+describe("phone.agent({ llm })", () => {
+  function makePhone() {
+    return new Patter({
+      carrier: new Twilio({ accountSid: "AC_test", authToken: "tok" }),
+      phoneNumber: "+15550001234",
+      webhookUrl: "example.com/wh",
+    });
+  }
+
+  it("stores a valid LLMProvider on the resolved agent", () => {
+    const phone = makePhone();
+    const llm = new anthropicLlm.LLM({ apiKey: "sk-ant-x" });
+    const resolved = phone.agent({ systemPrompt: "pipe", llm });
+    expect(resolved.llm).toBe(llm);
+  });
+
+  it("throws a clear error for a non-LLMProvider plain object", () => {
+    const phone = makePhone();
+    expect(() =>
+      phone.agent({
+        systemPrompt: "pipe",
+        // Intentional bad value — missing `.stream`.
+        llm: { foo: "bar" } as unknown as LLMProvider,
+      }),
+    ).toThrow(/LLMProvider/);
+  });
+
+  it("throws for null passed as llm", () => {
+    const phone = makePhone();
+    expect(() =>
+      phone.agent({ systemPrompt: "pipe", llm: null as unknown as LLMProvider }),
+    ).toThrow(/LLMProvider/);
+  });
+
+  it("engine + llm: agent constructs, logger.warn is called (does not throw)", () => {
+    const phone = makePhone();
+    const warnSpy = vi.fn();
+    const original = getLogger();
+    const mockLogger: Logger = {
+      info: () => {},
+      warn: warnSpy,
+      error: () => {},
+      debug: () => {},
+    };
+    setLogger(mockLogger);
+    try {
+      const engine = new flat.OpenAIRealtime({ apiKey: "sk-x" });
+      const llm = new anthropicLlm.LLM({ apiKey: "sk-ant-x" });
+      const resolved = phone.agent({ systemPrompt: "p", engine, llm });
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toMatch(/ignored.*engine|engine.*ignored/i);
+      // Still stored — the warning is advisory, not destructive.
+      expect(resolved.llm).toBe(llm);
+    } finally {
+      setLogger(original);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLMLoop accepts an injected llmProvider
+// ---------------------------------------------------------------------------
+
+describe("LLMLoop with injected llmProvider", () => {
+  it("constructs with an AnthropicLLM instance without touching the network", () => {
+    const provider = new anthropicLlm.LLM({ apiKey: "sk-ant-x" });
+    const loop = new LLMLoop("", "", "system", null, provider);
+    expect(loop).toBeDefined();
+  });
+
+  it("still supports the legacy positional (apiKey, model, prompt) form", () => {
+    const loop = new LLMLoop("sk-x", "gpt-4o-mini", "system");
+    expect(loop).toBeDefined();
+  });
+
+  it("routes llm.stream through the LLMLoop.run generator", async () => {
+    const calls: Array<{ messages: Array<Record<string, unknown>> }> = [];
+    const stubProvider: LLMProvider = {
+      async *stream(messages) {
+        calls.push({ messages });
+        const chunks: LLMChunk[] = [
+          { type: "text", content: "hello " },
+          { type: "text", content: "world" },
+        ];
+        for (const c of chunks) yield c;
+      },
+    };
+    const loop = new LLMLoop("", "", "sys", null, stubProvider);
+    const tokens: string[] = [];
+    for await (const t of loop.run("hi", [], {})) tokens.push(t);
+    expect(tokens).toEqual(["hello ", "world"]);
+    expect(calls).toHaveLength(1);
+    expect((calls[0].messages[0] as Record<string, unknown>).role).toBe("system");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflict: serve({ onMessage }) + agent({ llm })
+// ---------------------------------------------------------------------------
+
+describe("serve({ onMessage }) + agent({ llm }) conflict", () => {
+  it("StreamHandler throws when both are supplied", async () => {
+    // Import lazily so the module-level WebSocket dependency can load cleanly.
+    const { StreamHandler } = await import("../../src/stream-handler");
+    const { MetricsStore } = await import("../../src/dashboard/store");
+    const { RemoteMessageHandler } = await import("../../src/remote-message");
+
+    const stubLlm: LLMProvider = {
+      // eslint-disable-next-line @typescript-eslint/require-await, require-yield
+      async *stream() {
+        return;
+      },
+    };
+
+    // Minimal stub bridge — only fields touched by initializeProvider() matter.
+    const stubBridge = {
+      label: "test",
+      telephonyProvider: "twilio" as const,
+      sendAudio: () => {},
+      sendMark: () => {},
+      sendClear: () => {},
+      transferCall: async () => {},
+      endCall: async () => {},
+      createStt: async () => null,
+      queryTelephonyCost: async () => {},
+    };
+
+    // Stub AI adapter builder — never invoked because provider is 'pipeline'
+    // with no engine, but the deps shape requires a function.
+    const buildAIAdapter = () => {
+      throw new Error("should not be called");
+    };
+
+    const deps = {
+      config: { openaiKey: "sk-test" },
+      agent: {
+        systemPrompt: "pipe",
+        provider: "pipeline" as const,
+        llm: stubLlm,
+      },
+      bridge: stubBridge,
+      metricsStore: new MetricsStore(),
+      pricing: null,
+      remoteHandler: new RemoteMessageHandler(),
+      onMessage: async () => "reply",
+      recording: false,
+      buildAIAdapter: buildAIAdapter as never,
+      sanitizeVariables: (raw: Record<string, unknown>) =>
+        Object.fromEntries(
+          Object.entries(raw).map(([k, v]) => [k, String(v)]),
+        ) as Record<string, string>,
+      resolveVariables: (template: string) => template,
+    };
+
+    // A bare WebSocket-like object is enough — initializeProvider() does not
+    // write to it before the llm/onMessage conflict check fires.
+    const fakeWs = {} as unknown as import("ws").WebSocket;
+    const handler = new StreamHandler(deps as never, fakeWs, "+15550001111", "+15550002222");
+
+    // ``initPipeline`` is private; invoke via bracket access. The bridge stub
+    // returns null STT + TTS so execution proceeds past the connect() step
+    // and hits the llm/onMessage conflict check.
+    const init = (handler as unknown as {
+      initPipeline: (prompt: string) => Promise<void>;
+    }).initPipeline.bind(handler);
+    await expect(init("pipe")).rejects.toThrow(/Cannot pass both/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flat re-exports from the package root
+// ---------------------------------------------------------------------------
+
+describe("flat re-exports from getpatter (LLM)", () => {
+  it("OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM are classes", () => {
+    expect(typeof flat.OpenAILLM).toBe("function");
+    expect(typeof flat.AnthropicLLM).toBe("function");
+    expect(typeof flat.GroqLLM).toBe("function");
+    expect(typeof flat.CerebrasLLM).toBe("function");
+    expect(typeof flat.GoogleLLM).toBe("function");
+  });
+
+  it("each flat LLM constructs with an explicit apiKey", () => {
+    expect(new flat.OpenAILLM({ apiKey: "sk-x" })).toBeDefined();
+    expect(new flat.AnthropicLLM({ apiKey: "sk-ant-x" })).toBeDefined();
+    expect(new flat.GroqLLM({ apiKey: "gsk_x" })).toBeDefined();
+    expect(new flat.CerebrasLLM({ apiKey: "csk-x" })).toBeDefined();
+    expect(new flat.GoogleLLM({ apiKey: "AIza-x" })).toBeDefined();
+  });
+
+  it("flat LLMs read their env vars", () => {
+    process.env.OPENAI_API_KEY = "sk-env";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-env";
+    process.env.GROQ_API_KEY = "gsk-env";
+    process.env.CEREBRAS_API_KEY = "csk-env";
+    process.env.GEMINI_API_KEY = "AIza-env";
+    expect(new flat.OpenAILLM()).toBeDefined();
+    expect(new flat.AnthropicLLM()).toBeDefined();
+    expect(new flat.GroqLLM()).toBeDefined();
+    expect(new flat.CerebrasLLM()).toBeDefined();
+    expect(new flat.GoogleLLM()).toBeDefined();
+  });
+});

--- a/sdk-ts/tsup.config.ts
+++ b/sdk-ts/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "tsup";
+
+/**
+ * tsup build config for the Patter TypeScript SDK.
+ *
+ * The entry point is ``src/index.ts`` (dual CJS + ESM). The CLI build
+ * (``src/cli.ts``, CJS-only) runs as a second invocation from
+ * ``package.json`` scripts — tsup CLI flags there override `entry` for
+ * that pass.
+ *
+ * External packages (NOT bundled into dist): these are dynamic imports
+ * resolved at runtime from the consumer's ``node_modules``. Bundling
+ * them breaks when they are CJS and try to call ``require()`` from
+ * inside the ESM dist (e.g. cloudflared uses ``require("path")``).
+ */
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  external: [
+    // Optional tunnel adapters — loaded via ``await import(...)`` in
+    // src/tunnel.ts. Must stay as runtime imports so the consumer's
+    // installed package is used rather than a bundled copy.
+    "cloudflared",
+    "@ngrok/ngrok",
+  ],
+});


### PR DESCRIPTION
## Summary

Adds `llm=` as a first-class selector on `phone.agent()`, mirroring the `stt=`/`tts=` pattern shipped in 0.5.0. Five LLM provider classes with env-var fallback ship in both SDKs:

```python
from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS

phone = Patter(carrier=Twilio(), phone_number="+15550001234")
agent = phone.agent(
    stt=DeepgramSTT(),                    # DEEPGRAM_API_KEY
    llm=AnthropicLLM(),                   # ANTHROPIC_API_KEY (new in 0.5.1)
    tts=ElevenLabsTTS(voice_id="rachel"), # ELEVENLABS_API_KEY
    system_prompt="You are helpful.",
)
await phone.serve(agent)
```

TypeScript mirror uses the same names with `new AnthropicLLM()` etc.

## What's new

- `getpatter.llm.{openai,anthropic,groq,cerebras,google}.LLM` namespaced classes (Python + TS)
- Flat re-exports: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`
- Env-var fallback per provider (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `CEREBRAS_API_KEY`, `GEMINI_API_KEY` → `GOOGLE_API_KEY`)
- Tool calling works across all 5 providers — each adapter normalizes vendor-specific formats to Patter's unified chunk protocol
- Docs refreshed: `docs/{python,typescript}-sdk/llm.mdx` full rewrites, `concepts.mdx` pipeline example updated, reference tables + agent pages updated, CHANGELOG entry added

## Semantics

- `llm=` + `on_message` are **mutually exclusive** — conflict raises a clear error at `serve()` time
- `engine=` + `llm=` → one-time log warning, `llm=` is ignored (the engine handles its own LLM)
- Default OpenAI LLMLoop still auto-constructs when `llm=` is absent and `openai_key` is present → no break from 0.5.0

## Test plan

- [x] Python: 1327 → **1350 passed** (+23 new in `tests/unit/test_llm_api.py`), 8 skipped, 0 failures
- [x] TypeScript: 1013 → **1042 passed** across 61 files (+29 new in `tests/unit/llm-api.test.ts`); `tsc --noEmit` clean
- [x] 4-line quickstart with `llm=AnthropicLLM()` smoke tested under `-W error::DeprecationWarning` (Python) and via `tsx` (TypeScript)
- [x] Each of the 5 LLM wrappers: explicit apiKey, env fallback, missing-key error
- [x] `engine + llm` → agent builds, warning logged once
- [x] `llm + on_message` → raises at serve/handler init

## Version

`0.5.0` → `0.5.1` — patch bump because the feature is additive and backward-compatible. Existing code using `on_message` keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)