### PR TITLE
feat(sdk-ts): add manageWebhook opt-out to ServeOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-_(no entries yet — next version will land here)_
+### Added — `manageWebhook` opt-out for `serve()` (TS)
+
+- New `manageWebhook?: boolean` option on `ServeOptions`. **Default: `true`** (preserves existing behaviour — backward compatible).
+- When set to `false`, `serve()` skips the call to `autoConfigureCarrier` so the carrier's webhook URL (`voice_url` for Twilio) is left untouched. Use this when the webhook is managed externally — Terraform, an edge gateway, or a router function in front of the agent — so every boot doesn't silently overwrite the externally-managed value.
+- `tunnel: true` overrides `manageWebhook: false`: the tunnel hostname is dynamic and only known at runtime, so the carrier MUST be reconfigured for inbound calls to land.
+- Parity note: the Python SDK has never auto-configured carriers, so this brings the TS `manageWebhook: false` mode in line with default Python behaviour.
 
 ## 0.5.5 (2026-04-28)
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -1,0 +1,45 @@
+# Development Log
+
+## Log
+
+### [2026-05-07] — `manageWebhook` opt-out for `serve()` (TS)
+
+**Type:** feat
+**Branch:** feat/manage-webhook-opt-out
+**PR:** _pending_
+
+**What it does:**
+Adds a new `manageWebhook?: boolean` option to `ServeOptions` (TypeScript SDK), defaulting to `true` so existing callers see no behaviour change. When set to `false`, `serve()` skips the call to `autoConfigureCarrier`, leaving the carrier's `voice_url` untouched. This is required for users running the SDK behind a router/gateway whose Twilio webhook is managed externally (Terraform, infra-as-code) — otherwise every container boot silently overwrites the externally-managed value, breaking the gating layer.
+
+`tunnel: true` overrides `manageWebhook: false` (the tunnel hostname is dynamic and only known at runtime, so the carrier MUST be reconfigured for inbound calls to land).
+
+**Why:**
+Discovered when a downstream consumer (Patter demo phone line, fronted by a Cloud Functions voice-router that does rate-limiting + killswitch enforcement) noticed Twilio's `voice_url` was being silently rewritten to point at the Cloud Run agent on every boot — bypassing the gating function. There was no SDK opt-out. Locally this same code path is also responsible for "I ran the SDK on my laptop and Twilio is now pointing at my dev tunnel" footguns: the SDK proactively patches Twilio without asking.
+
+**Implementation details:**
+- `ServeOptions.manageWebhook` is the only new field.
+- The gate (`opts.manageWebhook !== false || wantsCloudflared`) treats undefined as the default `true`, an explicit `true` as opt-in, an explicit `false` as opt-out (unless tunnel mode forces the auto-configure).
+- Python SDK has no auto-configure path, so it already behaves as-if `manageWebhook=false`. This is closing a parity gap, not creating one.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `sdk-ts/src/types.ts` | Added `manageWebhook?: boolean` to `ServeOptions` with full doc comment. |
+| `sdk-ts/src/client.ts` | Gated the `autoConfigureCarrier` call on `wantsCarrierManagement`. |
+| `sdk-ts/tests/unit/client.test.ts` | Added 3 tests: default, explicit `true`, explicit `false`. |
+| `docs/typescript-sdk/local-mode.mdx` | Added `manageWebhook` row to the ServeOptions table. |
+| `CHANGELOG.md` | Added Unreleased entry. |
+
+**Tests added:**
+- `sdk-ts/tests/unit/client.test.ts` — 3 cases under `serve() > manageWebhook opt-out`: asserts the Twilio API URL is hit by default, hit when `true`, and **not** hit when `false`. Uses real `globalThis.fetch` swap to capture call URLs (no mock-on-mock).
+
+**Breaking changes:** None. Default `true` preserves existing behaviour byte-for-byte.
+
+**Docs to update:**
+- [x] `docs/typescript-sdk/local-mode.mdx` — added row.
+- [ ] `docs/typescript-sdk/configuration.mdx` — add a callout under "Manual webhook management" if a section is added later.
+- [ ] `patter_sdk_features.xlsx` — log feature row (`manage_webhook`, status=shipped, sdk=typescript, version=unreleased).
+
+**Parity:**
+- Python: no equivalent change needed — Python SDK has never auto-configured carriers. This TS change brings `manageWebhook: false` mode into line with default Python behaviour.

--- a/docs/typescript-sdk/local-mode.mdx
+++ b/docs/typescript-sdk/local-mode.mdx
@@ -45,6 +45,7 @@ await phone.serve({ agent, port: 8000 });
 | `pricing` | `Record<string, Record<string, unknown>>` | No | — | Custom pricing overrides for cost calculation. |
 | `dashboard` | `boolean` | No | `true` | When `true`, serve a dashboard UI at `/dashboard`. |
 | `dashboardToken` | `string` | No | — | Bearer token for dashboard/API authentication. |
