### PR TITLE
docs(integrations): add Hermes Agent page + fix MDX-v3 <url> autolinks (restore Mintlify)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,7 +65,8 @@
             "group": "Integrations",
             "icon": "plug",
             "pages": [
-              "integrations/openclaw"
+              "integrations/openclaw",
+              "integrations/hermes"
             ]
           },
           {

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -96,16 +96,16 @@ Hermes Agent supports plugin-based integrations. A Patter bundle — an
 `optional-mcps/patter-voice` manifest plus a bundled `patter-voice` skill — is
 proposed for the Hermes catalog in
 [NousResearch/hermes-agent#33937](https://github.com/NousResearch/hermes-agent/pull/33937).
-Once it is merged upstream, installing both the MCP tools and the skill will be
-a single command:
+Once it is merged upstream, a single command installs both the MCP tools and
+the skill:
 
 ```bash
 hermes plugin add patter-voice
 ```
 
-<Note>
-  Until #33937 is merged, use the [skills](#install) (`npx skills add patterai/skills`) or the MCP server path described above — both work today.
-</Note>
+Until then, install Patter via the skills (`npx skills add patterai/skills`) or
+the MCP server path described above — both work today, with no upstream
+dependency.
 
 ## Quick start: outbound call from Hermes Agent
 

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -141,11 +141,11 @@ tools:
 - **Provision your provider keys**: the `setup-patter` skill walks the agent
   (and you) through every provider dashboard, one at a time, with curl
   validation for each key.
-- **Browse the skill content**: <https://github.com/PatterAI/skills>.
+- **Browse the skill content**: [https://github.com/PatterAI/skills](https://github.com/PatterAI/skills).
 
 ## Need help?
 
-- Patter SDK source: <https://github.com/PatterAI/Patter>
-- Patter Skills repository: <https://github.com/PatterAI/skills>
-- Patter Discord: <https://discord.gg/patter>
-- Hermes Agent docs: <https://github.com/NousResearch/hermes-agent>
+- Patter SDK source: [https://github.com/PatterAI/Patter](https://github.com/PatterAI/Patter)
+- Patter Skills repository: [https://github.com/PatterAI/skills](https://github.com/PatterAI/skills)
+- Patter Discord: [https://discord.gg/patter](https://discord.gg/patter)
+- Hermes Agent docs: [https://github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -92,18 +92,22 @@ Once registered, tools surface to your Hermes Agent under names like `patter-voi
 
 ## Use as an optional plugin
 
-Hermes Agent supports plugin-based integrations. If you prefer the plugin route over
-MCP, install the Patter optional bundle directly:
+Hermes Agent supports plugin-based integrations. A Patter bundle — an
+`optional-mcps/patter-voice` manifest plus a bundled `patter-voice` skill — is
+proposed for the Hermes catalog in
+[NousResearch/hermes-agent#33937](https://github.com/NousResearch/hermes-agent/pull/33937).
 
-```bash
-hermes plugin add patter-voice
-```
+<Note>
+  Once that PR is merged upstream, installing both the MCP tools and the skill
+  will be a single command:
 
-This installs the manifest from [NousResearch/hermes-agent → optional-mcps/patter-voice](https://github.com/NousResearch/hermes-agent/tree/main/optional-mcps/patter-voice)
-and the bundled [`patter-voice` skill](https://github.com/NousResearch/hermes-agent/tree/main/optional-skills/productivity/patter-voice), part of the
-[optional-skills/productivity](https://github.com/NousResearch/hermes-agent/tree/main/optional-skills/productivity)
-catalog. Reload Hermes (`hermes reload`) and the agent picks up both the MCP tools and
-the skill automatically.
+  ```bash
+  hermes plugin add patter-voice
+  ```
+
+  Until then, use the [skills](#install) (`npx skills add patterai/skills`) or
+  the MCP server path described above — both work today.
+</Note>
 
 ## Quick start: outbound call from Hermes Agent
 

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -104,8 +104,7 @@ hermes plugin add patter-voice
 ```
 
 <Note>
-  Until #33937 is merged, use the [skills](#install) (`npx skills add
-  patterai/skills`) or the MCP server path described above — both work today.
+  Until #33937 is merged, use the [skills](#install) (`npx skills add patterai/skills`) or the MCP server path described above — both work today.
 </Note>
 
 ## Quick start: outbound call from Hermes Agent

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -96,17 +96,16 @@ Hermes Agent supports plugin-based integrations. A Patter bundle — an
 `optional-mcps/patter-voice` manifest plus a bundled `patter-voice` skill — is
 proposed for the Hermes catalog in
 [NousResearch/hermes-agent#33937](https://github.com/NousResearch/hermes-agent/pull/33937).
+Once it is merged upstream, installing both the MCP tools and the skill will be
+a single command:
+
+```bash
+hermes plugin add patter-voice
+```
 
 <Note>
-  Once that PR is merged upstream, installing both the MCP tools and the skill
-  will be a single command:
-
-  ```bash
-  hermes plugin add patter-voice
-  ```
-
-  Until then, use the [skills](#install) (`npx skills add patterai/skills`) or
-  the MCP server path described above — both work today.
+  Until #33937 is merged, use the [skills](#install) (`npx skills add
+  patterai/skills`) or the MCP server path described above — both work today.
 </Note>
 
 ## Quick start: outbound call from Hermes Agent

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -1,0 +1,149 @@
+---
+title: "Hermes Agent"
+description: "Give your Hermes Agent a phone with Patter — install the skill in one line, configure your Twilio or Telnyx number, and your agent makes and receives calls."
+icon: "phone"
+---
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is a self-hosted AI assistant
+that grows with you through modular skills and persistent memory. Once you install the
+Patter skill, your Hermes Agent can place outbound calls, receive inbound calls, and use
+the full Patter SDK without any further setup on the Hermes side.
+
+## Install
+
+Patter skills work in every agent harness that consumes the
+[Anthropic Agent Skills](https://agentskills.io) standard — Hermes Agent included. Install
+with one command:
+
+```bash
+# Install all five Patter skills
+npx skills add patterai/skills
+
+# Or install just the one you need
+npx skills add patterai/skills --skill build-voice-agent
+```
+
+The CLI auto-detects Hermes Agent on your machine and creates symlinks from
+`~/.hermes/skills/` (or your `HERMES_HOME` override) into the canonical
+`~/.agents/skills/` directory. Restart your Hermes Agent and the agent will pick the
+skills up at session start.
+
+<Tip>
+  Pin to a specific Patter SDK version for reproducibility:
+  ```bash
+  npx skills add patterai/skills#v0.6.2 --skill build-voice-agent
+  ```
+</Tip>
+
+## Available skills
+
+| Skill | What it teaches the agent |
+|---|---|
+| [`setup-patter`](https://github.com/PatterAI/skills/tree/main/setup-patter) | Walk the user through installing Patter and obtaining provider/carrier API keys, with validation. |
+| [`build-voice-agent`](https://github.com/PatterAI/skills/tree/main/build-voice-agent) | Build a voice agent — pick between OpenAI Realtime / ElevenLabs ConvAI / STT→LLM→TTS Pipeline. |
+| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Wire up Twilio or Telnyx — phone numbers, webhooks, tunnels, AMD, voicemail drop. |
+| [`add-tools-and-handoffs`](https://github.com/PatterAI/skills/tree/main/add-tools-and-handoffs) | Custom tools, `transfer_call`, `end_call`, output guardrails. |
+| [`inspect-calls-and-metrics`](https://github.com/PatterAI/skills/tree/main/inspect-calls-and-metrics) | Live dashboard, `CallMetrics`, cost tracking, CSV/JSON export. |
+
+Every skill ships full Python and TypeScript code examples side-by-side. Your Hermes
+Agent can pick the runtime that matches the rest of your project.
+
+## Use Patter as an MCP server (alternative path)
+
+If you want Hermes Agent to call Patter through the [Model Context Protocol](https://modelcontextprotocol.io)
+instead of (or in addition to) the skills, register the Patter MCP server with one
+command:
+
+<CodeGroup>
+
+```bash stdio
+hermes mcp install patter-voice '{
+  "command": "npx",
+  "args": ["-y", "getpatter-mcp"],
+  "env": {
+    "TWILIO_ACCOUNT_SID": "AC...",
+    "TWILIO_AUTH_TOKEN": "...",
+    "OPENAI_API_KEY": "sk-..."
+  }
+}'
+```
+
+```bash streamable-http
+hermes mcp install patter-voice '{
+  "url": "https://patter-mcp.yourdomain.com",
+  "transport": "streamable-http",
+  "headers": { "Authorization": "Bearer ..." }
+}'
+```
+
+</CodeGroup>
+
+The Patter MCP server is hosted at [`PatterAI/patter-mcp`](https://github.com/PatterAI/patter-mcp).
+Once registered, tools surface to your Hermes Agent under names like `patter-voice__make_call`,
+`patter-voice__get_transcript`, and `patter-voice__list_calls`.
+
+<Warning>
+  Allowlist outbound calls. By default, Hermes Agent may invoke MCP tools without
+  explicit approval. If you don't want your agent dialing arbitrary numbers without
+  confirmation, configure `tools.confirm: ["patter-voice__make_call"]` in your Hermes Agent
+  `~/.hermes/config.yaml`, or wrap the tool in a small plugin that gates it behind
+  user approval.
+</Warning>
+
+## Use as an optional plugin
+
+Hermes Agent supports plugin-based integrations. If you prefer the plugin route over
+MCP, install the Patter optional bundle directly:
+
+```bash
+hermes plugin add patter-voice
+```
+
+This installs the manifest from [NousResearch/hermes-agent → optional-mcps/patter-voice](https://github.com/NousResearch/hermes-agent/tree/main/optional-mcps/patter-voice)
+and the bundled [`patter-voice` skill](https://github.com/NousResearch/hermes-agent/tree/main/optional-skills/productivity/patter-voice), part of the
+[optional-skills/productivity](https://github.com/NousResearch/hermes-agent/tree/main/optional-skills/productivity)
+catalog. Reload Hermes (`hermes reload`) and the agent picks up both the MCP tools and
+the skill automatically.
+
+## Quick start: outbound call from Hermes Agent
+
+Once skills are installed and your provider/carrier keys are in `~/.hermes/.env`,
+ask your Hermes Agent something like:
+
+> *"Call my plumber at +15550001234 and ask if they have time tomorrow morning.
+> Then text me the summary."*
+
+The agent loads `build-voice-agent` automatically (its description triggers on
+phrases like "call", "phone", "voicemail"), writes a small Python or TypeScript
+script using the Patter SDK, runs it, and reports the transcript back to you in
+the Hermes thread.
+
+If you'd prefer to skip the per-call SDK script and have the agent use the MCP
+server tools directly, ensure `patter-voice` is in your `tools.allow` list:
+
+```yaml
+# ~/.hermes/config.yaml
+tools:
+  allow:
+    - bundle-mcp
+    - patter-voice__*
+```
+
+## What's next
+
+- **Read the [Concepts](/concepts) page** to understand Patter's three modes
+  (Realtime / ConvAI / Pipeline) and which one matches your latency / cost
+  trade-off.
+- **Get a phone number**: [Twilio console](https://console.twilio.com/us1/develop/phone-numbers/manage/incoming)
+  or [Telnyx portal](https://portal.telnyx.com/#/app/numbers/my-numbers).
+- **Provision your provider keys**: the `setup-patter` skill walks the agent
+  (and you) through every provider dashboard, one at a time, with curl
+  validation for each key.
+- **Browse the skill content**: <https://github.com/PatterAI/skills>.
+
+## Need help?
+
+- Patter SDK source: <https://github.com/PatterAI/Patter>
+- Patter Skills repository: <https://github.com/PatterAI/skills>
+- Patter Discord: <https://discord.gg/patter>
+- Hermes Agent docs: <https://github.com/NousResearch/hermes-agent>

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -125,11 +125,11 @@ tools:
 - **Provision your provider keys**: the `setup-patter` skill walks the agent
   (and you) through every provider dashboard, one at a time, with curl
   validation for each key.
-- **Browse the skill content**: <https://github.com/PatterAI/skills>.
+- **Browse the skill content**: [https://github.com/PatterAI/skills](https://github.com/PatterAI/skills).
 
 ## Need help?
 
-- Patter SDK source: <https://github.com/PatterAI/Patter>
-- Patter Skills repository: <https://github.com/PatterAI/skills>
-- Patter Discord: <https://discord.gg/patter>
-- OpenClaw docs: <https://docs.openclaw.ai>
+- Patter SDK source: [https://github.com/PatterAI/Patter](https://github.com/PatterAI/Patter)
+- Patter Skills repository: [https://github.com/PatterAI/skills](https://github.com/PatterAI/skills)
+- Patter Discord: [https://discord.gg/patter](https://discord.gg/patter)
+- OpenClaw docs: [https://docs.openclaw.ai](https://docs.openclaw.ai)


### PR DESCRIPTION
## Summary

Adds \`docs/integrations/hermes.mdx\` — a Hermes Agent integration page mirroring the OpenClaw integration page that landed in #117. Documents three install paths (skills, MCP, optional plugin) and registers the new page in \`docs.json\` under Integrations.

## Why

Hermes Agent (NousResearch) is the second-largest open-source AI agent harness after OpenClaw and has a first-class plugin/skill catalog (\`optional-mcps/\`, \`optional-skills/\`). Patter belongs in both — the catalog submission lives in a parallel PR on \`NousResearch/hermes-agent\`.

## Install paths documented

1. **Skills** — \`npx skills add patterai/skills\` auto-detects Hermes (\`~/.hermes/skills/\`).
2. **MCP** — \`hermes mcp install patter-voice\` with stdio or streamable-http examples.
3. **Optional plugin** — \`hermes plugin add patter-voice\` pulls the manifest + bundled \`patter-voice\` skill from the upstream catalog PR.

## Naming

Patter uses \`patter-voice\` (kebab-case) in the Hermes ecosystem to follow the catalog convention and coexist with the existing \`telephony\` skill that Hermes ships for Twilio + Bland.ai + Vapi. Tool names surface as \`patter-voice__make_call\`, \`patter-voice__get_transcript\`, etc.

## Test plan

- [ ] \`mintlify dev\` renders the page without YAML/JSX errors
- [ ] Sidebar shows "Hermes Agent" under Integrations, after OpenClaw
- [ ] All external links resolve (PatterAI/skills, NousResearch/hermes-agent)