### PR TITLE
ci: skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,13 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip on fork PRs. GitHub Actions does not pass repository secrets
+    # (``CLAUDE_CODE_OAUTH_TOKEN``) or emit OIDC tokens for ``pull_request``
+    # workflows triggered by forks — the action fails with
+    # "Could not fetch an OIDC token" no matter what. Skipping here keeps
+    # fork-PR check rollups clean; maintainers can still trigger a review
+    # manually via ``claude.yml`` (the @claude mention workflow).
+    if: github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Skip the `Claude Code Review` workflow on PRs opened from forks (1-line `if:` guard on the job).
- Fork PRs cannot receive repository secrets or OIDC tokens for `pull_request`-triggered workflows — `anthropics/claude-code-action@v1` consequently fails with `Could not fetch an OIDC token` and leaves a spurious red check on every external contribution.

## Implementation

- `.github/workflows/claude-code-review.yml`: add `if: github.event.pull_request.head.repo.fork == false` to the `claude-review` job.
- Replaced the (commented-out) author-filter template with this concrete guard + a comment explaining the rationale and the manual fallback (`@claude` mention via `claude.yml`).

## Breaking change?

No. The workflow keeps its full behaviour for PRs opened from branches in the upstream repo. Only fork PRs are affected — they previously failed with an OIDC error, now they skip the job cleanly.

## Test plan

- [x] `gh workflow view "Claude Code Review"` — syntax valid (action YAML loads).
- [ ] Once merged, re-run CI on #106 (an external fork PR) — `claude-review` should report `Skipped`, not `Failure`.
- [ ] An upstream-branch PR run should still execute the review (e.g. next internal change).

## Docs updates

N/A (CI-only change, not user-visible — no CHANGELOG entry per `documentation-best-practices.md` invariant 0 exemption for pure refactors with zero behaviour change to the SDKs).

## Why now

Surfaced by #106 (external contributor's Telnyx recording parity PR). The failing `claude-review` check is non-required so it doesn't actually block the merge, but it adds noise to every fork-PR rollup and makes "all green" status checks impossible for external contributors. Cleaner to skip than to fail.