### PR TITLE
fix(cerebras): default to llama3.1-8b and clarify 404 model errors

### DIFF
--- a/sdk-py/getpatter/providers/cerebras_llm.py
+++ b/sdk-py/getpatter/providers/cerebras_llm.py
@@ -27,12 +27,15 @@ from __future__ import annotations
 
 import gzip
 import json
+import logging
 import os
 from typing import Any, AsyncIterator
 
 from getpatter.services.llm_loop import OpenAILLMProvider
 
 __all__ = ["CerebrasLLMProvider"]
+
+logger = logging.getLogger("getpatter.providers.cerebras_llm")
 
 
 _CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1"
@@ -188,21 +191,27 @@ class CerebrasLLMProvider(OpenAILLMProvider):
         messages: list[dict],
         tools: list[dict] | None = None,
     ) -> AsyncIterator[dict]:
+        # 404 model_not_found on Cerebras almost always means the model name
+        # isn't available on the caller's tier (Cerebras gates models per
+        # plan). Surface a concrete recovery hint at ERROR level, matching the
+        # TS provider's log-and-return contract — voice pipelines treat LLM
+        # provider failures as recoverable (the call continues, the user just
+        # hears no LLM response), so raising would be a behavioural change.
         try:
             async for chunk in super().stream(messages, tools):
                 yield chunk
         except Exception as exc:
-            # 404 model_not_found on Cerebras almost always means the model
-            # name isn't available on the caller's tier (Cerebras gates models
-            # per plan). Re-raise with a concrete recovery hint instead of the
-            # opaque upstream message.
             text = str(exc)
             if "404" in text and "model_not_found" in text:
-                raise RuntimeError(
-                    f'Cerebras: model "{self._model}" not available on your '
-                    f"tier. Override via `CerebrasLLM(model='<id>')` and list "
-                    f"tier-available ids with `GET {_CEREBRAS_BASE_URL}/models` "
-                    f"(common: llama3.1-8b, qwen-3-235b-a22b-instruct-2507, "
-                    f"llama-3.3-70b on paid). Upstream: {text}"
-                ) from exc
+                logger.error(
+                    'Cerebras: model "%s" not available on your tier. Override '
+                    "via `CerebrasLLM(model='<id>')` and list tier-available "
+                    "ids with `GET %s/models` (common: llama3.1-8b, "
+                    "qwen-3-235b-a22b-instruct-2507, llama-3.3-70b on paid). "
+                    "Upstream: %s",
+                    self._model,
+                    _CEREBRAS_BASE_URL,
+                    text,
+                )
+                return
             raise

--- a/sdk-py/getpatter/providers/cerebras_llm.py
+++ b/sdk-py/getpatter/providers/cerebras_llm.py
@@ -36,9 +36,18 @@ __all__ = ["CerebrasLLMProvider"]
 
 
 _CEREBRAS_BASE_URL = "https://api.cerebras.ai/v1"
-# ``llama3.1-8b`` was retired by Cerebras; default to the current
-# production-grade model. Override via ``model=`` if you need a different one.
-_DEFAULT_MODEL = "llama-3.3-70b"
+# Default to the smallest fast Cerebras model available on the free tier so
+# the SDK works out of the box. ``llama-3.3-70b`` exists on Cerebras but is
+# gated to paid tiers — using it as default surfaces a confusing 404 for free
+# users. ``llama3.1-8b`` is 8B params, sub-100ms TTFT on Cerebras hardware,
+# and matches the LiveKit/Pipecat "small and fast for voice" philosophy.
+#
+# TODO(deprecation 2026-05-27): Cerebras has scheduled both ``llama3.1-8b``
+# and ``qwen-3-235b-a22b-instruct-2507`` for retirement on this date. Before
+# then, retest the free tier and switch the default to whichever 8B-class
+# model replaces them (likely a Llama 4 Scout variant). Track at
+# https://inference-docs.cerebras.ai/change-log
+_DEFAULT_MODEL = "llama3.1-8b"
 
 
 def _build_cerebras_client(
@@ -127,7 +136,10 @@ class CerebrasLLMProvider(OpenAILLMProvider):
 
     Args:
         api_key: Cerebras API key. Reads ``CEREBRAS_API_KEY`` if omitted.
-        model: Cerebras chat model ID. Defaults to ``llama-3.3-70b``.
+        model: Cerebras chat model ID. Defaults to ``llama3.1-8b`` (free-tier
+            available, sub-100ms TTFT). Override with ``llama-3.3-70b`` on paid
+            tiers for higher quality, or query ``GET /v1/models`` to discover
+            tier-available IDs.
         base_url: Optional Cerebras base URL override.
         gzip_compression: Gzip request payloads for faster TTFT.
         msgpack_encoding: Encode request payloads with msgpack for smaller
@@ -176,5 +188,21 @@ class CerebrasLLMProvider(OpenAILLMProvider):
         messages: list[dict],
         tools: list[dict] | None = None,
     ) -> AsyncIterator[dict]:
