### PR TITLE
docs: align documentation with 0.5.3 / 0.5.4 SDK state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 _(no entries yet — next version will land here)_
 
+## 0.5.4 (2026-04-27)
+
+Fast-follow to align the Cerebras default with what 0.5.3 already promised in docs and changelog.
+
+### Changed — Cerebras default model
+- **Default model bumped to `gpt-oss-120b`** (production tier, ~3000 tok/sec on WSE-3, no deprecation date) in both Python and TypeScript SDKs. 0.5.3 had temporarily kept the default at `llama3.1-8b` while `gpt-oss-120b` rolled out across the Cerebras catalogue; that's no longer needed. Pass `model="llama3.1-8b"` (or any free-tier ID) to opt back into the smaller model.
+- 404 `model_not_found` recovery hint and the `"common: …"` candidate list updated to surface `gpt-oss-120b` first. The `TODO(deprecation 2026-05-27)` note for `llama3.1-8b` retirement is preserved in the source.
+
 ## 0.5.3 (2026-04-27)
 
 Cost-accuracy, audio-pipeline, and observability hardening across both SDKs, plus opt-in per-call filesystem logging.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Patter is purpose-built for production voice over real telephony. Out of the box
 | Voicemail drop | `call(voicemailMessage="...")` | [patter-outbound-calls](https://github.com/PatterAI/patter-outbound-calls) |
 | Test mode (no phone) | `phone.test(agent)` | [docs](https://docs.getpatter.com) |
 | Built-in tunnel | Cloudflare (auto) | [docs](https://docs.getpatter.com) |
+| Phone-as-a-tool (LangChain / OpenAI Assistants / Hermes) | `PatterTool(phone, agent).execute(...)` | [examples/integrations](./examples/integrations) |
 
 ## How It Works
 
@@ -196,8 +197,8 @@ Pipeline mode composes STT + LLM + TTS sequentially and inherits the latency of 
 - **ElevenLabs free tier** — the library voice catalog is not reachable via API (`402 Payment Required`). Set `ELEVENLABS_VOICE_ID` to a voice you own (cloned or generated) before `phone.serve()`. The SDK resolves ~45 well-known names (`"rachel"`, `"adam"`, …) to their UUIDs automatically; custom voices must be referenced by ID.
 - **Telnyx outbound** — calls will return `403 D38` until your connection has an "Outbound Profile" attached in the Telnyx portal. Inbound and Call Control answer flows work without it.
 - **Google Gemini free tier** — `gemini-2.0-flash` has a hard `quota=0` on the free tier. Enable billing on the project before using Gemini as the LLM.
-- **Whisper STT** — on mulaw 8 kHz inputs Whisper routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`). The pipeline drops these by default plus any duplicate / sub-500 ms back-to-back final, so you won't hear overlapping turns.
-- **Model IDs** — keep these updated per vendor release notes. Examples currently in use: `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5`, `llama-3.3-70b-versatile` (Groq), `llama3.1-8b` (Cerebras).
+- **Whisper STT** — on mulaw 8 kHz inputs Whisper routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`). The pipeline drops these by default plus any duplicate / sub-500 ms back-to-back final, so you won't hear overlapping turns. For production prefer `OpenAITranscribeSTT` (`gpt-4o-transcribe`) — same `OPENAI_API_KEY`, ~10× faster, no hallucination floor.
+- **Model IDs** — keep these updated per vendor release notes. Examples currently in use: `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5`, `llama-3.3-70b-versatile` (Groq), `gpt-oss-120b` (Cerebras default — pass `model="llama3.1-8b"` for the smaller free-tier alternative).
 
 ## API Reference
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,6 +131,13 @@
                 ]
               },
               {
+                "group": "Integrations",
+                "icon": "plug",
+                "pages": [
+                  "python-sdk/patter-tool"
+                ]
+              },
+              {
                 "group": "Development",
                 "icon": "code",
                 "pages": [
@@ -209,7 +216,15 @@
                 "pages": [
                   "typescript-sdk/metrics",
                   "typescript-sdk/dashboard",
-                  "typescript-sdk/call-logging"
+                  "typescript-sdk/call-logging",
+                  "typescript-sdk/tracing"
+                ]
+              },
+              {
+                "group": "Integrations",
+                "icon": "plug",
+                "pages": [
+                  "typescript-sdk/patter-tool"
                 ]
               },
               {

--- a/docs/python-sdk/events.mdx
+++ b/docs/python-sdk/events.mdx
@@ -20,6 +20,10 @@ All callbacks are **async functions**. They are passed as parameters to `serve()
 | `on_message` | User message received (pipeline mode) |
 | `on_metrics` | After each conversation turn (real-time cost/latency) |
 
+For **fine-grained pipeline observability** (every interim transcript, every LLM chunk, every TTS chunk, every tool start) subscribe to the [EventBus](#eventbus) below — it complements these callbacks rather than replacing them.
+
+For **mutating prompts and responses** (RAG augmentation, output validation, PII redaction) use [PipelineHooks](#pipelinehooks-before_llm--after_llm) — they sit *inside* the LLM step rather than firing alongside it.
+
 ---
 
 ## on_call_start
@@ -127,6 +131,66 @@ async def on_message(event) -> str:
 ### Return Value
 
 Return a `str` with the agent's response. This text is sent to the TTS provider and played back to the caller.
+
+---
+
+## EventBus
+
+The `EventBus` exposes fine-grained pipeline events that don't have first-class callbacks. Subscribe with `on(event_type, handler)` from inside `on_call_start` (or any place you have a `Patter` reference).
+
+```python
+from getpatter import EventBus, PatterEventType
+
+# `phone.events` is the per-process EventBus.
+phone.events.on(PatterEventType.TRANSCRIPT_PARTIAL, lambda ev: print("partial:", ev["text"]))
+phone.events.on(PatterEventType.LLM_CHUNK, lambda ev: log_chunk(ev["call_id"], ev["text"]))
+```
+
+| `PatterEventType` | Fires |
+|---|---|
+| `TRANSCRIPT_PARTIAL` | Every interim STT result (before endpointing). |
+| `TRANSCRIPT_FINAL` | Every final STT result (after endpointing). Same payload as `on_transcript`. |
+| `LLM_CHUNK` | Every streamed LLM token / chunk. |
+| `TTS_CHUNK` | Every TTS audio chunk written to the carrier. |
+| `TOOL_CALL_STARTED` | Tool dispatched (paired with the existing `tool_call_completed` you can observe via `on_call_end`). |
+
+Handlers are non-blocking (run in a fire-and-forget task). Throwing inside a handler logs the error but does not interrupt the call.
+
+---
+
+## PipelineHooks (`before_llm` / `after_llm`)
+
+`PipelineHooks` mutate the conversation *inside* the LLM step. Use them for RAG augmentation, prompt rewriting, PII redaction, or output validation — anywhere you'd otherwise wedge logic between the STT and TTS stages.
+
+```python
+from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS, PipelineHooks
+
+async def before_llm(messages, ctx):
+    # RAG: prepend retrieved context as a system message.
+    docs = await retrieve(ctx.user_text)
+    return [{"role": "system", "content": f"Context: {docs}"}, *messages]
+
+async def after_llm(text, ctx):
+    # Output validation: redact account numbers before TTS.
+    return redact_accounts(text)
+
+agent = phone.agent(
+    stt=DeepgramSTT(),
+    llm=AnthropicLLM(),
+    tts=ElevenLabsTTS(voice_id="rachel"),
+    system_prompt="You are a helpful assistant.",
+    hooks=PipelineHooks(before_llm=before_llm, after_llm=after_llm),
+)
+```
+
+| Hook | Signature | Returns |
+|---|---|---|
+| `before_llm` | `(messages: list[dict], ctx: HookContext) -> list[dict] \| None` | New messages list, or `None` to skip the LLM call entirely. |
+| `after_llm` | `(text: str, ctx: HookContext) -> str \| None` | Replacement text, or `None` to suppress TTS for this turn. |
+
+`HookContext` carries `call_id`, `caller`, `callee`, and `history`. Hooks run in pipeline mode only — engines (`OpenAIRealtime`, `ElevenLabsConvAI`) bundle the LLM step internally.
+
+`PipelineHooks` also exposes `before_stt` / `after_stt` and `before_tts` / `after_tts` for audio-stage interception. See the [API Reference](/python-sdk/reference) for the full signature.
 
 ---
 

--- a/docs/python-sdk/llm.mdx
+++ b/docs/python-sdk/llm.mdx
@@ -73,6 +73,8 @@ llm = openai.LLM(api_key="sk-...", model="gpt-4o-mini")
 
 Anthropic Messages API with native streaming and `tool_use` blocks, normalised to Patter's chunk protocol. Default model `"claude-haiku-4-5-20251001"`, default `max_tokens=1024` (Anthropic requires an explicit cap on every request).
 
+Prompt caching is enabled by default — `cache_control: { type: "ephemeral" }` is attached to the system prompt and the last tool block, which cuts time-to-first-token on long system prompts and large tool catalogs. Pass `prompt_caching=False` to disable.
+
 ```python
 from getpatter import AnthropicLLM                 # flat
 from getpatter.llm import anthropic                # namespaced
@@ -103,7 +105,9 @@ Install: `pip install 'getpatter[groq]'`.
 
 ### CerebrasLLM
 
-Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"llama-3.3-70b"`. Supports optional msgpack + gzip payload compression (enabled by default) to reduce time-to-first-token on large prompts — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization).
+Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"gpt-oss-120b"` — production tier, ~3000 tok/sec on WSE-3, no deprecation date. Pass `model="llama3.1-8b"` (8B params, sub-100ms TTFT) for the smaller free-tier alternative. The 404 `model_not_found` error includes a recovery hint listing other valid IDs (`qwen-3-235b-a22b-instruct-2507`, `llama-3.3-70b` on paid tier).
+
+Supports forwarding all OpenAI-style sampling kwargs (`response_format`, `parallel_tool_calls`, `tool_choice`, `seed`, `top_p`, `frequency_penalty`, `presence_penalty`, `stop`) and optional msgpack + gzip payload compression (enabled by default) — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization). Failures retry once with exponential backoff and honour `x-ratelimit-reset-*` advisory headers; terminal errors raise `PatterError`.
 
 ```python
 from getpatter import CerebrasLLM                  # flat
@@ -112,9 +116,10 @@ from getpatter.llm import cerebras                 # namespaced
 llm = CerebrasLLM()                                 # reads CEREBRAS_API_KEY
 llm = cerebras.LLM(
     api_key="csk-...",
-    model="llama-3.3-70b",
+    model="gpt-oss-120b",                           # default
     gzip_compression=True,                          # defaults to True
     msgpack_encoding=True,                          # defaults to True
+    response_format={"type": "json_object"},        # OpenAI-style structured outputs
 )
 ```
 

--- a/docs/python-sdk/metrics.mdx
+++ b/docs/python-sdk/metrics.mdx
@@ -45,11 +45,16 @@ The `LatencyBreakdown` object provides per-component latency in milliseconds:
 | Field | Description |
 |-------|-------------|
 | `stt_ms` | Time from user speech to transcript. |
-| `llm_ms` | Time from transcript to LLM response. |
-| `tts_ms` | Time from LLM response to first audio byte. |
+| `endpoint_ms` | Time the endpointer waited after the last word before declaring end-of-utterance. |
+| `llm_ttft_ms` | Time from end-of-utterance to the first LLM token. |
+| `llm_total_ms` | Time from end-of-utterance to the last LLM token (full response). |
+| `llm_ms` | Alias for `llm_ttft_ms` (kept for back-compat). |
+| `tts_ms` | Time from first LLM token to first TTS audio byte. |
+| `tts_total_ms` | Time from first LLM token to last TTS audio byte. |
+| `bargein_ms` | Time from caller voice detected to TTS playback cancelled (only set on barge-in turns). |
 | `total_ms` | End-to-end latency (user speech to first audio). |
 
-`CallMetrics` exposes the full distribution: `latency_avg`, `latency_p50` (median / typical UX), `latency_p95` (SLA), and `latency_p99` (cold-start outliers).
+`CallMetrics` exposes the full distribution: `latency_avg`, `latency_p50` (median / typical UX), `latency_p90` (steady-state outliers), `latency_p95` (SLA), and `latency_p99` (cold-start outliers).
 
 ## Per-Turn Metrics
 
@@ -147,6 +152,7 @@ from getpatter import CallMetrics, CostBreakdown, LatencyBreakdown, TurnMetrics
 | `cost` | `CostBreakdown` | Cost breakdown. |
 | `latency_avg` | `LatencyBreakdown` | Average latency. |
 | `latency_p50` | `LatencyBreakdown` | Median (50th percentile) latency. |
+| `latency_p90` | `LatencyBreakdown` | 90th percentile latency (steady-state outliers). |
 | `latency_p95` | `LatencyBreakdown` | 95th percentile latency. |
 | `latency_p99` | `LatencyBreakdown` | 99th percentile latency (cold-start outliers). |
 | `provider_mode` | `str` | Voice mode used. |

--- a/docs/python-sdk/patter-tool.mdx
+++ b/docs/python-sdk/patter-tool.mdx
@@ -1,0 +1,119 @@
+---
+title: "PatterTool — phone as a tool"
+description: "Wrap a Patter instance so external agents (LangChain, OpenAI Assistants, Anthropic Claude, Hermes, MCP) can place real phone calls as a single tool invocation."
+icon: "phone-arrow-up-right"
+---
+
+# PatterTool
+
+`PatterTool` exposes a live `Patter` instance as a single **`make_phone_call`** tool that any text-based agent framework can register and dispatch. The agent picks up the phone, Patter runs a short conversation against the caller, and the tool returns a JSON envelope with the call ID, status, transcript, cost, and metrics.
+
+This complements the **bring-your-own-agent** pattern (`serve(on_message=...)`) with the **inverse pattern** — phone-as-tool — covering the two realistic migration paths from LiveKit / ElevenLabs ConvAI / Pipecat customers.
+
+| Pattern | Where the brain lives | Where Patter sits | Use this when… |
+|---|---|---|---|
+| **A — Bring-your-own agent** (HTTP/WS endpoint) | Customer's existing service | Patter is STT + LLM proxy + TTS | Customer already runs a voice agent and wants to swap the voice transport but keep their conversation logic. Use `serve(on_message='https://...')`. |
+| **B — Phone as a tool** (this page) | Customer's text-based agent | Patter is a tool the agent calls | Customer's agent is text-driven but needs to make phone calls during a conversation. |
+
+## Quickstart
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS, PatterTool
+
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    webhook_url="api.example.com",          # stable hostname — not a tunnel
+)
+
+tool = PatterTool(
+    phone=phone,
+    agent={
+        "stt": DeepgramSTT(),
+        "llm": AnthropicLLM(),
+        "tts": ElevenLabsTTS(voice_id="rachel"),
+    },
+)
+
+async def main():
+    await tool.start()                       # boots phone.serve() once (idempotent)
+
+    result = await tool.execute({
+        "to": "+15551234567",
+        "goal": "Book a haircut for tomorrow at 3 pm.",
+    })
+    print(result)                            # PatterToolResult
+    # → call_id, status, duration_seconds, cost_usd, transcript, metrics
+
+asyncio.run(main())
+```
+
+## Schema exporters
+
+`PatterTool` ships three schema exporters with identical wire shape (parameter JSON-schema + result envelope), so a customer can switch frameworks without re-mapping fields.
+
+```python
+tool.openai_schema()      # { "type": "function", "function": { "name", "description", "parameters" } }
+tool.anthropic_schema()   # { "name", "description", "input_schema" }
+tool.hermes_schema()      # { "name", "description", "parameters" }   # same shape as Anthropic input_schema
+```
+
+For [Hermes Agent](https://hermes-agent.nousresearch.com), there's a one-line registry helper:
+
+```python
+tool.register_hermes(registry, toolset="patter")
+```
+
+## Tool arguments (JSON-schema)
+
+Identical across all three exporters:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `to` | string | ✓ | E.164 phone number |
+| `goal` | string | — | Becomes the in-call agent's system prompt |
+| `first_message` | string | — | First thing the agent speaks on answer |
+| `max_duration_sec` | integer | — | Hard timeout, default `180`, max `1800` |
+
+## Result envelope
+
+```python
+@dataclass(frozen=True)
+class PatterToolResult:
+    call_id: str
+    status: str                  # "completed" | "no-answer" | "busy" | "failed" | "timeout"
+    duration_seconds: float
+    cost_usd: float
+    transcript: list[dict]       # [{"role": "agent" | "user", "text": "..."}]
+    metrics: dict                # { p95_latency_ms, cost: { stt, tts, llm, telephony } }
+```
+
+When the model framework expects a JSON string (e.g. Hermes), use `tool.hermes_handler()` — it returns exactly that and wraps errors as `{"error": "..."}`.
+
+## Concurrency & timeouts
+
+- `start()` is idempotent — call it from your bootstrap, or let `execute()` boot it lazily.
+- Concurrent `execute()` calls are serialised through an `asyncio.Lock` so the per-`call_id` Future never races.
+- `max_duration_sec` is enforced by `asyncio.wait_for`; on timeout the tool hangs up the call and returns `status="timeout"`.
+
+## Production deployment
+
+`PatterTool` boots `phone.serve()` once. Make sure the `Patter` instance was constructed with a **stable webhook hostname** in `webhook_url` — never a tunnel — because Twilio/Telnyx need a long-lived HTTPS URL.
+
+For local development, use `tunnel=True` on the `Patter` constructor and let it spawn a cloudflared. For production deploys (Fly.io / Cloud Run / Fargate behind ALB), set `webhook_url` to your public hostname and disable the tunnel.
+
+## Examples
+
+See [`examples/integrations/`](https://github.com/PatterAI/Patter/tree/main/examples/integrations) in the repo:
+
+- `hermes_phone_tool.py` — drop-in `tools/patter.py` for Hermes Agent.
+- `openai_assistant_phone_tool.ts` — minimal OpenAI Assistants run dispatching the tool.
+- `README.md` — Pattern A vs Pattern B decision matrix.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Tools" icon="wrench" href="/python-sdk/tools">In-call tool calling (function calling within a Patter agent).</Card>
+  <Card title="Agents" icon="robot" href="/python-sdk/agents">Configure the in-call agent that PatterTool wraps.</Card>
+</CardGroup>

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -398,18 +398,26 @@ from getpatter import (
 
     # Carriers
     Twilio, Telnyx,
+    TwilioAdapter, TelnyxAdapter,                  # advanced: direct adapter access
 
     # Engines
     OpenAIRealtime, ElevenLabsConvAI,
 
     # STT classes
-    DeepgramSTT, WhisperSTT, CartesiaSTT, AssemblyAISTT, SonioxSTT,
+    DeepgramSTT, WhisperSTT, OpenAITranscribeSTT,
+    CartesiaSTT, AssemblyAISTT, SonioxSTT, SpeechmaticsSTT,
 
     # TTS classes
     ElevenLabsTTS, OpenAITTS, CartesiaTTS, RimeTTS, LMNTTTS,
 
     # LLM classes
     OpenAILLM, AnthropicLLM, GroqLLM, CerebrasLLM, GoogleLLM,
+
+    # VAD (opt-in: pip install 'getpatter[silero]')
+    SileroVAD,
+
+    # Integrations
+    PatterTool,                                    # phone-as-a-tool for external agents
 
     # Public primitives
     Tool, Guardrail, tool, guardrail,
@@ -419,6 +427,12 @@ from getpatter import (
     LatencyBreakdown, IncomingMessage, TurnMetrics, PipelineHooks,
     HookContext, STTConfig, TTSConfig,
 
+    # Observability
+    init_tracing, is_tracing_enabled, start_span,
+    SPAN_CALL, SPAN_STT, SPAN_LLM, SPAN_TTS, SPAN_TOOL,
+    SPAN_ENDPOINT, SPAN_BARGEIN,
+    EventBus, PatterEventType,
+
     # Services / utilities
     SentenceChunker, PipelineHookExecutor,
     filter_markdown, filter_emoji, filter_for_tts,
@@ -426,15 +440,16 @@ from getpatter import (
     ChatContext, ChatMessage,
     IVRActivity, TfidfLoopDetector, DtmfEvent, format_dtmf,
     ScheduleHandle, schedule_cron, schedule_once, schedule_interval,
-    mix_pcm,
+    BackgroundAudioPlayer, BuiltinAudioClip, mix_pcm,
 
     # Errors
-    PatterError, PatterConnectionError, AuthenticationError, ProvisionError,
+    PatterError, PatterConnectionError, AuthenticationError,
+    ProvisionError, RateLimitError,
 )
 
 from getpatter.carriers import twilio, telnyx
 from getpatter.engines import openai, elevenlabs
-from getpatter.stt import deepgram, whisper, cartesia, assemblyai, soniox, speechmatics
+from getpatter.stt import deepgram, whisper, openai_transcribe, cartesia, assemblyai, soniox, speechmatics
 from getpatter.tts import elevenlabs, openai, cartesia, rime, lmnt
 from getpatter.llm import openai, anthropic, groq, cerebras, google
 from getpatter.tunnels import CloudflareTunnel, Static, Ngrok

--- a/docs/python-sdk/stt.mdx
+++ b/docs/python-sdk/stt.mdx
@@ -50,6 +50,7 @@ agent = phone.agent(
 |-------------|-------------------|---------|---------------|
 | `DeepgramSTT` | `getpatter.stt.deepgram.STT` | `DEEPGRAM_API_KEY` | included |
 | `WhisperSTT` | `getpatter.stt.whisper.STT` | `OPENAI_API_KEY` | included |
+| `OpenAITranscribeSTT` | `getpatter.stt.openai_transcribe.STT` | `OPENAI_API_KEY` | included |
 | `CartesiaSTT` | `getpatter.stt.cartesia.STT` | `CARTESIA_API_KEY` | `getpatter[cartesia]` |
 | `AssemblyAISTT` | `getpatter.stt.assemblyai.STT` | `ASSEMBLYAI_API_KEY` | `getpatter[assemblyai]` |
 | `SonioxSTT` | `getpatter.stt.soniox.STT` | `SONIOX_API_KEY` | `getpatter[soniox]` |
@@ -75,7 +76,7 @@ stt = DeepgramSTT(api_key="dg_...", endpointing_ms=80)   # explicit
 | `sample_rate` | `int` | `16000` | Sample rate in Hz. |
 | `endpointing_ms` | `int` | `150` | Utterance endpointing in milliseconds. |
 | `utterance_end_ms` | `int \| None` | `1000` | Grace period after speech ends. |
-| `smart_format` | `bool` | `True` | Enable smart formatting (numbers, dates, punctuation). |
+| `smart_format` | `bool` | `False` | Smart formatting (numbers, dates, punctuation). Defaults to `False` because telephony agents feed transcripts straight back into an LLM, where smart-format rewrites can confuse downstream tool-call argument parsing. Pass `smart_format=True` to opt back in. |
 | `interim_results` | `bool` | `True` | Stream interim transcripts. |
 | `vad_events` | `bool` | `True` | Emit VAD start/end markers. |
 
@@ -95,6 +96,29 @@ stt = WhisperSTT(api_key="sk-...", language="es")
 | `api_key` | `str \| None` | `None` | API key — reads from `OPENAI_API_KEY` if omitted. |
 | `language` | `str` | `"en"` | BCP-47 language code. |
 | `model` | `str` | `"whisper-1"` | Whisper model ID. |
+
+<Note>
+Whisper on mulaw 8 kHz routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`) and emits `is_final=true` on every chunk regardless of speech. The pipeline drops these by default plus duplicate / sub-500 ms back-to-back finals, but for production prefer `OpenAITranscribeSTT` (`gpt-4o-transcribe`) — same `OPENAI_API_KEY`, ~10× faster, no hallucination floor.
+</Note>
+
+## OpenAI Transcribe (gpt-4o-transcribe)
+
+First-class STT for OpenAI's `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` models — drop-in replacement for `WhisperSTT` with stronger multilingual quality and significantly lower latency. Reuses `OPENAI_API_KEY`.
+
+```python
+from getpatter import OpenAITranscribeSTT
+
+stt = OpenAITranscribeSTT()                                # reads OPENAI_API_KEY, defaults to gpt-4o-transcribe
+stt = OpenAITranscribeSTT(model="gpt-4o-mini-transcribe")  # cheaper variant
+stt = OpenAITranscribeSTT(api_key="sk-...", language="es")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `api_key` | `str \| None` | `None` | API key — reads from `OPENAI_API_KEY` if omitted. |
+| `language` | `str \| None` | `None` | BCP-47 language code. Auto-detect when omitted. |
+| `model` | `str` | `"gpt-4o-transcribe"` | Either `"gpt-4o-transcribe"` or `"gpt-4o-mini-transcribe"`. |
+| `response_format` | `str` | `"json"` | Pass `"verbose_json"` to expose segment-level confidence and timestamps. |
 
 ## Cartesia
 

--- a/docs/python-sdk/tracing.mdx
+++ b/docs/python-sdk/tracing.mdx
@@ -34,10 +34,15 @@ If `PATTER_OTEL_ENABLED` is not set, `init_tracing` returns `False` and every sp
 
 | Span name | Fires | Attributes |
 |---|---|---|
+| `getpatter.call` | One per call (root span) | `getpatter.call.id`, `getpatter.call.direction`, `getpatter.call.provider_mode` |
 | `getpatter.stt` | One per final transcript | `getpatter.stt.text_len`, `getpatter.stt.confidence` |
-| `getpatter.llm` | One per LLM iteration (incl. tool rounds) | `getpatter.llm.iteration`, `getpatter.llm.history_size` |
+| `getpatter.endpoint` | One per detected end-of-utterance | `getpatter.endpoint.silence_ms` |
+| `getpatter.llm` | One per LLM iteration (incl. tool rounds) — wraps the pipeline LLM call so TTFT is measured per turn | `getpatter.llm.iteration`, `getpatter.llm.history_size`, `getpatter.llm.ttft_ms` |
 | `getpatter.tts` | One per synthesized sentence | `getpatter.tts.text_len` |
+| `getpatter.bargein` | One per barge-in event | `getpatter.bargein.cancelled_text_len` |
 | `getpatter.tool` | One per tool invocation | `getpatter.tool.name`, `getpatter.tool.transport` |
+
+All TS spans use the same `getpatter.*` namespace as Python (the legacy `patter.*` names were normalised in 0.5.3 — both SDKs now emit identical span names so a single dashboard query works across runtimes).
 
 ## PII hygiene
 
@@ -65,5 +70,5 @@ print(is_enabled())
 **Collector refuses spans** → the endpoint defaults to OTLP/HTTP on port 4318. If you're running the gRPC-only OTel Collector image, switch to `otel/opentelemetry-collector-contrib` or enable the HTTP receiver in your collector config.
 
 <Info>
-Tracing is currently a Python-only feature. TypeScript parity is on the roadmap.
+Tracing has full TypeScript parity since 0.5.3 — span names, attributes, and PII hygiene are identical. See [TS Tracing](/typescript-sdk/tracing).
 </Info>

--- a/docs/python-sdk/tts.mdx
+++ b/docs/python-sdk/tts.mdx
@@ -55,22 +55,38 @@ agent = phone.agent(
 
 ## ElevenLabs
 
-Streaming HTTP TTS via ElevenLabs `eleven_turbo_v2_5`.
+Streaming HTTP TTS via ElevenLabs. Default model `"eleven_flash_v2_5"` (~75 ms TTFB, drop-in replacement for `eleven_turbo_v2_5`). Other valid `model_id` literals: `"eleven_v3"`, `"eleven_turbo_v2_5"`, `"eleven_multilingual_v2"`, `"eleven_monolingual_v1"`.
 
 ```python
 from getpatter import ElevenLabsTTS
 
 tts = ElevenLabsTTS()                        # reads ELEVENLABS_API_KEY
 tts = ElevenLabsTTS(voice_id="rachel")
