### PR TITLE
fix(websockets): use is_ws_alive across modern websockets>=12 API

### DIFF
--- a/libraries/python/getpatter/providers/elevenlabs_ws_tts.py
+++ b/libraries/python/getpatter/providers/elevenlabs_ws_tts.py
@@ -59,6 +59,7 @@ from getpatter.providers.elevenlabs_tts import (
     ElevenLabsOutputFormat,
     resolve_voice_id,
 )
+from getpatter.utils.ws import is_ws_alive
 
 logger = logging.getLogger("getpatter")
 
@@ -450,7 +451,7 @@ class ElevenLabsWebSocketTTS(TTSProvider):
         self._adopted_connection = None
         bos_already_sent = False
         ws = None
-        if parked is not None and not parked.ws.closed:
+        if parked is not None and is_ws_alive(parked.ws):
             ws = parked.ws
             bos_already_sent = parked.bos_sent
         else:

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -47,29 +47,7 @@ from getpatter.utils.log_sanitize import mask_phone_number, sanitize_log_value
 logger = logging.getLogger("getpatter")
 
 
-def _is_parked_ws_alive(ws: object) -> bool:
-    """Best-effort liveness check across ``websockets`` library versions.
-
-    The legacy client (``websockets<11``) exposes ``ws.closed: bool``.
-    The current asyncio client (``websockets>=12``) exposes ``ws.state``
-    (an ``IntEnum`` with ``OPEN == 1``) and ``ws.close_code`` (``None``
-    while still open). Return ``True`` only when we can confirm the
-    socket is OPEN — never default to True on unknown shapes, otherwise
-    we'd hand a dead socket to the live adapter.
-    """
-    state = getattr(ws, "state", None)
-    if state is not None:
-        try:
-            return int(state) == 1
-        except Exception:
-            return getattr(state, "name", "").upper() == "OPEN"
-    close_code = getattr(ws, "close_code", "__unset__")
-    if close_code != "__unset__":
-        return close_code is None
-    closed = getattr(ws, "closed", None)
-    if closed is None:
-        return False
-    return not bool(closed)
+from getpatter.utils.ws import is_ws_alive as _is_parked_ws_alive  # noqa: E402
 
 
 # Minimum wall-clock duration (seconds) the agent must have been speaking
@@ -2189,7 +2167,7 @@ class PipelineStreamHandler(StreamHandler):
         parked_tts = (parked or {}).get("tts")
         if parked_tts is not None and self._tts is not None:
             adopt = getattr(self._tts, "adopt_websocket", None)
-            ws_alive = parked_tts.ws is not None and not parked_tts.ws.closed
+            ws_alive = parked_tts.ws is not None and _is_parked_ws_alive(parked_tts.ws)
             if callable(adopt) and ws_alive:
                 try:
                     adopt(parked_tts)
@@ -2227,7 +2205,7 @@ class PipelineStreamHandler(StreamHandler):
                 and len(parked_stt) == 2
             ):
                 session, ws = parked_stt
