### PR TITLE
docs: add Agent Skills bundle for AI agent harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Unreleased
 
+### Added
+
+- **Agent Skills bundle under `skills/`.** Five [Anthropic Agent Skills
+  spec](https://agentskills.io)-compliant `SKILL.md` files plus references —
+  `setup-patter`, `build-voice-agent`, `configure-telephony`,
+  `add-tools-and-handoffs`, `inspect-calls-and-metrics` — that teach any
+  compatible AI agent (Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor,
+  Codex, ~50 others via `npx skills add`) how to use the SDK end-to-end.
+  Both Python and TypeScript surfaces are covered in side-by-side code
+  examples; skill content reflects the 0.6.2 public API (`OpenAIRealtime2`,
+  `phone.metrics_store`, `dashboard_token` auth, `phone.serve(... on_call_end=...)`
+  kwarg, default `machine_detection=True`, `ring_timeout=25`, etc.). Discoverable
+  via `npx skills add patterai/patter --skill <name>` and listed on
+  [skills.sh](https://skills.sh) via install telemetry. README updated with
+  install snippet.
+
 ## 0.6.2 (2026-05-25)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -184,6 +184,23 @@ cp .env.example .env    # fill in your keys
 cd python && pip install -r requirements.txt && python main.py
 ```
 
+## Agent Skills
+
+Patter ships [Anthropic Agent Skills](https://agentskills.io) under [`skills/`](./skills) that teach
+any compatible AI agent — Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor, Codex, and ~50
+others — how to use the SDK end-to-end.
+
+```bash
+# Install one skill
+npx skills add patterai/patter --skill build-voice-agent
+
+# Or install all five
+npx skills add patterai/patter
+```
+
+The bundle covers `setup-patter`, `build-voice-agent`, `configure-telephony`, `add-tools-and-handoffs`,
+and `inspect-calls-and-metrics`. See [`skills/README.md`](./skills) for the full list and install options.
+
 ## Configuration
 
 ### Environment Variables

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,58 @@
+# Patter Agent Skills
+
+A bundle of [Anthropic Agent Skills](https://agentskills.io) that teach an AI agent
+how to use the [Patter](https://github.com/PatterAI/Patter) voice/telephony SDK —
+covering setup, building voice agents (Realtime / ConvAI / Pipeline modes), Twilio
+and Telnyx telephony, custom tools and handoffs, and call inspection.
+
+Skills work in Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor, Codex, and
+~50 other agent harnesses that consume the `npx skills add` CLI.
+
+## Install
+
+```bash
+# Install one skill
+npx skills add patterai/patter --skill build-voice-agent
+
+# Install all Patter skills
+npx skills add patterai/patter
+
+# Pin to a specific SDK version (recommended for production)
+npx skills add patterai/patter#v0.6.2 --skill build-voice-agent
+```
+
+Skills land in `~/.agents/skills/<skill-name>/` (global) or `./.agents/skills/<skill-name>/`
+(project-local), with symlinks into the per-agent skill directories.
+
+## Skills in this bundle
+
+| Skill | Purpose |
+|---|---|
+| [`setup-patter`](./setup-patter/) | Install Patter, configure provider API keys, and verify the environment for either Python or TypeScript. |
+| [`build-voice-agent`](./build-voice-agent/) | Build a voice agent — pick between OpenAI Realtime, ElevenLabs ConvAI, or the STT→LLM→TTS Pipeline, with full code examples for Python and TypeScript. |
+| [`configure-telephony`](./configure-telephony/) | Connect Twilio or Telnyx as the carrier — phone numbers, webhooks, tunnels, signature verification. |
+| [`add-tools-and-handoffs`](./add-tools-and-handoffs/) | Add custom tools (`@tool` / `defineTool`), enable built-in `transfer_call` / `end_call`, and wire output guardrails. |
+| [`inspect-calls-and-metrics`](./inspect-calls-and-metrics/) | Mount the live dashboard, read `CallMetrics`, export CSV/JSON, and track per-call cost. |
+
+## Requirements
+
+- **Python 3.11+** or **Node.js 20+**
+- `getpatter` package on PyPI or npm — `pip install "getpatter>=0.6.2"` or `npm install "getpatter@>=0.6.2"`
+- Provider credentials in env (OpenAI / ElevenLabs / Deepgram / Cerebras / Anthropic / Google as needed)
+- Carrier credentials in env (Twilio `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN`, or Telnyx `TELNYX_API_KEY`)
+
+## Versioning
+
+Skills version with the SDK. A skill at tag `v0.6.2` is guaranteed to match
+the API of `getpatter==0.6.2`. Skills on `main` track the next unreleased
+version — pin to a tag for reproducibility.
+
+## License
+
+MIT — same as the Patter SDK.
+
+## Links
+
+- SDK source: <https://github.com/PatterAI/Patter>
+- Mintlify docs: <https://docs.getpatter.com>
+- Skills spec: <https://agentskills.io/specification>

--- a/skills/add-tools-and-handoffs/SKILL.md
+++ b/skills/add-tools-and-handoffs/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: add-tools-and-handoffs
+description: >
+  Give a Patter voice agent custom tools (function calling), enable built-in
+  handoffs (`transfer_call`, `end_call`), and wire output guardrails. Use
+  when the user wants the agent to look up customer data, query a CRM,
+  schedule a callback, transfer to a human, hang up on abuse, refuse to say
+  certain phrases, validate caller intent, or do anything beyond
+  conversation. Covers `@tool` (Python) and `defineTool` (TypeScript), as
+  well as JSON-Schema webhook tools, in Patter 0.6.2.
+license: MIT
+compatibility: >
+  Requires Patter >= 0.6.2 and an agent already built via `build-voice-agent`.
+  Tools work in all three modes (Realtime, ConvAI, Pipeline), though
+  Realtime supports the richest tool flow with `reassurance` messages.
+metadata:
+  author: patter
+  version: "0.1.0"
+  parity: both
+---
+
+# Add tools and handoffs to a Patter agent
+
+Patter agents have **two built-in tools** (`transfer_call`, `end_call`) plus
+unlimited **custom tools**. Custom tools can be **handler-based** (your
+Python/TS function runs in-process) or **webhook-based** (the agent POSTs
+JSON arguments to your URL). Both shapes use the same `Tool` model. Output
+guardrails block or rephrase agent responses before they reach TTS.
+
+## Built-in tools (always available)
+
+Every agent automatically has:
+
+- **`transfer_call(target: str)`** — bridge to another phone number. Caller
+  hears the new party, your Patter session ends.
+- **`end_call()`** — hang up. Use for "goodbye" flows or abusive callers.
+
+You don't have to register these. The LLM picks them when the system prompt
+authorizes it.
+
+```python
+agent = phone.agent(
+    engine=OpenAIRealtime2(),
+    system_prompt=(
+        "You are Mia, the receptionist for Acme. "
+        "If the caller asks for a human, call `transfer_call` with target='+14155559999'. "
+        "If the caller wants to hang up, call `end_call`."
+    ),
+    first_message="Hi, how can I help?",
+)
+```
+
+## Custom tools — handler form
+
+The `@tool` decorator (Python) and `defineTool` (TypeScript) auto-extract the
+JSON schema from your function signature and docstring. Best for simple
+synchronous lookups.
+
+### Python
+
+```python
+from getpatter import Patter, Twilio, OpenAIRealtime2, tool
+
+@tool
+async def lookup_customer(phone: str) -> dict:
+    """Look up customer details by phone number.
+
+    Args:
+        phone: E.164 phone number, e.g. +14155551234.
+
+    Returns:
+        Customer name, tier, and last order date.
+    """
+    # your CRM call here
+    return {"name": "Jane Doe", "tier": "gold", "last_order": "2026-04-12"}
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+agent = phone.agent(
+    engine=OpenAIRealtime2(),
+    system_prompt="You are a customer-service agent. Use `lookup_customer` when you need account info.",
+    first_message="Hi, can I help with your account?",
+    tools=[lookup_customer],
+)
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2, defineTool } from "getpatter";
+
+const lookupCustomer = defineTool({
+  name: "lookup_customer",
+  description: "Look up customer details by phone number.",
+  parameters: {
+    type: "object",
+    properties: {
+      phone: { type: "string", description: "E.164 phone number, e.g. +14155551234." },
+    },
+    required: ["phone"],
+  },
+  handler: async ({ phone }) => {
+    // your CRM call here
+    return { name: "Jane Doe", tier: "gold", lastOrder: "2026-04-12" };
+  },
+});
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const agent = phone.agent({
+  engine: new OpenAIRealtime2(),
+  systemPrompt: "You are a customer-service agent. Use lookup_customer when you need account info.",
+  firstMessage: "Hi, can I help with your account?",
+  tools: [lookupCustomer],
+});
+```
+
+## Custom tools — webhook form
+
+Better for cross-language deployments or when the tool lives in a separate
+service. Patter POSTs the tool args as JSON to your URL and uses the JSON
+response as the tool result.
+
+```python
+from getpatter import Tool
+
+crm_lookup = Tool(
+    name="lookup_customer",
+    description="Look up customer details by phone number.",
+    parameters={
+        "type": "object",
+        "properties": {"phone": {"type": "string"}},
+        "required": ["phone"],
+    },
+    webhook_url="https://api.acme.com/crm/lookup",
+)
+
+agent = phone.agent(
+    engine=OpenAIRealtime2(),
+    system_prompt="…",
+    tools=[crm_lookup],
+)
+```
+
+The endpoint receives `POST` with body `{"phone": "+14155551234"}` and must
+respond with JSON. Authentication: add your own header via reverse proxy,
+or use Patter's `Tool(webhook_headers={...})` (omitted here for brevity).
+
+## Reassurance messages (Realtime mode)
+
+In Realtime mode, tool calls happen *during* the call — the LLM has to
+decide whether to keep talking while the tool runs. Set `reassurance` to
+play a "hold on" message while the handler executes:
+
+```python
+@tool(reassurance="Let me check that for you, one moment.")
+async def lookup_customer(phone: str) -> dict:
+    await asyncio.sleep(2)  # imagine a slow CRM
+    return {"name": "Jane"}
+```
+
+Without it, there's silence while the tool runs — which sounds broken to
+the caller.
+
+## Output guardrails
+
+Block specific phrases or run a custom check before the agent's response
+reaches the TTS.
+
+```python
+from getpatter import guardrail, Patter, Twilio, OpenAIRealtime2
+
+@guardrail
+def no_competitors(text: str) -> bool:
+    """Block any response that mentions a competitor."""
+    return "patter" not in text.lower() or "alternative" not in text.lower()
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+agent = phone.agent(
+    engine=OpenAIRealtime2(),
+    system_prompt="You are a sales agent for Acme.",
+    first_message="Hi, how can I help?",
+    guardrails=[no_competitors],
+)
+```
+
+When a guardrail blocks, the agent speaks the guardrail's `replacement`
+text instead (default: `"I'm sorry, I can't respond to that."`).
+
+For a simple keyword list:
+
+```python
+from getpatter import Guardrail
+
+agent = phone.agent(
+    ...,
+    guardrails=[Guardrail(
+        name="no-pii",
+        blocked_terms=["social security", "credit card"],
+        replacement="I can't help with sensitive information. Let me transfer you.",
+    )],
+)
+```
+
+## Pipeline hooks (advanced)
+
+For more control than guardrails, pipeline hooks intercept every leg of
+the pipeline (only available in Pipeline mode):
+
+| Hook | Fires when | Use case |
+|---|---|---|
+| `before_send_to_stt` | Audio in | Echo cancellation, noise gate. |
+| `after_transcribe` | After STT | PII redaction, command parsing. |
+| `before_llm` | Before LLM | RAG injection, context rewrites. |
+| `after_llm` | After LLM | Output filter, persona enforcement. |
+| `before_synthesize` | Before TTS | Sentence chunking, voice-tag insertion. |
+| `after_synthesize` | After TTS | Audio post-processing. |
+
+Hooks are async functions returning `None` (no change) or the modified
+value. See <https://docs.getpatter.com/python-sdk/events>.
+
+## Gotchas
+
+- **`transfer_call` requires `target`** in E.164. Tell the agent in the
+  system prompt: "Use `transfer_call` with the target number `+1...`."
+- **Webhook tools time out at 30 s**. For longer ops, return a job ID and
+  expose a second tool to poll.
+- **JSON Schema strict mode**: pass `strict=True` (Python) /
+  `strict: true` (TS) to force OpenAI's strict-mode schema validation.
+  Catches bad LLM args at the boundary.
+- **Guardrails fire post-LLM, pre-TTS** — the caller never hears the
+  filtered text. The agent's memory still has the original though.
+- **Reassurance only works in Realtime mode**. In Pipeline mode the LLM
+  generates the reassurance text itself; ConvAI mode doesn't expose this.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| LLM never calls the tool | System prompt isn't authorizing it. Add "Use the X tool when ..." explicitly. |
+| `ValueError: parameters must be a JSON Schema object` | You passed `parameters={"phone": "string"}` instead of `{"type": "object", "properties": {...}}`. |
+| Tool returns `None` and LLM gets stuck | Always return *something* — a status string, a dict, an empty `{}`. Never `None`. |
+| Transfer rings out | The `target` number isn't a Twilio-owned or verified caller ID (Twilio trial). |
+
+## Related skills
+
+- [`build-voice-agent`](../build-voice-agent/) — define the agent the tools attach to.
+- [`inspect-calls-and-metrics`](../inspect-calls-and-metrics/) — see tool-call latency in the dashboard.
+
+## References
+
+- Patter Tools doc: <https://docs.getpatter.com/python-sdk/tools> · <https://docs.getpatter.com/typescript-sdk/tools>
+- Patter Guardrails doc: <https://docs.getpatter.com/python-sdk/guardrails> · <https://docs.getpatter.com/typescript-sdk/guardrails>
+- Pipeline hooks: <https://docs.getpatter.com/python-sdk/events>

--- a/skills/build-voice-agent/SKILL.md
+++ b/skills/build-voice-agent/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: build-voice-agent
+description: >
+  Build a production voice agent with the Patter SDK — receive or place real
+  phone calls answered by an AI agent. Use when the user wants to make a
+  phone bot, IVR replacement, voice receptionist, outbound caller, survey
+  bot, customer-support voice agent, voice-AI demo, AI cold-caller, or any
+  flow where an LLM talks over the telephone. Covers the three Patter modes
+  — OpenAI Realtime / Realtime2 (GA, lowest latency), ElevenLabs ConvAI
+  (turn-taking), and the STT→LLM→TTS Pipeline (mix any providers) — in both
+  Python and TypeScript. Trigger this skill even if the user only says
+  "phone bot", "voice AI", "call my customers", or "answer the phone with
+  AI" without naming Patter.
+license: MIT
+compatibility: >
+  Requires Patter >= 0.6.2, a configured carrier (Twilio or Telnyx) and
+  provider key (OPENAI_API_KEY for Realtime; ELEVENLABS_API_KEY for ConvAI;
+  STT+LLM+TTS keys for Pipeline). Use the `setup-patter` skill first if the
+  user hasn't installed and configured Patter.
+metadata:
+  author: patter
+  version: "0.1.0"
+  parity: both
+---
+
+# Build a voice agent with Patter
+
+Patter is an open-source SDK that turns any AI agent into a phone agent. Pick
+one of three architectures (Realtime, ConvAI, Pipeline), describe the
+behaviour in a system prompt, and run a local server that connects to your
+Twilio or Telnyx number — no Patter Cloud, no managed service. The four-line
+pattern below is the entire surface.
+
+## Architecture in one diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                          Patter server (local)                      │
+│   ┌────────────────┐    ┌───────────────────┐    ┌───────────────┐ │
+│   │ Carrier WS     │───▶│  Agent (engine /  │───▶│  Carrier WS   │ │
+│   │ in (audio in)  │    │  pipeline) loop   │    │ out (TTS out) │ │
+│   └────────────────┘    └───────────────────┘    └───────────────┘ │
+│           ▲                                              │          │
+│           │                Built-in tools:               │          │
+│           │             transfer_call · end_call         │          │
+└───────────┼──────────────────────────────────────────────┼──────────┘
+            │                                              │
+            │ WSS (mulaw 8kHz / pcm 16kHz)                 │
+            ▼                                              ▼
+       ┌──────────┐                                   ┌──────────┐
+       │  Twilio  │  ────────  real phone call  ───── │   User   │
+       │  Telnyx  │                                   └──────────┘
+       └──────────┘
+```
+
+**You write**: system prompt, optional tools, optional guardrails, choice of engine.
+**Patter writes**: WebSocket framing, audio transcoding, barge-in, VAD, cost tracking, tunnel, dashboard.
+
+## Decide the mode
+
+| Mode | When to use | Latency | Cost |
+|---|---|---|---|
+| **`OpenAIRealtime2`** (GA, default) | Default for everything. Lowest latency, single key. | ~200 ms turn | $$$ |
+| **`OpenAIRealtime`** | Legacy `gpt-realtime-mini`; pick only if explicitly required. | ~200 ms turn | $$ |
+| **`ElevenLabsConvAI`** | Turn-taking conversations (slower but better at long pauses). | ~600 ms turn | $$ |
+| **`Pipeline`** | Custom STT/LLM/TTS combinations. Use when the user wants Anthropic Claude / Cerebras / Whisper / a specific TTS voice. | ~800 ms turn | $-$$$$ |
+
+**Default pick**: `OpenAIRealtime2`. Switch only if the user explicitly asks for
+custom voice/LLM, lower cost, or a non-OpenAI provider.
+
+## Quick start
+
+### Python
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        engine=OpenAIRealtime2(),
+        system_prompt=(
+            "You are Mia, the AI receptionist for Acme Plumbing. "
+            "Greet the caller warmly. Help them book a service visit. "
+            "Keep replies under two sentences."
+        ),
+        first_message="Hi, this is Mia at Acme Plumbing — how can I help?",
+    )
+    await phone.serve(agent, tunnel=True)
+
+asyncio.run(main())
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+});
+
+const agent = phone.agent({
+  engine: new OpenAIRealtime2(),
+  systemPrompt:
+    "You are Mia, the AI receptionist for Acme Plumbing. " +
+    "Greet the caller warmly. Help them book a service visit. " +
+    "Keep replies under two sentences.",
+  firstMessage: "Hi, this is Mia at Acme Plumbing — how can I help?",
+});
+
+await phone.serve({ agent, tunnel: true });
+```
+
+Both expose a tunnel URL on startup (`tunnel ready: https://abc.trycloudflare.com`).
+Point your Twilio number's voice webhook at that URL (see `configure-telephony`),
+call the number, talk to Mia.
+
+## Pick the right mode
+
+The default works for 80% of agents. Switch when:
+
+| Want this | Pick this mode | Reference |
+|---|---|---|
+| Lowest possible latency, OpenAI voice | `OpenAIRealtime2` (default) | [references/realtime-mode.md](references/realtime-mode.md) |
+| Better long-pause handling, ElevenLabs voice | `ElevenLabsConvAI` | [references/convai-mode.md](references/convai-mode.md) |
+| Mix custom STT / LLM / TTS (Anthropic, Deepgram, Cartesia, …) | Pipeline | [references/pipeline-mode.md](references/pipeline-mode.md) |
+| Save cost on high-volume outbound | Pipeline with Cerebras LLM + Deepgram STT + ElevenLabs Turbo | [references/pipeline-mode.md](references/pipeline-mode.md) |
+
+Read the corresponding reference only when the user picks that mode — do not
+preload all three.
+
+## Outbound calls
+
+Same `Patter` instance does outbound. After `phone.serve(...)`, call:
+
+```python
+# Python — machine_detection defaults to True in 0.6.2
+await phone.call(
+    to="+14155551234",
+    agent=agent,
+    first_message="Hi, this is Mia from Acme.",
+    voicemail_message="Sorry we missed you. Call back at +1...",
+)
+```
+
+```typescript
+// TypeScript
+await phone.call({
+  to: "+14155551234",
+  agent,
+  firstMessage: "Hi, this is Mia from Acme.",
+  voicemailMessage: "Sorry we missed you. Call back at +1...",
+});
+```
+
+`machine_detection` is on by default in 0.6.2. Patter auto-detects voicemail
+and plays the call's `voicemail_message` before hanging up. A non-empty
+`voicemail_message` implicitly enables AMD even if you pass
+`machine_detection=False`. Otherwise the live person hears `first_message`
+and the agent starts the conversation. See `configure-telephony` for the
+full set of outbound options.
+
+## System prompt — what matters for voice
+
+Voice prompts are different from chat prompts. Patter doesn't add hidden
+instructions, so be explicit:
+
+1. **Identity**: "You are <name>, calling on behalf of <company>."
+2. **Goal**: "Help the caller book a service visit." (one line)
+3. **Length rule**: "Keep every reply under two sentences." (LLMs over-explain on voice.)
+4. **Stop conditions**: "If the caller wants a human, call `transfer_call`."
+5. **Persona**: "Warm, professional, never robotic. Say 'mm-hm' when listening."
+
+The `first_message` is what the agent says immediately on pickup — keep it
+to 1 sentence under 8 seconds of audio.
+
+## Gotchas
+
+- **Patter has no Patter Cloud in 0.6.2** — `Patter(api_key=...)` raises
+  `NotImplementedError`. Always use `carrier=...` + `phone_number=...`.
+- **Built-in tools are always present**: every agent gets `transfer_call` and
+  `end_call` for free. You don't have to register them.
+- **Mulaw vs PCM audio**: Twilio carrier = mulaw 8 kHz, Telnyx = PCM 16 kHz.
+  Patter transcodes both transparently — you never touch raw audio unless
+  you write a pipeline hook.
+- **`tunnel=True` is dev-only**. For production, use a static webhook URL
+  (your own subdomain or paid ngrok). Cloudflare quick tunnels work but
+  occasionally have a ~3 s WSS upgrade race on first call.
+- **`first_message` is played before the LLM responds**. If you omit it,
+  there's an awkward 1–2 s pause while the LLM warms up.
+- **Barge-in works by default** in 0.6.2 (VAD activation 0.8, deactivation
+  0.65 — tuned for room noise). If your callers are interrupting at the
+  wrong moments, see [`inspect-calls-and-metrics`](../inspect-calls-and-metrics/)
+  to read the VAD events from the call log.
+- **`prewarm_first_message=False` is the default** in 0.6.2 — it was briefly
+  flipped to `True` mid-release and reverted because it conflicted with
+  barge-in.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `RuntimeError: Patter Cloud is not implemented` | Don't pass `api_key=`. Use `carrier=Twilio()` + `phone_number="..."`. |
+| Agent says nothing on pickup | Missing `first_message=`. Add one. |
+| LLM responses are 4 paragraphs long | Add "Keep replies under two sentences" to system prompt. |
+| Caller hears garbled audio | Wrong audio rate. Check you're using the right carrier (mulaw 8 kHz Twilio, PCM 16 kHz Telnyx). Patter handles this; user code only breaks it via custom pipeline hooks. |
+| Connection drops after 30 s | Either the tunnel died (use static URL) or barge-in hung. Check `MetricsStore` for the last event. |
+
+## Related skills
+
+- [`setup-patter`](../setup-patter/) — install + env vars (run this first if user hasn't).
+- [`configure-telephony`](../configure-telephony/) — set up the Twilio/Telnyx webhook.
+- [`add-tools-and-handoffs`](../add-tools-and-handoffs/) — custom tools, `transfer_call`, guardrails.
+- [`inspect-calls-and-metrics`](../inspect-calls-and-metrics/) — live dashboard, cost per call, transcript.
+
+## References
+
+- Patter overview: <https://docs.getpatter.com/python-sdk/overview> · <https://docs.getpatter.com/typescript-sdk/overview>
+- Concepts: <https://docs.getpatter.com/concepts>
+- Agent configuration: <https://docs.getpatter.com/python-sdk/agents> · <https://docs.getpatter.com/typescript-sdk/agents>
+- Examples: <https://docs.getpatter.com/examples>

--- a/skills/build-voice-agent/references/convai-mode.md
+++ b/skills/build-voice-agent/references/convai-mode.md
@@ -1,0 +1,76 @@
+# ConvAI mode (`ElevenLabsConvAI`)
+
+Turn-taking voice agent powered by ElevenLabs ConversationAI. The agent
+listens, then speaks — more conventional phone flow with longer pauses
+tolerated. Use when you specifically want ElevenLabs voices (50+ voice
+clones, multilingual, expressive) or smoother long-pause behaviour.
+
+## When to use
+
+- ElevenLabs voice is required (voice cloning, multilingual).
+- Turn-taking is preferred over fluid interruption.
+- Caller demographics include long pauses (older callers, complex IVR).
+
+## When NOT to use
+
+- You want sub-300 ms latency → Realtime.
+- You want the cheapest tier → Pipeline with Cerebras + ElevenLabs Turbo.
+
+## Python
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, ElevenLabsConvAI
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        engine=ElevenLabsConvAI(
+            api_key="xi-...",          # defaults to ELEVENLABS_API_KEY
+            voice="rachel",            # ElevenLabs voice ID or preset name
+            model="eleven_turbo_v2_5", # default
+        ),
+        system_prompt="You are a friendly receptionist.",
+        first_message="Hi, how can I help?",
+    )
+    await phone.serve(agent, tunnel=True)
+
+asyncio.run(main())
+```
+
+## TypeScript
+
+```typescript
+import { Patter, Twilio, ElevenLabsConvAI } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  engine: new ElevenLabsConvAI({
+    apiKey: process.env.ELEVENLABS_API_KEY,
+    voice: "rachel",
+    model: "eleven_turbo_v2_5",
+  }),
+  systemPrompt: "You are a friendly receptionist.",
+  firstMessage: "Hi, how can I help?",
+});
+
+await phone.serve({ agent, tunnel: true });
+```
+
+## Tuning notes
+
+- **Voice cloning**: pass any ElevenLabs voice ID (24-char string) — the agent
+  will speak in that voice if your account has access to it.
+- **Multi-language**: ElevenLabs Turbo v2.5 handles 32 languages. Set
+  `language="es"` on the agent to bias the LLM toward Spanish (Patter
+  forwards this to the engine).
+- **Long-pause tolerance**: ConvAI doesn't aggressively barge in. Callers who
+  pause to think aren't interrupted as often as in Realtime mode.
+
+## Costs
+
+ElevenLabs charges per character of generated TTS + a flat per-conversation
+fee on ConvAI plans. See <https://elevenlabs.io/pricing>. Patter's `MetricsStore`
+breaks down `cost.tts_usd` and `cost.realtime_usd` separately so you can audit
+spend.

--- a/skills/build-voice-agent/references/pipeline-mode.md
+++ b/skills/build-voice-agent/references/pipeline-mode.md
@@ -1,0 +1,126 @@
+# Pipeline mode (STT → LLM → TTS)
+
+Modular voice agent that wires together a Speech-to-Text provider, an LLM
+provider, and a Text-to-Speech provider. Highest flexibility, every component
+swappable. Use when you want a non-OpenAI voice, a custom LLM (Anthropic
+Claude, Cerebras for speed, Groq for cost), or to mix-and-match providers
+for cost optimization.
+
+## When to use
+
+- You want Anthropic Claude / Cerebras / Groq / Gemini as the brain.
+- You want a specific voice (Cartesia Sonic, Rime, LMNT) not available in
+  Realtime/ConvAI.
+- You want the cheapest stack: Cerebras LLM + Deepgram STT + ElevenLabs Turbo
+  TTS can run at < $0.05 / minute.
+
+## When NOT to use
+
+- You want lowest latency — Pipeline is ~600–800 ms turn time vs ~200 ms for
+  Realtime. The three round-trips (STT→LLM→TTS) add up.
+- You want the simplest setup — needs three keys minimum.
+
+## Python (canonical low-cost stack)
+
+```python
+import asyncio
+from getpatter import (
+    Patter, Twilio,
+    DeepgramSTT, CerebrasLLM, ElevenLabsTTS,
+)
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        # No engine= → pipeline mode
+        stt=DeepgramSTT(model="nova-3"),
+        llm=CerebrasLLM(model="gpt-oss-120b"),         # default in 0.5.4+
+        tts=ElevenLabsTTS(voice_id="rachel"),
+        system_prompt="You are a friendly receptionist.",
+        first_message="Hi, how can I help?",
+    )
+    await phone.serve(agent, tunnel=True)
+
+asyncio.run(main())
+```
+
+## TypeScript (canonical low-cost stack)
+
+```typescript
+import {
+  Patter, Twilio,
+  DeepgramSTT, CerebrasLLM, ElevenLabsTTS,
+} from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  // No engine → pipeline mode
+  stt: new DeepgramSTT({ model: "nova-3" }),
+  llm: new CerebrasLLM({ model: "gpt-oss-120b" }),
+  tts: new ElevenLabsTTS({ voiceId: "rachel" }),
+  systemPrompt: "You are a friendly receptionist.",
+  firstMessage: "Hi, how can I help?",
+});
+
+await phone.serve({ agent, tunnel: true });
+```
+
+## Provider matrix
+
+### STT (Speech-to-Text)
+
+| Provider | Class | Env | Notes |
+|---|---|---|---|
+| Deepgram | `DeepgramSTT` | `DEEPGRAM_API_KEY` | Default. Nova-3 is fast + accurate. |
+| Whisper (OpenAI hosted) | `WhisperSTT` | `OPENAI_API_KEY` | Slower, batch-style. |
+| OpenAI Transcribe | `OpenAITranscribeSTT` | `OPENAI_API_KEY` | Realtime transcribe API. |
+| Cartesia | `CartesiaSTT` | `CARTESIA_API_KEY` | Sonic voice ecosystem. |
+| Soniox | `SonioxSTT` | `SONIOX_API_KEY` | Multilingual specialist. |
+| Speechmatics | `SpeechmaticsSTT` | `SPEECHMATICS_API_KEY` | Enterprise telephony. |
+| AssemblyAI | `AssemblyAISTT` | `ASSEMBLYAI_API_KEY` | Universal model. |
+
+### LLM
+
+| Provider | Class | Env | Notes |
+|---|---|---|---|
+| OpenAI | `OpenAILLM` | `OPENAI_API_KEY` | `gpt-4o-mini` default. |
+| Anthropic | `AnthropicLLM` | `ANTHROPIC_API_KEY` | Claude 3.5 Sonnet by default. |
+| Cerebras | `CerebrasLLM` | `CEREBRAS_API_KEY` | `gpt-oss-120b` default (0.5.4+). Fastest. |
+| Groq | `GroqLLM` | `GROQ_API_KEY` | `mixtral-8x7b` default. |
+| Google | `GoogleLLM` | `GOOGLE_API_KEY` | Gemini 2.0 Flash. |
+
+### TTS (Text-to-Speech)
+
+| Provider | Class | Env | Notes |
+|---|---|---|---|
+| ElevenLabs (WebSocket) | `ElevenLabsTTS` / `ElevenLabsWebSocketTTS` | `ELEVENLABS_API_KEY` | Default in 0.6.1+. Streaming. |
+| ElevenLabs (HTTP REST) | `ElevenLabsRestTTS` | `ELEVENLABS_API_KEY` | Slower, simpler. |
+| OpenAI | `OpenAITTS` | `OPENAI_API_KEY` | `tts-1` default. |
+| Cartesia | `CartesiaTTS` | `CARTESIA_API_KEY` | Sonic — sub-100ms first byte. |
+| Rime | `RimeTTS` | `RIME_API_KEY` | English casual. |
+| LMNT | `LMNTTTS` | `LMNT_API_KEY` | Fast, low-cost. |
+| Inworld | `InworldTTS` | `INWORLD_API_KEY` | Game voice. |
+
+## Tuning notes
+
+- **Default low-latency stack**: Deepgram + Cerebras + ElevenLabs WebSocket.
+  Cerebras runs at ~3000 tok/s on WSE-3 hardware, so `gpt-oss-120b` saturates
+  the downstream TTS rate just as well as a smaller model — no latency
+  penalty for using the bigger brain.
+- **Cost-optimized stack**: Deepgram + Cerebras + LMNT — ~$0.03/min observed.
+- **Quality-optimized stack**: AssemblyAI + Anthropic Claude 3.5 Sonnet +
+  Cartesia Sonic — slower, more expensive, more natural.
+- **Watch the per-leg latency** in `CallMetrics.latency_breakdown` to identify
+  which leg is the bottleneck (e.g. if TTS first-byte is 400 ms, swap to
+  Cartesia).
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `RuntimeError: no engine and no STT/LLM/TTS configured` | You forgot all three provider args. Add `stt=...`, `llm=...`, `tts=...`. |
+| Agent talks but doesn't hear | STT provider key missing or wrong. Check `DEEPGRAM_API_KEY`. |
+| Agent hears but doesn't talk | TTS provider key missing or wrong. Check `ELEVENLABS_API_KEY`. |
+| Agent speaks slowly | Switch LLM to Cerebras or Groq (faster than OpenAI for short replies). |
+| First TTS byte is slow | Switch TTS to Cartesia or ElevenLabs WebSocket (avoid REST/HTTP). |

--- a/skills/build-voice-agent/references/realtime-mode.md
+++ b/skills/build-voice-agent/references/realtime-mode.md
@@ -1,0 +1,88 @@
+# Realtime mode (`OpenAIRealtime2` / `OpenAIRealtime`)
+
+Speech-to-speech architecture: audio in → OpenAI Realtime API → audio out, over
+a single bidirectional WebSocket. Lowest latency (~200 ms turn time), single
+provider, simplest setup.
+
+## When to use
+
+- **Default for any new voice agent**.
+- Real-time conversation where interruption needs to feel natural.
+- Short prompts and few tools.
+- One-key setup (`OPENAI_API_KEY` only).
+
+## When NOT to use
+
+- You want a non-OpenAI voice → use ConvAI or Pipeline.
+- You want Anthropic Claude / Cerebras / a custom LLM → use Pipeline.
+- You're trying to minimize cost per minute → Pipeline with Cerebras + Deepgram
+  is significantly cheaper at scale.
+
+## Engine choice
+
+| Engine | Model | Status | When to pick |
+|---|---|---|---|
+| `OpenAIRealtime2` | `gpt-realtime-2` | **GA in 0.6.2 (recommended)** | New code |
+| `OpenAIRealtime` | `gpt-realtime-mini` | Maintained for compat | Existing 0.5.x → 0.6.x upgrades |
+
+## Python
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        engine=OpenAIRealtime2(
+            api_key="sk-...",            # optional; defaults to OPENAI_API_KEY env
+            model="gpt-realtime-2",      # default
+            voice="alloy",               # alloy / echo / fable / onyx / nova / shimmer / coral / sage / verse
+            reasoning_effort="medium",   # low / medium / high
+            input_audio_transcription_model="whisper-1",  # logs the user's words
+        ),
+        system_prompt="You are a friendly receptionist.",
+        first_message="Hi, how can I help?",
+    )
+    await phone.serve(agent, tunnel=True)
+
+asyncio.run(main())
+```
+
+## TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  engine: new OpenAIRealtime2({
+    apiKey: process.env.OPENAI_API_KEY,
+    model: "gpt-realtime-2",
+    voice: "alloy",
+    reasoningEffort: "medium",
+    inputAudioTranscriptionModel: "whisper-1",
+  }),
+  systemPrompt: "You are a friendly receptionist.",
+  firstMessage: "Hi, how can I help?",
+});
+
+await phone.serve({ agent, tunnel: true });
+```
+
+## Tuning notes
+
+- **`reasoning_effort`**: `low` is fast and good for chitchat; `medium` is the
+  default and balances quality+speed; `high` is for complex multi-step reasoning
+  (booking, troubleshooting). Higher values add 100–400 ms latency.
+- **`voice`**: try a few — `alloy` is the safest default, `verse` is more
+  expressive. Check OpenAI's docs for current options.
+- **`input_audio_transcription_model="whisper-1"`** logs what the caller said
+  to the dashboard. Without it, only the assistant's text is captured.
+
+## Costs (rough, see <https://openai.com/api/pricing>)
+
+OpenAI Realtime is billed per audio second in + out. Expect $0.06–$0.24 / min
+end-to-end depending on input/output mix. Use `MetricsStore` to track exact
+per-call cost (`inspect-calls-and-metrics` skill).

--- a/skills/configure-telephony/SKILL.md
+++ b/skills/configure-telephony/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: configure-telephony
+description: >
+  Configure Twilio or Telnyx as the telephony carrier for a Patter voice
+  agent — buy or use a phone number, set up the carrier console, point the
+  voice/Call-Control webhook at your Patter server (via Cloudflare tunnel,
+  ngrok, or a static URL), and verify webhook signatures. Use when the user
+  is wiring up Twilio, Telnyx, a phone number, a webhook URL, a tunnel, AMD
+  (Answering Machine Detection), call recording, voicemail drop, or DTMF
+  routing — even if they don't say "telephony". Covers both Patter 0.6.2
+  SDKs (Python and TypeScript).
+license: MIT
+compatibility: >
+  Requires Patter >= 0.6.2, an active Twilio or Telnyx account with at least
+  one purchased number, and the ability to expose a public webhook URL
+  (tunnel for dev, static URL for prod).
+metadata:
+  author: patter
+  version: "0.1.0"
+  parity: both
+---
+
+# Configure telephony for Patter
+
+Telephony is the leg between the user's phone and your Patter server. Patter
+supports two carriers with full feature parity:
+
+| Carrier | Audio | Webhook framework | Why pick it |
+|---|---|---|---|
+| **Twilio** | mulaw 8 kHz | TwiML | Largest US/EU coverage, mature ecosystem, AMD + recording. |
+| **Telnyx** | PCM 16 kHz | Call Control + Ed25519 sigs | Lower per-minute cost, native PCM, EU-friendly. |
+
+Both expose the **same surface** in Patter (`phone.serve(agent)`, `phone.call(to)`).
+The differences are in how you configure the carrier console.
+
+## Decision tree
+
+1. **Already have a Twilio or Telnyx account?** Use that one.
+2. **Starting fresh in the US?** → Twilio. Easier onboarding, larger phone-number inventory.
+3. **Starting fresh in Europe / cost-sensitive?** → Telnyx.
+4. **Need carrier features Patter doesn't bridge yet?** Check the per-carrier
+   reference below.
+
+Detailed setup per carrier:
+
+| Carrier | Reference |
+|---|---|
+| Twilio | [references/twilio.md](references/twilio.md) |
+| Telnyx | [references/telnyx.md](references/telnyx.md) |
+
+Read one — not both — once the user has chosen.
+
+## Webhook URL options
+
+Whichever carrier you use, the carrier needs a public URL to reach your
+Patter server. Three patterns, ranked by reliability:
+
+| Option | Setup | When to use |
+|---|---|---|
+| **Static URL** (`webhook_url="https://yourdomain.com"`) | Own subdomain pointed at your server's IP (DNS A record + TLS via Caddy/Cloudflare/etc.) | **Production**. Most reliable. |
+| **ngrok** (`webhook_url="abc.ngrok.io"`) | Paid ngrok account with reserved subdomain | Acceptance / dev with stable URL. |
+| **Cloudflare quick tunnel** (`tunnel=True`) | Patter spawns a tunnel automatically — no setup. URL changes every restart. | Dev / local demos only. |
+
+**`webhook_url` is set on the `Patter` constructor**, not on `serve()`. `tunnel`
+can be set on either — passing it to `serve()` is the most common pattern.
+
+### Python
+
+```python
+from getpatter import Patter, Twilio, Ngrok
+
+# Static (production) — set webhook_url on the constructor
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    webhook_url="patter.acme.com",   # no scheme, no trailing slash
+)
+await phone.serve(agent)
+
+# Cloudflare tunnel (dev) — no webhook_url; pass tunnel=True to serve()
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+await phone.serve(agent, tunnel=True)
+
+# Ngrok with reserved subdomain
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    tunnel=Ngrok(hostname="acme-patter.ngrok.io"),
+)
+await phone.serve(agent)
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, Ngrok } from "getpatter";
+
+// Static (production) — set webhookUrl on the constructor
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  webhookUrl: "patter.acme.com",
+});
+await phone.serve({ agent });
+
+// Cloudflare tunnel (dev) — no webhookUrl; pass tunnel: true to serve()
+const dev = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+await dev.serve({ agent, tunnel: true });
+
+// Ngrok with reserved subdomain
+const prod = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  tunnel: new Ngrok({ hostname: "acme-patter.ngrok.io" }),
+});
+await prod.serve({ agent });
+```
+
+## Outbound calls (AMD, voicemail drop)
+
+After `phone.serve(...)`, place an outbound call. `machine_detection` is **on
+by default** in 0.6.2 — pass `False` only to skip per-call AMD billing.
+
+### Python
+
+```python
+await phone.call(
+    to="+14155551234",
+    agent=agent,
+    first_message="Hi, this is Mia from Acme.",
+    machine_detection=True,                            # default in 0.6.2
+    voicemail_message="Sorry we missed you. Call back at +1...",
+    ring_timeout=30,                                    # default 25 s
+)
+```
+
+### TypeScript
+
+```typescript
+await phone.call({
+  to: "+14155551234",
+  agent,
+  firstMessage: "Hi, this is Mia from Acme.",
+  machineDetection: true,
+  voicemailMessage: "Sorry we missed you. Call back at +1...",
+  ringTimeout: 30,
+});
+```
+
+**AMD on Twilio**: requires the number to have voice capability. Setting a
+non-empty `voicemail_message` implicitly enables AMD, so you can omit
+`machine_detection=True` if you've set the voicemail. Patter normalizes
+the Twilio parameter shape automatically in 0.6.2 — older versions required
+PascalCase like `MachineDetection`.
+
+**Recording is server-wide**, not per-call: pass `recording=True` to
+`phone.serve(...)` to enable carrier-side recording for every call routed
+through that server (inbound and outbound).
+
+## Verify webhook signatures
+
+Patter validates carrier webhook signatures by default. You don't have to
+write code — the validators live in `getpatter.handlers.common`:
+
+- **Twilio**: `validate_twilio_signature(headers, body, auth_token, url)` — HMAC-SHA1
+  against the request URL + sorted body params.
+- **Telnyx**: `validate_telnyx_signature(headers, body, public_key)` — Ed25519
+  with anti-replay check (timestamp within ±5 min).
+
+Both return `False` on missing header (do **not** raise). Patter's default
+handler returns 401 on `False`. Don't disable signature verification.
+
+## Gotchas
+
+- **Twilio mulaw 8 kHz vs Telnyx PCM 16 kHz**: Patter transcodes both — your
+  agent code never touches raw audio. Don't try to set sample rate manually.
+- **Twilio Cloudflare tunnel race**: occasionally first call drops because
+  the WSS upgrade hasn't propagated through the CF edge yet. Fixed by bumping
+  grace to 5 s in 0.5.5; still less reliable than a static URL.
+- **Telnyx connection ID** is required (not just API key). Find it in
+  `Portal → Connections → SIP/SDK`. Set `TELNYX_CONNECTION_ID`.
+- **Number formats**: always E.164 (`+15550001234`). Patter validates before
+  dialing; non-E.164 raises `ValueError`.
+- **Outbound trunking** on Telnyx requires an Outbound Voice Profile attached
+  to the number — Twilio handles this automatically.
+- **Recording** stores on the carrier side (Twilio Media / Telnyx Storage),
+  never re-uploaded by Patter. URL appears in `CallMetrics.recording_url`.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| Carrier dials but no audio | Webhook URL is wrong — carrier can't reach your server. Test with `curl <webhook>/health`. |
+| Twilio 12300 (TwiML response invalid) | Your local server crashed before responding. Check Patter logs for stack trace. |
+| Telnyx "no answer" on outbound | Outbound Voice Profile not attached to the number. Set in portal. |
+| `signature verification failed` warning | Tunnel URL mismatch — Twilio signed for URL A, Patter validates against URL B. Use static URL or set `webhook_url` to the same one Twilio has. |
+| AMD always returns "human" | Patter uses Twilio async AMD by default for low latency. If you need synchronous AMD accuracy, contact Twilio support to switch your account default. |
+
+## Related skills
+
+- [`setup-patter`](../setup-patter/) — install + provider API keys (do this first).
+- [`build-voice-agent`](../build-voice-agent/) — define what the agent says once a call connects.
+- [`inspect-calls-and-metrics`](../inspect-calls-and-metrics/) — dashboard, recordings, cost.
+
+## References
+
+- Twilio console: <https://console.twilio.com>
+- Telnyx portal: <https://portal.telnyx.com>
+- Patter Tunneling guide: <https://docs.getpatter.com/dev-tools/tunneling>
+- Patter Carrier reference: <https://docs.getpatter.com/python-sdk/carrier> · <https://docs.getpatter.com/typescript-sdk/carrier>

--- a/skills/configure-telephony/references/telnyx.md
+++ b/skills/configure-telephony/references/telnyx.md
@@ -1,0 +1,84 @@
+# Telnyx carrier setup
+
+## Required env
+
+```bash
+TELNYX_API_KEY=KEY...
+TELNYX_CONNECTION_ID=2000...        # your Voice API SDK connection
+PATTER_PHONE_NUMBER=+15550001234    # the number you bought
+```
+
+`API key` is in **Portal → Account → API V2 Keys**. `Connection ID` is in
+**Portal → Connections → SIP / SDK Connections** — pick the one you want
+Patter to use (or create a new **Voice API SDK** connection).
+
+## Buy a number
+
+1. Open <https://portal.telnyx.com/#/app/numbers/search-numbers>.
+2. Search by country / area code → buy.
+3. Open the number's settings, set **Connection** to your SDK connection.
+
+## Wire the Call Control webhook
+
+1. **Portal → Connections → your SDK connection → Webhook URL**.
+2. URL: paste your Patter server's public URL + `/webhooks/telnyx/incoming`.
+3. HTTP method: `POST`.
+4. **Webhook API version**: v2 (not v1).
+5. Save.
+
+## Code
+
+### Python
+
+```python
+from getpatter import Patter, Telnyx, OpenAIRealtime2
+
+phone = Patter(
+    carrier=Telnyx(
+        api_key="KEY...",              # defaults to TELNYX_API_KEY
+        connection_id="2000...",       # defaults to TELNYX_CONNECTION_ID
+    ),
+    phone_number="+15550001234",
+    webhook_url="https://patter.yourdomain.com",
+)
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Telnyx, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Telnyx({
+    apiKey: process.env.TELNYX_API_KEY,
+    connectionId: process.env.TELNYX_CONNECTION_ID,
+  }),
+  phoneNumber: "+15550001234",
+  webhookUrl: "https://patter.yourdomain.com",
+});
+```
+
+## Outbound on Telnyx
+
+| Feature | How |
+|---|---|
+| **AMD** | `phone.call(to=..., machine_detection=True)` — defaults to True. Telnyx AMD is on the Call Control API. |
+| **Voicemail drop** | `phone.call(to=..., voicemail_message="...")` — implicitly enables AMD. |
+| **Ring timeout** | `phone.call(to=..., ring_timeout=30)` — default 25 s. |
+| **Recording** | `phone.serve(agent, recording=True)` — server-wide. URL appears in logs / Telnyx Storage. |
+| **Caller ID** | `phone.call(to=..., from_number="+1...")`. |
+| **Outbound Voice Profile** required | Attach a profile to the number in **Portal → Outbound Voice Profiles**, otherwise dial-out fails. |
+
+## Telnyx-specific gotchas
+
+- **Ed25519 signature verification with timestamp**: Telnyx signs every
+  webhook with Ed25519 and includes a timestamp. Patter rejects requests
+  older than ±5 min — clock skew on your server matters.
+- **Connection ID is required**, not optional. Telnyx error 90001 means
+  the number isn't bound to a connection.
+- **Outbound Voice Profile** must be attached to the number for outbound
+  calls. Inbound works without it.
+- **Native PCM 16 kHz**: Telnyx sends 16 kHz PCM up to Patter. Patter
+  transcodes to whatever the engine expects. You don't need to touch this.
+- **EU traffic**: Telnyx data residency can be locked to EU regions —
+  useful for GDPR. Set the connection's region in the portal.

--- a/skills/configure-telephony/references/twilio.md
+++ b/skills/configure-telephony/references/twilio.md
@@ -1,0 +1,85 @@
+# Twilio carrier setup
+
+## Required env
+
+```bash
+TWILIO_ACCOUNT_SID=AC...
+TWILIO_AUTH_TOKEN=...
+PATTER_PHONE_NUMBER=+15550001234   # the number you bought from Twilio
+```
+
+`AccountSid` starts with `AC`. `AuthToken` is in **Console → Account → API
+Keys & Tokens → Live Credentials**.
+
+## Buy a number
+
+1. Open <https://console.twilio.com/us1/develop/phone-numbers/manage/incoming>.
+2. **Buy a number** → search by country / area code.
+3. Confirm the number has **Voice** capability (not just SMS).
+
+## Wire the voice webhook
+
+1. Click the number you just bought.
+2. **Voice Configuration** → **A call comes in** → **Webhook**.
+3. URL: paste your Patter server's public URL + `/webhooks/twilio/incoming`.
+   - For dev: copy the `tunnel ready:` URL Patter prints on startup, e.g.
+     `https://abc.trycloudflare.com/webhooks/twilio/incoming`.
+   - For prod: `https://patter.yourdomain.com/webhooks/twilio/incoming`.
+4. HTTP method: `POST`.
+5. Save.
+
+## Code
+
+### Python
+
+```python
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+phone = Patter(
+    carrier=Twilio(
+        account_sid="AC...",        # optional, defaults to TWILIO_ACCOUNT_SID
+        auth_token="...",            # optional, defaults to TWILIO_AUTH_TOKEN
+    ),
+    phone_number="+15550001234",
+    webhook_url="https://patter.yourdomain.com",   # production
+)
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Twilio({
+    accountSid: process.env.TWILIO_ACCOUNT_SID,
+    authToken: process.env.TWILIO_AUTH_TOKEN,
+  }),
+  phoneNumber: "+15550001234",
+  webhookUrl: "https://patter.yourdomain.com",   // production
+});
+```
+
+## Outbound features Twilio handles natively
+
+| Feature | How |
+|---|---|
+| **AMD** | `phone.call(to=..., machine_detection=True)` — defaults to True in 0.6.2. |
+| **Voicemail drop** | `phone.call(to=..., voicemail_message="...")` — implicitly enables AMD. |
+| **Ring timeout** | `phone.call(to=..., ring_timeout=30)` — default 25 s. |
+| **Recording** | `phone.serve(agent, recording=True)` — server-wide, all calls recorded. URL surfaced in logs. |
+| **Caller ID** | `phone.call(to=..., from_number="+1...")` — must be a Twilio-owned number or verified caller ID. |
+| **DTMF** | Patter forwards in/out DTMF events to the agent automatically. |
+
+## Twilio-specific gotchas
+
+- **Trial accounts** can only dial **verified** numbers. Verify the
+  destination in **Console → Phone Numbers → Verified Caller IDs**.
+- **Geographic permissions**: Twilio blocks high-cost destinations by
+  default. Enable per-region in **Voice → Geo Permissions**.
+- **AMD `Status` PascalCase**: Twilio's API uses PascalCase params, but
+  Patter 0.6.2 normalizes Python `machine_detection` / TS `machineDetection`
+  automatically. Don't pass `MachineDetection=`.
+- **Public TwiML apps** can override the per-number webhook. If your
+  number is bound to a TwiML App, change the App's voice URL, not the
+  per-number setting.

