### PR TITLE
fix(pipeline): inject built-in transfer_call / end_call tools into LLMLoop

### DIFF
--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -171,6 +171,42 @@ END_CALL_TOOL: dict = {
 }
 
 
+def _augment_with_builtin_handoff_tools(
+    user_tools: list[dict] | None,
+    *,
+    transfer_fn: Any | None,
+    hangup_fn: Any | None,
+) -> list[dict]:
+    """Return ``user_tools`` with the built-in ``transfer_call`` and
+    ``end_call`` tools appended, each wired with a handler closure that
+    routes to the telephony-level ``_transfer_fn`` / ``_hangup_fn``
+    already attached to the stream handler.
+
+    Used by pipeline mode to match the realtime path's tool surface
+    (see ``OpenAIRealtimeStreamHandler.start`` where the same two
+    built-ins are injected into ``session.update``). Without this the
+    pipeline LLM never sees the built-in tools and cannot initiate a
+    transfer or hangup regardless of system-prompt instructions.
+
+    Tools are appended (not prepended) so user-provided tools keep their
+    original order. The handler signature ``(arguments, call_context)``
+    matches the calling convention used by ``ToolExecutor._invoke_handler``.
+    """
+    out: list[dict] = list(user_tools or [])
+    if transfer_fn is not None:
+        async def _transfer_handler(arguments: dict, call_context: dict) -> str:
+            number = (arguments or {}).get("number", "")
+            await transfer_fn(number)
+            return f"Transferring to {number}" if number else "Transfer rejected"
+        out.append({**TRANSFER_CALL_TOOL, "handler": _transfer_handler})
+    if hangup_fn is not None:
+        async def _hangup_handler(arguments: dict, call_context: dict) -> str:
+            await hangup_fn()
+            return "Call ended"
+        out.append({**END_CALL_TOOL, "handler": _hangup_handler})
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Audio sender protocol — abstracts Twilio vs Telnyx audio output
 # ---------------------------------------------------------------------------
@@ -2415,7 +2451,18 @@ class PipelineStreamHandler(StreamHandler):
             from getpatter.services.llm_loop import LLMLoop
             from getpatter.tools.tool_executor import ToolExecutor
 
-            tool_executor = ToolExecutor() if self.agent.tools else None
+            # Inject the built-in transfer_call / end_call tools — parity with
+            # the realtime path (see ``OpenAIRealtimeStreamHandler.start``
+            # where ``openai_tools = agent_tools + [TRANSFER_CALL_TOOL,
+            # END_CALL_TOOL]``). Without this, pipeline-mode LLMs never see
+            # the built-ins and can't initiate a handoff or hangup no matter
+            # what the system prompt says.
+            combined_tools = _augment_with_builtin_handoff_tools(
+                self.agent.tools,
+                transfer_fn=self._transfer_fn,
+                hangup_fn=self._hangup_fn,
+            )
+            tool_executor = ToolExecutor() if combined_tools else None
             llm_model = self.agent.model
             if "realtime" in llm_model:
                 llm_model = "gpt-4o-mini"
@@ -2423,7 +2470,7 @@ class PipelineStreamHandler(StreamHandler):
                 openai_key=self._openai_key,
                 model=llm_model,
                 system_prompt=self.resolved_prompt,
-                tools=self.agent.tools,
+                tools=combined_tools,
                 tool_executor=tool_executor,
                 llm_provider=agent_llm,
                 metrics=self.metrics,

