### PR TITLE
docs(changelog): backfill Unreleased entry for #123 (dashboard Plivo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+
+- **Dashboard: Plivo carrier support in the UI.** The call dashboard now
+  renders a Plivo `CarrierBadge` and maps Plivo calls across the cost,
+  live-call, and metrics panels, alongside Twilio and Telnyx
+  (`dashboard-app/`). Also added `"plivo"` to the PyPI / npm package keywords
+  so the SDK surfaces in Plivo-related searches. (#123)
+
 ## 0.6.3 (2026-05-29)
 
 ### Added


### PR DESCRIPTION
## Summary
Backfills the missing `## Unreleased` CHANGELOG entry for #123, which landed Plivo support in the dashboard UI (CarrierBadge + cost/live-call/metrics panel mappers) and the `"plivo"` package keyword but merged without a changelog line.

## Why
Per `documentation-best-practices.md` (invariant 0), every user-visible change gets a `## Unreleased` entry in the same unit of work. #123's dashboard change is user-visible (operators see Plivo badges/cost mapping) and dashboard changes are historically tracked in the CHANGELOG. Docs-only PRs #119/#122 are exempt, so this is the only gap.

## SDK parity
Verified clean — `CallResult` / `CallOutcome` / `Plivo` / `PlivoAdapter` are exported from both SDKs, and the `"plivo"` keyword is in both `pyproject.toml` and `package.json`. #123 touched no dual-SDK source.

## Breaking change?
No — CHANGELOG-only.

## Test plan
- [x] CHANGELOG-only diff; no code touched