### PR TITLE
fix(metrics): re-arm turn guard in anchorUserSpeechStart — pipeline turns emit no metrics/transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
   (`dashboard-app/`). Also added `"plivo"` to the PyPI / npm package keywords
   so the SDK surfaces in Plivo-related searches. (#123)
 
+### Fixed
+
+- **Pipeline-mode turns after the first now record per-turn metrics and
+  broadcast the live dashboard transcript.** `anchorUserSpeechStart()` re-opened
+  a turn (set `_turnStart`) without clearing the `_turnAlreadyClosed` guard, so
+  every user→agent turn after the `firstMessage` made `recordTurnComplete()` a
+  no-op — silently dropping per-turn latency/cost AND the live SSE
+  `turn_complete` event that feeds the dashboard transcript (the transcript only
+  appeared after the call ended). Cleared the flag in `anchorUserSpeechStart()`,
+  mirroring what `startTurn()` already does, in both SDKs
+  (`libraries/typescript/src/metrics.ts`,
+  `libraries/python/getpatter/services/metrics.py`). The post-commit barge-in
+  guard is untouched — the method no-ops once the turn is committed.
+
 ## 0.6.3 (2026-05-29)
 
 ### Added

--- a/libraries/python/getpatter/services/metrics.py
+++ b/libraries/python/getpatter/services/metrics.py
@@ -262,6 +262,15 @@ class CallMetricsAccumulator:
         if self._turn_committed_mono is not None:
             return
         self._turn_start = time.monotonic()
+        # A pre-commit VAD speech_start opens a NEW turn — re-arm the guard
+        # exactly as start_turn() does. Without this, the guard set by the
+        # previous turn's record_turn_complete persists, and every later
+        # anchor-opened turn makes record_turn_complete a no-op (dropping
+        # per-turn metrics AND the live SSE transcript). Safe: this method
+        # no-ops after commit (guard above), so we only ever re-arm at the
+        # start of a fresh, uncommitted turn — never the post-commit
+        # barge-in path that _turn_already_closed protects.
+        self._turn_already_closed = False
         self._endpoint_signal_at = None
         self._vad_stopped_at = None
         self._stt_final_at = None

--- a/libraries/python/tests/unit/test_metrics_turn_rearm.py
+++ b/libraries/python/tests/unit/test_metrics_turn_rearm.py
@@ -1,0 +1,61 @@
+"""Regression: pipeline-mode turns after the first emitted no metrics.
+
+`anchor_user_speech_start()` re-opened a turn (set ``_turn_start``) but left the
+``_turn_already_closed`` guard set from the previous turn's
+``record_turn_complete``, so the next ``record_turn_complete`` short-circuited
+to ``None`` — dropping per-turn latency/cost AND the live SSE transcript that
+feeds the dashboard. Mirrors libraries/typescript/tests/unit/metrics-turn-rearm.test.ts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from getpatter.services.metrics import CallMetricsAccumulator
+
+
+def _make_acc() -> CallMetricsAccumulator:
+    return CallMetricsAccumulator(
+        call_id="rearm-test",
+        provider_mode="pipeline",
+        telephony_provider="twilio",
+        stt_provider="deepgram",
+        tts_provider="elevenlabs",
+        llm_provider="custom",
+    )
+
+
+@pytest.mark.unit
+def test_turn_recorded_after_vad_anchor_following_prior_turn():
+    acc = _make_acc()
+
+    # Turn 0 — opened with start_turn (the firstMessage path); clears the guard.
+    acc.start_turn()
+    acc.record_stt_complete("hello")
+    assert acc.record_turn_complete("hi there") is not None
+
+    # Turn 1 — opened via the real pipeline path: a legitimate VAD speech_start
+    # anchors the turn (NOT start_turn). start_turn_if_idle is then a no-op
+    # because _turn_start is already set. record_turn_complete must still return
+    # a turn — pre-fix it returned None (guard never re-armed).
+    acc.anchor_user_speech_start()
+    acc.start_turn_if_idle()
+    acc.record_stt_complete("how are you")
+    assert acc.record_turn_complete("good, thanks") is not None
+
+
+@pytest.mark.unit
+def test_keeps_recording_across_several_anchor_opened_turns():
+    acc = _make_acc()
+    acc.start_turn()
+    acc.record_stt_complete("q0")
+    acc.record_turn_complete("a0")
+
+    for i in range(1, 4):
+        acc.anchor_user_speech_start()
+        acc.start_turn_if_idle()
+        acc.record_stt_complete(f"q{i}")
+        assert acc.record_turn_complete(f"a{i}") is not None
+
+    # turn 0 + 3 anchor-opened turns all recorded.
+    assert len(acc.end_call().turns) == 4

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/libraries/typescript/src/metrics.ts
+++ b/libraries/typescript/src/metrics.ts
@@ -433,6 +433,15 @@ export class CallMetricsAccumulator {
   anchorUserSpeechStart(): void {
     if (this._turnCommittedMono !== null) return;
     this._turnStart = hrTimeMs();
+    // A pre-commit VAD speech_start opens a NEW turn — re-arm the guard
+    // exactly as startTurn() does. Without this, the guard set by the
+    // previous turn's recordTurnComplete persists, and every later
+    // anchor-opened turn makes recordTurnComplete a no-op (dropping per-turn
+    // metrics AND the live SSE transcript). Safe: this method no-ops after
+    // commit (guard above), so we only ever re-arm at the start of a fresh,
+    // uncommitted turn — never the post-commit barge-in path that
+    // _turnAlreadyClosed protects.
+    this._turnAlreadyClosed = false;
     this._endpointSignalAt = null;
     this._vadStoppedAt = null;
     this._sttFinalAt = null;

--- a/libraries/typescript/tests/unit/metrics-turn-rearm.test.ts
+++ b/libraries/typescript/tests/unit/metrics-turn-rearm.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { CallMetricsAccumulator } from '../../src/metrics';
+
+// Regression for the pipeline-mode bug where every user→agent turn after the
+// firstMessage emitted no per-turn metrics (and no live SSE transcript).
+// `anchorUserSpeechStart()` re-opened a turn (set `_turnStart`) but left the
+// `_turnAlreadyClosed` guard set from the previous turn's `recordTurnComplete`,
+// so the next `recordTurnComplete` short-circuited to `null`.
+describe('[unit] CallMetricsAccumulator — turn re-arm after VAD anchor', () => {
+  function makeAcc(): CallMetricsAccumulator {
+    return new CallMetricsAccumulator({
+      callId: 'rearm-test',
+      providerMode: 'pipeline',
+      telephonyProvider: 'twilio',
+      sttProvider: 'deepgram',
+      ttsProvider: 'elevenlabs',
+      llmProvider: 'custom',
+    });
+  }
+
+  it('records a turn opened via anchorUserSpeechStart after a prior turn completed', () => {
+    const acc = makeAcc();
+
+    // Turn 0 — opened with startTurn (the firstMessage path). This clears the
+    // guard, so it records fine even today.
+    acc.startTurn();
+    acc.recordSttComplete('hello');
+    expect(acc.recordTurnComplete('hi there')).not.toBeNull();
+
+    // Turn 1 — opened via the real pipeline path: a legitimate VAD
+    // speech_start anchors the turn (NOT startTurn). startTurnIfIdle is then a
+    // no-op because _turnStart is already set. recordTurnComplete must still
+    // return a turn — pre-fix it returned null (guard never re-armed).
+    acc.anchorUserSpeechStart();
+    acc.startTurnIfIdle();
+    acc.recordSttComplete('how are you');
+    expect(acc.recordTurnComplete('good, thanks')).not.toBeNull();
+  });
+
+  it('keeps recording across several anchor-opened turns', () => {
+    const acc = makeAcc();
+    acc.startTurn();
+    acc.recordSttComplete('q0');
+    acc.recordTurnComplete('a0');
+
+    for (let i = 1; i <= 3; i++) {
+      acc.anchorUserSpeechStart();
+      acc.startTurnIfIdle();
+      acc.recordSttComplete(`q${i}`);
+      expect(acc.recordTurnComplete(`a${i}`)).not.toBeNull();
+    }
+    // turn 0 + 3 anchor-opened turns all recorded.
+    expect(acc.endCall().turns.length).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
One-line bug in **both** SDKs. In pipeline mode, every user→agent turn *after* the `firstMessage` emitted **no per-turn metrics** and **no live dashboard transcript**. Root cause: `anchorUserSpeechStart()` re-opens a turn (sets `_turnStart`) but did not clear the `_turnAlreadyClosed` guard left set by the previous turn's `recordTurnComplete`. Since `startTurnIfIdle()` no-ops once `_turnStart` is non-null, the guard never re-armed, so every subsequent `recordTurnComplete()` short-circuited to `null`.

`emitTurnMetrics(null)` then bails before `MetricsStore.recordTurn()`, which is what broadcasts the SSE `turn_complete` event the dashboard transcript subscribes to — so **both** the metrics and the live transcript share that dropped path (one root cause, not two bugs).

## Symptoms (real Twilio + Deepgram + Cerebras + Inworld pipeline call)
- Dashboard LATENCY panel all `—` / `0 ms`; COST panel empty per turn.
- Transcript only appears **after** the call ends, not live.
- Only one `[event] metrics` fired (turn 0 = `firstMessage`); the real user turns emitted `transcript` but no `metrics`.
- `call_end` `metrics.turns` had a single element despite 8 transcript entries.

## Fix
Clear the guard in `anchorUserSpeechStart()`, mirroring what `startTurn()` already does:
- `libraries/typescript/src/metrics.ts` → `this._turnAlreadyClosed = false;`
- `libraries/python/getpatter/services/metrics.py` → `self._turn_already_closed = False`

**Safe**: `anchorUserSpeechStart()` no-ops once the turn is committed (`_turnCommittedMono`/`_turn_committed_mono` guard), so the flag is only re-armed at the start of a fresh, uncommitted turn — never the post-commit barge-in path the guard protects.

## Breaking change?
No. Internal metrics-accumulator fix, no public API change.

## Versioning
**No version bump** — lands under `## Unreleased` → `### Fixed`. Release rolls it into the next version later (not blocking). (`package-lock.json` `version` synced 0.6.2 → 0.6.3 to match `package.json` on main — stale lockfile, not a bump.)

## Test plan
- [x] New `metrics-turn-rearm` tests (TS + Python) — **fail before** the fix (`recordTurnComplete` returns null), **pass after**.
- [x] Python: `pytest tests/ -m "not soak"` → **1940 passed**.
- [x] TypeScript: `npm test` → **1555 passed**; `npm run lint` + `npm run build` clean.
- [x] Parity: identical one-line fix + symmetric tests in both SDKs.