### PR TITLE
fix(security): patch ws, qs, brace-expansion advisories in the TypeScript SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@
   `libraries/python/getpatter/services/metrics.py`). The post-commit barge-in
   guard is untouched — the method no-ops once the turn is committed.
 
+### Security
+
+- **Bumped vulnerable transitive/runtime dependencies in the TypeScript SDK**
+  (`libraries/typescript/package-lock.json`). `ws` 8.20.0 → 8.21.0 closes an
+  uninitialised-memory disclosure (GHSA-58qx-3vcg-4xpx); `qs` 6.15.1 → 6.15.2
+  (pulled in by `express` / `body-parser`) closes a `qs.stringify` DoS
+  (GHSA-q8mj-m7cp-5q26); `brace-expansion` → 5.0.6 / 2.1.0 closes a regex DoS
+  (GHSA-jxxr-4gwj-5jf2). All within the existing semver ranges — no `package.json`
+  change, no public API change. `npm audit` now reports 0 vulnerabilities for the
+  shipped SDK.
+
 ## 0.6.3 (2026-05-29)
 
 ### Added

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3080,9 +3080,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4195,9 +4195,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- Lockfile-only security bumps in the shipped **TypeScript SDK** (`libraries/typescript`), all within existing semver ranges — no `package.json` change, no public API change.
- `npm audit` for `libraries/typescript` now reports **0 vulnerabilities**.
- Closes **2 of the 4** open Dependabot security alerts (`ws`, `qs`).

## Implementation
- `ws` 8.20.0 → 8.21.0 — uninitialised-memory disclosure ([GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx)). Direct dep, declared `^8.18.0` (unchanged).
- `qs` 6.15.1 → 6.15.2 — `qs.stringify` DoS ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26)). Transitive via `express` / `body-parser` (both accept `^6.14.x`).
- `brace-expansion` → 5.0.6 / 2.1.0 — regex DoS ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)). Transitive.
- Applied via targeted `npm audit fix` (non-`--force`). Files touched: `libraries/typescript/package-lock.json` + `CHANGELOG.md`.

### Why vite/esbuild are NOT in this PR
The other two open alerts (`vite`, `esbuild`) live in **`dashboard-app`** dev tooling, not in any published package. Their only fix path is `npm audit fix --force`, which pulls **vite 5 → 8** (3 major versions) and cascades to `@vitejs/plugin-react`, `vitest` 2 → 3+, `vite-node`, `@vitest/mocker` — a breaking migration. The `esbuild` advisory (GHSA-67mh-4wv8-2f99) affects only the local `vite dev` server, not production builds or shipped artifacts. Deferred to a dedicated dashboard-modernisation PR rather than risk breaking the dashboard build inside a "small security PR".

## Breaking change?
No. Lockfile-only, all bumps within existing caret ranges.

## Test plan
- [x] TypeScript: `npm test` — 89 files, 1555 passed, 8 skipped
- [x] TypeScript: `npm run lint` (`tsc --noEmit`) — clean
- [x] TypeScript: `npm run build` — success (CJS + DTS + CLI)
- [x] `npm audit` (libraries/typescript) — 0 vulnerabilities
- [ ] Python: N/A (no Python change)
- [ ] /parity-check: N/A (no public API change)

## Docs updates
N/A