--- a/skills/inspect-calls-and-metrics/SKILL.md
+++ b/skills/inspect-calls-and-metrics/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: inspect-calls-and-metrics
+description: >
+  Inspect Patter call data — mount the live dashboard, read CallMetrics
+  (duration, cost, latency, transcript), export call history to CSV/JSON,
+  and track per-call provider costs. Use when the user wants to debug a
+  call, see which calls cost the most, audit transcripts, monitor a live
+  agent, find a recording URL, check latency p99, export call history for
+  reporting, or watch the dashboard during a demo. Covers Patter 0.6.2's
+  in-memory MetricsStore + 500-call ring buffer, the FastAPI/Express
+  dashboard mount, the REST API and SSE stream — in both Python and
+  TypeScript.
+license: MIT
+compatibility: >
+  Requires Patter >= 0.6.2 and a running Patter server (`phone.serve(...)`).
+  Dashboard auth (basic auth) is recommended when serving on anything
+  other than 127.0.0.1.
+metadata:
+  author: patter
+  version: "0.1.0"
+  parity: both
+---
+
+# Inspect calls and metrics with Patter
+
+Patter persists every call to an in-memory `MetricsStore` (500-call ring
+buffer by default), optionally backed by disk. The dashboard surfaces
+live calls, transcripts, latency breakdowns, per-leg cost, and recordings.
+You can also pull `CallMetrics` programmatically and export to CSV/JSON
+for offline analysis.
+
+## Mount the live dashboard
+
+Patter ships a dashboard route you can mount on the same server as your
+agent. Visit `http://localhost:8000/dashboard` to see live calls.
+
+### Python
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        engine=OpenAIRealtime2(),
+        system_prompt="...",
+        first_message="Hi!",
+    )
+    # dashboard=True mounts /dashboard (UI) + /api/calls (REST) + /sse (live stream)
+    await phone.serve(agent, tunnel=True, dashboard=True)
+
+asyncio.run(main())
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const agent = phone.agent({
+  engine: new OpenAIRealtime2(),
+  systemPrompt: "...",
+  firstMessage: "Hi!",
+});
+
+await phone.serve({ agent, tunnel: true, dashboard: true });
+```
+
+Open `http://localhost:8000/dashboard`. Live calls appear at the top, with
+real-time transcript, current cost, and latency p50/p90/p95/p99.
+
+## Read metrics in code
+
+`CallMetrics` is the canonical model — every finished call produces one.
+The hook is **`on_call_end`** passed as a kwarg to `phone.serve(...)`. It
+receives a `dict` (the `CallMetrics` serialized form), and is async.
+
+### Python
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+async def on_end(metrics: dict) -> None:
+    print(f"Call {metrics['call_id']} | {metrics['duration_seconds']:.1f}s")
+    cost = metrics.get("cost", {})
+    print(f"  Cost ${cost.get('total_usd', 0):.4f}: "
+          f"STT ${cost.get('stt_usd', 0):.4f} · "
+          f"LLM ${cost.get('llm_usd', 0):.4f} · "
+          f"TTS ${cost.get('tts_usd', 0):.4f} · "
+          f"Realtime ${cost.get('realtime_usd', 0):.4f} · "
+          f"Telephony ${cost.get('telephony_usd', 0):.4f}")
+    print(f"  Latency p99: {metrics.get('latency_p99', 0):.0f} ms")
+
+agent = phone.agent(engine=OpenAIRealtime2(), system_prompt="...", first_message="Hi!")
+asyncio.run(phone.serve(agent, tunnel=True, on_call_end=on_end))
+```
+
+### TypeScript
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  engine: new OpenAIRealtime2(),
+  systemPrompt: "...",
+  firstMessage: "Hi!",
+});
+
+await phone.serve({
+  agent,
+  tunnel: true,
+  onCallEnd: async (metrics) => {
+    console.log(`Call ${metrics.call_id} | ${metrics.duration_seconds.toFixed(1)}s`);
+    console.log(`  Cost $${metrics.cost?.total_usd?.toFixed(4) ?? "0"}`);
+    console.log(`  Latency p99: ${metrics.latency_p99?.toFixed(0) ?? "0"} ms`);
+  },
+});
+```
+
+You can also pull live data programmatically from the `MetricsStore`
+attached to the server — `phone.metrics_store` (Python) /
+`phone.metricsStore` (TypeScript). It returns `None`/`null` until
+`serve()` has bound; once the server is live, you can iterate calls.
+
+## Export call history
+
+`calls_to_csv` and `calls_to_json` operate on the `MetricsStore` exposed on
+the running server.
+
+### Python
+
+```python
+from getpatter import calls_to_csv, calls_to_json
+
+store = phone.metrics_store          # available after serve() has bound
+if store is not None:
+    with open("calls.csv", "w") as f:
+        f.write(calls_to_csv(store))
+    import json
+    with open("calls.json", "w") as f:
+        json.dump(calls_to_json(store), f, indent=2)
+```
+
+### TypeScript
+
+```typescript
+import { callsToCsv, callsToJson } from "getpatter";
+import { writeFileSync } from "fs";
+
+const store = phone.metricsStore;     // available after serve() has bound
+if (store) {
+  writeFileSync("calls.csv", callsToCsv(store));
+  writeFileSync("calls.json", JSON.stringify(callsToJson(store), null, 2));
+}
+```
+
+## REST API (when dashboard is mounted)
+
+| Route | Purpose |
+|---|---|
+| `GET /api/calls` | List recent calls (newest first). |
+| `GET /api/calls/{call_id}` | Detailed metrics + transcript for one call. |
+| `GET /sse` | Server-Sent Events stream of live call updates. |
+
+Example with curl:
+
+```bash
+curl http://localhost:8000/api/calls | jq '.[] | {id: .call_id, cost: .cost.total_usd, duration: .duration_seconds}'
+```
+
+## Persist to disk (survive restarts)
+
+By default the ring buffer is in-memory. Pass `persist=True` (or a path) to
+mirror to disk:
+
+### Python
+
+```python
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    persist=True,                  # writes to ./.patter/calls.db
+    # persist="/var/patter/calls.db",  # or a custom path
+)
+```
+
+### TypeScript
+
+```typescript
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  persist: true,                   // writes to ./.patter/calls.db
+});
+```
+
+## Lock the dashboard down (bearer token)
+
+When exposing the dashboard beyond `127.0.0.1`, gate it with a bearer token.
+Patter ships token auth out of the box via the `dashboard_token` kwarg —
+all `/dashboard`, `/api/calls`, and `/sse` routes then require
+`Authorization: Bearer <token>`.
+
+### Python
+
+```python
+await phone.serve(agent, tunnel=True, dashboard_token="hunter2-rotate-me")
+```
+
+### TypeScript
+
+```typescript
+await phone.serve({ agent, tunnel: true, dashboardToken: "hunter2-rotate-me" });
+```
+
+For programmatic FastAPI/Express embedding (not just `phone.serve`), the
+lower-level `make_auth_dependency(...)` (Python) / `makeAuthMiddleware(...)`
+(TypeScript) factories are also exported — useful when you mount the
+dashboard onto your own app and need a custom auth scheme.
+
+Without auth, **do not bind to `0.0.0.0`** — call transcripts are PII.
+
+## What's inside `CallMetrics`
+
+Key fields (see `models.py` / `metrics.ts` for the full list):
+
+| Field | Meaning |
+|---|---|
+| `call_id` | UUID, persistent across the call. |
+| `duration_seconds` | Total call wall time. |
+| `turns` | List of `TurnMetrics` (user/agent each). |
+| `cost` | `CostBreakdown(stt_usd, llm_usd, tts_usd, realtime_usd, telephony_usd, total_usd)`. |
+| `latency_avg / p50 / p90 / p95 / p99` | Turn-time percentiles in ms. |
+| `provider_mode` | `"openai_realtime"`, `"elevenlabs_convai"`, `"pipeline"`. |
+| `stt_provider / llm_provider / tts_provider / telephony_provider` | Provider identifiers. |
+| `stt_model / llm_model / tts_model` | Model strings. |
+| `transcript` | List of `(role, text)` tuples — set when `input_audio_transcription_model` is configured. |
+
+Recording URLs live in the carrier's payload, surfaced in the
+`call.recording.saved` log line — they are not exposed as a typed
+`CallMetrics` field in 0.6.2. Enable recording with `phone.serve(..., recording=True)`.
+
+## Gotchas
+
+- **Ring buffer is 500 calls by default**. Older calls are evicted from
+  memory (still on disk if `persist=True`). For long-running production,
+  use the on-disk SQLite to query history.
+- **Dashboard exposes transcripts (PII)** — always gate with auth + HTTPS
+  in production.
+- **`on_call_end` runs synchronously in the event loop**. Don't block —
+  push to a queue for slow exporters.
+- **Latency p99 == infinity for short calls** with < 100 turns. The
+  percentile estimator needs ~100 samples; for shorter calls use
+  `latency_avg`.
+- **Cost breakdown precision**: provider price tables are baked into
+  `pricing.py` at SDK release time. If a provider changes pricing
+  mid-quarter, your `cost.*_usd` will drift. Use `merge_pricing({...})`
+  to override.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| Dashboard 404s | You passed `dashboard=False` to `phone.serve(...)`. The default is `True` — drop the kwarg. |
+| Dashboard shows no calls | Server restarted with persistence off. `persist=True` is the default in 0.6.2; verify you didn't override it. |
+| Transcript is empty | Realtime mode without `input_audio_transcription_model` set, or guardrail blocked the response. |
+| Recording URL is missing from logs | `recording=True` wasn't passed to `phone.serve(...)`, or the carrier doesn't have recording enabled. |
+| `cost.total_usd` is 0 | The provider isn't in Patter's pricing table. Override per-provider rates via `merge_pricing({...})` on the `Patter` constructor. |
+
+## Related skills
+
+- [`build-voice-agent`](../build-voice-agent/) — agents must exist before they produce metrics.
+- [`add-tools-and-handoffs`](../add-tools-and-handoffs/) — tools' per-call latency shows in the dashboard.
+
+## References
+
+- Patter Dashboard guide: <https://docs.getpatter.com/python-sdk/dashboard> · <https://docs.getpatter.com/typescript-sdk/dashboard>
+- Metrics reference: <https://docs.getpatter.com/python-sdk/metrics> · <https://docs.getpatter.com/typescript-sdk/metrics>
+- Call logging: <https://docs.getpatter.com/python-sdk/call-logging>
+- Pricing module: <https://github.com/PatterAI/Patter/blob/main/libraries/python/getpatter/pricing.py>