-tts = ElevenLabsTTS(api_key="...", voice_id="EXAVITQu4vr4xnSDxMaL", model_id="eleven_turbo_v2_5")
+tts = ElevenLabsTTS(api_key="...", voice_id="EXAVITQu4vr4xnSDxMaL", model_id="eleven_v3")
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `api_key` | `str \| None` | `None` | API key — reads from `ELEVENLABS_API_KEY` if omitted. |
 | `voice_id` | `str` | `"EXAVITQu4vr4xnSDxMaL"` (Sarah) | ElevenLabs voice ID (or name). |
-| `model_id` | `str` | `"eleven_turbo_v2_5"` | Model preset. |
+| `model_id` | `ElevenLabsModel \| str` | `"eleven_flash_v2_5"` | Typed literal: `eleven_flash_v2_5` / `eleven_turbo_v2_5` / `eleven_v3` / `eleven_multilingual_v2` / `eleven_monolingual_v1`. |
 | `output_format` | `str` | `"pcm_16000"` | ElevenLabs output format. |
+
+### Telephony factories — `for_twilio()` / `for_telnyx()`
+
+When ElevenLabs runs in pipeline mode behind a phone carrier you can negotiate the carrier-native codec at the ElevenLabs HTTP layer and skip per-chunk SDK-side transcoding. The factory variants do that for you:
+
+```python
+from getpatter import ElevenLabsTTS
+
+# Twilio Media Streams: μ-law @ 8 kHz native — no resample, no μ-law encode in Python.
+tts = ElevenLabsTTS.for_twilio(voice_id="rachel")
+
+# Telnyx default: PCM @ 16 kHz native — no resample.
+tts = ElevenLabsTTS.for_telnyx(voice_id="rachel")
+```
+
+`CartesiaTTS.for_twilio()` / `for_telnyx()` and `ElevenLabsConvAI.for_twilio()` / `for_telnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls.
 
 ## OpenAI
 

--- a/docs/typescript-sdk/events.mdx
+++ b/docs/typescript-sdk/events.mdx
@@ -18,6 +18,10 @@ Patter emits events at key moments during a call. Register callbacks in `serve()
 | `onMessage` | User transcript ready for response (pipeline mode) | `serve()` |
 | `onMetrics` | After each conversational turn completes | `serve()` |
 
