### PR TITLE
docs(readme): simplify to About / How It Works / Quickstart / Skills / Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,85 +17,62 @@
 </p>
 
 <p align="center">
+  <a href="#about">About</a> •
+  <a href="#how-it-works">How It Works</a> •
+  <a href="#documentation">Documentation</a> •
   <a href="#quickstart">Quickstart</a> •
   <a href="#skills-for-coding-agents">Skills</a> •
-  <a href="#features">Features</a> •
-  <a href="#templates">Templates</a> •
-  <a href="#configuration">Configuration</a> •
-  <a href="https://docs.getpatter.com">Docs</a>
+  <a href="#templates">Templates</a>
 </p>
 
 ---
 
-Patter is the open-source SDK that gives your AI agent a phone number. Point it at any function that returns a string, and Patter handles the rest: telephony, speech-to-text, text-to-speech, and real-time audio streaming. You build the agent — we connect it to the phone.
+## About
+
+**Patter** is the open-source SDK that gives your AI agent a phone number. You build the agent; Patter handles everything between it and the phone network — the agent loop, the language model, speech-to-text, text-to-speech, real-time voice, audio processing, and the telephony carrier.
+
+- **Build** with one API in [Python](https://pypi.org/project/getpatter/) or [TypeScript](https://www.npmjs.com/package/getpatter) — same surface, same hooks, same events, at full parity.
+- **Choose** the provider for every layer — LLM, STT, TTS, realtime engine, carrier — and swap any of them with one line.
+- **Run** locally with a built-in tunnel and dashboard, or simulate a whole call from your terminal — no phone required.
+
+## How It Works
+
+Patter is the **full voice stack** between your application and the phone network — not just glue between an LLM and a carrier. It runs the agent loop and owns every layer of the call, and **you pick the provider for each one**. Compose them in **Realtime**, **Pipeline**, or **Hybrid** mode.
+
+> **27+ provider integrations across the voice stack · 3 voice modes · 2 SDKs (Python & TypeScript) at parity.**
+
+| Layer | Choose from |
+|---|---|
+| **LLM** — text generation | OpenAI · Anthropic · Google Gemini · Groq · Cerebras |
+| **STT** — speech-to-text | Deepgram · AssemblyAI · Cartesia · Soniox · Speechmatics · Whisper |
+| **TTS** — text-to-speech | ElevenLabs · OpenAI · Cartesia · LMNT · Rime · Telnyx |
+| **Realtime** — all-in-one voice | OpenAI Realtime · Gemini Live · Ultravox · ElevenLabs ConvAI |
+| **Telephony** — phone carriers | Twilio · Telnyx · Plivo |
+| **Audio** — VAD & suppression | Silero VAD · Krisp · DeepFilterNet |
+
+On top of the stack: an automatic **LLM fallback chain** (provider failover mid-call), built-in **tools / call transfer / guardrails** that behave identically on every carrier, and a vendor-neutral **OpenTelemetry** trace of each call.
+
+## Documentation
+
+Visit the [docs](https://docs.getpatter.com), or jump straight to a quickstart: [TypeScript](#typescript) · [Python](#python).
+
+## Skills for Coding Agents
+
+> Using Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor, Codex, or another AI coding agent?
+>
+> **[Install Patter skills for voice agents →](https://www.skills.sh/patterai/skills)**
+
+```bash
+npx skills add patterai/skills
+```
+
+The bundle works in ~55 agent harnesses that consume the [Anthropic Agent Skills](https://agentskills.io) standard. Install once; every agent on your machine learns the SDK. Skills live in their own repository: **[`PatterAI/skills`](https://github.com/PatterAI/skills)**.
 
 ## Quickstart
 
-Set the env vars your carrier and engine need:
+Provider and carrier credentials are read from environment variables (e.g. `TWILIO_ACCOUNT_SID`, `OPENAI_API_KEY`) — the [docs](https://docs.getpatter.com) list the full catalog. Swap `Twilio` for `Telnyx` or `Plivo` to change carrier.
 
-**Twilio**
-
-```bash
-export TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-export TWILIO_AUTH_TOKEN=your_auth_token
-export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-**Telnyx**
-
-```bash
-export TELNYX_API_KEY=KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-export TELNYX_CONNECTION_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-**Plivo**
-
-```bash
-export PLIVO_AUTH_ID=MAxxxxxxxxxxxxxxxxxx
-export PLIVO_AUTH_TOKEN=your_auth_token
-export OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-<details open>
-<summary><strong>Python</strong></summary>
-
-```bash
-pip install getpatter
-```
-
-```python
-from getpatter import Patter, Twilio, OpenAIRealtime
-
-phone = Patter(carrier=Twilio(), phone_number="+15550001234")
-agent = phone.agent(engine=OpenAIRealtime(), system_prompt="You are a friendly receptionist for Acme Corp.", first_message="Hello! How can I help?")
-await phone.serve(agent, tunnel=True)
-```
-
-Or with **Telnyx**:
-
-```python
-from getpatter import Patter, Telnyx, OpenAIRealtime
-
-phone = Patter(carrier=Telnyx(), phone_number="+15550001234")
-agent = phone.agent(engine=OpenAIRealtime(), system_prompt="You are a friendly receptionist for Acme Corp.", first_message="Hello! How can I help?")
-await phone.serve(agent, tunnel=True)
-```
-
-Or with **Plivo**:
-
-```python
-from getpatter import Patter, Plivo, OpenAIRealtime
-
-phone = Patter(carrier=Plivo(), phone_number="+15550001234")
-agent = phone.agent(engine=OpenAIRealtime(), system_prompt="You are a friendly receptionist for Acme Corp.", first_message="Hello! How can I help?")
-await phone.serve(agent, tunnel=True)
-```
-
-</details>
-
-<details>
-<summary><strong>TypeScript</strong></summary>
+### TypeScript
 
 ```bash
 npm install getpatter
@@ -105,95 +82,37 @@ npm install getpatter
 import { Patter, Twilio, OpenAIRealtime } from "getpatter";
 
 const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
-const agent = phone.agent({ engine: new OpenAIRealtime(), systemPrompt: "You are a friendly receptionist for Acme Corp.", firstMessage: "Hello! How can I help?" });
+const agent = phone.agent({
+  engine: new OpenAIRealtime(),
+  systemPrompt: "You are a friendly receptionist for Acme Corp.",
+  firstMessage: "Hello! How can I help?",
+});
 await phone.serve({ agent, tunnel: true });
 ```
 
-Or with **Telnyx**:
+### Python
 
-```typescript
-import { Patter, Telnyx, OpenAIRealtime } from "getpatter";
-
-const phone = new Patter({ carrier: new Telnyx(), phoneNumber: "+15550001234" });
-const agent = phone.agent({ engine: new OpenAIRealtime(), systemPrompt: "You are a friendly receptionist for Acme Corp.", firstMessage: "Hello! How can I help?" });
-await phone.serve({ agent, tunnel: true });
+```bash
+pip install getpatter
 ```
 
-Or with **Plivo**:
+```python
+from getpatter import Patter, Twilio, OpenAIRealtime
 
-```typescript
-import { Patter, Plivo, OpenAIRealtime } from "getpatter";
-
-const phone = new Patter({ carrier: new Plivo(), phoneNumber: "+15550001234" });
-const agent = phone.agent({ engine: new OpenAIRealtime(), systemPrompt: "You are a friendly receptionist for Acme Corp.", firstMessage: "Hello! How can I help?" });
-await phone.serve({ agent, tunnel: true });
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+agent = phone.agent(
+    engine=OpenAIRealtime(),
+    system_prompt="You are a friendly receptionist for Acme Corp.",
+    first_message="Hello! How can I help?",
+)
+await phone.serve(agent, tunnel=True)
 ```
 
-</details>
-
-`tunnel: true` spawns a Cloudflare quick tunnel and points your Twilio number at it — great for dev / acceptance. For production outbound calls (especially on Twilio), replace it with [ngrok](https://ngrok.com) or a static `webhook_url` to avoid WSS upgrade races on first call. See [Tunneling](/docs/dev-tools/tunneling) for details.
-
-Every carrier and provider reads its credentials from environment variables by default; see each SDK's README for the full catalog.
-
-## How Patter compares
-
-Patter is purpose-built for production voice over real telephony. Out of the box you get **Twilio + Telnyx + Plivo parity** (DTMF, transfer, AMD, voicemail drop, recording), **both architectures from one API** — speech-to-speech (Realtime / ConvAI engines) and the sandwich pipeline (STT → LLM → TTS) — and **production-grade barge-in / VAD / IVR primitives** that work the same on every carrier. Observability is vendor-neutral OpenTelemetry tracing, plus a built-in dashboard and tunnel; no extra collector required. The 4-line quickstart above replaces ~50 lines of glue you'd otherwise write against a generic voice-agent toolkit, and the **Python and TypeScript SDKs are identical** — same surface, same hooks, same events — so cross-runtime teams ship the same agent twice without rewriting it.
-
-## Features
-
-| Feature | Method | Template |
-|---|---|---|
-| Inbound calls | `phone.serve(agent)` | [patter-inbound-agent](https://github.com/PatterAI/patter-inbound-agent) |
-| Outbound calls + AMD | `phone.call(to, machineDetection)` | [patter-outbound-calls](https://github.com/PatterAI/patter-outbound-calls) |
-| Tool calling (webhooks) | `agent(tools=[...])` | [patter-tool-calling](https://github.com/PatterAI/patter-tool-calling) |
-| Custom STT + TTS | `agent(provider="pipeline")` | [patter-custom-voice](https://github.com/PatterAI/patter-custom-voice) |
-| Dynamic variables | `agent(variables={...})` | [patter-dynamic-variables](https://github.com/PatterAI/patter-dynamic-variables) |
-| Custom LLM (any model) | `serve(onMessage=handler)` | [patter-custom-llm](https://github.com/PatterAI/patter-custom-llm) |
-| Dashboard + metrics | `serve(dashboard=True)` | [patter-dashboard](https://github.com/PatterAI/patter-dashboard) |
-| Output guardrails | `agent(guardrails=[...])` | [docs](https://docs.getpatter.com) |
-| Call recording | `serve(recording=True)` | [docs](https://docs.getpatter.com) |
-| Call transfer | `transfer_call` (auto-injected) | [docs](https://docs.getpatter.com) |
-| Voicemail drop | `call(voicemailMessage="...")` | [patter-outbound-calls](https://github.com/PatterAI/patter-outbound-calls) |
-| Test mode (no phone) | `phone.test(agent)` | [docs](https://docs.getpatter.com) |
-| Built-in tunnel | Cloudflare (auto) | [docs](https://docs.getpatter.com) |
-| Phone-as-a-tool (LangChain / OpenAI Assistants / Hermes) | `PatterTool(phone, agent).execute(...)` | [docs](https://docs.getpatter.com) |
-
-## How It Works
-
-> **From code to phone call** — Your AI agent connects to real phone calls through the Patter SDK.
-
-<table>
-<tr>
-<th align="center">AI Agents</th>
-<th align="center"></th>
-<th align="center">Patter SDK</th>
-<th align="center"></th>
-<th align="center">Phone Calls</th>
-</tr>
-<tr>
-<td align="center">
-  <strong>ChatGPT</strong><br><sub>OpenAI</sub><br><br>
-  <strong>Claude</strong><br><sub>Anthropic</sub><br><br>
-  <strong>Your AI Agent</strong><br><sub><code>on_message</code></sub>
-</td>
-<td align="center">→</td>
-<td align="center">
-  <strong>Patter SDK</strong><br>
-  <em>Connect any AI to any phone</em><br><br>
-  <code>STT</code> · <code>TTS</code> · <code>WebSocket</code>
-</td>
-<td align="center">→</td>
-<td align="center">
-  <strong>Twilio</strong><br><sub>Telephony</sub><br><br>
-  <strong>Telnyx</strong><br><sub>Telephony</sub><br><br>
-  <strong>Plivo</strong><br><sub>Telephony</sub>
-</td>
-</tr>
-</table>
+`tunnel: true` spawns a Cloudflare quick tunnel and points your number at it — ideal for local dev. For production, use a static `webhook_url` (or [ngrok](https://ngrok.com)); see [Tunneling](https://docs.getpatter.com).
 
 ## Templates
 
-Each template is a self-contained repo — clone, add your `.env`, and run. Both Python and TypeScript included.
+Each template is a self-contained repo — clone, add your `.env`, and run. Python and TypeScript both included.
 
 | Template | Description | Repo |
 |---|---|---|
@@ -202,164 +121,16 @@ Each template is a self-contained repo — clone, add your `.env`, and run. Both
 | **Tool Calling** | CRM lookup + ticket creation via webhook tools | [patter-tool-calling](https://github.com/PatterAI/patter-tool-calling) |
 | **Custom Voice** | Pipeline mode: Deepgram STT + ElevenLabs TTS | [patter-custom-voice](https://github.com/PatterAI/patter-custom-voice) |
 | **Dynamic Variables** | Personalize prompts per caller using CRM data | [patter-dynamic-variables](https://github.com/PatterAI/patter-dynamic-variables) |
-| **Custom LLM** | Bring your own model (Claude, Mistral, LLaMA) | [patter-custom-llm](https://github.com/PatterAI/patter-custom-llm) |
+| **Custom LLM** | Bring your own model | [patter-custom-llm](https://github.com/PatterAI/patter-custom-llm) |
 | **Dashboard** | Real-time monitoring with cost + latency tracking | [patter-dashboard](https://github.com/PatterAI/patter-dashboard) |
 | **Production Setup** | Everything enabled: tools, guardrails, recording, dashboard | [patter-production](https://github.com/PatterAI/patter-production) |
 
 ```bash
-# Example: clone and run the inbound agent template
 git clone https://github.com/PatterAI/patter-inbound-agent
 cd patter-inbound-agent
 cp .env.example .env    # fill in your keys
 cd python && pip install -r requirements.txt && python main.py
 ```
-
-## Skills for Coding Agents
-
-> Using Claude Code, Claude Desktop, OpenClaw, Hermes, Cursor, Codex, or other AI coding agents?
->
-> **[Install Patter skills for voice agents →](https://www.skills.sh/patterai/skills)**
-
-```bash
-# Install all five skills (recommended)
-npx skills add patterai/skills
-
-# Or install one
-npx skills add patterai/skills --skill build-voice-agent
-```
-
-The bundle works in **~55 agent harnesses** that consume the
-[Anthropic Agent Skills](https://agentskills.io) standard — Claude Code,
-Claude Desktop, OpenClaw, Hermes Agent, Cursor, GitHub Copilot, Codex, Cline,
-Crush, Goose, Amp, Antigravity, and more. Install once; every agent on your
-machine learns the SDK.
-
-| Skill | What it teaches the agent |
-|---|---|
-| [`setup-patter`](https://github.com/PatterAI/skills/tree/main/setup-patter) | Install Patter, walk the user through provider/carrier consoles, validate each API key, write `.env` |
-| [`build-voice-agent`](https://github.com/PatterAI/skills/tree/main/build-voice-agent) | Build a voice agent — Realtime / ConvAI / Pipeline modes, with full Python and TypeScript examples |
-| [`configure-telephony`](https://github.com/PatterAI/skills/tree/main/configure-telephony) | Twilio, Telnyx, or Plivo carrier setup — phone numbers, webhooks, tunnels, AMD, voicemail drop |
-| [`add-tools-and-handoffs`](https://github.com/PatterAI/skills/tree/main/add-tools-and-handoffs) | Custom tools, `transfer_call`, `end_call`, output guardrails |
-| [`inspect-calls-and-metrics`](https://github.com/PatterAI/skills/tree/main/inspect-calls-and-metrics) | Live dashboard, `CallMetrics`, cost tracking, CSV/JSON export |
-
-Skills live in a dedicated repository: **[`PatterAI/skills`](https://github.com/PatterAI/skills)**.
-
-Pin to an SDK version for reproducibility:
-
-```bash
-npx skills add patterai/skills#v0.6.2 --skill build-voice-agent
-```
-
-Pages on [skills.sh](https://www.skills.sh/patterai/skills) update automatically
-via install telemetry — no submission required.
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Required | Description |
-|---|---|---|
-| `OPENAI_API_KEY` | Yes (Realtime mode) | OpenAI API key with Realtime access |
-| `TWILIO_ACCOUNT_SID` | Yes | Twilio account SID |
-| `TWILIO_AUTH_TOKEN` | Yes | Twilio auth token |
-| `TWILIO_PHONE_NUMBER` | Yes | Your Twilio phone number (E.164) |
-| `TELNYX_API_KEY` | Yes (Telnyx) | Telnyx API key |
-| `TELNYX_CONNECTION_ID` | Yes (Telnyx) | Telnyx Call Control Application connection ID |
-| `TELNYX_PHONE_NUMBER` | Yes (Telnyx) | Your Telnyx phone number (E.164) |
-| `PLIVO_AUTH_ID` | Yes (Plivo) | Plivo Auth ID (also the V3 webhook signature account) |
-| `PLIVO_AUTH_TOKEN` | Yes (Plivo) | Plivo Auth Token (Basic auth + V3 webhook signature key) |
-| `PLIVO_PHONE_NUMBER` | Yes (Plivo) | Your Plivo phone number (E.164) |
-| `DEEPGRAM_API_KEY` | Pipeline mode | Deepgram STT key |
-| `ELEVENLABS_API_KEY` | Pipeline mode | ElevenLabs TTS key |
-| `ANTHROPIC_API_KEY` | Custom LLM | For bringing your own model |
-| `WEBHOOK_URL` | No | Public URL (auto-tunneled via Cloudflare if omitted) |
-
-```bash
-cp .env.example .env
-# Edit .env with your API keys
-```
-
-> **Telnyx:** Telnyx is a fully supported telephony provider alternative to Twilio. Both carriers receive equal support for DTMF, transfer, and metrics. Recording parity is supported via Telnyx Call Control; consult the Telnyx portal for configuration details.
-
-### Docker
-
-```bash
-docker compose up
-```
-
-See [`Dockerfile`](./Dockerfile) and [`docker-compose.yml`](./docker-compose.yml) for the default configuration.
-
-## Voice Modes
-
-| Mode | Quality | Best For |
-|---|---|---|
-| **OpenAI Realtime** (`engine=OpenAIRealtime()`) | High | Fluid, low-latency conversations |
-| **ElevenLabs ConvAI** (`engine=ElevenLabsConvAI()`) | High | ElevenLabs-managed conversation flow |
-| **Pipeline** (`stt=DeepgramSTT(), tts=ElevenLabsTTS()`) | High | Independent control over STT / LLM / TTS |
-
-Pipeline mode composes STT + LLM + TTS sequentially and inherits the latency of each provider plus the endpointing window. For the fastest turn UX pick `engine=OpenAIRealtime()`, or pair the pipeline with low-latency providers such as Cerebras/Groq for the LLM and ElevenLabs Turbo v2.5 for TTS.
-
-### Provider Notes
-
-- **ElevenLabs free tier** — the library voice catalog is not reachable via API (`402 Payment Required`). Set `ELEVENLABS_VOICE_ID` to a voice you own (cloned or generated) before `phone.serve()`. The SDK resolves ~45 well-known names (`"rachel"`, `"adam"`, …) to their UUIDs automatically; custom voices must be referenced by ID.
-- **Telnyx outbound** — calls will return `403 D38` until your connection has an "Outbound Profile" attached in the Telnyx portal. Inbound and Call Control answer flows work without it.
-- **Google Gemini free tier** — `gemini-2.0-flash` has a hard `quota=0` on the free tier. Enable billing on the project before using Gemini as the LLM.
-- **Whisper STT** — on mulaw 8 kHz inputs Whisper routinely hallucinates short fillers (`"you"`, `"."`, `"thank you"`). The pipeline drops these by default plus any duplicate / sub-500 ms back-to-back final, so you won't hear overlapping turns. For production prefer `OpenAITranscribeSTT` (`gpt-4o-transcribe`) — same `OPENAI_API_KEY`, ~10× faster, no hallucination floor.
-- **Model IDs** — keep these updated per vendor release notes. Examples currently in use: `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5`, `llama-3.3-70b-versatile` (Groq), `gpt-oss-120b` (Cerebras default — pass `model="llama3.1-8b"` for the smaller free-tier alternative).
-
-## API Reference
-
-### `Patter` (Python & TypeScript)
-
-| Method | Description |
-|---|---|
-| `Patter(carrier=Twilio(), phone_number, ...)` | Create client bound to a carrier and phone number |
-| `agent(engine=..., system_prompt, first_message?, tools?, ...)` | Create an agent configuration |
-| `serve(agent, port?, tunnel?, dashboard?, ...)` | Start the embedded server and listen for calls |
-| `call(to, agent?, machine_detection?, voicemail_message?, ring_timeout?, ...)` | Place an outbound call |
-
-`call()` accepts a `ring_timeout` (seconds) that maps to Twilio's `Timeout` dial parameter, Telnyx's `timeout_secs`, and Plivo's `ring_timeout`. When the carrier reports `no-answer`, `busy`, or `canceled`, the outcome is forwarded to the dashboard via the per-carrier status callback (`/webhooks/twilio/status`, `/webhooks/plivo/status`, or Telnyx's `call.hangup` event) so it appears in the call log even if no media frames were ever exchanged.
-
-**`serve()` options:**
-
-| Option | Type | Description |
-|---|---|---|
-| `agent` | `Agent` | Agent configuration to use for calls |
-| `port` | `int` | Port to listen on (default: 8000) |
-| `dashboard` | `bool` | Enable the built-in monitoring dashboard |
-| `recording` | `bool` | Enable call recording via the telephony provider |
-| `onCallStart` | `callable` | Called when a call connects |
-| `onCallEnd` | `callable` | Called when a call ends with transcript and metrics |
-| `onTranscript` | `callable` | Called on each transcript turn |
-
-**`agent()` options:**
-
-| Option | Type | Description |
-|---|---|---|
-| `system_prompt` | `str` | Prompt with optional `{variable}` placeholders |
-| `variables` | `dict` | Values substituted into prompts |
-| `voice` | `str` | TTS voice name |
-| `first_message` | `str` | Opening message (supports `{variable}` placeholders) |
-| `tools` | `list` | Tool definitions with `name`, `description`, `parameters`, `webhook_url` |
-| `guardrails` | `list` | Output guardrail rules |
-
-## Contributing
-
-Pull requests are welcome.
-
-```bash
-# Python SDK
-cd libraries/python && pip install -e ".[dev]" && pytest tests/ -v
-
-# TypeScript SDK
-cd libraries/typescript && npm install && npm test
-```
-
-Please open an issue before submitting large changes so we can discuss the approach first.
-
-## License
-
-MIT — see [LICENSE](./LICENSE).
 
 ## Star History
 
@@ -378,3 +149,7 @@ Thanks to all our amazing contributors!
 <a href="https://github.com/PatterAI/Patter/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=PatterAI/Patter" />
 </a>
+
+## License
+
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Simplify the README to the same shape as our reference layout now that the consult work has merged (#148).

- **New structure**: About → How It Works → Documentation → Skills → Quickstart (TypeScript, then Python) → Templates → Star History → Contributors → License.
- **Removed**: "How Patter compares", Features, Configuration, Docker, Provider Notes, API Reference, Voice Modes, and the per-provider `export ...` env blocks in the quickstart.
- **Reframed How It Works**: Patter is the full voice stack — LLM / STT / TTS / Realtime / Telephony / Audio with a swappable provider per layer — instead of reading as just STT/TTS/WebSocket glue. Adds the per-layer provider grid (27+ integrations · 3 voice modes · 2 SDKs at parity).
- Quickstart now shows one carrier with a swap note, and reads credentials from env vars (no inline secrets).

## Breaking change?

No — documentation only.

## Test plan

- [x] Renders as GitHub-flavored Markdown; nav anchors resolve to headings; verified no removed sections remain and no `export` secret blocks left.

## Docs updates

- `README.md` only.
