### PR TITLE
docs: fix dangling per-library CLAUDE.md references to point at AGENTS.md / CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ docs/                         Mintlify docs site
 scripts/pr-validate.sh        Local mirror of PR-blocking CI
 ```
 
-Per-library quickstarts: `libraries/python/CLAUDE.md` and
-`libraries/typescript/CLAUDE.md` (local, not published — but worth reading if
-present in your checkout).
+Per-library quickstarts (committed alongside each SDK):
+`libraries/python/CLAUDE.md` and `libraries/typescript/CLAUDE.md` — read the one
+for the SDK you're touching.
 
 ## Commits & PRs
 

--- a/libraries/python/CLAUDE.md
+++ b/libraries/python/CLAUDE.md
@@ -14,19 +14,23 @@ libraries/python/
 └── getpatter/              # the published package (`pip install getpatter`)
     ├── __init__.py
     ├── client.py           # Patter entry point
+    ├── cli.py              # `getpatter` console-script entry point
+    ├── local_config.py     # LocalOptions + local-mode config
     ├── models.py           # public dataclasses (frozen=True)
     ├── exceptions.py       # PatterError + ErrorCode enum
     ├── pricing.py          # PricingUnit enum + provider price tables
     ├── server.py           # FastAPI app
     ├── stream_handler.py   # per-call orchestrator
-    ├── telephony/          # Twilio + Telnyx adapters (twilio.py / telnyx.py / common.py)
+    ├── telephony/          # Twilio + Telnyx + Plivo adapters (twilio.py / telnyx.py / plivo.py / common.py)
+    ├── carriers/           # carrier classes (twilio.py / telnyx.py / plivo.py)
     ├── audio/              # transcoding, pcm_mixer, background_audio
     ├── tools/              # tool_decorator, tool_executor
-    ├── providers/          # voice / LLM / STT / TTS providers
+    ├── providers/          # voice / LLM / STT / TTS provider adapters
     ├── services/           # llm_loop, metrics, sentence_chunker, text_transforms, ivr, ...
     ├── observability/      # event_bus + OTel tracing
+    ├── evals/ engines/ integrations/   # eval runner, engines, external integrations
     ├── dashboard/
-    ├── tts/ stt/           # public namespaces (env-var auto-resolve)
+    ├── llm/ tts/ stt/      # public provider namespaces (env-var auto-resolve)
     └── ...
 ```
 
@@ -45,7 +49,7 @@ pip install -e ".[dev]"                # editable install for development
 - pytest with `asyncio_mode = "auto"` — write `async def test_*`, no decorator needed.
 - Public dataclasses are `@dataclass(frozen=True)`. Tuples, not lists.
 - Async I/O everywhere. `httpx.AsyncClient`, `websockets.connect`. No `time.sleep`.
-- Logger: `logging.getLogger("patter")` — never `print()`.
+- Logger: `logging.getLogger("getpatter")` — never `print()`. Sub-namespaces like `getpatter.providers.deepgram_stt` are used per-module.
 - New config fields are optional with safe defaults (backward compat).
 - Authentic tests: mock only at paid/external boundary, tag `@pytest.mark.mocked`.
 

--- a/libraries/python/CLAUDE.md
+++ b/libraries/python/CLAUDE.md
@@ -1,6 +1,6 @@
 # Python SDK — agent quickstart
 
-This file is the per-library guide for AI agents working in `libraries/python/`. For repo-wide rules, see the root `CLAUDE.md` and `.claude/rules/`.
+This file is the per-library guide for AI agents working in `libraries/python/`. For repo-wide rules, see [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## Layout
 

--- a/libraries/typescript/CLAUDE.md
+++ b/libraries/typescript/CLAUDE.md
@@ -1,6 +1,6 @@
 # TypeScript SDK — agent quickstart
 
-This file is the per-library guide for AI agents working in `libraries/typescript/`. For repo-wide rules, see the root `CLAUDE.md` and `.claude/rules/`.
+This file is the per-library guide for AI agents working in `libraries/typescript/`. For repo-wide rules, see [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## Layout
 

--- a/libraries/typescript/CLAUDE.md
+++ b/libraries/typescript/CLAUDE.md
@@ -22,14 +22,15 @@ libraries/typescript/
     ├── pricing.ts          # PricingUnit + provider price tables
     ├── server.ts           # Express app
     ├── stream-handler.ts   # per-call lifecycle
-    ├── telephony/          # Twilio + Telnyx adapters (twilio.ts / telnyx.ts)
+    ├── telephony/          # Twilio + Telnyx + Plivo adapters (twilio.ts / telnyx.ts / plivo.ts)
+    ├── carrier-config.ts   # carrier audio/format config
     ├── audio/              # transcoding, background-audio
     ├── tools/              # tool-decorator
-    ├── providers/          # voice / LLM / STT / TTS providers
+    ├── providers/          # voice / LLM / STT / TTS provider adapters
     ├── services/           # call-log, ivr (mostly top-level files in src/)
     ├── observability/
     ├── dashboard/
-    ├── tts/ stt/           # public namespaces (env-var auto-resolve)
+    ├── llm/ tts/ stt/      # public provider namespaces (env-var auto-resolve)
     └── ...
 ```
 


### PR DESCRIPTION
## Summary

The two tracked per-library agent quickstarts (`libraries/python/CLAUDE.md`, `libraries/typescript/CLAUDE.md`) told agents: *"For repo-wide rules, see the root `CLAUDE.md` and `.claude/rules/`."* Both of those paths are **gitignored** — so for anyone who clones the repo (every external contributor and their AI agent), that's a dead reference pointing at files they don't have.

This points them instead at the **committed** repo-wide guides that already exist on `main`: [`AGENTS.md`](../AGENTS.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md).

## Changes

- `libraries/python/CLAUDE.md` / `libraries/typescript/CLAUDE.md` — line 3 now links to `AGENTS.md` + `CONTRIBUTING.md` (relative `../../`) instead of the gitignored root `CLAUDE.md` / `.claude/rules/`.
- `AGENTS.md` — corrected the "Where things live" note: the per-library `CLAUDE.md` files are **tracked/committed**, not "local, not published".

## Breaking change?

No — documentation only.

## Test plan

- [x] Docs-only change (`.md`), no SDK code touched → no CHANGELOG entry required (refactor/docs exemption).
- [ ] CI green (pre-commit / hygiene).

## Docs updates

- `AGENTS.md`, `libraries/python/CLAUDE.md`, `libraries/typescript/CLAUDE.md`