+For **fine-grained pipeline observability** (every interim transcript, every LLM chunk, every TTS chunk, every tool start) subscribe to the [EventBus](#eventbus) below — it complements these callbacks rather than replacing them.
+
+For **mutating prompts and responses** (RAG augmentation, output validation, PII redaction) use [PipelineHooks](#pipelinehooks-beforellm--afterllm) — they sit *inside* the LLM step rather than firing alongside it.
+
 ## onCallStart
 
 Fires when a new call connects. Use it for logging, CRM lookups, or initializing per-call state.
@@ -236,6 +240,66 @@ await phone.serve({
   };
 }
 ```
+
+## EventBus
+
+The `EventBus` exposes fine-grained pipeline events that don't have first-class callbacks. Subscribe with `events.on(eventType, handler)` from anywhere you have a `Patter` reference.
+
+```typescript
+import { Patter, PatterEventType } from "getpatter";
+
+phone.events.on(PatterEventType.TRANSCRIPT_PARTIAL, (ev) => console.log("partial:", ev.text));
+phone.events.on(PatterEventType.LLM_CHUNK, (ev) => logChunk(ev.call_id, ev.text));
+```
+
+| `PatterEventType` | Fires |
+|---|---|
+| `TRANSCRIPT_PARTIAL` | Every interim STT result (before endpointing). |
+| `TRANSCRIPT_FINAL` | Every final STT result (after endpointing). Same payload as `onTranscript`. |
+| `LLM_CHUNK` | Every streamed LLM token / chunk. |
+| `TTS_CHUNK` | Every TTS audio chunk written to the carrier. |
+| `TOOL_CALL_STARTED` | Tool dispatched (paired with the existing `tool_call_completed` you can observe via `onCallEnd`). |
+
+Handlers are non-blocking (fire-and-forget). Throwing inside a handler logs the error but does not interrupt the call.
+
+---
+
+## PipelineHooks (`beforeLlm` / `afterLlm`)
+
+`PipelineHooks` mutate the conversation *inside* the LLM step. Use them for RAG augmentation, prompt rewriting, PII redaction, or output validation.
+
+```typescript
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS } from "getpatter";
+
+const agent = phone.agent({
+  stt: new DeepgramSTT(),
+  llm: new AnthropicLLM(),
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }),
+  systemPrompt: "You are a helpful assistant.",
+  hooks: {
+    beforeLlm: async (messages, ctx) => {
+      // RAG: prepend retrieved context as a system message.
+      const docs = await retrieve(ctx.userText);
+      return [{ role: "system", content: `Context: ${docs}` }, ...messages];
+    },
+    afterLlm: async (text, ctx) => {
+      // Output validation: redact account numbers before TTS.
+      return redactAccounts(text);
+    },
+  },
+});
+```
+
+| Hook | Signature | Returns |
+|---|---|---|
+| `beforeLlm` | `(messages, ctx) => Message[] \| null` | New messages array, or `null` to skip the LLM call entirely. |
+| `afterLlm` | `(text, ctx) => string \| null` | Replacement text, or `null` to suppress TTS for this turn. |
+
+`HookContext` carries `callId`, `caller`, `callee`, and `history`. Hooks run in pipeline mode only — engines (`OpenAIRealtime`, `ElevenLabsConvAI`) bundle the LLM step internally.
+
+`PipelineHooks` also exposes `beforeStt` / `afterStt` and `beforeTts` / `afterTts` for audio-stage interception.
+
+---
 
 ## Type Signatures
 

--- a/docs/typescript-sdk/llm.mdx
+++ b/docs/typescript-sdk/llm.mdx
@@ -69,6 +69,8 @@ const llm2 = new OpenAILLM({ apiKey: "sk-...", model: "gpt-4o-mini" });
 
 Anthropic Messages API with native streaming and `tool_use` blocks, normalised to Patter's chunk protocol. Default model `"claude-haiku-4-5-20251001"`. Pass `maxTokens` to override the default token cap.
 
+Prompt caching is enabled by default — `cache_control: { type: "ephemeral" }` is attached to the system prompt and the last tool block, which cuts time-to-first-token on long system prompts and large tool catalogs. Pass `promptCaching: false` to disable.
+
 ```typescript
 import { AnthropicLLM } from "getpatter";
 
