### PR TITLE
docs(plivo): add Plivo to per-SDK carrier docs + sweep stale Twilio/Telnyx mentions

### DIFF
--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -31,7 +31,7 @@ When someone dials your number, audio flows through five layers. Each layer is *
        │  (phone network, PSTN)
        ▼
 ┌─────────────┐
-│ Carrier     │  Twilio or Telnyx — answers the call, opens a media stream
+│ Carrier     │  Twilio, Telnyx, or Plivo — answers, opens a media stream
 └──────┬──────┘
        │  (WebSocket, audio frames)
        ▼
@@ -179,6 +179,6 @@ OpenAI TTS returns 24 kHz PCM — Patter resamples to 16 kHz before sending to t
 <CardGroup cols={2}>
   <Card title="Python Quickstart" icon="rocket" href="/python-sdk/quickstart">Answer a real phone call in 5 minutes.</Card>
   <Card title="TypeScript Quickstart" icon="rocket" href="/typescript-sdk/quickstart">Same, but in TS.</Card>
-  <Card title="Carrier setup" icon="phone" href="/python-sdk/carrier">Twilio / Telnyx credentials.</Card>
+  <Card title="Carrier setup" icon="phone" href="/python-sdk/carrier">Twilio / Telnyx / Plivo credentials.</Card>
   <Card title="Engines" icon="bolt" href="/python-sdk/engines">OpenAI Realtime, ElevenLabs ConvAI.</Card>
 </CardGroup>

--- a/docs/home/index.mdx
+++ b/docs/home/index.mdx
@@ -8,7 +8,7 @@ icon: "house"
 
 Connect any AI agent to phone calls with 4 lines of code. Patter handles telephony, speech-to-text, and text-to-speech so you can focus on your agent.
 
-Patter is the open-source SDK that gives your AI agent a phone number. Point it at any function that returns a string and Patter handles the rest — telephony, speech-to-text, text-to-speech, and real-time audio streaming. You build the agent, we connect it to the phone. Works with Python and TypeScript, supports Twilio and Telnyx, and runs locally on your own infrastructure.
+Patter is the open-source SDK that gives your AI agent a phone number. Point it at any function that returns a string and Patter handles the rest — telephony, speech-to-text, text-to-speech, and real-time audio streaming. You build the agent, we connect it to the phone. Works with Python and TypeScript, supports Twilio, Telnyx, and Plivo, and runs locally on your own infrastructure.
 
 <Note>A hosted Patter Cloud option will return in a future release. For now the SDK runs entirely in your process — bring your own carrier and AI provider credentials.</Note>
 

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenClaw"
-description: "Give your OpenClaw agent a phone with Patter — install the skill in one line, configure your Twilio or Telnyx number, and your agent answers calls."
+description: "Give your OpenClaw agent a phone with Patter — install the skill in one line, configure your Twilio, Telnyx, or Plivo number, and your agent answers calls."
 icon: "phone"
 ---
 