--- a/skills/setup-patter/SKILL.md
+++ b/skills/setup-patter/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: setup-patter
+description: >
+  Install the Patter voice/telephony SDK (Python or TypeScript) and configure
+  the provider and carrier API keys required for real phone calls. Use when
+  the user is starting a new Patter project, hitting "missing API key" errors,
+  setting up Twilio or Telnyx, integrating OpenAI Realtime / ElevenLabs /
+  Deepgram, or asking how to get Patter running — even if they don't
+  explicitly say "setup" or "credentials". Covers Patter 0.6.2 in both
+  Python (>=3.11) and TypeScript (Node >=20) runtimes.
+license: MIT
+compatibility: >
+  Requires Python 3.11+ or Node.js 20+. Needs at least one provider key
+  (e.g. OPENAI_API_KEY) and one carrier credential set (Twilio
+  TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN, or Telnyx TELNYX_API_KEY) in env.
+  Patter >= 0.6.2.
+metadata:
+  author: patter
+  version: "0.1.0"
+  parity: both
+---
+
+# Set up Patter
+
+Install the Patter SDK and provision the credentials required to place or
+receive real phone calls. Patter is open-source — there is no Patter API key.
+You bring your own provider (OpenAI / ElevenLabs / Deepgram / …) and your own
+carrier (Twilio or Telnyx) keys, and Patter wires them together.
+
+## Workflow
+
+### Step 1 — Pick a runtime
+
+Ask the user which SDK they want. Both have full feature parity.
+
+- **Python** (3.11+): `pip install "getpatter>=0.6.2"`
+- **TypeScript** (Node 20+): `npm install "getpatter@>=0.6.2"`
+
+If they're unsure, default to whichever language the rest of their project
+is in. Do not install both.
+
+### Step 2 — Pick an engine (decides which provider keys are needed)
+
+| Engine | What it does | Required keys |
+|---|---|---|
+| `OpenAIRealtime2` (recommended, GA in 0.6.2) | Speech-to-speech via OpenAI Realtime API — lowest latency | `OPENAI_API_KEY` |
+| `OpenAIRealtime` (legacy) | Older `gpt-realtime-mini` model. Same key. | `OPENAI_API_KEY` |
+| `ElevenLabsConvAI` | ElevenLabs ConversationAI — turn-taking model | `ELEVENLABS_API_KEY` |
+| `Pipeline` (no engine arg) | STT → LLM → TTS — mix providers freely | At least one each of STT/LLM/TTS key |
+
+If the user wants the simplest setup, default to **`OpenAIRealtime2`** — single
+key, lowest latency, GA quality. Mention Pipeline only if they ask for custom
+STT/LLM/TTS or for cost tuning.
+
+### Step 3 — Pick a carrier
+
+| Carrier | Audio format | Required env |
+|---|---|---|
+| **Twilio** | mulaw 8 kHz | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` |
+| **Telnyx** | PCM 16 kHz | `TELNYX_API_KEY` |
+
+Twilio is the default suggestion — broader US/EU coverage, mature TwiML
+ecosystem. Telnyx is preferable in regions where Twilio coverage is weak
+and for users who want lower carrier cost.
+
+Buying a phone number is **the user's job**, not the AI agent's — link the
+console:
+
+- Twilio: <https://console.twilio.com/us1/develop/phone-numbers/manage/incoming>
+- Telnyx: <https://portal.telnyx.com/#/app/numbers/my-numbers>
+
+### Step 4 — Write the keys to `.env`
+
+Create or append to `.env` in the project root:
+
+```bash
+# Engine
+OPENAI_API_KEY=sk-...
+
+# Carrier (pick one)
+TWILIO_ACCOUNT_SID=AC...
+TWILIO_AUTH_TOKEN=...
+
+# Phone number you bought from the carrier console
+PATTER_PHONE_NUMBER=+15550001234
+```
+
+Verify `.env` is in `.gitignore`. If not, add it:
+
+```
+.env
+```
+
+**Never commit credentials.** Patter will pick these up automatically — every
+carrier and provider reads its key from env by default.
+
+### Step 5 — Smoke-test the install
+
+Run the canonical 4-line example and verify it boots without ImportError or
+KeyError. The agent does not have to place a real call — `serve(... tunnel=True)`
+exiting cleanly with a tunnel URL is enough.
+
+**Python** (`test_setup.py`):
+
+```python
+import asyncio
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+async def main():
+    phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+    agent = phone.agent(
+        engine=OpenAIRealtime2(),
+        system_prompt="You are a friendly receptionist.",
+        first_message="Hello!",
+    )
+    await phone.serve(agent, tunnel=True)  # Ctrl+C to stop once tunnel URL prints
+
+asyncio.run(main())
+```
+
+**TypeScript** (`test-setup.ts`):
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const agent = phone.agent({
+  engine: new OpenAIRealtime2(),
+  systemPrompt: "You are a friendly receptionist.",
+  firstMessage: "Hello!",
+});
+await phone.serve({ agent, tunnel: true });
+```
+
+Run with `python test_setup.py` or `tsx test-setup.ts`. Expected output: a
+log line like `tunnel ready: https://<random>.trycloudflare.com` within ~5 seconds.
+
+### Step 6 — Confirm and hand off
+
+If smoke-test passes, tell the user:
+
+> Patter 0.6.2 is set up. You can now use the `build-voice-agent` skill to
+> design the agent, `configure-telephony` to wire the carrier webhook to the
+> tunnel URL, or `add-tools-and-handoffs` to give the agent tools.
+
+## Gotchas
+
+- **`Patter(api_key=...)` raises `NotImplementedError`** in 0.6.2 — Patter
+  Cloud was removed in 0.5.3 and will return as a future release. Always
+  instantiate with `carrier=` + `phone_number=`, never with `api_key=`.
+- **`pip install patter`** (no `get` prefix) installs an unrelated package.
+  Always install `getpatter`.
+- **Twilio kwargs in 0.6.2 normalize automatically** — `status_callback`,
+  `machine_detection`, `timeout`, `async_amd` work as snake_case (Python) and
+  camelCase (TS); no need to PascalCase them.
+- **OpenAIRealtime vs OpenAIRealtime2** — both work in 0.6.2. Default to
+  `OpenAIRealtime2` for new projects. `OpenAIRealtime` (model `gpt-realtime-mini`)
+  is kept for back-compat.
+- **Cloudflare `tunnel=True` is dev-only**. Production should use a static
+  webhook URL (ngrok paid, or your own subdomain). The tunnel race on first
+  call was fixed in 0.5.5 but a static URL is still more reliable for
+  outbound campaigns.
+
+## Common errors
+
+| Symptom | Fix |
+|---|---|
+| `KeyError: OPENAI_API_KEY` | The env var isn't loaded. Source `.env` (`source .env` in bash, or use `python-dotenv` / `dotenv` package). |
+| `twilio.base.exceptions.TwilioRestException: HTTP 401` | Wrong `TWILIO_AUTH_TOKEN`. Re-copy from console. |
+| `RuntimeError: NotImplementedError: Patter Cloud …` | You passed `api_key=` to `Patter()`. Switch to `carrier=` + `phone_number=`. |
+| TypeScript `Cannot find module 'getpatter'` | Wrong Node version (need 20+) or missed `npm install`. Check `node --version`. |
+| `ModuleNotFoundError: No module named 'getpatter'` | Wrong Python venv active, or installed in the wrong interpreter. `pip list | grep getpatter`. |
+
+## Related skills
+
+- [`build-voice-agent`](../build-voice-agent/) — once setup is done, build the actual agent.
+- [`configure-telephony`](../configure-telephony/) — full Twilio / Telnyx config beyond keys.
+
+## References
+
+- Patter Python quickstart: <https://docs.getpatter.com/python-sdk/quickstart>
+- Patter TypeScript quickstart: <https://docs.getpatter.com/typescript-sdk/quickstart>
+- Twilio console: <https://console.twilio.com>
+- Telnyx portal: <https://portal.telnyx.com>


