### PR TITLE
fix(0.6.1): Cerebras usage-chunk log + Krisp TS status refresh (re-base of #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.6.1 (2026-05-12)
 
+### Changed — Cerebras usage-chunk fallback: INFO-once + DEBUG per iteration (Python + TypeScript parity)
+
+The char/4 fallback billing path in `services/llm_loop.py` /
+`src/llm-loop.ts` previously emitted `logger.warning` /
+`getLogger().warn` on every tool-loop iteration when the upstream
+provider stream did not include a `usage` chunk. On Cerebras (the
+common case for this fallback), a multi-tool turn could log 5-10
+identical WARN lines for the same call — drowning real warnings.
+
+Replaced with: first fallback in the call → INFO (so operators
+still see it once with the full diagnostic context — `provider`,
+`model`, `input_chars`, `output_chars`, `est_input_tokens`,
+`est_output_tokens`); subsequent iterations → DEBUG with the
+iteration index and a per-LLMLoop `_usage_missing_count` /
+`_usageMissingCount` total so the volume is still visible at
+DEBUG level. No behavioural change — billing still uses char/4
+estimation. Files: `libraries/python/getpatter/services/llm_loop.py`,
+`libraries/typescript/src/llm-loop.ts`.
+
 ### Fixed — Barge-in gate regression test: prewarmed first message must remain interruptible
 
 Locked in with parity tests on both SDKs that `_stream_prewarm_bytes` / `streamPrewarmBytes` open the barge-in gate (`_first_audio_sent_at` / `firstAudioSentAt`) once the first chunk reaches the wire. The gate was already opened by `_begin_speaking(is_first_message=True)` ahead of streaming, but a future refactor of the `_begin_speaking` path could regress the prewarm path silently — the per-chunk `_mark_first_audio_sent` call inside the streaming loop is the last line of defence and now has explicit coverage in `test_stream_prewarm_bytes_opens_barge_in_gate_on_first_chunk` (Python) and `opens the barge-in gate by stamping firstAudioSentAt after the first chunk` (TypeScript).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ DEBUG level. No behavioural change — billing still uses char/4
 estimation. Files: `libraries/python/getpatter/services/llm_loop.py`,
 `libraries/typescript/src/llm-loop.ts`.
 
+### Changed — Krisp VIVA TypeScript scaffold: refreshed unavailability message (2026-05)
+
+The `KrispVivaFilter` constructor in
+`libraries/typescript/src/providers/krisp-filter.ts` already throws
+with guidance because Krisp does not publish a Node.js server SDK.
+Refreshed the message to include the verification date (2026-05),
+explicitly distinguish "server Node SDK" from existing browser
+wrappers, and list the LiveKit browser/RN packages
+(`@livekit/krisp-noise-filter`, `@livekit/react-native-krisp-noise-filter`)
+that exist but cannot process Patter's server-side PCM/mulaw audio.
+Python `KrispVivaFilter` and TS `DeepFilterNetFilter` remain the
+only shipped paths. No code behaviour change.
+
 ### Fixed — Barge-in gate regression test: prewarmed first message must remain interruptible
 
 Locked in with parity tests on both SDKs that `_stream_prewarm_bytes` / `streamPrewarmBytes` open the barge-in gate (`_first_audio_sent_at` / `firstAudioSentAt`) once the first chunk reaches the wire. The gate was already opened by `_begin_speaking(is_first_message=True)` ahead of streaming, but a future refactor of the `_begin_speaking` path could regress the prewarm path silently — the per-chunk `_mark_first_audio_sent` call inside the streaming loop is the last line of defence and now has explicit coverage in `test_stream_prewarm_bytes_opens_barge_in_gate_on_first_chunk` (Python) and `opens the barge-in gate by stamping firstAudioSentAt after the first chunk` (TypeScript).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,14 @@ estimation. Files: `libraries/python/getpatter/services/llm_loop.py`,
 
 The `KrispVivaFilter` constructor in
 `libraries/typescript/src/providers/krisp-filter.ts` already throws
-with guidance because Krisp does not publish a Node.js server SDK.
-Refreshed the message to include the verification date (2026-05),
-explicitly distinguish "server Node SDK" from existing browser
-wrappers, and list the LiveKit browser/RN packages
-(`@livekit/krisp-noise-filter`, `@livekit/react-native-krisp-noise-filter`)
-that exist but cannot process Patter's server-side PCM/mulaw audio.
-Python `KrispVivaFilter` and TS `DeepFilterNetFilter` remain the
-only shipped paths. No code behaviour change.
+with guidance because Krisp does not publish a Node.js server SDK as
+of 2026-05. Refreshed the message to include the verification date,
+explicitly distinguish "server Node SDK" from existing browser/RN
+third-party wrappers, and note that those wrappers (browser WASM and
+mobile client variants) are scoped to local microphone capture and
+cannot process Patter's server-side PCM/mulaw audio. Python
+`KrispVivaFilter` and TS `DeepFilterNetFilter` remain the only
+shipped paths. No code behaviour change.
 
 ### Fixed — Barge-in gate regression test: prewarmed first message must remain interruptible
 

--- a/libraries/python/getpatter/services/llm_loop.py
+++ b/libraries/python/getpatter/services/llm_loop.py
@@ -712,6 +712,12 @@ class LLMLoop:
         else:
             self._provider_name = "openai"
 
+        # Diagnostics for the char/4 fallback billing path (see _run_completion).
+        # Counted per-LLMLoop instance (i.e. per call). Surfaced only via logs
+        # — keeps record_llm_usage's public signature unchanged.
+        self._usage_missing_count = 0
+        self._logged_usage_fallback = False
+
         # Build OpenAI-format tool definitions (without handler/webhook_url)
         self._openai_tools: list[dict] | None = None
         if tools:
@@ -911,14 +917,36 @@ class LLMLoop:
                     input_tokens=estimated_input,
                     output_tokens=estimated_output,
                 )