@@ -42,7 +42,7 @@ skills up at session start.
 |---|---|
 | [`setup-patter`](https://github.com/PatterAI/skills/tree/main/setup-patter) | Walk the user through installing Patter and obtaining provider/carrier API keys, with validation. |
 | [`build-voice-agent`](https://github.com/PatterAI/skills/tree/main/build-voice-agent) | Build a voice agent — pick between OpenAI Realtime / ElevenLabs ConvAI / STT→LLM→TTS Pipeline. |
-| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Wire up Twilio or Telnyx — phone numbers, webhooks, tunnels, AMD, voicemail drop. |
+| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Wire up Twilio, Telnyx, or Plivo — phone numbers, webhooks, tunnels, AMD, voicemail drop. |
 | [`add-tools-and-handoffs`](https://github.com/PatterAI/skills/tree/main/add-tools-and-handoffs) | Custom tools, `transfer_call`, `end_call`, output guardrails. |
 | [`inspect-calls-and-metrics`](https://github.com/PatterAI/skills/tree/main/inspect-calls-and-metrics) | Live dashboard, `CallMetrics`, cost tracking, CSV/JSON export. |
 

--- a/docs/python-sdk/carrier.mdx
+++ b/docs/python-sdk/carrier.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Carrier"
-description: "Telephony providers: Twilio and Telnyx."
+description: "Telephony providers: Twilio, Telnyx, and Plivo."
 icon: "phone"
 ---
 
 # Carrier
 
-The carrier delivers the phone call to Patter. Patter supports **Twilio** and **Telnyx**. Both share DTMF, call transfer, AMD, status callbacks, and cost tracking; recording is Twilio-only.
+The carrier delivers the phone call to Patter. Patter supports **Twilio**, **Telnyx**, and **Plivo**. All three share inbound DTMF, call transfer, AMD, status callbacks, recording, voicemail drop, and cost tracking. **Plivo** additionally supports native DTMF *send* over the media WebSocket — a capability Twilio Media Streams lacks.
 
 You configure one carrier per `Patter` instance by passing an instance to the `carrier=` keyword argument. Each carrier class falls back to environment variables when constructor arguments are omitted.
 
-Each carrier ships as both a **flat alias** (`from getpatter import Twilio`) and a **namespaced** class (`from getpatter.carriers import twilio` → `twilio.Carrier()`). They are equivalent.
+Each carrier ships as both a **flat alias** (`from getpatter import Twilio, Telnyx, Plivo`) and a **namespaced** class (`from getpatter.carriers import twilio` → `twilio.Carrier()`). They are equivalent.
 
 ## Twilio
 
@@ -90,6 +90,52 @@ carrier = telnyx.Carrier()                            # reads env
 
 When `public_key` is set (or `TELNYX_PUBLIC_KEY` is present), every Telnyx webhook is verified with Ed25519. Requests older than 5 minutes are rejected (replay protection).
 
+## Plivo
+
+```python
+from getpatter import Patter, Plivo
+
+phone = Patter(carrier=Plivo(), phone_number="+15550001234")    # reads env
+# Or explicitly:
+phone = Patter(
+    carrier=Plivo(auth_id="MA...", auth_token="..."),
+    phone_number="+15550001234",
+)
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `auth_id` | `str` | `""` | Plivo Auth ID (starts with `MA` or `SA`). Reads from `PLIVO_AUTH_ID` when empty. |
+| `auth_token` | `str` | `""` | Plivo Auth Token. Used for HTTP Basic auth on the Plivo REST API *and* as the V3 webhook signature key. Reads from `PLIVO_AUTH_TOKEN` when empty. |
+
+Namespaced form:
+
+```python
+from getpatter.carriers import plivo
+
+carrier = plivo.Carrier()                              # reads env
+carrier = plivo.Carrier(auth_id="MA...", auth_token="...")
+```
+
+On `serve()`, Patter best-effort creates a Plivo Application bound to `https://<webhook_url>/webhooks/plivo/voice` and links it to your phone number via the Plivo REST API. Most production deployments pre-configure the Plivo Application in the console — pass `manage_webhook=False` on `serve()` to opt out.
+
+### Wire format and parity gains
+
+- **Audio**: mulaw 8 kHz, pinned via the `<Stream contentType="audio/x-mulaw;rate=8000">` answer XML. Plivo's `<Stream>` element places the WSS URL as its text content (not a `url=` attribute, as Twilio does).
+- **Native DTMF send** over the media WebSocket via `sendDTMF` — a parity gain over Twilio Media Streams.
+- **Voicemail drop** uses Plivo's live-call Speak API + `DELETE /Call/{uuid}/` hangup.
+- **AMD** is async: Patter sets `machine_detection="true"` + `machine_detection_url=/webhooks/plivo/amd` so human pickups don't incur the detection-window latency.
+- **Status callback**: Patter wires `hangup_url=/webhooks/plivo/status` on outbound calls so no-answer / busy / failed transitions reach the dashboard before any media webhook fires.
+
+### Signature verification
+
+The Auth Token doubles as the V3 webhook signature key. The V3 scheme is:
+
+- **POST**: `signed = url + sorted_post_params + "." + nonce` — POST params sorted alphabetically by key (case-sensitive) and concatenated as `key1value1key2value2…` with no delimiters.
+- **GET**:  `signed = url + "." + nonce` — query parameters live in the URL already.
+
+Both are HMAC-SHA256 keyed on the Auth Token and base64-encoded, delivered as the `X-Plivo-Signature-V3` header alongside `X-Plivo-Signature-V3-Nonce`. The signature header may carry comma-separated values during key rotation; any matching value accepts. Requests with invalid signatures are rejected with HTTP 403.
+
 ## Webhook Endpoints
 
 The embedded server exposes these endpoints regardless of carrier choice:
@@ -101,6 +147,10 @@ The embedded server exposes these endpoints regardless of carrier choice:
 | `POST /webhooks/twilio/recording` | Recording completion callbacks. |
 | `POST /webhooks/twilio/amd` | Async AMD (answering machine detection) results. |
 | `POST /webhooks/telnyx/voice` | Incoming Telnyx call → returns Call Control commands. |
+| `POST /webhooks/plivo/voice` | Incoming Plivo call → returns Plivo XML to start streaming. Also serves outbound `answer_url`. |
+| `POST /webhooks/plivo/status` | Plivo `hangup_url` callback — call lifecycle (completed, busy, no-answer, failed, timeout, cancel). |
+| `POST /webhooks/plivo/amd` | Async AMD result (`machine_detection_url`). |
+| `GET|POST /webhooks/plivo/transfer` | `<Dial>` XML for blind transfer (Plivo `aleg_url`). |
 
 ## Outbound calls
 

--- a/docs/python-sdk/local-mode.mdx
+++ b/docs/python-sdk/local-mode.mdx
@@ -6,7 +6,7 @@ icon: "server"
 
 # Local Mode (Self-Hosted)
 
-Local mode runs an embedded server on your infrastructure. You bring your own telephony credentials (Twilio or Telnyx) and AI provider keys. No Patter backend required.
+Local mode runs an embedded server on your infrastructure. You bring your own telephony credentials (Twilio, Telnyx, or Plivo) and AI provider keys. No Patter backend required.
 
 ## When to Use Local Mode
 

--- a/docs/python-sdk/overview.mdx
+++ b/docs/python-sdk/overview.mdx
@@ -17,7 +17,7 @@ pip install getpatter
 ## Requirements
 
 - Python 3.11 or higher
-- A telephony account — Twilio or Telnyx (both fully supported)
+- A telephony account — Twilio, Telnyx, or Plivo (all three fully supported)
 - An AI provider key (OpenAI, ElevenLabs, or Deepgram)
 
 ## Minimal Example
@@ -35,7 +35,7 @@ That's the full file. Every provider class reads its API key from an env var whe
 
 ## How Patter runs
 
-Patter runs entirely in your own process. You bring your own telephony (Twilio or Telnyx) and AI provider credentials — no external platform or hosted backend required.
+Patter runs entirely in your own process. You bring your own telephony (Twilio, Telnyx, or Plivo) and AI provider credentials — no external platform or hosted backend required.
 
 <Note>A hosted Patter Cloud option will return in a future release.</Note>
 

--- a/docs/python-sdk/providers/elevenlabs-convai.mdx
+++ b/docs/python-sdk/providers/elevenlabs-convai.mdx
@@ -164,7 +164,7 @@ The adapter normalises ConvAI server messages into a unified event stream so the
 
 ## Pricing
 
-ElevenLabs ConvAI is billed by ElevenLabs per-minute (premium tiers add features like RAG and analytics). Patter does not currently meter ConvAI minutes — the engine cost shows up on your ElevenLabs invoice. Carrier minutes (Twilio / Telnyx) are still tracked as normal in `CallMetrics`.
+ElevenLabs ConvAI is billed by ElevenLabs per-minute (premium tiers add features like RAG and analytics). Patter does not currently meter ConvAI minutes — the engine cost shows up on your ElevenLabs invoice. Carrier minutes (Twilio, Telnyx, or Plivo) are still tracked as normal in `CallMetrics`.
 
 ## See also
 

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -456,7 +456,7 @@ except PatterError as exc:
 | `AUTH` | Provider rejected our credentials (HTTP 401/403, invalid signature). |
 | `TIMEOUT` | Provider response, voicemail post, or other awaited operation timed out. |
 | `RATE_LIMIT` | Provider returned HTTP 429. |
-| `WEBHOOK_VERIFICATION` | Twilio / Telnyx webhook signature verification failed. |
+| `WEBHOOK_VERIFICATION` | Twilio / Telnyx / Plivo webhook signature verification failed. |
 | `INPUT_VALIDATION` | Caller passed a malformed phone number, tool arg, etc. |
 | `PROVIDER_ERROR` | Generic catch-all for unexpected upstream provider failures. |
 | `PROVISION` | Phone number provisioning, webhook configuration, or carrier setup failed. |

--- a/docs/python-sdk/tracing.mdx
+++ b/docs/python-sdk/tracing.mdx
@@ -55,7 +55,7 @@ Beyond the spans listed above, every billable hot path stamps `patter.cost.*` an
 | Attribute | Type | Where it fires |
 |---|---|---|
 | `patter.call_id`, `patter.side` | str | Every cost/latency span (routing tags) |
-| `patter.cost.telephony_minutes`, `patter.telephony`, `patter.direction` | float / str | Twilio + Telnyx adapters on call end |
+| `patter.cost.telephony_minutes`, `patter.telephony`, `patter.direction` | float / str | Twilio, Telnyx, and Plivo adapters on call end |
 | `patter.cost.stt_seconds`, `patter.stt.provider` | float / str | Each final transcript (Deepgram, AssemblyAI, Whisper, OpenAI-Transcribe, Soniox, Speechmatics, Cartesia) |
 | `patter.cost.tts_chars`, `patter.tts.provider` | int / str | Each synthesis (ElevenLabs, OpenAI, Cartesia, LMNT, Rime) |
 | `patter.cost.llm_input_tokens`, `patter.cost.llm_output_tokens`, `patter.llm.provider` | int / int / str | Each completion (OpenAI, Anthropic, Google Gemini, Groq, Cerebras) |

--- a/docs/python-sdk/tts.mdx
+++ b/docs/python-sdk/tts.mdx
@@ -101,7 +101,7 @@ tts = ElevenLabsTTS.for_twilio(voice_id="rachel")
 tts = ElevenLabsTTS.for_telnyx(voice_id="rachel")
 ```
 
-`CartesiaTTS.for_twilio()` / `for_telnyx()` and `ElevenLabsConvAI.for_twilio()` / `for_telnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls.
+`CartesiaTTS.for_twilio()` / `for_telnyx()` and `ElevenLabsConvAI.for_twilio()` / `for_telnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls. **Plivo** pins mulaw 8 kHz in its answer XML, so the `.for_twilio()` factories apply unchanged.
 
 ### WebSocket variant
 

--- a/docs/typescript-sdk/carrier.mdx
+++ b/docs/typescript-sdk/carrier.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Carrier"
-description: "Telephony providers: Twilio and Telnyx."
+description: "Telephony providers: Twilio, Telnyx, and Plivo."
 icon: "phone"
 ---
 
 # Carrier
 
-The carrier delivers the phone call to Patter. Patter supports **Twilio** and **Telnyx**. Both share DTMF, call transfer, AMD, status callbacks, and cost tracking; recording is Twilio-only.
+The carrier delivers the phone call to Patter. Patter supports **Twilio**, **Telnyx**, and **Plivo**. All three share inbound DTMF, call transfer, AMD, status callbacks, recording, voicemail drop, and cost tracking. **Plivo** additionally supports native DTMF *send* over the media WebSocket — a capability Twilio Media Streams lacks.
 
 You configure one carrier per `Patter` instance by passing an instance to the `carrier` field. Each carrier class falls back to environment variables when constructor arguments are omitted.
 
-Both carriers are imported by name from the package barrel: `import { Twilio, Telnyx } from "getpatter"`.
+All three carriers are imported by name from the package barrel: `import { Twilio, Telnyx, Plivo } from "getpatter"`.
 
 ## Twilio
 
@@ -79,6 +79,51 @@ The Telnyx WS upgrade URL carries the metadata as query-string parameters: `wss:
 
 When `publicKey` is set (or `TELNYX_PUBLIC_KEY` is present), every Telnyx webhook is verified with Ed25519. Requests older than 5 minutes are rejected (replay protection).
 
+## Plivo
+
+```typescript
+import { Patter, Plivo } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Plivo(),                                 // reads env
+  phoneNumber: "+15550001234",
+});
+
+// Or explicitly:
+const phone = new Patter({
+  carrier: new Plivo({ authId: "MA...", authToken: "..." }),
+  phoneNumber: "+15550001234",
+});
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `authId` | `string` | — | Plivo Auth ID (starts with `MA` or `SA`). Reads from `PLIVO_AUTH_ID` when omitted. |
+| `authToken` | `string` | — | Plivo Auth Token. Used for HTTP Basic auth on the Plivo REST API *and* as the V3 webhook signature key. Reads from `PLIVO_AUTH_TOKEN` when omitted. |
+
+On `serve()`, Patter best-effort creates a Plivo Application bound to `https://<webhookUrl>/webhooks/plivo/voice` and links it to your phone number via the Plivo REST API. Most production deployments pre-configure the Plivo Application in the console — pass `manageWebhook: false` on `serve()` to opt out.
+
+### How caller / callee reach the agent
+
+Plivo preserves the WebSocket query string through the handshake, so caller and callee travel on the WSS URL: `wss://<webhookUrl>/ws/plivo/stream/<callUuid>?caller=<from>&callee=<to>`. Patter also forwards them via the `extraHeaders` attribute on `<Stream>` as a belt-and-suspenders fallback — Plivo delivers `extraHeaders` back on the WS `start` frame's `extra_headers` field.
+
+### Wire format and parity gains
+
+- **Audio**: mulaw 8 kHz, pinned via the `<Stream contentType="audio/x-mulaw;rate=8000">` answer XML. Plivo's `<Stream>` element places the WSS URL as its text content (not a `url=` attribute, as Twilio does).
+- **Native DTMF send** over the media WebSocket via `sendDTMF` — a parity gain over Twilio Media Streams.
+- **Voicemail drop** uses Plivo's live-call Speak API + `DELETE /Call/{uuid}/` hangup.
+- **AMD** is async: Patter sets `machine_detection="true"` + `machine_detection_url=/webhooks/plivo/amd` so human pickups don't incur the detection-window latency.
+- **Status callback**: Patter wires `hangup_url=/webhooks/plivo/status` on outbound calls so no-answer / busy / failed transitions reach the dashboard before any media webhook fires.
+
+### Signature verification
+
+The Auth Token doubles as the V3 webhook signature key. The V3 scheme is:
+
+- **POST**: `signed = url + sortedPostParams + "." + nonce` — POST params sorted alphabetically by key (case-sensitive) and concatenated as `key1value1key2value2…` with no delimiters.
+- **GET**:  `signed = url + "." + nonce` — query parameters live in the URL already.
+
+Both are HMAC-SHA256 keyed on the Auth Token and base64-encoded, delivered as the `X-Plivo-Signature-V3` header alongside `X-Plivo-Signature-V3-Nonce`. The signature header may carry comma-separated values during key rotation; any matching value accepts. Requests with invalid signatures are rejected with HTTP 403.
+
 ## Webhook Endpoints
 
 The embedded server exposes these endpoints regardless of carrier choice:
@@ -90,6 +135,10 @@ The embedded server exposes these endpoints regardless of carrier choice:
 | `POST /webhooks/twilio/recording` | Recording completion callbacks. |
 | `POST /webhooks/twilio/amd` | Async AMD (answering machine detection) results. |
 | `POST /webhooks/telnyx/voice` | Incoming Telnyx call → returns Call Control commands. |
+| `POST /webhooks/plivo/voice` | Incoming Plivo call → returns Plivo XML to start streaming. Also serves outbound `answer_url`. |
+| `POST /webhooks/plivo/status` | Plivo `hangup_url` callback — call lifecycle (completed, busy, no-answer, failed, timeout, cancel). |
+| `POST /webhooks/plivo/amd` | Async AMD result (`machine_detection_url`). |
+| `GET|POST /webhooks/plivo/transfer` | `<Dial>` XML for blind transfer (Plivo `aleg_url`). |
 
 ## What's Next
 

--- a/docs/typescript-sdk/local-mode.mdx
+++ b/docs/typescript-sdk/local-mode.mdx
@@ -147,7 +147,7 @@ Phone Speaker
 Call `phone.disconnect()` to gracefully stop the embedded server. The shutdown sequence:
 
 1. **Stop accepting new connections** — the HTTP server stops listening.
-2. **Hang up active calls** — each active call is terminated via the telephony provider API (Twilio or Telnyx).
+2. **Hang up active calls** — each active call is terminated via the telephony provider API (Twilio, Telnyx, or Plivo).
 3. **Close WebSocket connections** — a close frame (`1001 Server shutting down`) is sent to all active WebSocket connections.
 4. **Wait for drain** — the server waits up to **10 seconds** for active connections to close cleanly.
 5. **Force-terminate** — any connections still open after the drain timeout are forcibly terminated.

--- a/docs/typescript-sdk/overview.mdx
+++ b/docs/typescript-sdk/overview.mdx
@@ -17,7 +17,7 @@ npm install getpatter
 ## Requirements
 
 - Node.js 18 or higher
-- A telephony account — Twilio or Telnyx (both fully supported)
+- A telephony account — Twilio, Telnyx, or Plivo (all three fully supported)
 - An AI provider key (OpenAI, ElevenLabs, or Deepgram)
 
 ## Minimal Example
@@ -35,7 +35,7 @@ That's the full file. Every provider class reads its API key from an env var whe
 
 ## How Patter runs
 
-Patter runs entirely in your own process — an embedded Express server and all provider adapters live directly in your application. Bring your own telephony (Twilio or Telnyx) and AI provider credentials; no external platform or hosted backend required.
+Patter runs entirely in your own process — an embedded Express server and all provider adapters live directly in your application. Bring your own telephony (Twilio, Telnyx, or Plivo) and AI provider credentials; no external platform or hosted backend required.
 
 <Note>A hosted Patter Cloud option will return in a future release.</Note>
 

--- a/docs/typescript-sdk/providers/elevenlabs-convai.mdx
+++ b/docs/typescript-sdk/providers/elevenlabs-convai.mdx
@@ -162,7 +162,7 @@ adapter.onEvent((type, data) => {
 
 ## Pricing
 
-ElevenLabs ConvAI is billed by ElevenLabs per-minute (premium tiers add features like RAG and analytics). Patter does not currently meter ConvAI minutes — the engine cost shows up on your ElevenLabs invoice. Carrier minutes (Twilio / Telnyx) are still tracked as normal in `CallMetrics`.
+ElevenLabs ConvAI is billed by ElevenLabs per-minute (premium tiers add features like RAG and analytics). Patter does not currently meter ConvAI minutes — the engine cost shows up on your ElevenLabs invoice. Carrier minutes (Twilio, Telnyx, or Plivo) are still tracked as normal in `CallMetrics`.
 
 ## See also
 

--- a/docs/typescript-sdk/tts.mdx
+++ b/docs/typescript-sdk/tts.mdx
@@ -87,7 +87,7 @@ const tts = ElevenLabsTTS.forTwilio({ voiceId: "rachel" });
 const tts2 = ElevenLabsTTS.forTelnyx({ voiceId: "rachel" });
 ```
 
-`CartesiaTTS.forTwilio()` / `forTelnyx()` and `ElevenLabsConvAI.forTwilio()` / `forTelnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls.
+`CartesiaTTS.forTwilio()` / `forTelnyx()` and `ElevenLabsConvAI.forTwilio()` / `forTelnyx()` work the same way. Use them whenever you know the call will go out over Twilio or Telnyx — they shave tens of milliseconds off TTFB and drop CPU on long calls. **Plivo** pins mulaw 8 kHz in its answer XML, so the `forTwilio()` factories apply unchanged.
 
 <Note>
   **WebSocket variant**: `ElevenLabsWebSocketTTS` is a drop-in alternative that streams audio over a WebSocket connection, saving ~50 ms of HTTP setup + TLS cold-start per utterance. See [ElevenLabs WebSocket TTS](/typescript-sdk/providers/elevenlabs-websocket) for the full reference and limitations.


### PR DESCRIPTION
## Summary

The merged Plivo carrier PR (#121) updated `docs/concepts.mdx` but missed the dedicated per-SDK carrier pages and a long tail of "Twilio or Telnyx" sentences scattered across the doc site. This PR closes both gaps — **15 files**, all docs, no code.

## Per-SDK carrier pages (`docs/{python,typescript}-sdk/carrier.mdx`)

New `## Plivo` section in each, mirroring the existing Twilio / Telnyx sections:

- construction example (env-fallback and explicit `auth_id`/`auth_token`)
- params table + namespaced form (Python)
- `serve()` auto-config behaviour — creates a Plivo Application + links the number; `manage_webhook=False` / `manageWebhook: false` opts out
- TS-only "how caller / callee reach the agent" section — WSS query string + `extraHeaders` fallback (mirrors the existing Telnyx explainer)
- wire format and parity gains: pinned mulaw 8 kHz, **native DTMF send** over the WS, Speak-API voicemail drop, async AMD wiring, `hangup_url` status callback
- V3 signature spec — POST `url + sorted_post_params + "." + nonce` vs GET `url + "." + nonce`, HMAC-SHA256, key rotation
- four new rows in the **Webhook Endpoints** table: `voice`, `status`, `amd`, `transfer`

Also corrected the opening capability summary — recording is no longer "Twilio-only" (Telnyx parity landed in #106, Plivo has the Record API too). Replaced with a call-out for **native DTMF send** as the Plivo-specific parity gain over Twilio Media Streams.

## Wider sweep — stale carrier-pair-only mentions

| File | Change |
|---|---|
| `docs/concepts.mdx` | Diagram (`anatomy of a call`) + `Carrier setup` card label |
| `docs/home/index.mdx` | Landing-page supported-carriers line |
| `docs/python-sdk/overview.mdx` + `typescript-sdk/overview.mdx` | Prerequisites + "How Patter runs" |
| `docs/python-sdk/local-mode.mdx` + `typescript-sdk/local-mode.mdx` | Opening blurb + graceful-shutdown step |
| `docs/python-sdk/reference.mdx` | `WEBHOOK_VERIFICATION` error-code row |
| `docs/python-sdk/tracing.mdx` | `patter.cost.telephony_minutes` span emitters |
| `docs/python-sdk/providers/elevenlabs-convai.mdx` + `typescript-sdk/providers/elevenlabs-convai.mdx` | Pricing carve-out |
| `docs/python-sdk/tts.mdx` + `typescript-sdk/tts.mdx` | `.for_twilio()` factories now noted to apply unchanged to Plivo (same mulaw 8 kHz wire) — no method rename |
| `docs/integrations/openclaw.mdx` | Page description + `configure-telephony` skill row |

`docs/docs.json` needs no change — it only references the single `carrier` page per SDK, not per-carrier subpages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)