### PR DESCRIPTION
## Summary

- Ship an [Anthropic Agent Skills](https://agentskills.io)-compliant bundle under `skills/` so any compatible AI agent (Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor, Codex, and ~50 others) can learn the Patter SDK end-to-end via `npx skills add patterai/patter`.
- Five skills + five references covering install, agent build, telephony, tools/handoffs, and call inspection. All code samples are dual Python + TypeScript.
- No SDK runtime changes; this is documentation shipped to the AI agent ecosystem.

## Implementation

- **Skills shipped** (each with YAML frontmatter `name` + `description` + `license` + `compatibility` + `metadata.{author,version,parity}`):
  - `skills/setup-patter/SKILL.md` — install + provider/carrier env keys.
  - `skills/build-voice-agent/SKILL.md` + `references/{realtime-mode,convai-mode,pipeline-mode}.md` — pick between OpenAI Realtime 2 (GA), ElevenLabs ConvAI, or the STT→LLM→TTS pipeline.
  - `skills/configure-telephony/SKILL.md` + `references/{twilio,telnyx}.md` — carrier setup, webhook URLs, tunnels.
  - `skills/add-tools-and-handoffs/SKILL.md` — `@tool` / `defineTool`, webhook tools, `reassurance`, `transfer_call`, `end_call`, guardrails.
  - `skills/inspect-calls-and-metrics/SKILL.md` — dashboard mount, `CallMetrics`, CSV/JSON export, `dashboard_token` auth.
- **Top-level documentation touched**: `README.md` gets an `## Agent Skills` section with the install snippet. `CHANGELOG.md` gets an `### Added` entry under `## Unreleased`.
- **No new dependencies, no runtime impact, no public-API change.**
- API surface in the skills verified against the 0.6.2 source: `OpenAIRealtime2` is the GA engine, `webhook_url` lives on the `Patter` constructor (not `serve()`), `on_call_end` is a `serve()` kwarg receiving a `dict`, dashboard auth uses `dashboard_token` (bearer), the metrics store is exposed via `phone.metrics_store` (Python) / `phone.metricsStore` (TypeScript), `machine_detection` defaults to `True` in 0.6.2, recording is server-wide via `phone.serve(recording=True)`.

## Breaking change?

No. Skills are reference content, not a new runtime surface. Existing imports and APIs are unchanged.

## Test plan

- [ ] `find skills -type f -name SKILL.md | xargs -I {} sh -c 'head -1 {} | grep -q "^---$"'` — every SKILL.md starts with valid frontmatter.
- [ ] For each SKILL.md, the YAML `name` matches the parent directory name (Anthropic Agent Skills spec requirement).
- [ ] `description` length ≤ 1024 chars for every skill (verified locally — longest is 676).
- [ ] Code samples compile/import against `getpatter==0.6.2` (Python) and `getpatter@0.6.2` (TypeScript). No reference to symbols that don't exist in `libraries/python/getpatter/__init__.py` or `libraries/typescript/src/index.ts`.
- [ ] No competitor SDK names in source files (only provider integrations we ship: OpenAI, ElevenLabs, Deepgram, Cartesia, Twilio, Telnyx). Compliant with `.claude/rules/no-competitor-references.md`.
- [ ] No internal paths, personal emails, or live secrets in skill text.
- [ ] After merge: `npx skills add patterai/patter --skill build-voice-agent` succeeds on `main`.

## Docs updates

- `skills/` — all new (11 files).
- `README.md` — added "Agent Skills" section between "Templates" and "Configuration".
- `CHANGELOG.md` — `## Unreleased` → `### Added` entry describing the bundle.