-                logger.warning(
-                    "LLM usage chunk missing from %s/%s stream; "
-                    "estimating output_tokens=%d (input_tokens=%d) via char/4 fallback",
-                    self._provider_name,
-                    self._model,
-                    estimated_output,
-                    estimated_input,
-                )
+                self._usage_missing_count += 1
+                # First fallback in this call → INFO so the operator sees it once.
+                # Subsequent iterations only DEBUG to avoid spamming logs on
+                # long tool-loop turns where every iteration is char/4-billed.
+                if not self._logged_usage_fallback:
+                    self._logged_usage_fallback = True
+                    logger.info(
+                        "llm_usage_fallback provider=%s model=%s input_chars=%d "
+                        "output_chars=%d est_input_tokens=%d est_output_tokens=%d",
+                        self._provider_name,
+                        self._model,
+                        input_chars,
+                        output_chars,
+                        estimated_input,
+                        estimated_output,
+                    )
+                else:
+                    logger.debug(
+                        "llm_usage_fallback provider=%s model=%s iteration=%d "
+                        "input_chars=%d output_chars=%d est_input_tokens=%d "
+                        "est_output_tokens=%d total_missing=%d",
+                        self._provider_name,
+                        self._model,
+                        iteration,
+                        input_chars,
+                        output_chars,
+                        estimated_input,
+                        estimated_output,
+                        self._usage_missing_count,
+                    )
 
             # If no tool calls, we're done
             if not has_tool_calls:

