### PR TITLE
docs(integrations): set up patter-mcp via local clone, not npx

### DIFF
--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -19,23 +19,21 @@ Pick one direction or wire up both — they are independent.
 
 ## Prerequisites
 
-Install the Patter SDK and the Patter MCP server:
+Patter's MCP server runs **locally** — it is not published to npm or PyPI. Clone and
+build it from [`PatterAI/patter-mcp`](https://github.com/PatterAI/patter-mcp):
 
 ```bash
-# Python SDK
-pip install getpatter
-
-# TypeScript SDK
-npm install getpatter
-
-# Patter MCP server (run it, or let Hermes launch it on demand)
-npx getpatter-mcp
+git clone https://github.com/PatterAI/patter-mcp
+cd patter-mcp
+npm install
+npm run build
+npm start          # Streamable HTTP on http://localhost:3000/mcp
 ```
 
-By default the MCP server speaks Streamable HTTP at `http://localhost:3000/mcp`.
 It can also run over stdio (see Direction A below). Provider and carrier keys are
-read from the environment: `OPENAI_API_KEY`, `ELEVENLABS_API_KEY`,
+read from the server's environment: `OPENAI_API_KEY`, `ELEVENLABS_API_KEY`,
 `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TELNYX_API_KEY`, and friends.
+See the [patter-mcp README](https://github.com/PatterAI/patter-mcp#readme) for full setup.
 
 ---
 
@@ -49,8 +47,8 @@ Register the Patter MCP server under the top-level `mcp_servers` key in
 
 ### HTTP recipe
 
-Run the MCP server (`npx getpatter-mcp`) so it is listening on
-`http://localhost:3000/mcp`, then point Hermes at it:
+With the server running locally (`npm start`) on
+`http://localhost:3000/mcp`, point Hermes at it:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -73,16 +71,17 @@ mcp_servers:
 
 ### stdio recipe
 
-Prefer to let Hermes spawn the server itself? Launch it over stdio with the
-`--stdio` flag and pass the provider keys through `env`:
+Prefer to let Hermes spawn the server itself? Point it at your local build
+(`patter-mcp/dist/index.js` from the clone above) with the `--stdio` flag and pass
+the provider keys through `env`:
 
 ```yaml
 # ~/.hermes/config.yaml
 mcp_servers:
   patter:
-    command: "npx"
+    command: "node"
     args:
-      - "getpatter-mcp"
+      - "/absolute/path/to/patter-mcp/dist/index.js"
       - "--stdio"
     env:
       OPENAI_API_KEY: "${OPENAI_API_KEY}"

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -23,26 +23,20 @@ agent calls back into OpenClaw when it needs deeper reasoning.
 
 ## Prerequisites
 
-Install Patter and run the MCP server. Either SDK works — the MCP server is the same
-binary regardless of which SDK you build agents with.
+Patter's MCP server runs **locally** — it is not published to npm or PyPI. Clone and
+build it from [`PatterAI/patter-mcp`](https://github.com/PatterAI/patter-mcp):
 
 ```bash
-# Python
-pip install getpatter
-
-# TypeScript
-npm install getpatter
+git clone https://github.com/PatterAI/patter-mcp
+cd patter-mcp
+npm install
+npm run build
+npm start          # Streamable HTTP on http://localhost:3000/mcp
 ```
 
-```bash
-# Run the Patter MCP server (Streamable HTTP on :3000 by default)
-npx getpatter-mcp
-```
-
-The server is hosted at [`PatterAI/patter-mcp`](https://github.com/PatterAI/patter-mcp)
-and listens on `http://localhost:3000/mcp`. Provider and carrier keys
-(`OPENAI_API_KEY`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TELNYX_API_KEY`, …) are
-read from the server's environment.
+Provider and carrier keys (`OPENAI_API_KEY`, `TWILIO_ACCOUNT_SID`,
+`TWILIO_AUTH_TOKEN`, `TELNYX_API_KEY`, …) are read from the server's environment.
+See the [patter-mcp README](https://github.com/PatterAI/patter-mcp#readme) for full setup.
 
 ## Direction A — OpenClaw places calls via Patter
 
@@ -51,7 +45,7 @@ OpenClaw reads MCP servers from `~/.openclaw/openclaw.json` (JSON5) under
 
 ### Option 1 — Streamable HTTP (server already running)
 
-This connects to the `npx getpatter-mcp` process from the prerequisites.
+This connects to the locally-running `patter-mcp` server from the prerequisites (`npm start`).
 
 ```json5
 {
@@ -81,16 +75,17 @@ This connects to the `npx getpatter-mcp` process from the prerequisites.
 
 ### Option 2 — stdio (OpenClaw launches the server)
 
-Let OpenClaw spawn the server itself over stdio. The `--stdio` flag switches the
-binary from its default HTTP transport to stdio.
+Let OpenClaw spawn the server itself over stdio, pointing at your local build
+(`patter-mcp/dist/index.js` from the clone above). The `--stdio` flag switches it
+from the default HTTP transport to stdio.
 
 ```json5
 {
   mcp: {
     servers: {
       patter: {
-        command: "npx",
-        args: ["getpatter-mcp", "--stdio"],
+        command: "node",
+        args: ["/absolute/path/to/patter-mcp/dist/index.js", "--stdio"],
         timeout: 120,
         toolFilter: {
           include: [


### PR DESCRIPTION
## Summary

`getpatter-mcp` is **not published to a package registry** — MCP servers run from a local clone. The OpenClaw and Hermes integration guides told users to `npx getpatter-mcp`, which does not work. Point them at the repo instead.

- **Prerequisites**: `git clone https://github.com/PatterAI/patter-mcp && cd patter-mcp && npm install && npm run build`, then `npm start` (Streamable HTTP on `http://localhost:3000/mcp`).
- **stdio recipe**: the MCP client spawns the local build — `command: "node"`, `args: ["/absolute/path/to/patter-mcp/dist/index.js", "--stdio"]` (was `command: "npx", args: ["getpatter-mcp", "--stdio"]`).

## Why this is a separate PR

The fix was authored on the `docs/readme-simplify` branch, but PR #149 merged with only the README-simplification commit before this guide fix was pushed — so it never reached `main`. This PR carries just the two guide files.

## Breaking change?

No — documentation only.

## Test plan

- [x] No `npx getpatter-mcp` references remain in either guide; the clone-and-run instructions are present.
- [x] No bare `<url>` autolinks (MDX v3 safe).

## Docs updates

- `docs/integrations/openclaw.mdx`, `docs/integrations/hermes.mdx`