--- a/libraries/python/tests/test_pipeline_builtin_tools.py
+++ b/libraries/python/tests/test_pipeline_builtin_tools.py
@@ -1,0 +1,120 @@
+"""Regression for upstream issue #110.
+
+Pipeline mode previously passed only the user-provided tools to
+``LLMLoop`` — the built-in ``transfer_call`` / ``end_call`` tools that
+the realtime path injects were missing, so pipeline LLMs could never
+initiate a handoff or hangup regardless of the system prompt.
+
+These tests exercise the helper that bolts the built-ins onto the
+tool list with handler closures wired to the telephony-level
+``transfer_fn`` / ``hangup_fn``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from getpatter.stream_handler import (
+    END_CALL_TOOL,
+    TRANSFER_CALL_TOOL,
+    _augment_with_builtin_handoff_tools,
+)
+
+
+def test_augments_empty_user_tools():
+    calls: list[tuple[str, str]] = []
+
+    async def fake_transfer(number: str) -> None:
+        calls.append(("transfer", number))
+
+    async def fake_hangup() -> None:
+        calls.append(("hangup", ""))
+
+    tools = _augment_with_builtin_handoff_tools(
+        None, transfer_fn=fake_transfer, hangup_fn=fake_hangup
+    )
+    names = [t["name"] for t in tools]
+    assert names == ["transfer_call", "end_call"]
+    # Schema preserved
+    assert tools[0]["parameters"] == TRANSFER_CALL_TOOL["parameters"]
+    assert tools[1]["parameters"] == END_CALL_TOOL["parameters"]
+    # Handlers attached
+    assert callable(tools[0]["handler"])
+    assert callable(tools[1]["handler"])
+
+
+def test_preserves_user_tools_order():
+    user_tools = [
+        {"name": "lookup_customer", "description": "", "parameters": {"type": "object"}},
+        {"name": "send_sms", "description": "", "parameters": {"type": "object"}},
+    ]
+    tools = _augment_with_builtin_handoff_tools(
+        user_tools,
+        transfer_fn=lambda n: None,
+        hangup_fn=lambda: None,
+    )
+    names = [t["name"] for t in tools]
+    assert names == ["lookup_customer", "send_sms", "transfer_call", "end_call"]
+
+
+def test_skips_builtin_when_fn_missing():
+    """If telephony adapter didn't supply a transfer_fn (e.g. non-Twilio
+    test harness), the corresponding built-in is not injected."""
+    user_tools = [{"name": "lookup_customer", "description": "", "parameters": {}}]
+    tools = _augment_with_builtin_handoff_tools(
+        user_tools, transfer_fn=None, hangup_fn=None
+    )
+    assert [t["name"] for t in tools] == ["lookup_customer"]
+
+
+@pytest.mark.asyncio
+async def test_transfer_handler_dispatches_to_transfer_fn():
+    captured: list[str] = []
+
+    async def fake_transfer(number: str) -> None:
+        captured.append(number)
+
+    tools = _augment_with_builtin_handoff_tools(
+        None, transfer_fn=fake_transfer, hangup_fn=None
+    )
+    transfer = tools[0]
+    result = await transfer["handler"](
+        {"number": "+14155551234"}, {"call_id": "CAtest"}
+    )
+    assert captured == ["+14155551234"]
+    assert "+14155551234" in result
+
+
+@pytest.mark.asyncio
+async def test_hangup_handler_dispatches_to_hangup_fn():
+    called = []
+
+    async def fake_hangup() -> None:
+        called.append(True)
+
+    tools = _augment_with_builtin_handoff_tools(
+        None, transfer_fn=None, hangup_fn=fake_hangup
+    )
+    end = tools[0]
+    assert end["name"] == "end_call"
+    result = await end["handler"]({}, {"call_id": "CAtest"})
+    assert called == [True]
+    assert "ended" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_transfer_handler_handles_missing_number_gracefully():
+    """LLM occasionally emits transfer_call without a number arg; the
+    handler must not crash."""
+    called: list[str] = []
+
+    async def fake_transfer(number: str) -> None:
+        called.append(number)
+
+    tools = _augment_with_builtin_handoff_tools(
+        None, transfer_fn=fake_transfer, hangup_fn=None
+    )
+    result = await tools[0]["handler"]({}, {"call_id": "CAtest"})
+    # Calls through with empty string (downstream _validate_e164 will reject)
+    assert called == [""]
+    assert "rejected" in result.lower() or result == "Transferring to "


### PR DESCRIPTION
## Summary

- Pipeline mode (`PipelineStreamHandler` → `LLMLoop`) was passing only the user-provided tools through, so the LLM never saw `transfer_call` or `end_call` — even though the docs and the `add-tools-and-handoffs` Agent Skill (PR #108) describe them as available across all three modes.
- Mirror the realtime path's `agent_tools + [TRANSFER_CALL_TOOL, END_CALL_TOOL]` injection (`stream_handler.py:997`) via a new helper `_augment_with_builtin_handoff_tools` that builds handler closures wired to the telephony-level `_transfer_fn` / `_hangup_fn` already attached to the stream handler.
- 6 new unit tests in `tests/test_pipeline_builtin_tools.py` cover empty-user-tools, non-empty-user-tools, missing-fn, handler-dispatch (transfer + hangup), and graceful-empty-args paths.

Closes #110.

## Why

Reproduced against `gpt-4o-mini` in pipeline mode (`OpenAILLM` + `DeepgramSTT` + `ElevenLabsRestTTS`). The LLM correctly heard the affirmative ("Yeah. Go ahead and transfer me.") and replied "Alright, transferring you now." — but emitted no tool call. Twilio call events showed zero `POST /Calls/{sid}.json`. The tool simply wasn't registered.

`stream_handler.py:2422-2435` (before this PR):

```python
self._llm_loop = LLMLoop(
    ...,
    tools=self.agent.tools,   # <-- only user tools
    ...,
)
```

vs realtime `stream_handler.py:997`:

```python
openai_tools = agent_tools + [TRANSFER_CALL_TOOL, END_CALL_TOOL]
```

## Implementation notes

The handler shape inside `LLMLoop` is `(arguments_dict, call_context_dict)` (see `ToolExecutor._invoke_handler` at `tools/tool_executor.py:46-63`). The helper builds two async closures with that exact signature and routes them to `self._transfer_fn(number)` / `self._hangup_fn()` which already exist on `PipelineStreamHandler` (assigned at `stream_handler.py:1899-1900` from the telephony adapter at `telephony/twilio.py:483-484`).

Built-ins are skipped when the corresponding telephony fn is missing — keeps the unit-test harness path clean (no Twilio adapter → no transfer/hangup tools, matching the prior behaviour for non-telephony tests).

## TypeScript parity

The TypeScript SDK's `libraries/typescript/src/server.ts` already injects the same two built-ins for both paths (`agentTools + [TRANSFER_CALL_TOOL, END_CALL_TOOL]`). Spot-checked against the source — TS is already correct; this PR brings Python to parity, not the other way around.

## Test plan

- [x] `pytest libraries/python/tests/test_pipeline_builtin_tools.py -v` — 6/6 pass
- [x] Verified end-to-end against `OpenAILLM(model="gpt-4o-mini")` + `DeepgramSTT` + `ElevenLabsRestTTS` on Twilio: caller says "transfer me," LLM emits `transfer_call({"number": "+1..."})`, helper dispatches to `_twilio_transfer`, Twilio call-update REST fires, GV number rings, audio bridges.
- [ ] CI green