--- a/libraries/typescript/src/llm-loop.ts
+++ b/libraries/typescript/src/llm-loop.ts
@@ -675,6 +675,11 @@ export class LLMLoop {
   // Fix 10: track provider/model so usage chunks can be attributed for billing.
   private readonly _providerName: string;
   private readonly _modelName: string;
+  // Diagnostics for the char/4 fallback billing path (see iterate loop).
+  // Counted per-LLMLoop instance (i.e. per call). Surfaced only via logs
+  // — keeps recordLlmUsage's public signature unchanged. Parity with Python.
+  private _usageMissingCount = 0;
+  private _loggedUsageFallback = false;
   // Optional async observer fired after a successful tool execution so
   // the host SDK (StreamHandler in pipeline mode) can surface tool calls
   // into the transcript timeline / `onTranscript` callback. Mirrors the
@@ -889,10 +894,28 @@ export class LLMLoop {
           0,
           0,
         );
-        getLogger().warn(
-          `LLM usage chunk missing from ${this._providerName}/${this._modelName} stream; ` +
-            `estimating output_tokens=${estimatedOutput} (input_tokens=${estimatedInput}) via char/4 fallback`,
-        );
+        this._usageMissingCount += 1;
+        // First fallback in this call → INFO so the operator sees it once.
+        // Subsequent iterations only DEBUG to avoid spamming logs on long
+        // tool-loop turns where every iteration is char/4-billed. Parity Py.
+        if (!this._loggedUsageFallback) {
+          this._loggedUsageFallback = true;
+          getLogger().info(
+            `llm_usage_fallback provider=${this._providerName} ` +
+              `model=${this._modelName} input_chars=${inputChars} ` +
+              `output_chars=${outputChars} est_input_tokens=${estimatedInput} ` +
+              `est_output_tokens=${estimatedOutput}`,
+          );
+        } else {
+          getLogger().debug(
+            `llm_usage_fallback provider=${this._providerName} ` +
+              `model=${this._modelName} iteration=${iter} ` +
+              `input_chars=${inputChars} output_chars=${outputChars} ` +
+              `est_input_tokens=${estimatedInput} ` +
+              `est_output_tokens=${estimatedOutput} ` +
+              `total_missing=${this._usageMissingCount}`,
+          );
+        }
       }
 
       if (!hasToolCalls) {

--- a/libraries/typescript/src/providers/krisp-filter.ts
+++ b/libraries/typescript/src/providers/krisp-filter.ts
@@ -2,9 +2,11 @@
  * Krisp VIVA noise-reduction AudioFilter — TypeScript scaffold.
  *
  * Mirrors the API of the Python `getpatter.providers.krisp_filter.KrispVivaFilter`
- * for SDK parity. Krisp does not publish a Node.js SDK as of 2026-05; this
- * class throws at construction time and points the caller at the available
- * paths (Python SDK or DeepFilterNet on TS).
+ * for SDK parity. As of 2026-05 Krisp does not publish an official Node.js
+ * (server) SDK; browser/RN wrappers exist (LiveKit) but cannot process
+ * server-received PCM/mulaw audio. This class throws at construction time
+ * and points the caller at the available paths (Python SDK or DeepFilterNet
+ * on TS).
  *
  * When Krisp publishes an official Node binding — or a community NAPI/WASM
  * wrapper becomes available — the import below and `process()` body will
@@ -57,9 +59,10 @@ export interface KrispVivaFilterOptions {
 
 const NODE_SDK_UNAVAILABLE_MESSAGE =
   'Krisp VIVA Filter is not yet available for the Patter TypeScript SDK.\n\n' +
-  'Krisp does not currently publish an official Node.js SDK. The Patter ' +
-  'TypeScript SDK ships only the AudioFilter interface scaffold (this file) ' +
-  'for parity with the Python implementation.\n\n' +
+  'As of 2026-05, Krisp does not publish an official Node.js (server) SDK. ' +
+  'The Patter TypeScript SDK ships only the AudioFilter interface scaffold ' +
+  '(this file) for parity with the Python implementation, since Patter runs ' +
+  'server-side on a real-time audio stream from the telephony carrier.\n\n' +
   'Available paths today:\n' +
   '  1. Use the Python SDK: `from getpatter.providers.krisp_filter import ' +
   'KrispVivaFilter` — fully implemented, requires `pip install ' +
@@ -67,6 +70,12 @@ const NODE_SDK_UNAVAILABLE_MESSAGE =
   '`KRISP_VIVA_FILTER_MODEL_PATH`.\n' +
   '  2. Use DeepFilterNet on TS: `new DeepFilterNetFilter({ modelPath: ' +
   "'.../DeepFilterNet3.onnx' })` — community ONNX export, no license needed.\n\n" +
+  'Browser/React Native (not applicable to Patter server-side, listed for ' +
+  'completeness):\n' +
+  '  - `@livekit/krisp-noise-filter` — browser WASM track processor on the ' +
+  'local microphone capture; cannot process server-received PCM/mulaw audio.\n' +
+  '  - `@livekit/react-native-krisp-noise-filter` — iOS/Android native ' +
+  'wrapper; mobile client only.\n\n' +
   'Track Node SDK status:\n' +
   '  - https://krisp.ai/developers/\n' +
   '  - Patter backlog: task #38 "Krisp TS port decision"\n';

--- a/libraries/typescript/src/providers/krisp-filter.ts
+++ b/libraries/typescript/src/providers/krisp-filter.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors the API of the Python `getpatter.providers.krisp_filter.KrispVivaFilter`
  * for SDK parity. As of 2026-05 Krisp does not publish an official Node.js
- * (server) SDK; browser/RN wrappers exist (LiveKit) but cannot process
+ * (server) SDK; third-party browser/RN wrappers exist but cannot process
  * server-received PCM/mulaw audio. This class throws at construction time
  * and points the caller at the available paths (Python SDK or DeepFilterNet
  * on TS).
@@ -72,10 +72,10 @@ const NODE_SDK_UNAVAILABLE_MESSAGE =
   "'.../DeepFilterNet3.onnx' })` — community ONNX export, no license needed.\n\n" +
   'Browser/React Native (not applicable to Patter server-side, listed for ' +
   'completeness):\n' +
-  '  - `@livekit/krisp-noise-filter` — browser WASM track processor on the ' +
-  'local microphone capture; cannot process server-received PCM/mulaw audio.\n' +
-  '  - `@livekit/react-native-krisp-noise-filter` — iOS/Android native ' +
-  'wrapper; mobile client only.\n\n' +
+  '  - Browser WASM wrappers (various third-party packages) process local ' +
+  'microphone capture, not server-received PCM/mulaw audio.\n' +
+  '  - Mobile client wrappers (iOS/Android, various third-party packages) ' +
+  'are likewise client-side only.\n\n' +
   'Track Node SDK status:\n' +
   '  - https://krisp.ai/developers/\n' +
   '  - Patter backlog: task #38 "Krisp TS port decision"\n';


### PR DESCRIPTION
## Summary
Replacement for PR #90 — rebased on top of `feat/observability-otel-attrs-0.6.1` HEAD (`efbee51`) so the CHANGELOG consolidation that landed on the base is honoured without a force-push.

## Implementation
- `chore(cerebras)`: per-instance counter for missing usage chunks; first fallback logged INFO, subsequent iterations DEBUG. Char/4 billing path unchanged.
- `docs(krisp)`: refresh thrown unavailable-message body for the TypeScript `KrispVivaFilter` constructor — no first-party Krisp Node SDK as of 2026-05.
- `fix(krisp)`: strip competitor package names from the refreshed message + matching CHANGELOG entry (per `.claude/rules/no-competitor-references.md`).

## Breaking change?
No. Same billing behaviour. Same throw on Krisp TS instantiation. Log verbosity reduced on Cerebras streams.

## Test plan
- [x] Python: `pytest tests/` — green locally
- [x] TypeScript: `npm test` — 1496 tests green
- [x] TypeScript: `tsc --noEmit` — clean

## Docs updates
- N/A (debug-log + thrown-message refresh; no public API change). CHANGELOG entries land directly under `## 0.6.1 (2026-05-12)`.