-        async for chunk in super().stream(messages, tools):
-            yield chunk
+        try:
+            async for chunk in super().stream(messages, tools):
+                yield chunk
+        except Exception as exc:
+            # 404 model_not_found on Cerebras almost always means the model
+            # name isn't available on the caller's tier (Cerebras gates models
+            # per plan). Re-raise with a concrete recovery hint instead of the
+            # opaque upstream message.
+            text = str(exc)
+            if "404" in text and "model_not_found" in text:
+                raise RuntimeError(
+                    f'Cerebras: model "{self._model}" not available on your '
+                    f"tier. Override via `CerebrasLLM(model='<id>')` and list "
+                    f"tier-available ids with `GET {_CEREBRAS_BASE_URL}/models` "
+                    f"(common: llama3.1-8b, qwen-3-235b-a22b-instruct-2507, "
+                    f"llama-3.3-70b on paid). Upstream: {text}"
+                ) from exc
+            raise

--- a/sdk-py/tests/unit/test_cerebras_llm.py
+++ b/sdk-py/tests/unit/test_cerebras_llm.py
@@ -1,0 +1,73 @@
+"""Regression tests for the Cerebras provider default model + 404 handling.
+
+Why: the previous default ``llama-3.3-70b`` returned a silent 404 on Cerebras
+free tier (model gated to paid plans). The fix lowers the default to
+``llama3.1-8b`` (free-tier available, sub-100ms TTFT) and translates 404
+model_not_found into a recovery hint that names override candidates.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from getpatter.providers.cerebras_llm import CerebrasLLMProvider
+
+
+def test_default_model_is_free_tier_safe() -> None:
+    provider = CerebrasLLMProvider(api_key="csk-test")
+    assert provider._model == "llama3.1-8b"
+
+
+def test_explicit_model_override_is_honoured() -> None:
+    provider = CerebrasLLMProvider(api_key="csk-test", model="llama-3.3-70b")
+    assert provider._model == "llama-3.3-70b"
+
+
+@pytest.mark.asyncio
+async def test_404_model_not_found_raises_recovery_hint() -> None:
+    """A gated model surfaces a clear error with override candidates."""
+
+    provider = CerebrasLLMProvider(api_key="csk-test", model="gated-model")
+
+    async def _raise_404(*_args: object, **_kwargs: object):
+        raise RuntimeError(
+            'HTTP 404 — {"message":"Model gated-model does not exist or you do '
+            'not have access to it.","type":"not_found_error","param":"model",'
+            '"code":"model_not_found"}'
+        )
+        yield  # make this an async generator (unreachable)
+
+    with patch(
+        "getpatter.services.llm_loop.OpenAILLMProvider.stream",
+        side_effect=_raise_404,
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            async for _ in provider.stream([{"role": "user", "content": "hi"}]):
+                pass
+
+    msg = str(excinfo.value)
+    assert "gated-model" in msg
+    assert "not available on your tier" in msg
+    assert "llama3.1-8b" in msg  # override hint
+    assert "/v1/models" in msg  # discovery hint
+
+
+@pytest.mark.asyncio
+async def test_other_errors_are_re_raised_unchanged() -> None:
+    """Non-model errors should propagate unchanged."""
+
+    provider = CerebrasLLMProvider(api_key="csk-test")
+
+    async def _raise_other(*_args: object, **_kwargs: object):
+        raise ValueError("unrelated failure")
+        yield
+
+    with patch(
+        "getpatter.services.llm_loop.OpenAILLMProvider.stream",
+        side_effect=_raise_other,
+    ):
+        with pytest.raises(ValueError, match="unrelated failure"):
+            async for _ in provider.stream([{"role": "user", "content": "hi"}]):
+                pass

--- a/sdk-py/tests/unit/test_cerebras_llm.py
+++ b/sdk-py/tests/unit/test_cerebras_llm.py
@@ -16,12 +16,17 @@ from getpatter.providers.cerebras_llm import CerebrasLLMProvider
 
 
 def test_default_model_is_free_tier_safe() -> None:
-    provider = CerebrasLLMProvider(api_key="csk-test")
+    provider = CerebrasLLMProvider(api_key="csk-test", gzip_compression=False, msgpack_encoding=False)
     assert provider._model == "llama3.1-8b"
 
 
 def test_explicit_model_override_is_honoured() -> None:
-    provider = CerebrasLLMProvider(api_key="csk-test", model="llama-3.3-70b")
+    provider = CerebrasLLMProvider(
+        api_key="csk-test",
+        model="llama-3.3-70b",
+        gzip_compression=False,
+        msgpack_encoding=False,
+    )
     assert provider._model == "llama-3.3-70b"
 
 
@@ -29,7 +34,12 @@ def test_explicit_model_override_is_honoured() -> None:
 async def test_404_model_not_found_raises_recovery_hint() -> None:
     """A gated model surfaces a clear error with override candidates."""
 
-    provider = CerebrasLLMProvider(api_key="csk-test", model="gated-model")
+    provider = CerebrasLLMProvider(
+        api_key="csk-test",
+        model="gated-model",
+        gzip_compression=False,
+        msgpack_encoding=False,
+    )
 
     async def _raise_404(*_args: object, **_kwargs: object):
         raise RuntimeError(
@@ -58,7 +68,7 @@ async def test_404_model_not_found_raises_recovery_hint() -> None:
 async def test_other_errors_are_re_raised_unchanged() -> None:
     """Non-model errors should propagate unchanged."""
 
-    provider = CerebrasLLMProvider(api_key="csk-test")
+    provider = CerebrasLLMProvider(api_key="csk-test", gzip_compression=False, msgpack_encoding=False)
 
     async def _raise_other(*_args: object, **_kwargs: object):
         raise ValueError("unrelated failure")

--- a/sdk-py/tests/unit/test_cerebras_llm.py
+++ b/sdk-py/tests/unit/test_cerebras_llm.py
@@ -3,80 +3,113 @@
 Why: the previous default ``llama-3.3-70b`` returned a silent 404 on Cerebras
 free tier (model gated to paid plans). The fix lowers the default to
 ``llama3.1-8b`` (free-tier available, sub-100ms TTFT) and translates 404
-model_not_found into a recovery hint that names override candidates.
+model_not_found into a clear log message that names override candidates.
+
+Behaviour matches the TS provider: log at ERROR level and exit the stream
+quietly. Voice pipelines treat LLM provider failures as recoverable (the
+call continues, the user just hears no LLM response), so raising would be
+a behavioural change for callers.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
 
 from getpatter.providers.cerebras_llm import CerebrasLLMProvider
+from getpatter.services.llm_loop import OpenAILLMProvider
+
+
+def _provider(model: str | None = None) -> CerebrasLLMProvider:
+    """Build a CerebrasLLMProvider with the optional extras disabled.
+
+    The base install of the test environment doesn't pull in ``msgpack``;
+    these tests don't exercise wire compression, so we always disable it.
+    """
+    kwargs: dict = {
+        "api_key": "csk-test",
+        "gzip_compression": False,
+        "msgpack_encoding": False,
+    }
+    if model is not None:
+        kwargs["model"] = model
+    return CerebrasLLMProvider(**kwargs)
+
+
+def _async_iter_raises(exc: Exception):
+    """Return an async-iterable that raises ``exc`` on the first ``__anext__``.
+
+    Replaces the prior ``side_effect=async_gen_func`` pattern, which relied on
+    the implicit semantics of mocking an async generator function. Returning
+    a real async iterable from ``side_effect`` is unambiguous: the mock call
+    returns this object, and the caller's ``async for`` invokes ``__anext__``,
+    which raises.
+    """
+
+    class _Iter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise exc
+
+    return _Iter()
 
 
 def test_default_model_is_free_tier_safe() -> None:
-    provider = CerebrasLLMProvider(api_key="csk-test", gzip_compression=False, msgpack_encoding=False)
-    assert provider._model == "llama3.1-8b"
+    assert _provider()._model == "llama3.1-8b"
 
 
 def test_explicit_model_override_is_honoured() -> None:
-    provider = CerebrasLLMProvider(
-        api_key="csk-test",
-        model="llama-3.3-70b",
-        gzip_compression=False,
-        msgpack_encoding=False,
-    )
-    assert provider._model == "llama-3.3-70b"
+    assert _provider("llama-3.3-70b")._model == "llama-3.3-70b"
 
 
 @pytest.mark.asyncio
-async def test_404_model_not_found_raises_recovery_hint() -> None:
-    """A gated model surfaces a clear error with override candidates."""
+async def test_404_model_not_found_is_logged_with_recovery_hint(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A gated model surfaces an ERROR log naming override candidates and
+    /v1/models, then the stream completes without yielding chunks."""
 
