### PR TITLE
fix(test): polling wait in server.test.ts fixes Node 22 flake

### DIFF
--- a/libraries/typescript/tests/server.test.ts
+++ b/libraries/typescript/tests/server.test.ts
@@ -369,9 +369,10 @@ describe('EmbeddedServer wraps logging callbacks with active-record fallback', (
         telephony_provider: 'twilio',
       });
 
-      // Allow the fire-and-forget logCallStart promise to drain.
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
+      // Poll for the fire-and-forget logCallStart promise to drain. A
+      // fixed 50 ms wait was enough on Node 20 but flakes on Node 22
+      // (~10 % failure rate in CI) because the async scheduler defers
+      // the atomic-write resolve a tick longer. Bounded poll up to 2 s.
       const metaPaths: string[] = [];
       const walk = (d: string): void => {
         for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
@@ -380,7 +381,13 @@ describe('EmbeddedServer wraps logging callbacks with active-record fallback', (
           else if (entry.name === 'metadata.json') metaPaths.push(full);
         }
       };
-      walk(tmp);
+      const deadline = Date.now() + 2000;
+      while (Date.now() < deadline) {
+        metaPaths.length = 0;
+        walk(tmp);
+        if (metaPaths.length >= 1) break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
       expect(metaPaths).toHaveLength(1);
       const payload = JSON.parse(fs.readFileSync(metaPaths[0], 'utf8')) as {
         caller: string;


### PR DESCRIPTION
## Summary

The `EmbeddedServer wraps logging callbacks with active-record fallback` test in `libraries/typescript/tests/server.test.ts` flakes on Node 22 (~10 % CI fail rate) because the `setTimeout(50)` used to drain a fire-and-forget `logCallStart` promise isn't enough — Node 22's async scheduler defers the atomic-write resolve a tick longer than Node 20 where the original 50 ms was tuned.

Same failure showed up on PR #103 CI and again on the post-merge run.

## Implementation

Replaced the fixed 50 ms wait with a bounded poll: walk `tmp` for `metadata.json` every 25 ms, break on first hit, hard ceiling 2 s. No behaviour change in the SUT.

## Breaking change?

No.

## Test plan

- [x] `cd libraries/typescript && npm run lint` clean
- [x] `npm test -- tests/server.test.ts` — 37/37 pass locally
- [ ] CI confirms Node 22 pass on this PR
