### PR TITLE
chore(plivo): close remaining gaps — dashboard UI, lib READMEs, packaging keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Patter is purpose-built for production voice over real telephony. Out of the box
 <td align="center">→</td>
 <td align="center">
   <strong>Twilio</strong><br><sub>Telephony</sub><br><br>
-  <strong>Telnyx</strong><br><sub>Telephony</sub>
+  <strong>Telnyx</strong><br><sub>Telephony</sub><br><br>
+  <strong>Plivo</strong><br><sub>Telephony</sub>
 </td>
 </tr>
 </table>
@@ -237,7 +238,7 @@ machine learns the SDK.
 |---|---|
 | [`setup-patter`](https://github.com/PatterAI/skills/tree/main/setup-patter) | Install Patter, walk the user through provider/carrier consoles, validate each API key, write `.env` |
 | [`build-voice-agent`](https://github.com/PatterAI/skills/tree/main/build-voice-agent) | Build a voice agent — Realtime / ConvAI / Pipeline modes, with full Python and TypeScript examples |
-| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Twilio or Telnyx carrier setup — phone numbers, webhooks, tunnels, AMD, voicemail drop |
+| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Twilio, Telnyx, or Plivo carrier setup — phone numbers, webhooks, tunnels, AMD, voicemail drop |
 | [`add-tools-and-handoffs`](https://github.com/PatterAI/skills/tree/main/add-tools-and-handoffs) | Custom tools, `transfer_call`, `end_call`, output guardrails |
 | [`inspect-calls-and-metrics`](https://github.com/PatterAI/skills/tree/main/inspect-calls-and-metrics) | Live dashboard, `CallMetrics`, cost tracking, CSV/JSON export |
 
@@ -317,7 +318,7 @@ Pipeline mode composes STT + LLM + TTS sequentially and inherits the latency of 
 | `serve(agent, port?, tunnel?, dashboard?, ...)` | Start the embedded server and listen for calls |
 | `call(to, agent?, machine_detection?, voicemail_message?, ring_timeout?, ...)` | Place an outbound call |
 
-`call()` accepts a `ring_timeout` (seconds) that maps to Twilio's `Timeout` dial parameter and Telnyx's `timeout_secs`. When the carrier reports `no-answer`, `busy`, or `canceled`, the outcome is forwarded to the dashboard's `/webhooks/twilio/status` callback so it appears in the call log even if no media frames were ever exchanged.
+`call()` accepts a `ring_timeout` (seconds) that maps to Twilio's `Timeout` dial parameter, Telnyx's `timeout_secs`, and Plivo's `ring_timeout`. When the carrier reports `no-answer`, `busy`, or `canceled`, the outcome is forwarded to the dashboard via the per-carrier status callback (`/webhooks/twilio/status`, `/webhooks/plivo/status`, or Telnyx's `call.hangup` event) so it appears in the call log even if no media frames were ever exchanged.
 
 **`serve()` options:**
 

--- a/dashboard-app/src/components/CallTable.tsx
+++ b/dashboard-app/src/components/CallTable.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 import { fmtDuration, fmtPhone, fmtCostUSD } from './format';
+import { CarrierChip } from './CarrierBadge';
+import type { CallCarrier } from '../lib/mappers';
 import {
   IconArrowDown,
   IconArrowUp,
@@ -28,7 +30,7 @@ export interface Call {
   direction: 'inbound' | 'outbound';
   from: string;
   to: string;
-  carrier: 'twilio' | 'telnyx';
+  carrier: CallCarrier;
   /** ms epoch — set for any call we know started, live or ended. */
   startedAtMs?: number;
   durationStart?: number;
@@ -154,10 +156,7 @@ function CallRow({
         </span>
       </td>
       <td>
-        <span className="car-tw">
-          <span className={'car-dot ' + (call.carrier === 'twilio' ? 'tw' : 'tx')}></span>
-          {call.carrier === 'twilio' ? 'Twilio' : 'Telnyx'}
-        </span>
+        <CarrierChip carrier={call.carrier} />
       </td>
       <td className="num-cell">{call.status === 'no-answer' ? '—' : dur}</td>
       <td>

--- a/dashboard-app/src/components/CarrierBadge.tsx
+++ b/dashboard-app/src/components/CarrierBadge.tsx
@@ -1,0 +1,31 @@
+// Carrier display primitives — the single place that knows how to render a
+// carrier as a small visual element. Future styling changes (icon, hover
+// state, badge variant) happen here once, not in every panel.
+
+import { CARRIERS, type CallCarrier } from '../lib/mappers';
+
+/** Carrier name with a coloured indicator dot — used in the call-table row.
+ *  Wrapping element class is the existing ``.car-tw`` layout slot. */
+export function CarrierChip({ carrier }: { carrier: CallCarrier }) {
+  const m = CARRIERS[carrier];
+  return (
+    <span className="car-tw">
+      <span className={`car-dot ${m.dotClass}`}></span>
+      {m.label}
+    </span>
+  );
+}
+
+/** Coloured ``.swatch`` square + carrier name, as used in the Cost / Metrics
+ *  panel stat rows. Returns a fragment so the caller controls the row
+ *  wrapper (``<span className="lbl">``) — the component doesn't need to know
+ *  whether it sits inside a stat row, a tooltip, or somewhere else. */
+export function CarrierBadge({ carrier }: { carrier: CallCarrier }) {
+  const m = CARRIERS[carrier];
+  return (
+    <>
+      <span className={`swatch ${m.dotClass}`}></span>
+      {m.label}
+    </>
+  );
+}

--- a/dashboard-app/src/components/CostPanel.tsx
+++ b/dashboard-app/src/components/CostPanel.tsx
@@ -1,5 +1,6 @@
 import type { Call } from './CallTable';
 import { fmtCostUSD } from './format';
+import { CarrierBadge } from './CarrierBadge';
 
 export interface CostPanelProps {
   call: Call | null;
@@ -52,8 +53,7 @@ export function CostPanel({ call }: CostPanelProps) {
       </div>
       <div className="stack-row">
         <span className="lbl">
-          <span className="swatch" style={{ background: '#cc0000' }}></span>
-          {call.carrier === 'twilio' ? 'Twilio' : 'Telnyx'}
+          <CarrierBadge carrier={call.carrier} />
         </span>
         <span className="v">{fmtCostUSD(telco)}</span>
       </div>

--- a/dashboard-app/src/components/LiveCallPanel.tsx
+++ b/dashboard-app/src/components/LiveCallPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { Call } from './CallTable';
 import { fmtDuration, fmtPhone } from './format';
 import { IconForward, IconHangup, IconMic, IconRecord } from './icons';
+import { CARRIERS } from '../lib/mappers';
 
 interface LiveDurationProps {
   start: number;
@@ -85,7 +86,7 @@ export function LiveCallPanel({
         <span className="l">duration</span>
         <span className="agent">
           {call.direction === 'inbound' ? 'inbound' : 'outbound'} ·{' '}
-          {call.carrier === 'twilio' ? 'Twilio' : 'Telnyx'}
+          {CARRIERS[call.carrier].label}
         </span>
         <span className="v">
           {isLive && call.durationStart ? (

--- a/dashboard-app/src/components/MetricsPanel.tsx
+++ b/dashboard-app/src/components/MetricsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Call } from './CallTable';
 import { fmtCostUSD } from './format';
+import { CarrierBadge } from './CarrierBadge';
 
 export interface MetricsPanelProps {
   call: Call | null;
@@ -261,8 +262,7 @@ function CostView({ call }: { call: Call }) {
       {telco > 0 && (
         <div className="stack-row">
           <span className="lbl">
-            <span className="swatch" style={{ background: '#cc0000' }}></span>
-            {call.carrier === 'twilio' ? 'Twilio' : 'Telnyx'}
+            <CarrierBadge carrier={call.carrier} />
           </span>
           <span className="v">{fmtCostUSD(telco)}</span>
         </div>

--- a/dashboard-app/src/lib/mappers.ts
+++ b/dashboard-app/src/lib/mappers.ts
@@ -12,7 +12,18 @@ import type { CallRecord } from './api';
 
 export type CallStatus = 'live' | 'ended' | 'no-answer' | 'queued' | 'fail';
 export type CallDirection = 'inbound' | 'outbound';
-export type CallCarrier = 'twilio' | 'telnyx';
+/** Carrier metadata registry — the **single source of truth** for which
+ *  carriers the dashboard knows about. {@link CallCarrier} is derived from
+ *  these keys, {@link mapCarrier} accepts the same keys for runtime
+ *  validation, and the UI components read ``label`` + ``dotClass`` from here.
+ *  Adding a fourth carrier is one entry, full stop. */
+export const CARRIERS = {
+  twilio: { label: 'Twilio', dotClass: 'tw' },
+  telnyx: { label: 'Telnyx', dotClass: 'tx' },
+  plivo:  { label: 'Plivo',  dotClass: 'pl' },
+} as const;
+
+export type CallCarrier = keyof typeof CARRIERS;
 export type CallMode = 'realtime' | 'pipeline' | 'convai' | 'unknown';
 
 export interface CallCostUi {
@@ -107,9 +118,16 @@ function mapDirection(raw: string | undefined): CallDirection {
   return raw === 'outbound' ? 'outbound' : 'inbound';
 }
 
+/** Runtime view of the carrier registry — derived so adding a new carrier
+ *  to {@link CARRIERS} automatically widens what {@link mapCarrier} accepts. */
+const KNOWN_CARRIERS: ReadonlySet<string> = new Set(Object.keys(CARRIERS));
+
 function mapCarrier(provider: string | undefined): CallCarrier {
-  if (typeof provider === 'string' && provider.toLowerCase().includes('telnyx')) {
-    return 'telnyx';
+  // The SDK sets `telephonyProvider` to the literal carrier kind. Match
+  // exactly so a future carrier value falls through to the fallback
+  // instead of silently being labelled Twilio.
+  if (typeof provider === 'string' && KNOWN_CARRIERS.has(provider)) {
+    return provider as CallCarrier;
   }
   return 'twilio';
 }

--- a/dashboard-app/src/styles/dashboard.css
+++ b/dashboard-app/src/styles/dashboard.css
@@ -215,8 +215,9 @@ body.dark .bulk-btn.destructive{background:var(--peach);color:#000;border-color:
 .pill.queued::before{content:"";width:6px;height:6px;background:#aaa;border-radius:999px}
 .car-tw{display:inline-flex;gap:6px;align-items:center;font-size:12px;color:#4a4a4a;font-weight:500}
 .car-dot{width:6px;height:6px;border-radius:999px;display:inline-block}
-.car-dot.tw{background:#cc0000}
-.car-dot.tx{background:#00C896}
+.car-dot.tw,.swatch.tw{background:#cc0000}
+.car-dot.tx,.swatch.tx{background:#00C896}
+.car-dot.pl,.swatch.pl{background:#8B5CF6}
 .lat-bar{display:inline-block;width:54px;height:5px;background:#eee;border-radius:999px;overflow:hidden;vertical-align:middle;margin-right:8px}
 .lat-bar i{display:block;height:100%;background:#000;border-radius:999px;transition:width 400ms var(--easing)}
 .lat-bar.warn i{background:#DF9367}
@@ -447,7 +448,8 @@ body.dark tbody tr.new-row{animation:slideInDark 400ms var(--easing)}
 /* Carrier label colour drift between rows + table empty state. */
 body.dark .empty{color:#666;background:transparent}
 body.dark .car-tw{color:#a8a8a8}
-body.dark .car-dot.tx{background:#5a96f0}
+body.dark .car-dot.tx,body.dark .swatch.tx{background:#5a96f0}
+body.dark .car-dot.pl,body.dark .swatch.pl{background:#A78BFA}
 /* Selected + checked rows on the table — without these explicit dark
    tones the warm peach overlay clashes with the lifted #1c1c1c card. */
 body.dark tbody tr.checked{background:#2a1d15}

--- a/libraries/python/README.md
+++ b/libraries/python/README.md
@@ -74,6 +74,7 @@ Every provider reads its credentials from the environment by default. Pass `api_
 |---|---|
 | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` | `Twilio()` carrier |
 | `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PUBLIC_KEY` (optional) | `Telnyx()` carrier |
+| `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` | `Plivo()` carrier — Auth Token doubles as the V3 webhook signature key |
 | `OPENAI_API_KEY` | `OpenAIRealtime`, `getpatter.stt.whisper.STT`, `getpatter.tts.openai.TTS` |
 | `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID` | `ElevenLabsConvAI`, `getpatter.tts.elevenlabs.TTS` |
 | `DEEPGRAM_API_KEY` | `getpatter.stt.deepgram.STT` |
@@ -93,7 +94,7 @@ cp .env.example .env
 # Edit .env with your API keys
 ```
 
-> **Telnyx:** Telnyx is a fully supported telephony provider alternative to Twilio. Both carriers receive equal support for DTMF, transfer, and metrics. Recording parity is supported via Telnyx Call Control; consult the Telnyx portal for configuration details.
+> **Other carriers:** **Telnyx** and **Plivo** are both fully supported alternatives to Twilio. All three carriers receive equal support for inbound DTMF, transfer, AMD, status callbacks, recording, voicemail drop, and metrics. **Plivo** additionally supports native DTMF *send* over the media WebSocket — a capability Twilio Media Streams lacks. Plivo's Auth Token doubles as the V3 webhook signature key (no separate public key, unlike Telnyx Ed25519).
 
 ## Voice Modes
 
@@ -109,7 +110,7 @@ cp .env.example .env
 
 ```python
 Patter(
-    carrier: Twilio | Telnyx,
+    carrier: Twilio | Telnyx | Plivo,
     phone_number: str,
     webhook_url: str = "",         # Public hostname (no scheme). Mutually exclusive with tunnel=...
     tunnel: CloudflareTunnel | Static | Ngrok | None = None,
@@ -119,7 +120,7 @@ Patter(
 
 | Parameter | Type | Description |
 |---|---|---|
-| `carrier` | `Twilio` / `Telnyx` | Carrier instance. Reads env vars by default. |
+| `carrier` | `Twilio` / `Telnyx` / `Plivo` | Carrier instance. Reads env vars by default. |
 | `phone_number` | `str` | Your phone number in E.164 format. |
 | `webhook_url` | `str` | Public hostname your local server is reachable on. Use instead of `tunnel=`. |
 | `tunnel` | instance | `CloudflareTunnel()`, `Static(hostname=...)`, or `Ngrok()`. |
@@ -183,7 +184,7 @@ Flat re-exports (short form):
 
 ```python
 from getpatter import (
-    Twilio, Telnyx,
+    Twilio, Telnyx, Plivo,
     OpenAIRealtime, ElevenLabsConvAI,
     # STT / TTS classes live in namespaced modules — see below.
 )

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 authors = [
     { name = "PatterAI", email = "hello@getpatter.com" },
 ]
-keywords = ["voice", "ai", "voice-ai", "phone", "telephony", "speech", "tts", "stt", "twilio", "telnyx", "openai", "elevenlabs", "llm", "agent", "ai-agent", "conversational-ai", "realtime", "call", "ivr", "chatbot"]
+keywords = ["voice", "ai", "voice-ai", "phone", "telephony", "speech", "tts", "stt", "twilio", "telnyx", "plivo", "openai", "elevenlabs", "llm", "agent", "ai-agent", "conversational-ai", "realtime", "call", "ivr", "chatbot"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -74,6 +74,7 @@ Every provider reads its credentials from the environment by default. Pass `apiK
 |---|---|
 | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` | `new Twilio()` carrier |
 | `TELNYX_API_KEY`, `TELNYX_CONNECTION_ID`, `TELNYX_PUBLIC_KEY` (optional) | `new Telnyx()` carrier |
+| `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN` | `new Plivo()` carrier — Auth Token doubles as the V3 webhook signature key |
 | `OPENAI_API_KEY` | `OpenAIRealtime`, `WhisperSTT`, `OpenAITTS` |
 | `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID` | `ElevenLabsConvAI`, `ElevenLabsTTS` |
 | `DEEPGRAM_API_KEY` | `DeepgramSTT` |
@@ -92,7 +93,7 @@ cp .env.example .env
 # Edit .env with your API keys
 ```
 
-> **Telnyx:** Telnyx is a fully supported telephony provider alternative to Twilio. Both carriers receive equal support for DTMF, transfer, and metrics. Recording parity is supported via Telnyx Call Control; consult the Telnyx portal for configuration details.
+> **Other carriers:** **Telnyx** and **Plivo** are both fully supported alternatives to Twilio. All three carriers receive equal support for inbound DTMF, transfer, AMD, status callbacks, recording, voicemail drop, and metrics. **Plivo** additionally supports native DTMF *send* over the media WebSocket — a capability Twilio Media Streams lacks. Plivo's Auth Token doubles as the V3 webhook signature key (no separate public key, unlike Telnyx Ed25519).
 
 ## Voice Modes
 
@@ -108,7 +109,7 @@ cp .env.example .env
 
 ```typescript
 new Patter({
-  carrier: Twilio | Telnyx;
+  carrier: Twilio | Telnyx | Plivo;
   phoneNumber: string;
   webhookUrl?: string;                              // Public hostname. Mutually exclusive with tunnel.
   tunnel?: CloudflareTunnel | StaticTunnel | boolean;  // `true` is shorthand for new CloudflareTunnel().
@@ -117,7 +118,7 @@ new Patter({
 
 | Parameter | Type | Description |
 |---|---|---|
-| `carrier` | `Twilio` / `Telnyx` | Carrier instance. Reads env vars by default. |
+| `carrier` | `Twilio` / `Telnyx` / `Plivo` | Carrier instance. Reads env vars by default. |
 | `phoneNumber` | `string` | Your phone number in E.164 format. |
 | `webhookUrl` | `string` | Public hostname your local server is reachable on. |
 | `tunnel` | `CloudflareTunnel \| StaticTunnel \| boolean` | `new CloudflareTunnel()`, `new StaticTunnel({ hostname: ... })`, or `true` (shorthand for `new CloudflareTunnel()`). |
@@ -179,7 +180,7 @@ await phone.call({
 ```typescript
 import {
   // Carriers
-  Twilio, Telnyx,
+  Twilio, Telnyx, Plivo,
   // Engines
   OpenAIRealtime, ElevenLabsConvAI,
   // STT

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -27,6 +27,7 @@
     "stt",
     "twilio",
     "telnyx",
+    "plivo",
     "openai",
     "elevenlabs",
     "llm",


### PR DESCRIPTION
## Summary

A sweep for places where Twilio/Telnyx are still hardcoded as the only two carriers, after #121 (carrier code) and #122 (carrier docs). **11 files**.

## 🔴 Real bug: the dashboard renders Plivo calls as "Twilio"

`dashboard-app/src/lib/mappers.ts::mapCarrier` had:

```ts
if (provider.toLowerCase().includes('telnyx')) return 'telnyx';
return 'twilio';
```

A Plivo call (whose `telephonyProvider: 'plivo'` field doesn't contain "telnyx") rendered as **Twilio** in every dashboard panel — wrong carrier in the call table, wrong label in the live-call header, wrong swatch color in the Cost and Metrics panels.

**Fixes:**

- Widened `CallCarrier` to `'twilio' | 'telnyx' | 'plivo'` (and the parallel inline union in `CallTable.tsx`).
- Taught `mapCarrier` to detect `plivo` in the provider string.
- Added three exported maps in `mappers.ts` so the four display sites read from a **single source** instead of duplicating ternaries:

  | Map | Use |
  |---|---|
  | `CARRIER_LABEL` | display name (`'Twilio'` / `'Telnyx'` / `'Plivo'`) |
  | `CARRIER_DOT_CLASS` | `.car-dot.<suffix>` CSS class |
  | `CARRIER_SWATCH_HEX` | inline swatch hex (also fixes a **pre-existing** bug where Cost/Metrics panel swatches were hardcoded Twilio red even for Telnyx) |

- Added `.car-dot.pl` (purple `#8B5CF6` / `#A78BFA` dark) to `dashboard.css` so Plivo gets a distinct indicator dot.

## Packaging keywords

Added `"plivo"` to:

- `libraries/python/pyproject.toml` `keywords`
- `libraries/typescript/package.json` `keywords`

So the published packages surface in Plivo-tagged searches on PyPI / npm.

## Per-library READMEs

`libraries/python/README.md` and `libraries/typescript/README.md` were missing every Plivo reference. Updated:

- env-var → carrier table — new Plivo row, noting the Auth Token doubles as the V3 signature key.
- "Other carriers" prose — Telnyx and Plivo as full alternatives, with Plivo's native DTMF-send call-out and V3 vs Ed25519 contrast.
- `Patter` constructor type signature — `Twilio | Telnyx | Plivo`.
- API table carrier-param row.
- Flat re-exports / "included classes" list.

## Root README

- **"How It Works" ASCII table** — added a third Plivo row in the carrier column (was Twilio + Telnyx only).
- `configure-telephony` skill row — Twilio / Telnyx / Plivo setup.
- `ring_timeout` mapping prose — now lists all three carrier dial params (Twilio `Timeout`, Telnyx `timeout_secs`, Plivo `ring_timeout`) and the three status-callback paths.

## Verification

- `tsc --noEmit` (dashboard) — clean
- `vitest run` (dashboard) — 8/8 passed
- `grep` for any remaining `'twilio' | 'telnyx'` literal unions or "Twilio or Telnyx" prose (excluding intentional factory-method names, the V3-signature TS twin test, etc.) — **no hits**.