-    provider = CerebrasLLMProvider(
-        api_key="csk-test",
-        model="gated-model",
-        gzip_compression=False,
-        msgpack_encoding=False,
+    provider = _provider("gated-model")
+
+    upstream = RuntimeError(
+        'HTTP 404 — {"message":"Model gated-model does not exist or you do '
+        'not have access to it.","type":"not_found_error","param":"model",'
+        '"code":"model_not_found"}'
     )
 
-    async def _raise_404(*_args: object, **_kwargs: object):
-        raise RuntimeError(
-            'HTTP 404 — {"message":"Model gated-model does not exist or you do '
-            'not have access to it.","type":"not_found_error","param":"model",'
-            '"code":"model_not_found"}'
-        )
-        yield  # make this an async generator (unreachable)
-
-    with patch(
-        "getpatter.services.llm_loop.OpenAILLMProvider.stream",
-        side_effect=_raise_404,
+    # Patch via the class object itself so MRO resolution from
+    # CerebrasLLMProvider's super().stream() unambiguously hits the mock,
+    # regardless of whether OpenAILLMProvider was imported under another name.
+    with patch.object(
+        OpenAILLMProvider, "stream", return_value=_async_iter_raises(upstream)
     ):
-        with pytest.raises(RuntimeError) as excinfo:
-            async for _ in provider.stream([{"role": "user", "content": "hi"}]):
-                pass
+        with caplog.at_level(logging.ERROR, logger="getpatter.providers.cerebras_llm"):
+            chunks = [
+                chunk async for chunk in provider.stream([{"role": "user", "content": "hi"}])
+            ]
 
-    msg = str(excinfo.value)
-    assert "gated-model" in msg
-    assert "not available on your tier" in msg
-    assert "llama3.1-8b" in msg  # override hint
-    assert "/v1/models" in msg  # discovery hint
+    assert chunks == []  # stream exits silently — no chunks emitted
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "gated-model" in log_text
+    assert "not available on your tier" in log_text
+    assert "llama3.1-8b" in log_text  # override hint
+    assert "/v1/models" in log_text  # discovery hint
 
 
 @pytest.mark.asyncio
 async def test_other_errors_are_re_raised_unchanged() -> None:
     """Non-model errors should propagate unchanged."""
 
-    provider = CerebrasLLMProvider(api_key="csk-test", gzip_compression=False, msgpack_encoding=False)
+    provider = _provider()
 
-    async def _raise_other(*_args: object, **_kwargs: object):
-        raise ValueError("unrelated failure")
-        yield
+    upstream = ValueError("unrelated failure")
 
-    with patch(
-        "getpatter.services.llm_loop.OpenAILLMProvider.stream",
-        side_effect=_raise_other,
+    with patch.object(
+        OpenAILLMProvider, "stream", return_value=_async_iter_raises(upstream)
     ):
         with pytest.raises(ValueError, match="unrelated failure"):
             async for _ in provider.stream([{"role": "user", "content": "hi"}]):

--- a/sdk-ts/src/providers/cerebras-llm.ts
+++ b/sdk-ts/src/providers/cerebras-llm.ts
@@ -27,9 +27,18 @@ import { getLogger } from '../logger';
 import { parseOpenAISseStream } from './groq-llm';
 
 const CEREBRAS_BASE_URL = 'https://api.cerebras.ai/v1';
-// ``llama3.1-8b`` was retired by Cerebras; default to the current
-// production-grade model. Override via ``model`` option if needed.
-const DEFAULT_MODEL = 'llama-3.3-70b';
+// Default to the smallest fast Cerebras model available on the free tier so
+// the SDK works out of the box. ``llama-3.3-70b`` exists on Cerebras but is
+// gated to paid tiers — using it as default surfaces a confusing 404 for free
+// users. ``llama3.1-8b`` is 8B params, sub-100ms TTFT on Cerebras hardware,
+// and matches the LiveKit/Pipecat "small and fast for voice" philosophy.
+//
+// TODO(deprecation 2026-05-27): Cerebras has scheduled both ``llama3.1-8b``
+// and ``qwen-3-235b-a22b-instruct-2507`` for retirement on this date. Before
+// then, retest the free tier and switch the default to whichever 8B-class
+// model replaces them (likely a Llama 4 Scout variant). Track at
+// https://inference-docs.cerebras.ai/change-log
+const DEFAULT_MODEL = 'llama3.1-8b';
 
 export interface CerebrasLLMOptions {
   apiKey: string;
@@ -95,7 +104,20 @@ export class CerebrasLLMProvider implements LLMProvider {
 
     if (!response.ok) {
       const errText = await response.text();
-      getLogger().error(`Cerebras API error: ${response.status} ${errText}`);
+      // 404 on /chat/completions almost always means the model name isn't
+      // available on the caller's tier (Cerebras gates models per plan). The
+      // generic 404 message is opaque, so add a concrete recovery hint.
+      if (response.status === 404 && errText.includes('model_not_found')) {
+        getLogger().error(
+          `Cerebras: model "${this.model}" not available on your tier. ` +
+            `Override via \`new CerebrasLLM({ model: '<id>' })\` and list ` +
+            `tier-available ids with \`GET ${this.baseUrl}/models\` ` +
+            `(common: llama3.1-8b, qwen-3-235b-a22b-instruct-2507, llama-3.3-70b on paid). ` +
+            `Raw response: ${errText}`,
+        );
+      } else {
+        getLogger().error(`Cerebras API error: ${response.status} ${errText}`);
+      }
       return;
     }
 

--- a/sdk-ts/tests/cerebras-llm.test.ts
+++ b/sdk-ts/tests/cerebras-llm.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression tests for the Cerebras provider default model + 404 handling.
+ *
+ * Why: the previous default ``llama-3.3-70b`` returned a silent 404 on
+ * Cerebras free tier (model gated to paid plans). The fix lowers the default
+ * to ``llama3.1-8b`` (free-tier available, sub-100ms TTFT) and translates
+ * 404 model_not_found into a recovery hint that names override candidates.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { CerebrasLLMProvider } from '../src/providers/cerebras-llm';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('CerebrasLLMProvider default model', () => {
+  it('uses llama3.1-8b by default (free-tier available)', () => {
+    const provider = new CerebrasLLMProvider({ apiKey: 'csk-test' });
+    expect(provider.model).toBe('llama3.1-8b');
+  });
+
+  it('honours explicit model override', () => {
+    const provider = new CerebrasLLMProvider({
+      apiKey: 'csk-test',
+      model: 'llama-3.3-70b',
+    });
+    expect(provider.model).toBe('llama-3.3-70b');
+  });
+});
+
+describe('CerebrasLLMProvider 404 model_not_found handling', () => {
+  it('logs a recovery hint with override candidates on 404 model_not_found', async () => {
+    const provider = new CerebrasLLMProvider({
+      apiKey: 'csk-test',
+      model: 'gated-model',
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'Model gated-model does not exist or you do not have access to it.',
+          type: 'not_found_error',
+          param: 'model',
+          code: 'model_not_found',
+        }),
+        { status: 404 },
+      ),
+    ) as unknown as typeof fetch;
+
+    // Capture stderr/console output from the SDK logger.
+    const logs: string[] = [];
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(' '));
+    });
+
+    // Drain the stream — the provider exits silently on error, so we just
+    // need to consume it and inspect side effects.
+    for await (const _ of provider.stream([{ role: 'user', content: 'hi' }])) {
+      // no-op
+    }
+
+    const combined = logs.join('\n');
+    expect(combined).toContain('gated-model');
+    expect(combined).toContain('not available on your tier');
+    expect(combined).toContain('llama3.1-8b'); // override hint
+    expect(combined).toContain('/v1/models'); // discovery hint
+    errSpy.mockRestore();
+  });
+
+  it('uses generic error log for non-model 404s', async () => {
+    const provider = new CerebrasLLMProvider({ apiKey: 'csk-test' });
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response('Not Found', { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const logs: string[] = [];
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((a) => String(a)).join(' '));
+    });
+
+    for await (const _ of provider.stream([{ role: 'user', content: 'hi' }])) {
+      // no-op
+    }
+
+    const combined = logs.join('\n');
+    expect(combined).toContain('Cerebras API error: 404');
+    expect(combined).not.toContain('not available on your tier');
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- **Default model**: `llama-3.3-70b` → `llama3.1-8b`. The previous default returns a 404 `model_not_found` on the Cerebras free tier — that model is gated to paid plans, so free-tier users got a silent failure with no actionable error during voice calls.
- **Error handling**: when the upstream returns 404 `model_not_found`, both SDKs now surface a recovery hint listing override candidates (`llama3.1-8b`, `qwen-3-235b-a22b-instruct-2507`, `llama-3.3-70b` on paid) and pointing at `/v1/models` for tier-specific discovery, instead of the opaque generic 404 log.
- **Regression tests**: 4 tests per SDK cover default, explicit override, 404 hint formatting, and pass-through of unrelated errors.

`llama3.1-8b` rationale: 8B params, sub-100ms TTFT on Cerebras hardware, matches the LiveKit / Pipecat "small and fast for voice" recommendation. Discovered while running a 16-call live matrix where the Cerebras combo was the only one to fail silently.

`TODO` notes added in both SDKs: Cerebras has scheduled `llama3.1-8b` for retirement on 2026-05-27. Re-test the free tier and switch the default to the 8B-class replacement before that date.

## Test plan

- [x] `npx vitest run tests/cerebras-llm.test.ts` — 4/4 pass
- [x] `pytest tests/unit/test_cerebras_llm.py` — 4/4 pass
- [x] Live smoke test against the real Cerebras API: `new CerebrasLLM().stream(...)` returns content streaming chunks (verified "Hello from me." 5-token response from `llama3.1-8b`).
- [ ] Reviewer: validate that the override hint message reads naturally in production logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)