+| `manageWebhook` | `boolean` | No | `true` | When `true`, `serve()` updates the carrier's webhook URL (Twilio `voice_url`) on startup. Set to `false` if the webhook is managed externally (Terraform, an edge gateway, or a router function in front of the agent) — otherwise every boot will silently overwrite the externally-managed value. Ignored when `tunnel: true`, because the tunnel hostname is dynamic and only known at runtime. |
 
 ## Webhook Endpoints
 

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -373,16 +373,27 @@ export class Patter {
 
     // Auto-configure the carrier so inbound calls hit this server without
     // manual Console setup. Mirrors Python's server.py start() flow.
-    const { autoConfigureCarrier } = await import('./carrier-config');
-    await autoConfigureCarrier({
-      telephonyProvider,
-      twilioSid: carrier.kind === 'twilio' ? carrier.accountSid : undefined,
-      twilioToken: carrier.kind === 'twilio' ? carrier.authToken : undefined,
-      telnyxKey: carrier.kind === 'telnyx' ? carrier.apiKey : undefined,
-      telnyxConnectionId: carrier.kind === 'telnyx' ? carrier.connectionId : undefined,
-      phoneNumber: this.localConfig.phoneNumber,
-      webhookHost: webhookUrl,
-    });
+    //
+    // Two opt-outs:
+    //   1. `manageWebhook: false` — for users running behind a router/gateway
+    //      whose Twilio voice_url is managed externally (Terraform, infra-as-code,
+    //      a voice-router function in front of the agent). Without this opt-out,
+    //      every boot silently overwrites the externally-managed value.
+    //   2. `tunnel: true` overrides any opt-out — the dynamic tunnel hostname is
+    //      only known at runtime, so the carrier MUST be reconfigured.
+    const wantsCarrierManagement = opts.manageWebhook !== false || wantsCloudflared;
+    if (wantsCarrierManagement) {
+      const { autoConfigureCarrier } = await import('./carrier-config');
+      await autoConfigureCarrier({
+        telephonyProvider,
+        twilioSid: carrier.kind === 'twilio' ? carrier.accountSid : undefined,
+        twilioToken: carrier.kind === 'twilio' ? carrier.authToken : undefined,
+        telnyxKey: carrier.kind === 'telnyx' ? carrier.apiKey : undefined,
+        telnyxConnectionId: carrier.kind === 'telnyx' ? carrier.connectionId : undefined,
+        phoneNumber: this.localConfig.phoneNumber,
+        webhookHost: webhookUrl,
+      });
+    }
 
     this.embeddedServer = new EmbeddedServer(
       {

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -286,6 +286,26 @@ export interface ServeOptions {
   dashboardDb?: string;
   /** When true (default), persist dashboard data. */
   dashboardPersist?: boolean;
+  /**
+   * When true (default), `serve()` calls the carrier's API on startup to
+   * point the configured phone number's webhook URL at this server. Set
+   * to `false` when the webhook is managed externally (Terraform, an edge
+   * gateway / voice-router, or any infra-as-code system) — otherwise every
+   * boot will silently overwrite the externally-managed value.
+   *
+   * Required `false` when:
+   *   - Twilio's voice_url should point at a router/gateway in front of
+   *     this server rather than directly at it.
+   *   - Multiple replicas share the same Twilio number; only one should
+   *     write the webhook.
+   *   - Compliance forbids the runtime from holding write credentials
+   *     against the carrier console.
+   *
+   * Ignored (treated as true) when `tunnel: true`, because the tunnel
+   * hostname is dynamic and only known at runtime — the carrier MUST be
+   * reconfigured for inbound calls to land.
+   */
+  manageWebhook?: boolean;
 }
 
 export interface LocalCallOptions {

--- a/sdk-ts/tests/unit/client.test.ts
+++ b/sdk-ts/tests/unit/client.test.ts
@@ -220,6 +220,68 @@ describe('Patter (local mode)', () => {
       await client.serve({ agent: { systemPrompt: 'Hello' } });
       // No throw means success — EmbeddedServer is mocked
     });
+
+    describe('manageWebhook opt-out', () => {
+      // Auth requests carry Basic auth + Twilio's API host — assert by URL.
+      const isTwilioCarrierApi = (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        return url.startsWith('https://api.twilio.com/2010-04-01/');
+      };
+
+      let originalFetch: typeof globalThis.fetch;
+      let fetchCalls: string[];
+
+      beforeEach(() => {
+        originalFetch = globalThis.fetch;
+        fetchCalls = [];
+        globalThis.fetch = (async (input: RequestInfo | URL) => {
+          if (isTwilioCarrierApi(input)) {
+            fetchCalls.push(typeof input === 'string' ? input : input.toString());
+            return new Response(
+              JSON.stringify({
+                incoming_phone_numbers: [{ sid: 'PN123', phone_number: '+15551234567' }],
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+          return new Response('not found', { status: 404 });
+        }) as typeof fetch;
+      });
+
+      afterEach(() => {
+        globalThis.fetch = originalFetch;
+      });
+
+      it('calls Twilio IncomingPhoneNumbers API by default (manageWebhook unset)', async () => {
+        const client = new Patter({
+          carrier: makeTwilioCarrier(),
+          phoneNumber: '+15551234567',
+          webhookUrl: 'example.com/wh',
+        });
+        await client.serve({ agent: { systemPrompt: 'Hello' } });
+        expect(fetchCalls.length).toBeGreaterThan(0);
+      });
+
+      it('calls Twilio IncomingPhoneNumbers API when manageWebhook is true', async () => {
+        const client = new Patter({
+          carrier: makeTwilioCarrier(),
+          phoneNumber: '+15551234567',
+          webhookUrl: 'example.com/wh',
+        });
+        await client.serve({ agent: { systemPrompt: 'Hello' }, manageWebhook: true });
+        expect(fetchCalls.length).toBeGreaterThan(0);
+      });
+
+      it('does NOT call Twilio IncomingPhoneNumbers API when manageWebhook is false', async () => {
+        const client = new Patter({
+          carrier: makeTwilioCarrier(),
+          phoneNumber: '+15551234567',
+          webhookUrl: 'example.com/wh',
+        });
+        await client.serve({ agent: { systemPrompt: 'Hello' }, manageWebhook: false });
+        expect(fetchCalls).toEqual([]);
+      });
+    });
   });
 
   // --- test() ---


### PR DESCRIPTION
## Summary

Adds a new `manageWebhook?: boolean` option on `ServeOptions` (TypeScript SDK), default `true`. When set to `false`, `serve()` skips the call to `autoConfigureCarrier`, leaving the carrier's `voice_url` untouched. `tunnel: true` overrides the opt-out (the dynamic tunnel hostname is only known at runtime).

## Why

The current behaviour is a hidden footgun for any user who runs the SDK behind a router/gateway whose Twilio webhook is managed externally:

- **Production:** A Cloud Functions voice-router fronts the agent for rate-limiting + killswitch enforcement. Twilio's `voice_url` is set to the router by Terraform / `deploy.sh`. Every container boot, the SDK silently rewrites it back to the agent — bypassing the gating layer. Drift detection caught this hourly until we shipped the opt-out downstream as a `patch-package` patch.
- **Local dev:** Running the SDK on a laptop with `tunnel: true` patches Twilio to point at the dev's `*.trycloudflare.com` URL. When the dev stops, the tunnel dies, but Twilio still points there — phone line offline. Same root cause, no opt-out.

The Python SDK has never auto-configured carriers (no `IncomingPhoneNumbers.update` call anywhere in `sdk/`). This PR makes the TS `manageWebhook: false` mode match default Python behaviour, closing a long-standing parity gap.

## Behaviour matrix

| `manageWebhook` | `tunnel` | Result |
|---|---|---|
| `undefined` (default) | `false` | Auto-configure (current behaviour, unchanged) |
| `true` | `false` | Auto-configure (explicit opt-in) |
| `false` | `false` | **Skip** auto-configure (the new opt-out) |
| any | `true` | Auto-configure forced (tunnel hostname is dynamic) |

## Backward compatibility

Default is `true` → byte-for-byte identical behaviour for every existing caller. No required field, no changed default.

## Tests

- `sdk-ts/tests/unit/client.test.ts` — 3 new authentic tests under `serve() > manageWebhook opt-out`. They swap `globalThis.fetch` to a real implementation that captures Twilio API URLs, then assert on call presence/absence:
  1. Default: Twilio API hit.
  2. `manageWebhook: true`: Twilio API hit.
  3. `manageWebhook: false`: Twilio API NOT hit.
- Full TS suite: 1166 passed (67 files).
- `npm run lint` (tsc --noEmit): clean.
- `npm run build`: clean.

## Test plan

- [x] `cd sdk-ts && npm test` — 1166/1166 passing
- [x] `cd sdk-ts && npm run lint` — clean
- [x] `cd sdk-ts && npm run build` — clean
- [x] `bash scripts/pr-validate.sh --quick` — pass
- [ ] CI: full matrix (Node 18/20/22)
- [ ] Reviewer: confirm the parity framing (Python has never auto-configured) is accurate

## Files changed

| File | Change |
|---|---|
| `sdk-ts/src/types.ts` | `manageWebhook?: boolean` added to `ServeOptions` with full doc comment |
| `sdk-ts/src/client.ts` | Gated `autoConfigureCarrier` on `opts.manageWebhook !== false \|\| wantsCloudflared` |
| `sdk-ts/tests/unit/client.test.ts` | 3 new tests |
| `docs/typescript-sdk/local-mode.mdx` | Added `manageWebhook` row to ServeOptions table |
| `CHANGELOG.md` | Unreleased entry |
| `docs/DEVLOG.md` | New file (rule mandate) |

## Future / out of scope

- A future major version could flip the default to `false` to remove the footgun entirely. Not in this PR — it would be a breaking change.
- Python SDK needs no change (no auto-configure path exists).