-                if not ws.closed:
+                if _is_parked_ws_alive(ws):
                     try:
                         adopt_stt(session, ws)
                         logger.info(

--- a/libraries/python/getpatter/utils/ws.py
+++ b/libraries/python/getpatter/utils/ws.py
@@ -1,0 +1,34 @@
+"""WebSocket compatibility utilities.
+
+Patter pins ``websockets>=14,<16`` in ``pyproject.toml``. The modern
+``websockets`` client (``websockets>=12``) no longer exposes a
+``ws.closed`` property — it surfaces ``state`` (an ``IntEnum`` where
+``OPEN == 1``) and ``close_code`` (``None`` while the socket is open).
+
+This helper papers over both APIs so SDK code can ask *"is this
+WebSocket still alive?"* without sprinkling version checks everywhere.
+"""
+
+from __future__ import annotations
+
+
+def is_ws_alive(ws: object) -> bool:
+    """Best-effort liveness check across ``websockets`` library versions.
+
+    Returns ``True`` only when we can confirm the socket is OPEN. Never
+    defaults to ``True`` on unknown shapes — handing a dead socket to a
+    live adapter is worse than re-opening a fresh one.
+    """
+    state = getattr(ws, "state", None)
+    if state is not None:
+        try:
+            return int(state) == 1
+        except Exception:
+            return getattr(state, "name", "").upper() == "OPEN"
+    close_code = getattr(ws, "close_code", "__unset__")
+    if close_code != "__unset__":
+        return close_code is None
+    closed = getattr(ws, "closed", None)
+    if closed is None:
+        return False
+    return not bool(closed)

--- a/libraries/python/tests/test_utils_ws.py
+++ b/libraries/python/tests/test_utils_ws.py
@@ -1,0 +1,84 @@
+"""Compat helper covers both modern (``state``) and legacy (``closed``)
+``websockets`` client shapes. Regression for upstream issue #111."""
+
+from __future__ import annotations
+
+from getpatter.utils.ws import is_ws_alive
+
+
+class _ModernOpenWS:
+    """Mimics ``websockets>=12`` `ClientConnection` (state=1 means OPEN)."""
+
+    state = 1
+
+
+class _ModernClosedWS:
+    state = 3  # CLOSED
+
+
+class _ModernByCloseCodeOpen:
+    """Some shapes only expose ``close_code`` (None == still open)."""
+
+    close_code = None
+
+
+class _ModernByCloseCodeClosed:
+    close_code = 1000
+
+
+class _LegacyOpenWS:
+    """Mimics ``websockets<11`` API (``closed`` bool property)."""
+
+    closed = False
+
+
+class _LegacyClosedWS:
+    closed = True
+
+
+class _UnknownShape:
+    """Neither state nor close_code nor closed — must fail closed."""
+
+
+def test_modern_open():
+    assert is_ws_alive(_ModernOpenWS()) is True
+
+
+def test_modern_closed():
+    assert is_ws_alive(_ModernClosedWS()) is False
+
+
+def test_modern_open_via_close_code():
+    assert is_ws_alive(_ModernByCloseCodeOpen()) is True
+
+
+def test_modern_closed_via_close_code():
+    assert is_ws_alive(_ModernByCloseCodeClosed()) is False
+
+
+def test_legacy_open():
+    assert is_ws_alive(_LegacyOpenWS()) is True
+
+
+def test_legacy_closed():
+    assert is_ws_alive(_LegacyClosedWS()) is False
+
+
+def test_unknown_shape_defaults_closed():
+    """Unknown WS shapes must NOT be reported alive — handing a dead socket
+    to the live adapter is worse than re-opening."""
+    assert is_ws_alive(_UnknownShape()) is False
+
+
+def test_state_intenum_open():
+    """``state`` may be an IntEnum where OPEN == 1."""
+    from enum import IntEnum
+
+    class _State(IntEnum):
+        OPEN = 1
+        CLOSED = 3
+
+    class WS:
+        state = _State.OPEN
+
+    assert is_ws_alive(WS()) is True


### PR DESCRIPTION
## Summary

- Promote the existing `_is_parked_ws_alive` helper out of `stream_handler.py` into `libraries/python/getpatter/utils/ws.py` as `is_ws_alive`, and re-use it at every WS-liveness check that goes through the `websockets` library.
- Fixes `AttributeError: 'ClientConnection' object has no attribute 'closed'` that crashed pipeline-mode calls immediately on stream start (Patter pins `websockets>=14,<16`, which dropped `.closed` in v12).
- 8 new unit tests in `tests/test_utils_ws.py` cover modern (`state`, `close_code`), legacy (`closed`), and unknown-shape paths.

Closes #111.

## Why

Two parked-WS-adoption sites still relied on `ws.closed`:

- `stream_handler.py:2192` (TTS WS adoption)
- `stream_handler.py:2230` (STT WS adoption)
- `providers/elevenlabs_ws_tts.py:453` (parked WS pickup in `synthesize`)

The `websockets` library removed `.closed` in v12, but `pyproject.toml` pins `websockets>=14,<16`. The result is that every pipeline-mode call crashes immediately on stream start:

```
[patter] ERROR getpatter: Stream error: 'ClientConnection' object has no attribute 'closed'
  File "libraries/python/getpatter/stream_handler.py", line 2192
  ws_alive = parked_tts.ws is not None and not parked_tts.ws.closed
AttributeError: 'ClientConnection' object has no attribute 'closed'. Did you mean: 'close'?
```

The existing `_is_parked_ws_alive` helper already handles both APIs cleanly; it just wasn't reused everywhere.

## Out of scope

The aiohttp-backed STT providers (`assemblyai_stt`, `cartesia_stt`, `soniox_stt`) still call `.closed` because `aiohttp.ClientWebSocketResponse.closed` remains valid. They are not affected by this bug. Docstring comments in `openai_realtime.py:465` and `cartesia_stt.py:307` still mention `not ws.closed` as a precondition — left as a follow-up since the code there is correct.

## Test plan

- [x] `pytest libraries/python/tests/test_utils_ws.py -v` — 8/8 pass
- [x] Verified locally that pipeline-mode call with `ElevenLabsWebSocketTTS` (via the `getpatter[local]` editable install) no longer raises `AttributeError` on stream start
- [ ] CI green