@@ -93,7 +95,9 @@ const llm2 = new GroqLLM({ apiKey: "gsk_...", model: "llama-3.3-70b-versatile" }
 
 ### CerebrasLLM
 
-Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"llama-3.3-70b"`. Supports optional gzip request-body compression via `gzipCompression: true` to reduce time-to-first-token on large prompts — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization).
+Cerebras Inference API (OpenAI-compatible) at `https://api.cerebras.ai/v1`. Default model `"gpt-oss-120b"` — production tier, ~3000 tok/sec on WSE-3, no deprecation date. Pass `model: "llama3.1-8b"` for the smaller free-tier alternative. The 404 `model_not_found` error includes a recovery hint listing other valid IDs.
+
+Supports forwarding OpenAI-style sampling kwargs (`responseFormat`, `parallelToolCalls`, `toolChoice`, `seed`, `topP`, `frequencyPenalty`, `presencePenalty`, `stop`) and gzip request-body compression (enabled by default) — see [Cerebras payload optimization](https://inference-docs.cerebras.ai/payload-optimization). Failures retry once with exponential backoff and honour `x-ratelimit-reset-*` advisory headers; terminal errors throw `PatterError`.
 
 ```typescript
 import { CerebrasLLM } from "getpatter";
@@ -101,8 +105,9 @@ import { CerebrasLLM } from "getpatter";
 const llm = new CerebrasLLM();                            // reads CEREBRAS_API_KEY
 const llm2 = new CerebrasLLM({
   apiKey: "csk-...",
-  model: "llama-3.3-70b",
-  gzipCompression: true,
+  model: "gpt-oss-120b",                                  // default
+  gzipCompression: true,                                  // defaults to true
+  responseFormat: { type: "json_object" },                // OpenAI-style structured outputs
 });
 ```
 

--- a/docs/typescript-sdk/metrics.mdx
+++ b/docs/typescript-sdk/metrics.mdx
@@ -51,11 +51,16 @@ The `LatencyBreakdown` object provides per-component latency in milliseconds:
 | Field | Description |
 |-------|-------------|
 | `stt_ms` | Time from user speech to transcript. |
-| `llm_ms` | Time from transcript to LLM response. |
-| `tts_ms` | Time from LLM response to first audio byte. |
+| `endpoint_ms` | Time the endpointer waited after the last word before declaring end-of-utterance. |
+| `llm_ttft_ms` | Time from end-of-utterance to the first LLM token. |
+| `llm_total_ms` | Time from end-of-utterance to the last LLM token (full response). |
+| `llm_ms` | Alias for `llm_ttft_ms` (kept for back-compat). |
+| `tts_ms` | Time from first LLM token to first TTS audio byte. |
+| `tts_total_ms` | Time from first LLM token to last TTS audio byte. |
+| `bargein_ms` | Time from caller voice detected to TTS playback cancelled (only set on barge-in turns). |
 | `total_ms` | End-to-end latency (user speech to first audio). |
 
-`CallMetrics` exposes the full distribution: `latency_avg`, `latency_p50` (median / typical UX), `latency_p95` (SLA), and `latency_p99` (cold-start outliers).
+`CallMetrics` exposes the full distribution: `latency_avg`, `latency_p50` (median / typical UX), `latency_p90` (steady-state outliers), `latency_p95` (SLA), and `latency_p99` (cold-start outliers).
 
 ## Per-Turn Metrics
 

--- a/docs/typescript-sdk/patter-tool.mdx
+++ b/docs/typescript-sdk/patter-tool.mdx
@@ -1,0 +1,112 @@
+---
+title: "PatterTool — phone as a tool"
+description: "Wrap a Patter instance so external agents (LangChain, OpenAI Assistants, Anthropic Claude, Hermes, MCP) can place real phone calls as a single tool invocation."
+icon: "phone-arrow-up-right"
+---
+
+# PatterTool
+
+`PatterTool` exposes a live `Patter` instance as a single **`make_phone_call`** tool that any text-based agent framework can register and dispatch. The agent picks up the phone, Patter runs a short conversation against the caller, and the tool returns a JSON envelope with the call ID, status, transcript, cost, and metrics.
+
+This complements the **bring-your-own-agent** pattern (`serve({ onMessage: 'https://...' })`) with the **inverse pattern** — phone-as-tool — covering the two realistic migration paths from LiveKit / ElevenLabs ConvAI / Pipecat customers.
+
+| Pattern | Where the brain lives | Where Patter sits | Use this when… |
+|---|---|---|---|
+| **A — Bring-your-own agent** (HTTP/WS endpoint) | Customer's existing service | Patter is STT + LLM proxy + TTS | Customer already runs a voice agent and wants to swap the voice transport but keep their conversation logic. Use `serve({ onMessage: 'https://...' })`. |
+| **B — Phone as a tool** (this page) | Customer's text-based agent | Patter is a tool the agent calls | Customer's agent is text-driven but needs to make phone calls during a conversation. |
+
+## Quickstart
+
+```typescript
+import { Patter, Twilio, DeepgramSTT, AnthropicLLM, ElevenLabsTTS, PatterTool } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  webhookUrl: "api.example.com",            // stable hostname — not a tunnel
+});
+
+const tool = new PatterTool({
+  phone,
+  agent: {
+    stt: new DeepgramSTT(),
+    llm: new AnthropicLLM(),
+    tts: new ElevenLabsTTS({ voiceId: "rachel" }),
+  },
+});
+
+await tool.start();                          // boots phone.serve() once (idempotent)
+
+const result = await tool.execute({
+  to: "+15551234567",
+  goal: "Book a haircut for tomorrow at 3 pm.",
+});
+console.log(result);
+// → { call_id, status, duration_seconds, cost_usd, transcript, metrics }
+```
+
+## Schema exporters
+
+`PatterTool` ships three schema exporters with identical wire shape (parameter JSON-schema + result envelope), so a customer can switch frameworks without re-mapping fields.
+
+```typescript
+tool.openaiSchema();     // { type: "function", function: { name, description, parameters } }
+tool.anthropicSchema();  // { name, description, input_schema }
+tool.hermesSchema();     // { name, description, parameters }   // same shape as Anthropic input_schema
+```
+
+When a framework expects a JSON-string handler (Hermes, MCP), use `tool.hermesHandler()` — it executes the call and returns either a JSON-string result or `{"error": "..."}`.
+
+## Tool arguments (JSON-schema)
+
+Identical across all three exporters:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `to` | string | ✓ | E.164 phone number |
+| `goal` | string | — | Becomes the in-call agent's system prompt |
+| `first_message` | string | — | First thing the agent speaks on answer |
+| `max_duration_sec` | integer | — | Hard timeout, default `180`, max `1800` |
+
+## Result envelope
+
+```typescript
+type PatterToolResult = {
+  call_id: string;
+  status: "completed" | "no-answer" | "busy" | "failed" | "timeout";
+  duration_seconds: number;
+  cost_usd: number;
+  transcript: { role: "agent" | "user"; text: string }[];
+  metrics: {
+    p95_latency_ms: number;
+    cost: { stt: number; tts: number; llm: number; telephony: number };
+  };
+};
+```
+
+## Concurrency & timeouts
+
+- `start()` is idempotent — call it from your bootstrap, or let `execute()` boot it lazily.
+- Concurrent `execute()` calls are serialised through a dial mutex so the per-`call_id` Future never races.
+- `max_duration_sec` is enforced via `setTimeout`; on timeout the tool hangs up the call and returns `status: "timeout"`.
+
+## Production deployment
+
+`PatterTool` boots `phone.serve()` once. Make sure the `Patter` instance was constructed with a **stable webhook hostname** in `webhookUrl` — never a tunnel — because Twilio/Telnyx need a long-lived HTTPS URL.
+
+For local development, use `tunnel: true` on the `Patter` constructor and let it spawn a cloudflared. For production deploys (Fly.io / Cloud Run / Fargate behind ALB), set `webhookUrl` to your public hostname and disable the tunnel.
+
+## Examples
+
+See [`examples/integrations/`](https://github.com/PatterAI/Patter/tree/main/examples/integrations) in the repo:
+
+- `hermes_phone_tool.py` — drop-in `tools/patter.py` for Hermes Agent.
+- `openai_assistant_phone_tool.ts` — minimal OpenAI Assistants run dispatching the tool.
+- `README.md` — Pattern A vs Pattern B decision matrix.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Tools" icon="wrench" href="/typescript-sdk/tools">In-call tool calling (function calling within a Patter agent).</Card>
+  <Card title="Agents" icon="robot" href="/typescript-sdk/agents">Configure the in-call agent that PatterTool wraps.</Card>
+</CardGroup>

--- a/docs/typescript-sdk/stt.mdx
+++ b/docs/typescript-sdk/stt.mdx
@@ -34,6 +34,7 @@ await phone.serve({ agent });
 |-------|---------|
 | `DeepgramSTT` | `DEEPGRAM_API_KEY` |
 | `WhisperSTT` | `OPENAI_API_KEY` |
+| `OpenAITranscribeSTT` | `OPENAI_API_KEY` |
 | `CartesiaSTT` | `CARTESIA_API_KEY` |
 | `AssemblyAISTT` | `ASSEMBLYAI_API_KEY` |
 | `SonioxSTT` | `SONIOX_API_KEY` |
@@ -62,7 +63,7 @@ const stt = new DeepgramSTT({ apiKey: "dg_...", endpointingMs: 80 });
 | `sampleRate` | `number` | `16000` | Sample rate in Hz. |
 | `endpointingMs` | `number` | `150` | Utterance endpointing in milliseconds. |
 | `utteranceEndMs` | `number \| null` | `1000` | Grace period after speech ends. |
-| `smartFormat` | `boolean` | `true` | Smart formatting (numbers, dates, punctuation). |
+| `smartFormat` | `boolean` | `false` | Smart formatting (numbers, dates, punctuation). Defaults to `false` because telephony agents feed transcripts straight back into an LLM, where smart-format rewrites can confuse downstream tool-call argument parsing. Pass `smartFormat: true` to opt back in. |
 | `interimResults` | `boolean` | `true` | Stream interim transcripts. |
 | `vadEvents` | `boolean` | `true` | Emit VAD start/end markers. |
 
@@ -76,6 +77,29 @@ import { WhisperSTT } from "getpatter";
 const stt = new WhisperSTT();                                     // reads OPENAI_API_KEY
 const stt = new WhisperSTT({ apiKey: "sk-...", language: "es" });
 ```
+
+<Note>
+Whisper on mulaw 8 kHz routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`). For production prefer `OpenAITranscribeSTT` (`gpt-4o-transcribe`) — same `OPENAI_API_KEY`, ~10× faster, no hallucination floor.
+</Note>
+
+## OpenAI Transcribe (gpt-4o-transcribe)
+
+First-class STT for OpenAI's `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` models — drop-in replacement for `WhisperSTT` with stronger multilingual quality and significantly lower latency. Reuses `OPENAI_API_KEY`.
+
+```typescript
+import { OpenAITranscribeSTT } from "getpatter";
+
+const stt = new OpenAITranscribeSTT();                                  // reads OPENAI_API_KEY, defaults to gpt-4o-transcribe
+const stt2 = new OpenAITranscribeSTT({ model: "gpt-4o-mini-transcribe" }); // cheaper variant
+const stt3 = new OpenAITranscribeSTT({ apiKey: "sk-...", language: "es" });
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `apiKey` | `string` | — | API key — reads from `OPENAI_API_KEY` if omitted. |
+| `language` | `string` | — | BCP-47 language code. Auto-detect when omitted. |
+| `model` | `string` | `"gpt-4o-transcribe"` | Either `"gpt-4o-transcribe"` or `"gpt-4o-mini-transcribe"`. |
+| `responseFormat` | `string` | `"json"` | Pass `"verbose_json"` to expose segment-level confidence and timestamps. |
 
 ## Cartesia
 

--- a/docs/typescript-sdk/tracing.mdx
+++ b/docs/typescript-sdk/tracing.mdx
@@ -1,0 +1,65 @@
+---
+title: "Tracing (OpenTelemetry)"
+description: "Opt-in OpenTelemetry tracing for STT, LLM, TTS, endpointing, barge-in, and tool calls."
+icon: "chart-network"
+---
+
+Patter ships opt-in OpenTelemetry tracing that covers the hot spots on the voice pipeline: STT, endpointing, LLM, TTS, barge-in, and tool calls. Every span carries the current `getpatter.call.id` so you can group by call in your backend. Span names are identical across Python and TypeScript — one dashboard query covers both runtimes.
+
+## Enable tracing
+
+Tracing is disabled by default. Set the env flag and call `initTracing` once at process start:
+
+```bash
+export PATTER_OTEL_ENABLED=1
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318   # any OTLP/HTTP collector
+```
+
+```typescript
+import { initTracing } from "getpatter";
+
+initTracing({
+  serviceName: "my-voice-bot",
+  otlpEndpoint: "http://localhost:4318",
+  resourceAttributes: { "deployment.environment": "staging" },
+});
+```
+
+If `PATTER_OTEL_ENABLED` is not set, `initTracing` is a no-op and every span becomes a no-op — **zero cost** when disabled.
+
+## Emitted spans
+
+| Span name | Fires | Attributes |
+|---|---|---|
+| `getpatter.call` | One per call (root span) | `getpatter.call.id`, `getpatter.call.direction`, `getpatter.call.provider_mode` |
+| `getpatter.stt` | One per final transcript | `getpatter.stt.text_len`, `getpatter.stt.confidence` |
+| `getpatter.endpoint` | One per detected end-of-utterance | `getpatter.endpoint.silence_ms` |
+| `getpatter.llm` | One per LLM iteration (incl. tool rounds) — wraps the pipeline LLM call so TTFT is measured per turn | `getpatter.llm.iteration`, `getpatter.llm.history_size`, `getpatter.llm.ttft_ms` |
+| `getpatter.tts` | One per synthesized sentence | `getpatter.tts.text_len` |
+| `getpatter.bargein` | One per barge-in event | `getpatter.bargein.cancelled_text_len` |
+| `getpatter.tool` | One per tool invocation | `getpatter.tool.name`, `getpatter.tool.transport` |
+
+## PII hygiene
+
+Patter never exports user utterances, tool payloads, or LLM content as span attributes. Only sizes, counts, and identifiers are emitted — traces are safe to ship to a shared Jaeger / Honeycomb / Grafana Cloud instance.
+
+## Shutdown
+
+Call `shutdownTracing()` during graceful shutdown to flush any pending spans:
+
+```typescript
+import { shutdownTracing } from "getpatter";
+
+await shutdownTracing();
+```
+
+## Troubleshooting
+
+**No spans appear** → confirm `PATTER_OTEL_ENABLED=1` is set *in the process that calls `initTracing`*. Quick check:
+
+```typescript
+import { isTracingEnabled } from "getpatter";
+console.log(isTracingEnabled());
+```
+
+**Collector refuses spans** → the endpoint defaults to OTLP/HTTP on port 4318. If you're running the gRPC-only OTel Collector image, switch to `otel/opentelemetry-collector-contrib` or enable the HTTP receiver in your collector config.

--- a/docs/typescript-sdk/tts.mdx
+++ b/docs/typescript-sdk/tts.mdx
@@ -39,22 +39,38 @@ await phone.serve({ agent });
 
 ## ElevenLabs
 
-Streaming HTTP TTS via ElevenLabs `eleven_turbo_v2_5`.
+Streaming HTTP TTS via ElevenLabs. Default model `"eleven_flash_v2_5"` (~75 ms TTFB, drop-in replacement for `eleven_turbo_v2_5`). Other valid `modelId` literals: `"eleven_v3"`, `"eleven_turbo_v2_5"`, `"eleven_multilingual_v2"`, `"eleven_monolingual_v1"`.
 
 ```typescript
 import { ElevenLabsTTS } from "getpatter";
 
 const tts = new ElevenLabsTTS();                                  // reads ELEVENLABS_API_KEY
-const tts = new ElevenLabsTTS({ voiceId: "rachel" });
-const tts = new ElevenLabsTTS({ apiKey: "...", voiceId: "EXAVITQu4vr4xnSDxMaL", modelId: "eleven_turbo_v2_5" });
+const tts2 = new ElevenLabsTTS({ voiceId: "rachel" });
+const tts3 = new ElevenLabsTTS({ apiKey: "...", voiceId: "EXAVITQu4vr4xnSDxMaL", modelId: "eleven_v3" });
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `apiKey` | `string` | — | API key — reads from `ELEVENLABS_API_KEY` if omitted. |
 | `voiceId` | `string` | `"EXAVITQu4vr4xnSDxMaL"` (Sarah) | ElevenLabs voice ID (or name). |
-| `modelId` | `string` | `"eleven_turbo_v2_5"` | Model preset. |
+| `modelId` | `ElevenLabsModel \| string` | `"eleven_flash_v2_5"` | Typed literal: `eleven_flash_v2_5` / `eleven_turbo_v2_5` / `eleven_v3` / `eleven_multilingual_v2` / `eleven_monolingual_v1`. |
 | `outputFormat` | `string` | `"pcm_16000"` | ElevenLabs output format. |
+
+### Telephony factories — `forTwilio()` / `forTelnyx()`
+
+When ElevenLabs runs in pipeline mode behind a phone carrier you can negotiate the carrier-native codec at the ElevenLabs HTTP layer and skip per-chunk SDK-side transcoding. The factory variants do that for you:
+
+```typescript
+import { ElevenLabsTTS } from "getpatter";
+
+// Twilio Media Streams: μ-law @ 8 kHz native — no resample, no μ-law encode in JS.
+const tts = ElevenLabsTTS.forTwilio({ voiceId: "rachel" });
+
+// Telnyx default: PCM @ 16 kHz native — no resample.
+const tts2 = ElevenLabsTTS.forTelnyx({ voiceId: "rachel" });
+```
+
+`CartesiaTTS.forTwilio()` / `forTelnyx()` and `ElevenLabsConvAI.forTwilio()` / `forTelnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls.
 
 ## OpenAI
 

--- a/sdk-py/README.md
+++ b/sdk-py/README.md
@@ -62,6 +62,7 @@ await phone.serve(agent, tunnel=True)
 | Call recording | `serve(recording=True)` | Record all calls |
 | Call transfer | `transfer_call` (auto-injected) | Transfer to a human |
 | Voicemail drop | `call(voicemail_message="...")` | Play message on voicemail |
+| Phone-as-a-tool (external agents) | `PatterTool(phone, agent).execute(...)` | Drop into LangChain / OpenAI Assistants / Hermes / MCP |
 
 ## Configuration
 
@@ -191,11 +192,13 @@ from getpatter import (
 Namespaced imports (one module per provider):
 
 ```python
-from getpatter.stt import deepgram, whisper, cartesia, soniox, speechmatics, assemblyai
+from getpatter.stt import deepgram, whisper, openai_transcribe, cartesia, soniox, speechmatics, assemblyai
 from getpatter.tts import elevenlabs, openai as openai_tts, cartesia as cartesia_tts, rime, lmnt
 
-stt = deepgram.STT()                    # reads DEEPGRAM_API_KEY
-tts = elevenlabs.TTS(voice="sarah")     # reads ELEVENLABS_API_KEY
+stt = deepgram.STT()                                  # reads DEEPGRAM_API_KEY
+stt = openai_transcribe.STT()                         # gpt-4o-transcribe — ~10× faster than Whisper
+tts = elevenlabs.TTS(voice_id="sarah")                # reads ELEVENLABS_API_KEY
+tts = elevenlabs.TTS.for_twilio(voice_id="sarah")     # μ-law @ 8 kHz native — no resample on Twilio
 ```
 
 ## Examples

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -62,6 +62,7 @@ await phone.serve({ agent, tunnel: true });
 | Call recording | `serve({ recording: true })` | Record all calls |
 | Call transfer | `transfer_call` (auto-injected) | Transfer to a human |
 | Voicemail drop | `call({ voicemailMessage: "..." })` | Play message on voicemail |
+| Phone-as-a-tool (external agents) | `new PatterTool({ phone, agent }).execute(...)` | Drop into LangChain / OpenAI Assistants / Hermes / MCP |
 
 ## Configuration
 
@@ -182,7 +183,7 @@ import {
   // Engines
   OpenAIRealtime, ElevenLabsConvAI,
   // STT
-  DeepgramSTT, WhisperSTT, CartesiaSTT, SonioxSTT, AssemblyAISTT,
+  DeepgramSTT, WhisperSTT, OpenAITranscribeSTT, CartesiaSTT, SonioxSTT, AssemblyAISTT,
   // TTS
   ElevenLabsTTS, OpenAITTS, CartesiaTTS, RimeTTS, LMNTTTS,
   // LLM
@@ -191,6 +192,8 @@ import {
   CloudflareTunnel, StaticTunnel,
   // Primitives
   Tool, Guardrail, tool, guardrail,
+  // Integrations
+  PatterTool,
 } from "getpatter";
 ```
 


### PR DESCRIPTION
## Summary

Documentation audit pass after the **0.5.3** release (latency + observability + parity) and the **0.5.4** fast-follow (Cerebras default → `gpt-oss-120b`). Closes the gap between what the SDKs actually expose today and what the docs were still describing.

No code changes — docs only.

### What landed

**CHANGELOG**
- New `0.5.4` entry covering the Cerebras default model change.

**Stale facts corrected**
- `CerebrasLLM` default: `llama-3.3-70b` → `gpt-oss-120b` (both SDKs).
- `DeepgramSTT.smart_format` default: `True` → `False` (telephony / LLM-friendly transcripts).
- `ElevenLabsTTS.model_id` default: `eleven_turbo_v2_5` → `eleven_flash_v2_5`.
- `tracing.mdx` (Python): dropped the "TypeScript parity is on the roadmap" note — parity shipped in 0.5.3.

**Newly documented features**
- **`OpenAITranscribeSTT`** (`gpt-4o-transcribe` / `gpt-4o-mini-transcribe`) — added to STT pages, reference exports, and READMEs.
- **`PatterTool`** (PR #75) — dedicated pages `docs/python-sdk/patter-tool.mdx` and `docs/typescript-sdk/patter-tool.mdx`, wired into the Mintlify nav under a new **Integrations** group.
- **`for_twilio()` / `for_telnyx()`** carrier-native factories on `ElevenLabsTTS`, `CartesiaTTS`, `ElevenLabsConvAI` — added to TTS pages.
- **Extended `LatencyBreakdown`**: `endpoint_ms`, `llm_ttft_ms`, `llm_total_ms`, `tts_total_ms`, `bargein_ms`, plus the new `latency_p90` aggregate.
- **New OTel spans**: `getpatter.endpoint`, `getpatter.bargein`. Note that the pre-existing `getpatter.llm` span now wraps the pipeline LLM call (was previously emitted but not measuring TTFT).
- **`EventBus` / `PatterEventType`** with the new event types: `transcript_partial`, `transcript_final`, `llm_chunk`, `tts_chunk`, `tool_call_started`.
- **`PipelineHooks.before_llm` / `after_llm`** — examples for RAG augmentation, output validation, PII redaction.
- **Anthropic prompt caching** — documented as default-on (`cache_control: ephemeral` on system prompt + last tool block) with the opt-out flag.
- **Cerebras**: documented `response_format`, `parallel_tool_calls`, `tool_choice`, `seed`, `top_p`, `frequency_penalty`, `presence_penalty`, `stop`, retry/backoff, and the 404 `model_not_found` recovery hint.

**New pages**
- `docs/python-sdk/patter-tool.mdx`
- `docs/typescript-sdk/patter-tool.mdx`
- `docs/typescript-sdk/tracing.mdx`

**Reference + READMEs**
- `python-sdk/reference.mdx`: surfaces `OpenAITranscribeSTT`, `SpeechmaticsSTT`, `PatterTool`, `EventBus` / `PatterEventType`, `init_tracing` / `SPAN_*`, `RateLimitError`, `BackgroundAudioPlayer`, `SileroVAD`, `TwilioAdapter` / `TelnyxAdapter`, and the `openai_transcribe` namespace.
- `README.md` / `sdk-py/README.md` / `sdk-ts/README.md`: feature-table rows for `PatterTool` and `OpenAITranscribeSTT`; updated Cerebras default model note.

## Test plan

- [x] `python3 -c "import json; json.load(open('docs/docs.json'))"` — Mintlify config still parses.
- [x] All documented defaults cross-checked against the 0.5.4 source (`sdk-py/getpatter/**` + `sdk-ts/src/**`).
- [ ] Reviewer: visual check of the rendered Mintlify nav (new "Integrations" group with PatterTool, new TS Tracing page).
- [ ] Reviewer: open the new pages in the Mintlify preview and confirm code samples run as written.