### PR TITLE
fix(security): fail-closed dashboard when exposed beyond loopback without auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,49 @@
 ## Unreleased
 
+### Security
+
+- **⚠️ Behavior change — the built-in metrics dashboard now FAILS CLOSED when it
+  would be reachable beyond `127.0.0.1` without a token.** The embedded server
+  no longer mounts the dashboard UI *or* the `/api/*` call-data routes when ALL
+  of the following hold: the dashboard is enabled, no `dashboard_token` /
+  `dashboardToken` is set, AND the server is reachable off-host (a tunnel is
+  active, an explicit public `webhook_url` / `webhookUrl` is configured, or
+  `PATTER_BIND_HOST` is set to a non-loopback address). Those routes serve call
+  transcripts and metadata (PII), so previously this configuration silently
+  published them to anyone who could reach the URL — the SDK only emitted a
+  soft warning, a foot-gun that was easy to miss in a tunnelled demo or a
+  containerised deploy. The gate now refuses to serve them and logs an `error`
+  explaining how to fix it. Loopback-only local dev is unchanged (still served
+  unauthenticated); setting a token serves them behind auth as before. The
+  carrier webhook, media-stream, and `/health` routes always mount, so inbound
+  and outbound calls keep working — only the PII surface is gated.
+  - **Migration** (pick one): set `dashboard_token=<secret>` /
+    `dashboardToken: "<secret>"` to require auth (recommended); set
+    `dashboard=False` / `dashboard: false` to disable it on the exposed host;
+    or set `allow_insecure_dashboard=True` / `allowInsecureDashboard: true` to
+    keep the old unauthenticated-on-a-public-bind behavior (NOT recommended).
+  - `libraries/python/getpatter/server.py`,
+    `libraries/typescript/src/server.ts`.
+
 ### Added
+
+- **`allow_insecure_dashboard` / `allowInsecureDashboard` escape hatch (opt-in,
+  default off).** New optional config on `Patter(...)` (Python) and `serve(...)`
+  `ServeOptions` (TypeScript), defaulting to `False` / `false`. When the new
+  fail-closed dashboard gate (see Security above) would refuse to serve the
+  dashboard on a publicly-reachable bind without a token, setting this to `True`
+  / `true` force-serves the dashboard unauthenticated anyway and logs a
+  `warning` instead of blocking. This preserves the pre-change behavior for
+  operators who deliberately run the dashboard open behind their own network
+  controls (a tailnet, Cloudflare Access, an upstream auth proxy). It is NOT
+  recommended on a public network — prefer a `dashboard_token` /
+  `dashboardToken`. Backward compatible: existing callers that pass no token and
+  are loopback-only are unaffected; the flag only matters on an exposed bind.
+  `libraries/python/getpatter/client.py` /
+  `libraries/python/getpatter/server.py`,
+  `libraries/typescript/src/types.ts` /
+  `libraries/typescript/src/client.ts` /
+  `libraries/typescript/src/server.ts`.
 
 - **OpenAI Realtime input noise reduction — stop speakerphone / room noise from
   cutting the agent off.** New `noise_reduction` on the Realtime engine markers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,25 @@
 
 ### Security
 
-- **⚠️ Behavior change — the built-in metrics dashboard now FAILS CLOSED when it
-  would be reachable beyond `127.0.0.1` without a token.** The embedded server
-  no longer mounts the dashboard UI *or* the `/api/*` call-data routes when ALL
-  of the following hold: the dashboard is enabled, no `dashboard_token` /
-  `dashboardToken` is set, AND the server is reachable off-host (a tunnel is
-  active, an explicit public `webhook_url` / `webhookUrl` is configured, or
-  `PATTER_BIND_HOST` is set to a non-loopback address). Those routes serve call
-  transcripts and metadata (PII), so previously this configuration silently
-  published them to anyone who could reach the URL — the SDK only emitted a
-  soft warning, a foot-gun that was easy to miss in a tunnelled demo or a
-  containerised deploy. The gate now refuses to serve them and logs an `error`
-  explaining how to fix it. Loopback-only local dev is unchanged (still served
-  unauthenticated); setting a token serves them behind auth as before. The
-  carrier webhook, media-stream, and `/health` routes always mount, so inbound
-  and outbound calls keep working — only the PII surface is gated.
-  - **Migration** (pick one): set `dashboard_token=<secret>` /
-    `dashboardToken: "<secret>"` to require auth (recommended); set
-    `dashboard=False` / `dashboard: false` to disable it on the exposed host;
-    or set `allow_insecure_dashboard=True` / `allowInsecureDashboard: true` to
-    keep the old unauthenticated-on-a-public-bind behavior (NOT recommended).
+- **The built-in metrics dashboard is now auto-protected with a generated token
+  when it would be reachable beyond `127.0.0.1`.** The dashboard UI and the
+  `/api/*` call-data routes serve call transcripts and metadata (PII).
+  Previously, when the dashboard was enabled with no `dashboard_token` /
+  `dashboardToken` on an off-host bind (a tunnel is active, an explicit public
+  `webhook_url` / `webhookUrl` is configured, or `PATTER_BIND_HOST` is set to a
+  non-loopback address), the SDK published those routes unauthenticated and only
+  emitted a soft warning — a foot-gun easy to miss in a tunnelled demo or a
+  containerised deploy. Now, in exactly that configuration, the SDK
+  auto-generates a one-time token, mounts the dashboard behind it, and prints
+  the ready-to-use URL (`http://127.0.0.1:<port>/?token=<token>`) in the startup
+  banner. The dashboard remains available with zero config — it is no longer
+  reachable unauthenticated by accident. This is **not a breaking change**: the
+  dashboard is still always served and inbound/outbound calls are unaffected
+  (the carrier webhook, media-stream, and `/health` routes always mount). The
+  token is per-process — set `dashboard_token` / `dashboardToken` for a stable
+  one across restarts. Loopback-only local dev is unchanged (still served open,
+  zero-friction); an explicit `dashboard_token` serves behind that token as
+  before.
   - `libraries/python/getpatter/server.py`,
     `libraries/typescript/src/server.ts`.
 
@@ -29,17 +28,18 @@
 
 - **`allow_insecure_dashboard` / `allowInsecureDashboard` escape hatch (opt-in,
   default off).** New optional config on `Patter(...)` (Python) and `serve(...)`
-  `ServeOptions` (TypeScript), defaulting to `False` / `false`. When the new
-  fail-closed dashboard gate (see Security above) would refuse to serve the
-  dashboard on a publicly-reachable bind without a token, setting this to `True`
-  / `true` force-serves the dashboard unauthenticated anyway and logs a
-  `warning` instead of blocking. This preserves the pre-change behavior for
+  `ServeOptions` (TypeScript), defaulting to `False` / `false`. When the
+  dashboard would be reachable beyond loopback without a configured token (see
+  Security above), the SDK auto-generates a token to protect it; setting this
+  flag to `True` / `true` instead serves the dashboard fully OPEN (no token,
+  unauthenticated) on that exposed bind and logs a `warning`. This is for
   operators who deliberately run the dashboard open behind their own network
-  controls (a tailnet, Cloudflare Access, an upstream auth proxy). It is NOT
-  recommended on a public network — prefer a `dashboard_token` /
-  `dashboardToken`. Backward compatible: existing callers that pass no token and
-  are loopback-only are unaffected; the flag only matters on an exposed bind.
-  `libraries/python/getpatter/client.py` /
+  controls (a tailnet, Cloudflare Access, an upstream auth proxy). It leaks call
+  transcripts and metadata (PII) to anyone who can reach the URL, so it is NOT
+  recommended on a public network — prefer the auto-generated token, or a stable
+  `dashboard_token` / `dashboardToken`. Backward compatible: existing callers
+  that pass no token and are loopback-only are unaffected; the flag only matters
+  on an exposed bind. `libraries/python/getpatter/client.py` /
   `libraries/python/getpatter/server.py`,
   `libraries/typescript/src/types.ts` /
   `libraries/typescript/src/client.ts` /

--- a/docs/dev-tools/production-deployment.mdx
+++ b/docs/dev-tools/production-deployment.mdx
@@ -1,0 +1,310 @@
+---
+title: "Production Deployment"
+description: "Take a Patter agent from a dev quick-tunnel to a hardened, always-on box: a named Cloudflare tunnel with INGRESS rules, a locked-down dashboard, and a per-client go-live checklist."
+icon: "shield-check"
+---
+
+# Production Deployment
+
+The [built-in Cloudflare Quick Tunnel](/dev-tools/tunneling) is perfect for development and
+acceptance demos: one line of config and you have a public URL. It is **not** a production
+posture. This guide walks through the gap between "it works on my machine over a quick
+tunnel" and "it runs unattended on a client's box and exposes only what it should".
+
+Three things change when you go live:
+
+1. The tunnel becomes a **named** Cloudflare tunnel with a **stable** hostname, run as a
+   system service so it survives reboots and reconnects on its own.
+2. The tunnel's **ingress rules** route only the carrier webhook path to the local port —
+   everything else (`/health`, the dashboard, `/api/*`) returns `404` at the edge.
+3. The **dashboard** is either turned off or put behind authentication and a private
+   network, so call transcripts and metadata (PII) are never reachable unauthenticated.
+
+## Why the built-in quick tunnel is dev-only
+
+The built-in `CloudflareTunnel()` runs a Cloudflare *Quick Tunnel* (`cloudflared --url
+http://localhost:PORT`). It is the right tool to get going, and the wrong tool to leave
+running:
+
+- **The hostname rotates.** Every quick tunnel gets a fresh random
+  `*.trycloudflare.com` hostname. Restart the process — a crash, a deploy, a reboot — and
+  the hostname changes. Your carrier's voice webhook still points at the old, now-dead
+  hostname, so inbound calls silently fail until you re-point it. A production line cannot
+  depend on a hostname that changes on restart.
+- **There is no watchdog.** The quick tunnel lives and dies with your `serve()` process.
+  Nothing restarts it if the machine reboots overnight or the process is killed. An
+  after-hours line that is down until someone notices is not a production line.
+- **It exposes the WHOLE port.** `cloudflared --url http://localhost:8000` publishes
+  *everything* served on port 8000 to the public internet: the carrier webhook **and**
+  `/health` **and** the dashboard at `/` **and** every `/api/dashboard/*` route. If the
+  dashboard is on and unauthenticated (the default for local dev), your call transcripts
+  and metadata are one URL away from anyone who finds the hostname.
+
+The fix for all three is a **named** Cloudflare tunnel with a config file you control.
+
+## Named Cloudflare tunnel with a stable hostname
+
+A named tunnel is tied to your Cloudflare account and a DNS record you own, so the
+hostname is **stable** across restarts. You point your carrier webhook at it once and
+never touch it again.
+
+### 1. Create the tunnel and route DNS
+
+You need a domain on Cloudflare (free plan is fine). Run these once on the box that will
+host the agent:
+
+```bash
+# Authenticate cloudflared with your Cloudflare account (opens a browser once).
+cloudflared tunnel login
+
+# Create a named tunnel. This writes a credentials JSON under ~/.cloudflared/.
+cloudflared tunnel create patter-prod
+
+# Route a stable hostname at the tunnel (replace with a subdomain you own).
+cloudflared tunnel route dns patter-prod voice.example.com
+```
+
+`cloudflared tunnel create` prints a tunnel UUID and the path to its credentials file
+(e.g. `~/.cloudflared/<UUID>.json`). You will reference both in the config below.
+
+### 2. Write a config.yml with INGRESS rules
+
+This is the part that closes the "whole port is public" hole. Cloudflare ingress rules are
+evaluated top to bottom; the **first** match wins, and the final catch-all decides what
+happens to everything else. Route **only** the carrier webhook path to the local port and
+return `404` for everything else, so `/health`, the dashboard, and `/api/*` are never
+reachable from the public hostname.
+
+```yaml
+# ~/.cloudflared/config.yml
+tunnel: patter-prod
+credentials-file: /home/USERNAME/.cloudflared/TUNNEL_UUID.json
+
+ingress:
+  # Allow ONLY the carrier webhook + media-stream path through to the local server.
+  # Patter mounts the carrier routes under a stable prefix — point this at the
+  # exact path your carrier posts to (Twilio voice webhook / Telnyx Call Control /
+  # the media-stream WebSocket upgrade). Use a path that matches your deployment.
+  - hostname: voice.example.com
+    path: ^/(twilio|telnyx|media-stream|webhooks/.*)$
+    service: http://localhost:8000
+
+  # Everything else on this hostname is refused at the edge: /health, the
+  # dashboard at /, and every /api/dashboard/* route never reach the box.
+  - hostname: voice.example.com
+    service: http_status:404
+
+  # Required final catch-all for any other hostname.
+  - service: http_status:404
+```
+
+<Note>
+  **Match the path to your carrier and SDK version.** The exact webhook + media-stream
+  paths depend on which carrier you use and how Patter mounts them in your installed
+  version. Before going live, place one real test call with the catch-all `404` in place
+  and confirm the call connects *and* that requesting `https://voice.example.com/` returns
+  `404` (the dashboard must not load). Tighten the `path:` regex until only the carrier
+  paths get through. The placeholder hostname `voice.example.com` and the local port
+  `8000` are examples — use your own.
+</Note>
+
+### 3. Run it as an always-on service
+
+The tunnel must outlive your shell, restart on reboot, and reconnect on its own. Install
+it as a system service. On macOS (a common per-client always-on box model — see the
+[OpenClaw integration](/integrations/openclaw)) that means a `launchd` service:
+
+```bash
+# Install cloudflared as a launchd service that runs the named tunnel on boot.
+# cloudflared reads ~/.cloudflared/config.yml for the tunnel + ingress rules.
+sudo cloudflared service install
+
+# Manage it like any launchd service:
+sudo launchctl list | grep cloudflared
+sudo launchctl kickstart -k system/com.cloudflare.cloudflared   # restart
+```
+
+On Linux, `sudo cloudflared service install` registers a `systemd` unit instead
+(`systemctl status cloudflared`, `systemctl restart cloudflared`). Either way you get
+always-on behaviour: the tunnel starts at boot, reconnects automatically if the edge
+connection drops, and is supervised by the OS rather than your `serve()` process.
+
+### 4. Point Patter at the stable hostname
+
+With the named tunnel running as a service, Patter should **not** manage a tunnel process
+itself. Pass the stable hostname as the webhook URL and let Patter skip process
+management:
+
+<CodeGroup>
+```python Python
+from getpatter import Patter, Twilio
+
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    webhook_url="voice.example.com",   # stable named-tunnel hostname; no tunnel= process
+)
+await phone.serve(agent, port=8000)
+```
+
+```typescript TypeScript
+import { Patter, Twilio } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  webhookUrl: "voice.example.com",     // stable named-tunnel hostname; no tunnel process
+});
+await phone.serve(agent, { port: 8000 });
+```
+</CodeGroup>
+
+Because the hostname is stable, your carrier's voice webhook stays valid across restarts —
+no re-pointing after a reboot or a deploy. See the
+[Static / user-managed tunnel](/dev-tools/tunneling#static-user-managed-tunnel) section for
+the equivalent `Static` tunnel marker if you prefer to express the hostname that way.
+
+## Dashboard hardening
+
+The embedded dashboard serves **call transcripts and metadata — PII**. On an
+internet-reachable box it must never be served unauthenticated. Patter enforces this for
+you: the SDK **fails closed** when the dashboard would be reachable beyond `127.0.0.1`
+without a token. Pick one of the two safe postures below.
+
+### Posture A — turn the dashboard off on the exposed box
+
+If you do not need the dashboard on the production box (you can run the
+[standalone dashboard](/dev-tools/dashboard#standalone-dashboard) elsewhere, or just rely on
+[call logging](/python-sdk/call-logging)), disable it:
+
+<CodeGroup>
+```python Python
+await phone.serve(agent, port=8000, dashboard=False)
+```
+
+```typescript TypeScript
+await phone.serve(agent, { port: 8000, dashboard: false });
+```
+</CodeGroup>
+
+### Posture B — keep it, but require a token AND keep it private
+
+If you want the dashboard, set a strong `dashboard_token` / `dashboardToken` so every
+dashboard and `/api/dashboard/*` request must authenticate, **and** keep it off the public
+internet entirely. The ingress rules above already do the second part — the dashboard path
+returns `404` at the Cloudflare edge — but defence in depth means also requiring a token at
+the app, and reaching the dashboard only over
+[Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/) or a
+private tailnet (e.g. [Tailscale](https://tailscale.com)) rather than the public hostname.
+
+<CodeGroup>
+```python Python
+import os
+
+await phone.serve(
+    agent,
+    port=8000,
+    dashboard=True,
+    dashboard_token=os.environ["PATTER_DASHBOARD_TOKEN"],   # strong secret from env
+)
+```
+
+```typescript TypeScript
+await phone.serve(agent, {
+  port: 8000,
+  dashboard: true,
+  dashboardToken: process.env.PATTER_DASHBOARD_TOKEN,        // strong secret from env
+});
+```
+</CodeGroup>
+
+Never hardcode the token — read it from an environment variable or a secret manager.
+
+### How the fail-closed behaviour works
+
+The SDK computes whether the server is **exposed** (a tunnel directive is active, a public
+`webhook_url` / `webhookUrl` is configured or was assigned by a tunnel, or the bind host
+was explicitly overridden to a non-loopback address). When the dashboard is on, the token
+is empty, **and** the server is exposed, the SDK does **not** mount the dashboard or the
+`/api/dashboard/*` (call-data) routes, and logs an error explaining how to fix it. The
+carrier webhook, media-stream, and `/health` routes still mount normally, so **calls keep
+working** — only the unauthenticated PII surface is withheld.
+
+| Situation | What the SDK does |
+|---|---|
+| Loopback-only (local dev), dashboard on, no token | Dashboard served as today — unchanged. |
+| Token set | Dashboard + API mounted; requests must authenticate. |
+| Dashboard off | Nothing dashboard-related mounted. |
+| **Exposed, dashboard on, no token** | **Dashboard + API NOT mounted; error logged.** Calls still work. |
+| Exposed, dashboard on, no token, escape hatch on | Dashboard + API mounted unauthenticated; warning logged. |
+
+### The escape hatch (default off)
+
+If you understand the risk and still want to force-serve the dashboard unauthenticated on
+an exposed box (for example, you front it with Cloudflare Access at the edge and accept the
+app-level exposure), opt in explicitly with `allow_insecure_dashboard` (Python) /
+`allowInsecureDashboard` (TypeScript). It defaults to `False` / `false`; when enabled on an
+exposed box the SDK mounts the routes and logs a warning that transcripts and metadata are
+exposed to anyone who can reach the URL. This is **not recommended on a public network** —
+prefer Posture A or a token.
+
+<CodeGroup>
+```python Python
+# NOT recommended on a public network — serve the dashboard unauthenticated anyway.
+await phone.serve(
+    agent,
+    port=8000,
+    dashboard=True,
+    allow_insecure_dashboard=True,
+)
+```
+
+```typescript TypeScript
+// NOT recommended on a public network — serve the dashboard unauthenticated anyway.
+await phone.serve(agent, {
+  port: 8000,
+  dashboard: true,
+  allowInsecureDashboard: true,
+});
+```
+</CodeGroup>
+
+## Keep the OpenClaw gateway and consult on loopback
+
+If you run the [OpenClaw integration](/integrations/openclaw), keep the OpenClaw gateway's
+`/v1/chat/completions` endpoint and the consult adapter bound to **loopback** (the
+default). The only thing the named tunnel exposes is the carrier webhook path; the
+gateway, the consult adapter, and any MCP server stay private on `127.0.0.1` (or a private
+tailnet). Patter's consult URL validator rejects loopback by default — opt in with
+`allow_loopback` / `allowLoopback` for the consult URL only, which is your own
+configuration and not caller-derived. See the
+[OpenClaw loopback / SSRF note](/integrations/openclaw#direction-b--patter-consults-openclaw-mid-call)
+for the full caveat.
+
+## Per-client go-live acceptance checklist
+
+Run this once per client box before the line goes live. All five must pass:
+
+- [ ] **Dashboard is off or tokened.** Either `dashboard=False` / `dashboard: false`, **or**
+  a strong `dashboard_token` / `dashboardToken` is set from an environment variable. Confirm
+  an unauthenticated dashboard request returns `401` (token set) and the SDK logged no
+  fail-closed error.
+- [ ] **The tunnel exposes only the webhook path.** Requesting `https://<hostname>/` and
+  `https://<hostname>/api/dashboard/calls` returns `404` at the edge; only the carrier
+  webhook + media-stream path reaches the local port. Verify with one real test call that
+  connects.
+- [ ] **The OpenClaw gateway and consult adapter are loopback-only.** `/v1/chat/completions`
+  and the consult adapter are bound to `127.0.0.1` (or a private tailnet) and are not
+  reachable from the public hostname.
+- [ ] **Webhook signature verification is on.** Twilio `X-Twilio-Signature` (or Telnyx
+  Ed25519) verification is enabled so the carrier webhook is fail-closed at the public
+  boundary.
+- [ ] **The tunnel is an always-on service.** `cloudflared` runs under `launchd` /
+  `systemd`, starts on boot, and reconnects on its own — not a foreground process tied to
+  your shell.
+
+## What's next
+
+- **Tunneling options**: [dev quick tunnel, static, and production](/dev-tools/tunneling).
+- **Dashboard**: [architecture, standalone mode, and API](/dev-tools/dashboard).
+- **OpenClaw integration**: [reference architecture and security model](/integrations/openclaw).

--- a/docs/dev-tools/production-deployment.mdx
+++ b/docs/dev-tools/production-deployment.mdx
@@ -36,9 +36,11 @@ running:
   after-hours line that is down until someone notices is not a production line.
 - **It exposes the WHOLE port.** `cloudflared --url http://localhost:8000` publishes
   *everything* served on port 8000 to the public internet: the carrier webhook **and**
-  `/health` **and** the dashboard at `/` **and** every `/api/dashboard/*` route. If the
-  dashboard is on and unauthenticated (the default for local dev), your call transcripts
-  and metadata are one URL away from anyone who finds the hostname.
+  `/health` **and** the dashboard at `/` **and** every `/api/dashboard/*` route. The SDK
+  auto-protects an exposed dashboard with a generated token (see
+  [Dashboard hardening](#dashboard-hardening)), but leaving the whole port public still
+  exposes `/health` and the surface area unnecessarily — a named tunnel with ingress rules
+  publishes only the carrier paths.
 
 The fix for all three is a **named** Cloudflare tunnel with a config file you control.
 
@@ -71,22 +73,27 @@ cloudflared tunnel route dns patter-prod voice.example.com
 
 This is the part that closes the "whole port is public" hole. Cloudflare ingress rules are
 evaluated top to bottom; the **first** match wins, and the final catch-all decides what
-happens to everything else. Route **only** the carrier webhook path to the local port and
-return `404` for everything else, so `/health`, the dashboard, and `/api/*` are never
-reachable from the public hostname.
+happens to everything else. Route **only** the carrier's webhook **and** media-stream
+WebSocket paths to the local port and return `404` for everything else, so `/health`, the
+dashboard, and `/api/*` are never reachable from the public hostname.
 
-```yaml
+Patter mounts each carrier under its own prefix: the HTTP webhooks live under
+`/webhooks/<carrier>/...` and the media-stream WebSocket upgrade lives under
+`/ws/<carrier>/stream/...` (Twilio's stream is the bare `/ws/stream/...`). Allow **both**
+the webhook and the stream path — the regex below does that per carrier. Pick the block for
+the carrier you use; the previous `^/(twilio|telnyx|media-stream|webhooks/.*)$` example was
+wrong (it never matched the real `/ws/stream/...` upgrade and would drop the call at pickup).
+
+<CodeGroup>
+```yaml Twilio
 # ~/.cloudflared/config.yml
 tunnel: patter-prod
 credentials-file: /home/USERNAME/.cloudflared/TUNNEL_UUID.json
 
 ingress:
-  # Allow ONLY the carrier webhook + media-stream path through to the local server.
-  # Patter mounts the carrier routes under a stable prefix — point this at the
-  # exact path your carrier posts to (Twilio voice webhook / Telnyx Call Control /
-  # the media-stream WebSocket upgrade). Use a path that matches your deployment.
+  # Twilio: voice/status/recording/AMD webhooks + the media-stream WebSocket.
   - hostname: voice.example.com
-    path: ^/(twilio|telnyx|media-stream|webhooks/.*)$
+    path: ^/(webhooks/twilio/.*|ws/stream/.*)$
     service: http://localhost:8000
 
   # Everything else on this hostname is refused at the edge: /health, the
@@ -98,14 +105,54 @@ ingress:
   - service: http_status:404
 ```
 
+```yaml Telnyx
+# ~/.cloudflared/config.yml
+tunnel: patter-prod
+credentials-file: /home/USERNAME/.cloudflared/TUNNEL_UUID.json
+
+ingress:
+  # Telnyx: Call Control webhooks + the media-stream WebSocket.
+  - hostname: voice.example.com
+    path: ^/(webhooks/telnyx/.*|ws/telnyx/stream/.*)$
+    service: http://localhost:8000
+
+  # Everything else on this hostname is refused at the edge: /health, the
+  # dashboard at /, and every /api/dashboard/* route never reach the box.
+  - hostname: voice.example.com
+    service: http_status:404
+
+  # Required final catch-all for any other hostname.
+  - service: http_status:404
+```
+
+```yaml Plivo
+# ~/.cloudflared/config.yml
+tunnel: patter-prod
+credentials-file: /home/USERNAME/.cloudflared/TUNNEL_UUID.json
+
+ingress:
+  # Plivo: voice/status/AMD/transfer webhooks + the media-stream WebSocket.
+  - hostname: voice.example.com
+    path: ^/(webhooks/plivo/.*|ws/plivo/stream/.*)$
+    service: http://localhost:8000
+
+  # Everything else on this hostname is refused at the edge: /health, the
+  # dashboard at /, and every /api/dashboard/* route never reach the box.
+  - hostname: voice.example.com
+    service: http_status:404
+
+  # Required final catch-all for any other hostname.
+  - service: http_status:404
+```
+</CodeGroup>
+
 <Note>
-  **Match the path to your carrier and SDK version.** The exact webhook + media-stream
-  paths depend on which carrier you use and how Patter mounts them in your installed
-  version. Before going live, place one real test call with the catch-all `404` in place
-  and confirm the call connects *and* that requesting `https://voice.example.com/` returns
-  `404` (the dashboard must not load). Tighten the `path:` regex until only the carrier
-  paths get through. The placeholder hostname `voice.example.com` and the local port
-  `8000` are examples — use your own.
+  **Confirm against your installed version before going live.** The paths above match the
+  current routes (`/webhooks/<carrier>/...` for HTTP, `/ws/stream/...` for Twilio media and
+  `/ws/<carrier>/stream/...` for Telnyx/Plivo media). Place one real test call with the
+  catch-all `404` in place and confirm the call connects *and* that requesting
+  `https://voice.example.com/` returns `404` (the dashboard must not load). The placeholder
+  hostname `voice.example.com` and the local port `8000` are examples — use your own.
 </Note>
 
 ### 3. Run it as an always-on service
@@ -167,9 +214,12 @@ the equivalent `Static` tunnel marker if you prefer to express the hostname that
 ## Dashboard hardening
 
 The embedded dashboard serves **call transcripts and metadata — PII**. On an
-internet-reachable box it must never be served unauthenticated. Patter enforces this for
-you: the SDK **fails closed** when the dashboard would be reachable beyond `127.0.0.1`
-without a token. Pick one of the two safe postures below.
+internet-reachable box it must never be served unauthenticated. Patter protects this for
+you with **zero configuration**: when the dashboard would be reachable beyond `127.0.0.1`
+without a configured token, the SDK auto-generates a one-time token, mounts the dashboard
+behind it, and prints a ready-to-click URL (with `?token=...`) at startup. The dashboard
+stays available — it just requires the printed token. Pick one of the postures below to make
+that explicit and stable on a production box.
 
 ### Posture A — turn the dashboard off on the exposed box
 
@@ -189,11 +239,13 @@ await phone.serve(agent, { port: 8000, dashboard: false });
 
 ### Posture B — keep it, but require a token AND keep it private
 
-If you want the dashboard, set a strong `dashboard_token` / `dashboardToken` so every
-dashboard and `/api/dashboard/*` request must authenticate, **and** keep it off the public
-internet entirely. The ingress rules above already do the second part — the dashboard path
-returns `404` at the Cloudflare edge — but defence in depth means also requiring a token at
-the app, and reaching the dashboard only over
+An exposed dashboard is already token-protected by the auto-generated token, but that
+token rotates on every restart, so the URL you have to share changes each time. For a
+production box, set a strong `dashboard_token` / `dashboardToken` so the token is **stable**
+across restarts and every dashboard and `/api/dashboard/*` request authenticates against a
+secret you control. Keep the dashboard off the public internet entirely as well: the ingress
+rules above already do that — the dashboard path returns `404` at the Cloudflare edge — but
+defence in depth means also reaching the dashboard only over
 [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/) or a
 private tailnet (e.g. [Tailscale](https://tailscale.com)) rather than the public hostname.
 
@@ -220,33 +272,38 @@ await phone.serve(agent, {
 
 Never hardcode the token — read it from an environment variable or a secret manager.
 
-### How the fail-closed behaviour works
+### How the auto-token behaviour works
 
 The SDK computes whether the server is **exposed** (a tunnel directive is active, a public
 `webhook_url` / `webhookUrl` is configured or was assigned by a tunnel, or the bind host
-was explicitly overridden to a non-loopback address). When the dashboard is on, the token
-is empty, **and** the server is exposed, the SDK does **not** mount the dashboard or the
-`/api/dashboard/*` (call-data) routes, and logs an error explaining how to fix it. The
-carrier webhook, media-stream, and `/health` routes still mount normally, so **calls keep
-working** — only the unauthenticated PII surface is withheld.
+was explicitly overridden to a non-loopback address). When the dashboard is on, no token is
+configured, **and** the server is exposed, the SDK generates a one-time token, mounts the
+dashboard and the `/api/dashboard/*` (call-data) routes behind it, logs a warning that it
+did so, and prints the ready-to-use URL with `?token=...` in the startup banner. The
+dashboard is **always available** — it just requires the printed (or configured) token when
+the box is exposed. On loopback-only local dev, nothing changes: no token is generated and
+the dashboard is served open.
 
 | Situation | What the SDK does |
 |---|---|
-| Loopback-only (local dev), dashboard on, no token | Dashboard served as today — unchanged. |
-| Token set | Dashboard + API mounted; requests must authenticate. |
+| Loopback-only (local dev), dashboard on, no token | Dashboard + API mounted **open** — unchanged. |
+| Token set (`dashboard_token` / `dashboardToken`) | Dashboard + API mounted; requests must authenticate with that token. |
 | Dashboard off | Nothing dashboard-related mounted. |
-| **Exposed, dashboard on, no token** | **Dashboard + API NOT mounted; error logged.** Calls still work. |
-| Exposed, dashboard on, no token, escape hatch on | Dashboard + API mounted unauthenticated; warning logged. |
+| **Exposed, dashboard on, no token** | **Dashboard + API mounted behind an auto-generated token; warning logged and the `?token=...` URL printed.** |
+| Exposed, dashboard on, no token, `allow_insecure_dashboard` on | Dashboard + API mounted **open**; warning logged. |
+
+In every case the carrier webhook, media-stream, and `/health` routes mount normally, so
+**calls keep working** regardless of the dashboard posture.
 
 ### The escape hatch (default off)
 
-If you understand the risk and still want to force-serve the dashboard unauthenticated on
-an exposed box (for example, you front it with Cloudflare Access at the edge and accept the
-app-level exposure), opt in explicitly with `allow_insecure_dashboard` (Python) /
+If you understand the risk and still want to serve the dashboard fully **open** (no token)
+on an exposed box — for example, you front it with Cloudflare Access at the edge and accept
+the app-level exposure — opt in explicitly with `allow_insecure_dashboard` (Python) /
 `allowInsecureDashboard` (TypeScript). It defaults to `False` / `false`; when enabled on an
-exposed box the SDK mounts the routes and logs a warning that transcripts and metadata are
-exposed to anyone who can reach the URL. This is **not recommended on a public network** —
-prefer Posture A or a token.
+exposed box the SDK skips the auto-generated token, mounts the routes unauthenticated, and
+logs a warning that transcripts and metadata are exposed to anyone who can reach the URL.
+This is **not recommended on a public network** — prefer Posture A or a token.
 
 <CodeGroup>
 ```python Python
@@ -286,9 +343,11 @@ for the full caveat.
 Run this once per client box before the line goes live. All five must pass:
 
 - [ ] **Dashboard is off or tokened.** Either `dashboard=False` / `dashboard: false`, **or**
-  a strong `dashboard_token` / `dashboardToken` is set from an environment variable. Confirm
-  an unauthenticated dashboard request returns `401` (token set) and the SDK logged no
-  fail-closed error.
+  a strong `dashboard_token` / `dashboardToken` is set from an environment variable so the
+  token is stable across restarts. (If you leave it unset on an exposed box the SDK still
+  auto-protects the dashboard with a generated token, but it rotates each restart.) Confirm
+  an unauthenticated dashboard request returns `401` and that `allow_insecure_dashboard` /
+  `allowInsecureDashboard` is **not** enabled unless you intend an open dashboard.
 - [ ] **The tunnel exposes only the webhook path.** Requesting `https://<hostname>/` and
   `https://<hostname>/api/dashboard/calls` returns `404` at the edge; only the carrier
   webhook + media-stream path reaches the local port. Verify with one real test call that

--- a/docs/dev-tools/tunneling.mdx
+++ b/docs/dev-tools/tunneling.mdx
@@ -175,3 +175,7 @@ const phone = new Patter({
 </CodeGroup>
 
 No tunnel needed — the telephony provider connects directly to your server.
+
+---
+
+For a production-ready tunnel setup with INGRESS rules that expose only the carrier webhook path and dashboard hardening, see [Production Deployment](/dev-tools/production-deployment).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,7 +74,8 @@
             "icon": "wrench",
             "pages": [
               "dev-tools/dashboard",
-              "dev-tools/tunneling"
+              "dev-tools/tunneling",
+              "dev-tools/production-deployment"
             ]
           }
         ]

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -279,9 +279,17 @@ phone.serve(agent)
   or hostname instead and give Patter that address.
 </Warning>
 
+<Note>
+  **Deploying with a tunnel?** When you expose this stack to the internet, expose only the
+  carrier webhook path — keep the OpenClaw gateway and the consult adapter on loopback, and
+  secure the dashboard. See [Production Deployment](/dev-tools/production-deployment) for
+  named-tunnel ingress rules and dashboard hardening.
+</Note>
+
 ## What's next
 
 - **Consult feature**: [Python](/python-sdk/consult) · [TypeScript](/typescript-sdk/consult).
+- **Production deployment**: [securing the tunnel and dashboard](/dev-tools/production-deployment).
 - **Concepts**: read the [Concepts](/concepts) page to pick a mode
   (Realtime / ConvAI / Pipeline) for the in-call agent.
 - **Get a phone number**: [Twilio console](https://console.twilio.com/us1/develop/phone-numbers/manage/incoming)

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1817,15 +1817,21 @@ class Patter:
                 at ``http://localhost:{port}/dashboard``.
             dashboard_token: Optional bearer token for dashboard authentication.
                 When set, all dashboard routes require this token.
-            allow_insecure_dashboard: When ``False`` (default, safe), the
-                embedded metrics dashboard and call-data ``/api/*`` routes are
-                NOT served if the server would be reachable beyond ``127.0.0.1``
-                (e.g. via a tunnel or a public ``webhook_url``) without a
-                ``dashboard_token`` — they expose call transcripts and metadata
-                (PII). Set ``True`` to force-serve them unauthenticated on a
+            allow_insecure_dashboard: Opt-out from the auto-token protection.
+                The embedded metrics dashboard and call-data ``/api/*`` routes
+                expose call transcripts and metadata (PII). With ``False``
+                (default, safe), when the server is reachable beyond
+                ``127.0.0.1`` (e.g. via a tunnel or a public ``webhook_url``)
+                without a configured ``dashboard_token``, the SDK
+                auto-generates a one-time token and mounts the dashboard behind
+                it — the startup banner prints the ready-to-use URL with
+                ``?token=...``. The dashboard is always available; it just
+                requires the printed or configured token. Set ``True`` to serve
+                the dashboard fully OPEN (unauthenticated) on a
                 publicly-reachable bind (NOT recommended on a public network).
-                Carrier webhooks and ``/health`` always mount, so calls keep
-                working regardless of this flag.
+                Loopback-only local dev is unchanged: served open with no
+                token. Carrier webhooks and ``/health`` always mount, so calls
+                keep working regardless of this flag.
             tunnel: When ``True``, start a cloudflared tunnel automatically.
                 Requires ``cloudflared`` binary on PATH. Mutually exclusive
                 with ``webhook_url``.

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1794,6 +1794,7 @@ class Patter:
         on_metrics: Callable[[dict], Awaitable[None]] | None = None,
         dashboard: bool = True,
         dashboard_token: str = "",
+        allow_insecure_dashboard: bool = False,
         tunnel: bool = False,
     ) -> None:
         """Start the embedded server for inbound calls.
@@ -1816,6 +1817,15 @@ class Patter:
                 at ``http://localhost:{port}/dashboard``.
             dashboard_token: Optional bearer token for dashboard authentication.
                 When set, all dashboard routes require this token.
+            allow_insecure_dashboard: When ``False`` (default, safe), the
+                embedded metrics dashboard and call-data ``/api/*`` routes are
+                NOT served if the server would be reachable beyond ``127.0.0.1``
+                (e.g. via a tunnel or a public ``webhook_url``) without a
+                ``dashboard_token`` — they expose call transcripts and metadata
+                (PII). Set ``True`` to force-serve them unauthenticated on a
+                publicly-reachable bind (NOT recommended on a public network).
+                Carrier webhooks and ``/health`` always mount, so calls keep
+                working regardless of this flag.
             tunnel: When ``True``, start a cloudflared tunnel automatically.
                 Requires ``cloudflared`` binary on PATH. Mutually exclusive
                 with ``webhook_url``.
@@ -1915,6 +1925,7 @@ class Patter:
             pricing=self._pricing,
             dashboard=dashboard,
             dashboard_token=dashboard_token,
+            allow_insecure_dashboard=allow_insecure_dashboard,
         )
         self._server.on_call_start = on_call_start
         self._server.on_call_end = on_call_end

--- a/libraries/python/getpatter/server.py
+++ b/libraries/python/getpatter/server.py
@@ -45,6 +45,60 @@ _BLOCKED_WEBHOOK_HOSTNAMES = frozenset(
 # Mirrors libraries/typescript/src/server.ts:1041 (MAX_WS_PER_IP = 10).
 MAX_WS_PER_IP = 10
 
+# Hosts that are loopback-only (not reachable from another machine). Used by
+# the fail-closed dashboard gate to decide whether the server is "exposed".
+# A non-empty ``webhook_url`` or ``PATTER_BIND_HOST`` whose hostname is NOT in
+# this set is treated as publicly reachable. Mirrors the TS counterpart.
+_LOOPBACK_HOSTS = frozenset(
+    {
+        "localhost",
+        "ip6-localhost",
+        "ip6-loopback",
+        "::1",
+        "::ffff:127.0.0.1",
+    }
+)
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return True when *host* refers to loopback only (not externally reachable).
+
+    Strips an optional scheme, ``[...]`` IPv6 brackets, and a trailing port,
+    then matches against :data:`_LOOPBACK_HOSTS` and the full ``127.0.0.0/8``
+    range. A ``webhook_url`` like ``"abc.trycloudflare.com"`` returns ``False``
+    (publicly reachable); ``"127.0.0.1:8000"`` returns ``True``. Mirrors the
+    TypeScript ``isLoopbackHost`` byte-for-byte so the exposure gate classifies
+    hosts identically across SDKs.
+    """
+    if not host:
+        return True
+    raw = host.strip()
+    # Drop scheme if present (webhook_url is normally bare hostname, but be safe)
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    # Drop any path / query
+    raw = raw.split("/", 1)[0]
+    raw = raw.lower()
+    # IPv6 in brackets, optionally with a port: ``[::1]:8000``
+    if raw.startswith("["):
+        inner = raw[1:].split("]", 1)[0]
+        return inner in _LOOPBACK_HOSTS
+    # Strip a trailing :port for IPv4 / hostname (a bare IPv6 has many colons)
+    if raw.count(":") == 1:
+        raw = raw.split(":", 1)[0]
+    if raw in _LOOPBACK_HOSTS:
+        return True
+    # The entire 127.0.0.0/8 block is loopback (RFC 1122), not just 127.0.0.1.
+    parts = raw.split(".")
+    if len(parts) == 4 and all(p.isdigit() for p in parts):
+        try:
+            octets = [int(p) for p in parts]
+        except ValueError:  # pragma: no cover - defensive
+            return False
+        if octets[0] == 127 and all(0 <= o <= 255 for o in octets):
+            return True
+    return False
+
 
 def validate_webhook_url(url: str) -> bool:
     """Return True when *url* is safe to fetch (SSRF protection).
@@ -319,6 +373,7 @@ class EmbeddedServer:
         pricing: dict | None = None,
         dashboard: bool = True,
         dashboard_token: str = "",
+        allow_insecure_dashboard: bool = False,
     ) -> None:
         self.config = config
         self.agent = agent
@@ -327,6 +382,13 @@ class EmbeddedServer:
         self.pricing = pricing
         self.dashboard = dashboard
         self.dashboard_token = dashboard_token
+        # Escape hatch for the fail-closed dashboard gate. When ``True``, the
+        # dashboard + call-data API routes are mounted even on a
+        # publicly-reachable bind without a ``dashboard_token`` (with a loud
+        # WARNING). Default ``False`` => fail closed: those routes are NOT
+        # mounted when the server would be reachable beyond loopback without
+        # auth. See ``_dashboard_is_exposed`` and the gate in ``_create_app``.
+        self.allow_insecure_dashboard = allow_insecure_dashboard
         self._server = None
         self._app = None
         self._active_connections: set[WebSocket] = set()
@@ -667,6 +729,37 @@ class EmbeddedServer:
 
         return _on_call_start, _on_call_end, _on_metrics
 
+    def _dashboard_is_exposed(self) -> bool:
+        """Return True when this server would be reachable beyond loopback.
+
+        Drives the fail-closed dashboard gate in :meth:`_create_app`. Returns
+        ``True`` if ANY of these signals holds:
+
+        (a)/(b) A public ``webhook_url`` is configured — set either explicitly
+            via ``Patter(webhook_url=...)`` or auto-assigned by a tunnel
+            (CloudflareTunnel / Ngrok / Static) in ``serve()``. Both collapse
+            to "``config.webhook_url`` is non-empty and not a loopback host",
+            which is the PARITY-CRITICAL signal shared with the TypeScript SDK.
+        (c) ``PATTER_BIND_HOST`` is EXPLICITLY set to a non-loopback host. The
+            default bind is ``127.0.0.1`` (loopback, safe); reading that
+            default never trips this signal, so normal local dev is unaffected.
+
+        Returns ``False`` for the local-dev path (loopback-only bind, no
+        tunnel, no public webhook_url) so that case keeps serving as before.
+        """
+        # Signals (a) + (b): a public webhook hostname (tunnel- or
+        # caller-assigned) means the whole port is reachable publicly.
+        webhook_url = getattr(self.config, "webhook_url", "") or ""
+        if webhook_url and not _is_loopback_host(webhook_url):
+            return True
+
+        # Signal (c): explicit non-loopback PATTER_BIND_HOST override only.
+        bind_host = os.environ.get("PATTER_BIND_HOST")
+        if bind_host is not None and not _is_loopback_host(bind_host):
+            return True
+
+        return False
+
     def _create_app(self):
         """Build the FastAPI application with webhook + stream routes."""
         from getpatter.telephony.plivo import (
@@ -709,11 +802,43 @@ class EmbeddedServer:
                         "Dashboard hydration failed: %s", exc
                     )
 
-            mount_dashboard(app, self._metrics_store, token=self.dashboard_token)
+            # --- Fail-closed dashboard gate ---
+            #
+            # The dashboard + call-data API expose call transcripts and
+            # metadata (PII). When the server would be reachable beyond
+            # loopback (a tunnel is active, or a public webhook_url / explicit
+            # non-loopback PATTER_BIND_HOST is set) AND no dashboard_token is
+            # configured, we refuse to mount those routes unless the operator
+            # has explicitly opted into allow_insecure_dashboard. The carrier
+            # webhook + media-stream + /health routes always mount, so calls
+            # keep working. Mirrors the TypeScript SDK.
+            is_exposed = self._dashboard_is_exposed()
+            unauthenticated = not self.dashboard_token
 
-            from getpatter.api_routes import mount_api
+            if is_exposed and unauthenticated and not self.allow_insecure_dashboard:
+                logger.error(
+                    "Dashboard NOT served: it would be reachable beyond "
+                    "127.0.0.1 without authentication, exposing call "
+                    "transcripts and metadata (PII). Fix one of: (1) set "
+                    "dashboard_token=<secret> to require auth, (2) set "
+                    "dashboard=False to disable it on this host, or (3) set "
+                    "allow_insecure_dashboard=True to force-serve it "
+                    "unauthenticated (NOT recommended on a public network)."
+                )
+            else:
+                if is_exposed and unauthenticated and self.allow_insecure_dashboard:
+                    logger.warning(
+                        "Dashboard served WITHOUT authentication on a "
+                        "publicly-reachable bind (allow_insecure_dashboard=True). "
+                        "Call transcripts and metadata are exposed to anyone "
+                        "who can reach this URL."
+                    )
 
-            mount_api(app, self._metrics_store, token=self.dashboard_token)
+                mount_dashboard(app, self._metrics_store, token=self.dashboard_token)
+
+                from getpatter.api_routes import mount_api
+
+                mount_api(app, self._metrics_store, token=self.dashboard_token)
 
         @app.get("/health")
         async def health():
@@ -1647,7 +1772,18 @@ class EmbeddedServer:
                 "under-report.",
                 sanitize_log_value(model),
             )
-        if self.dashboard:
+        # The detailed ERROR/WARNING about the fail-closed gate is emitted in
+        # ``_create_app`` (where the routes are actually mounted or skipped).
+        # Here we only show the friendly local-dev banner when the dashboard
+        # will in fact be served — i.e. NOT in the exposed+unauthenticated+
+        # not-allowed case where ``_create_app`` already refused to mount it.
+        _dashboard_blocked = (
+            self.dashboard
+            and not self.dashboard_token
+            and self._dashboard_is_exposed()
+            and not self.allow_insecure_dashboard
+        )
+        if self.dashboard and not _dashboard_blocked:
             logger.info(
                 "\n──── Dashboard ─────────────────────────────────────\n"
                 "URL: http://127.0.0.1:%s/\n"

--- a/libraries/python/getpatter/server.py
+++ b/libraries/python/getpatter/server.py
@@ -10,6 +10,7 @@ import os
 import re
 import signal
 import time
+import uuid
 from collections import defaultdict
 from urllib.parse import urlparse
 
@@ -24,7 +25,7 @@ from getpatter.services.call_log import (
     alog_turn,
     resolve_log_root,
 )
-from getpatter.utils.log_sanitize import sanitize_log_value
+from getpatter.utils.log_sanitize import mask_phone_number, sanitize_log_value
 
 logger = logging.getLogger("getpatter")
 
@@ -46,7 +47,7 @@ _BLOCKED_WEBHOOK_HOSTNAMES = frozenset(
 MAX_WS_PER_IP = 10
 
 # Hosts that are loopback-only (not reachable from another machine). Used by
-# the fail-closed dashboard gate to decide whether the server is "exposed".
+# the dashboard auto-token gate to decide whether the server is "exposed".
 # A non-empty ``webhook_url`` or ``PATTER_BIND_HOST`` whose hostname is NOT in
 # this set is treated as publicly reachable. Mirrors the TS counterpart.
 _LOOPBACK_HOSTS = frozenset(
@@ -382,13 +383,21 @@ class EmbeddedServer:
         self.pricing = pricing
         self.dashboard = dashboard
         self.dashboard_token = dashboard_token
-        # Escape hatch for the fail-closed dashboard gate. When ``True``, the
-        # dashboard + call-data API routes are mounted even on a
-        # publicly-reachable bind without a ``dashboard_token`` (with a loud
-        # WARNING). Default ``False`` => fail closed: those routes are NOT
-        # mounted when the server would be reachable beyond loopback without
-        # auth. See ``_dashboard_is_exposed`` and the gate in ``_create_app``.
+        # Opt-out from the auto-token protection. When ``True``, the dashboard +
+        # call-data API routes are served fully OPEN (no token) even on a
+        # publicly-reachable bind, with a loud WARNING. Default ``False`` =>
+        # when the server is reachable beyond loopback without a configured
+        # ``dashboard_token``, the SDK auto-generates a one-time token so the
+        # dashboard is always available but protected with zero config. See
+        # ``_dashboard_is_exposed`` and the token resolution in ``_create_app``.
         self.allow_insecure_dashboard = allow_insecure_dashboard
+        # The dashboard token actually in effect for this process — resolved in
+        # ``_create_app``: the configured ``dashboard_token`` when set, an
+        # auto-generated UUID when the bind is exposed and no token was given
+        # (unless ``allow_insecure_dashboard``), or ``""`` (OPEN) for loopback
+        # local-dev / the insecure opt-out. Read by the startup banner (to print
+        # the ready URL incl. ``?token=``) and by tests to authenticate.
+        self._effective_dashboard_token = ""
         self._server = None
         self._app = None
         self._active_connections: set[WebSocket] = set()
@@ -462,6 +471,19 @@ class EmbeddedServer:
         # Per-client-IP active WebSocket counter for DoS protection.
         # Mirrors TS server.ts:1042 (wsConnectionsByIp).
         self._ws_conn_counts: defaultdict[str, int] = defaultdict(int)
+
+    @property
+    def effective_dashboard_token(self) -> str:
+        """The dashboard token in effect for this process.
+
+        Resolved in :meth:`_create_app`. An empty string means the dashboard
+        is served OPEN (loopback-only local dev, or the
+        ``allow_insecure_dashboard`` opt-out); a non-empty value is required to
+        authenticate (the explicit ``dashboard_token`` or an auto-generated
+        one when the bind is exposed). Public mirror of the TypeScript SDK's
+        ``EmbeddedServer.resolvedDashboardToken`` getter — see sdk-parity.
+        """
+        return self._effective_dashboard_token
 
     # === Outbound completion registry (call(wait=True)) ===
 
@@ -732,7 +754,7 @@ class EmbeddedServer:
     def _dashboard_is_exposed(self) -> bool:
         """Return True when this server would be reachable beyond loopback.
 
-        Drives the fail-closed dashboard gate in :meth:`_create_app`. Returns
+        Drives the dashboard auto-token gate in :meth:`_create_app`. Returns
         ``True`` if ANY of these signals holds:
 
         (a)/(b) A public ``webhook_url`` is configured — set either explicitly
@@ -802,43 +824,57 @@ class EmbeddedServer:
                         "Dashboard hydration failed: %s", exc
                     )
 
-            # --- Fail-closed dashboard gate ---
+            # --- Resolve the effective dashboard token ---
             #
             # The dashboard + call-data API expose call transcripts and
-            # metadata (PII). When the server would be reachable beyond
-            # loopback (a tunnel is active, or a public webhook_url / explicit
-            # non-loopback PATTER_BIND_HOST is set) AND no dashboard_token is
-            # configured, we refuse to mount those routes unless the operator
-            # has explicitly opted into allow_insecure_dashboard. The carrier
-            # webhook + media-stream + /health routes always mount, so calls
-            # keep working. Mirrors the TypeScript SDK.
+            # metadata (PII). The dashboard is ALWAYS mounted; how it is
+            # protected depends on the bind exposure and config:
+            #
+            #   * explicit ``dashboard_token`` set       => use it (auth required)
+            #   * exposed + no token + NOT insecure      => auto-generate a
+            #       one-time UUID token (always available, zero-config protected)
+            #   * exposed + no token + insecure opt-out  => OPEN (no token), WARN
+            #   * loopback-only + no token               => OPEN (no token) —
+            #       unchanged zero-friction local-dev behaviour
+            #
+            # The carrier webhook + media-stream + /health routes always mount
+            # too, so calls keep working regardless. Mirrors the TypeScript SDK.
             is_exposed = self._dashboard_is_exposed()
-            unauthenticated = not self.dashboard_token
 
-            if is_exposed and unauthenticated and not self.allow_insecure_dashboard:
-                logger.error(
-                    "Dashboard NOT served: it would be reachable beyond "
-                    "127.0.0.1 without authentication, exposing call "
-                    "transcripts and metadata (PII). Fix one of: (1) set "
-                    "dashboard_token=<secret> to require auth, (2) set "
-                    "dashboard=False to disable it on this host, or (3) set "
-                    "allow_insecure_dashboard=True to force-serve it "
-                    "unauthenticated (NOT recommended on a public network)."
+            if self.dashboard_token:
+                effective_token = self.dashboard_token
+            elif is_exposed and not self.allow_insecure_dashboard:
+                # RFC 4122 v4 UUID with dashes (str(), not .hex) so the
+                # generated token is byte-for-byte the same shape as the
+                # TypeScript SDK's ``crypto.randomUUID()`` — see sdk-parity.
+                effective_token = str(uuid.uuid4())
+                logger.warning(
+                    "Dashboard is reachable beyond 127.0.0.1 without a "
+                    "configured token; protecting it with an auto-generated "
+                    "token. Set dashboard_token for a stable token, or "
+                    "allow_insecure_dashboard=true to serve it open. "
+                    "(The ready-to-use URL with the token is printed in the "
+                    "startup banner.)"
+                )
+            elif is_exposed and self.allow_insecure_dashboard:
+                effective_token = ""
+                logger.warning(
+                    "Dashboard served WITHOUT authentication on a "
+                    "publicly-reachable bind (allow_insecure_dashboard=True). "
+                    "Call transcripts and metadata are exposed to anyone "
+                    "who can reach this URL."
                 )
             else:
-                if is_exposed and unauthenticated and self.allow_insecure_dashboard:
-                    logger.warning(
-                        "Dashboard served WITHOUT authentication on a "
-                        "publicly-reachable bind (allow_insecure_dashboard=True). "
-                        "Call transcripts and metadata are exposed to anyone "
-                        "who can reach this URL."
-                    )
+                # Loopback-only, no token: open local-dev path (unchanged).
+                effective_token = ""
 
-                mount_dashboard(app, self._metrics_store, token=self.dashboard_token)
+            self._effective_dashboard_token = effective_token
 
-                from getpatter.api_routes import mount_api
+            mount_dashboard(app, self._metrics_store, token=effective_token)
 
-                mount_api(app, self._metrics_store, token=self.dashboard_token)
+            from getpatter.api_routes import mount_api
+
+            mount_api(app, self._metrics_store, token=effective_token)
 
         @app.get("/health")
         async def health():
@@ -1772,25 +1808,28 @@ class EmbeddedServer:
                 "under-report.",
                 sanitize_log_value(model),
             )
-        # The detailed ERROR/WARNING about the fail-closed gate is emitted in
-        # ``_create_app`` (where the routes are actually mounted or skipped).
-        # Here we only show the friendly local-dev banner when the dashboard
-        # will in fact be served — i.e. NOT in the exposed+unauthenticated+
-        # not-allowed case where ``_create_app`` already refused to mount it.
-        _dashboard_blocked = (
-            self.dashboard
-            and not self.dashboard_token
-            and self._dashboard_is_exposed()
-            and not self.allow_insecure_dashboard
-        )
-        if self.dashboard and not _dashboard_blocked:
-            logger.info(
-                "\n──── Dashboard ─────────────────────────────────────\n"
-                "URL: http://127.0.0.1:%s/\n"
-                "────────────────────────────────────────────────────\n",
-                port,
-            )
-            if not self.dashboard_token:
+        # The dashboard is always served (``_create_app`` resolved the
+        # effective token: explicit, auto-generated, or "" when open). Print a
+        # ready-to-click URL — with ``?token=`` when a token is in effect so the
+        # operator can open the protected dashboard directly, or the plain URL
+        # plus an unauthenticated warning when it is served open.
+        if self.dashboard:
+            token = self._effective_dashboard_token
+            if token:
+                logger.info(
+                    "\n──── Dashboard ─────────────────────────────────────\n"
+                    "URL: http://127.0.0.1:%s/?token=%s\n"
+                    "────────────────────────────────────────────────────\n",
+                    port,
+                    token,
+                )
+            else:
+                logger.info(
+                    "\n──── Dashboard ─────────────────────────────────────\n"
+                    "URL: http://127.0.0.1:%s/\n"
+                    "────────────────────────────────────────────────────\n",
+                    port,
+                )
                 logger.warning(
                     "Dashboard is enabled without authentication. "
                     "Set dashboard_token to protect call data. "

--- a/libraries/python/tests/test_dashboard_autotoken.py
+++ b/libraries/python/tests/test_dashboard_autotoken.py
@@ -1,17 +1,18 @@
-"""Fail-closed dashboard gate — authentic real-app route-mounting tests.
+"""Auto-token dashboard protection — authentic real-app route tests.
 
 These tests build the REAL FastAPI application via ``EmbeddedServer._create_app``
 and drive it through the REAL Starlette ``TestClient`` (real ASGI routing, real
 route mounting, real auth dependency). Nothing under test is mocked — replacing
-the gate with a no-op (always mount) makes these tests fail, which is the
-litmus per ``.claude/rules/authentic-tests.md``.
+the auto-token branch with a no-op (leaving ``effective_token=""``) makes the
+exposed-default case answer 200 unauthenticated, which flips the protection
+assertion to a failure. That is the litmus per ``.claude/rules/authentic-tests.md``.
 
-The gate's purpose: when the embedded metrics dashboard + call-data API would be
-reachable beyond loopback (a tunnel / public ``webhook_url`` / explicit
-non-loopback ``PATTER_BIND_HOST``) without a ``dashboard_token``, the dashboard
-and ``/api/*`` call-data routes are NOT mounted (they expose call transcripts and
-metadata — PII). The carrier webhook + ``/health`` routes always mount so calls
-keep working. ``allow_insecure_dashboard=True`` is the explicit escape hatch.
+Behaviour: the dashboard + call-data API (call transcripts + metadata = PII) are
+ALWAYS mounted. When the server is reachable beyond loopback (a tunnel / public
+``webhook_url`` / explicit non-loopback ``PATTER_BIND_HOST``) without a configured
+``dashboard_token``, the SDK auto-generates a one-time token so the dashboard is
+available but protected with zero config. ``allow_insecure_dashboard=True`` is the
+explicit opt-out that serves it fully open. Loopback-only local dev stays open.
 """
 
 import pytest
@@ -58,24 +59,23 @@ def _config(webhook_url: str) -> LocalConfig:
     )
 
 
-def _build_app(
+def _make_server(
     webhook_url: str,
     *,
     dashboard: bool = True,
     dashboard_token: str = "",
     allow_insecure_dashboard: bool = False,
 ):
-    """Construct a real EmbeddedServer and return its real FastAPI app."""
+    """Construct a real EmbeddedServer (not yet built into an app)."""
     from getpatter.server import EmbeddedServer
 
-    server = EmbeddedServer(
+    return EmbeddedServer(
         config=_config(webhook_url),
         agent=_agent(),
         dashboard=dashboard,
         dashboard_token=dashboard_token,
         allow_insecure_dashboard=allow_insecure_dashboard,
     )
-    return server._create_app()
 
 
 def _route_paths(app) -> set[str]:
@@ -90,102 +90,168 @@ def _clear_bind_host(monkeypatch):
 
 @pytest.mark.skipif(not _has_fastapi, reason="fastapi not installed")
 @pytest.mark.integration
-class TestDashboardFailClosed:
-    """Real-app gate behaviour across the four spec'd scenarios."""
+class TestDashboardAutoToken:
+    """Auto-token protection behaviour across the four spec'd scenarios."""
 
-    # --- Case 1: exposed + dashboard on + token "" + default flag => gated ---
+    # --- Case 1: exposed + dashboard on + token "" + default flag ---
+    #
+    # The dashboard + call-data API ARE mounted, but protected by an
+    # auto-generated token: unauthenticated => 401, with the token => 200.
 
-    def test_exposed_unauthenticated_does_not_mount_dashboard_or_api(self):
-        app = _build_app(_PUBLIC_WEBHOOK)
+    def test_exposed_default_mounts_dashboard_and_api(self):
+        server = _make_server(_PUBLIC_WEBHOOK)
+        app = server._create_app()
         paths = _route_paths(app)
-        assert _DASHBOARD_ROOT not in paths
-        assert _DASHBOARD_API not in paths
-        assert _CALLDATA_API not in paths
+        assert _DASHBOARD_ROOT in paths
+        assert _DASHBOARD_API in paths
+        assert _CALLDATA_API in paths
 
-    def test_exposed_unauthenticated_still_mounts_carrier_webhook_and_health(self):
+    def test_exposed_default_still_mounts_carrier_webhook_and_health(self):
         # Calls MUST keep working: webhook + media + health always mount.
-        app = _build_app(_PUBLIC_WEBHOOK)
+        server = _make_server(_PUBLIC_WEBHOOK)
+        app = server._create_app()
         paths = _route_paths(app)
         assert _WEBHOOK_ROUTE in paths
         assert _HEALTH_ROUTE in paths
 
-    def test_exposed_unauthenticated_dashboard_and_api_return_404_over_http(self):
+    def test_exposed_default_resolves_nonempty_uuid_token(self):
+        import uuid
+
+        server = _make_server(_PUBLIC_WEBHOOK)
+        server._create_app()
+        token = server.effective_dashboard_token
+        assert token  # non-empty
+        # RFC 4122 v4 UUID with dashes — byte-for-byte the same shape the
+        # TypeScript SDK's crypto.randomUUID() emits (parity, blocking #1).
+        # 36 chars, version nibble 4; parse to prove it's a real UUID.
+        assert len(token) == 36
+        parsed = uuid.UUID(token)  # raises ValueError if not a valid UUID
+        assert parsed.version == 4
+        assert str(parsed) == token
+
+    def test_exposed_default_unauthenticated_request_is_401(self):
         from starlette.testclient import TestClient
 
-        client = TestClient(_build_app(_PUBLIC_WEBHOOK))
-        assert client.get(_DASHBOARD_ROOT).status_code == 404
-        assert client.get(_DASHBOARD_API).status_code == 404
-        assert client.get(_CALLDATA_API).status_code == 404
+        client = TestClient(_make_server(_PUBLIC_WEBHOOK)._create_app())
+        # LITMUS: with no auto-token these would be 200 — protection proof.
+        assert client.get(_DASHBOARD_ROOT).status_code == 401
+        assert client.get(_CALLDATA_API).status_code == 401
         # Health still answers so liveness probes / calls are unaffected.
         assert client.get(_HEALTH_ROUTE).status_code == 200
 
-    # --- Case 2: exposed + dashboard on + token SET => mounted, 401 ---
-
-    def test_exposed_with_token_mounts_dashboard_and_api(self):
-        app = _build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret")
-        paths = _route_paths(app)
-        assert _DASHBOARD_ROOT in paths
-        assert _DASHBOARD_API in paths
-        assert _CALLDATA_API in paths
-
-    def test_exposed_with_token_unauthenticated_request_is_401(self):
+    def test_exposed_default_authorized_with_query_token_succeeds(self):
         from starlette.testclient import TestClient
 
-        client = TestClient(_build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret"))
+        server = _make_server(_PUBLIC_WEBHOOK)
+        client = TestClient(server._create_app())
+        token = server.effective_dashboard_token
+        assert client.get(f"{_DASHBOARD_ROOT}?token={token}").status_code == 200
+        assert client.get(f"{_CALLDATA_API}?token={token}").status_code == 200
+
+    def test_exposed_default_authorized_with_bearer_header_succeeds(self):
+        from starlette.testclient import TestClient
+
+        server = _make_server(_PUBLIC_WEBHOOK)
+        client = TestClient(server._create_app())
+        token = server.effective_dashboard_token
+        ok = client.get(_CALLDATA_API, headers={"Authorization": f"Bearer {token}"})
+        assert ok.status_code == 200
+
+    # --- Case 2: exposed + explicit dashboard_token => mounted, 401/200 ---
+
+    def test_exposed_with_explicit_token_uses_it(self):
+        server = _make_server(_PUBLIC_WEBHOOK, dashboard_token="secret")
+        server._create_app()
+        assert server.effective_dashboard_token == "secret"
+
+    def test_exposed_with_explicit_token_unauthenticated_is_401(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(
+            _make_server(_PUBLIC_WEBHOOK, dashboard_token="secret")._create_app()
+        )
         assert client.get(_DASHBOARD_ROOT).status_code == 401
         assert client.get(_CALLDATA_API).status_code == 401
 
-    def test_exposed_with_token_authorized_request_succeeds(self):
+    def test_exposed_with_explicit_token_authorized_is_200(self):
         from starlette.testclient import TestClient
 
-        client = TestClient(_build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret"))
-        ok = client.get(_CALLDATA_API, headers={"Authorization": "Bearer s3cret"})
+        client = TestClient(
+            _make_server(_PUBLIC_WEBHOOK, dashboard_token="secret")._create_app()
+        )
+        ok = client.get(_CALLDATA_API, headers={"Authorization": "Bearer secret"})
         assert ok.status_code == 200
 
-    # --- Case 3: loopback-only + dashboard on + token "" => mounted ---
+    # --- Case 3: loopback-only + no token => mounted and OPEN (local dev) ---
 
-    def test_loopback_only_unauthenticated_mounts_dashboard_and_api(self):
-        # Local-dev path: backward compatible, still served unauthenticated.
-        app = _build_app(_LOOPBACK_WEBHOOK)
+    def test_loopback_only_mounts_dashboard_and_api(self):
+        server = _make_server(_LOOPBACK_WEBHOOK)
+        app = server._create_app()
         paths = _route_paths(app)
         assert _DASHBOARD_ROOT in paths
         assert _DASHBOARD_API in paths
         assert _CALLDATA_API in paths
 
-    def test_loopback_only_dashboard_and_api_reachable_over_http(self):
+    def test_loopback_only_is_open_no_autotoken(self):
+        # Zero-friction local dev: no token generated, served open.
+        server = _make_server(_LOOPBACK_WEBHOOK)
+        server._create_app()
+        assert server.effective_dashboard_token == ""
+
+    def test_loopback_only_reachable_unauthenticated_over_http(self):
         from starlette.testclient import TestClient
 
-        client = TestClient(_build_app(_LOOPBACK_WEBHOOK))
+        client = TestClient(_make_server(_LOOPBACK_WEBHOOK)._create_app())
         assert client.get(_DASHBOARD_ROOT).status_code == 200
         assert client.get(_CALLDATA_API).status_code == 200
 
-    def test_empty_webhook_url_local_dev_mounts_dashboard_and_api(self):
-        # No tunnel, no webhook_url at all (pure local dev) — still served.
-        app = _build_app("")
-        paths = _route_paths(app)
-        assert _DASHBOARD_ROOT in paths
-        assert _CALLDATA_API in paths
-
-    # --- Case 4: exposed + token "" + allow_insecure_dashboard=True => mounted ---
-
-    def test_exposed_with_escape_hatch_mounts_dashboard_and_api(self):
-        app = _build_app(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True)
-        paths = _route_paths(app)
-        assert _DASHBOARD_ROOT in paths
-        assert _DASHBOARD_API in paths
-        assert _CALLDATA_API in paths
-
-    def test_exposed_with_escape_hatch_dashboard_reachable_over_http(self):
+    def test_empty_webhook_url_local_dev_is_open(self):
+        # No tunnel, no webhook_url at all (pure local dev) — open.
         from starlette.testclient import TestClient
 
-        client = TestClient(_build_app(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True))
+        server = _make_server("")
+        client = TestClient(server._create_app())
+        assert server.effective_dashboard_token == ""
         assert client.get(_DASHBOARD_ROOT).status_code == 200
         assert client.get(_CALLDATA_API).status_code == 200
+
+    # --- Case 4: exposed + no token + allow_insecure_dashboard=True => OPEN ---
+
+    def test_exposed_insecure_optout_is_open(self):
+        server = _make_server(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True)
+        server._create_app()
+        assert server.effective_dashboard_token == ""
+
+    def test_exposed_insecure_optout_reachable_unauthenticated_over_http(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(
+            _make_server(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True)._create_app()
+        )
+        assert client.get(_DASHBOARD_ROOT).status_code == 200
+        assert client.get(_CALLDATA_API).status_code == 200
+
+    def test_exposed_insecure_optout_logs_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="getpatter"):
+            _make_server(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True)._create_app()
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "WITHOUT authentication" in joined
+        assert "allow_insecure_dashboard=True" in joined
+
+    def test_exposed_default_logs_autotoken_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="getpatter"):
+            _make_server(_PUBLIC_WEBHOOK)._create_app()
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "auto-generated" in joined
 
     # --- dashboard=False disables everything regardless of exposure ---
 
     def test_dashboard_disabled_mounts_neither_but_keeps_webhook(self):
-        app = _build_app(_PUBLIC_WEBHOOK, dashboard=False)
+        app = _make_server(_PUBLIC_WEBHOOK, dashboard=False)._create_app()
         paths = _route_paths(app)
         assert _DASHBOARD_ROOT not in paths
         assert _CALLDATA_API not in paths
@@ -198,25 +264,28 @@ class TestDashboardFailClosed:
 class TestDashboardExposureSignalBindHost:
     """Signal (c): explicit non-loopback PATTER_BIND_HOST triggers exposure."""
 
-    def test_explicit_nonloopback_bind_host_gates_unauthenticated_dashboard(
-        self, monkeypatch
-    ):
+    def test_explicit_nonloopback_bind_host_protects_dashboard(self, monkeypatch):
         # Even with a loopback webhook_url, an explicit 0.0.0.0 bind exposes
-        # the port; the gate must fire.
-        monkeypatch.setenv("PATTER_BIND_HOST", "0.0.0.0")
-        app = _build_app(_LOOPBACK_WEBHOOK)
-        paths = _route_paths(app)
-        assert _DASHBOARD_ROOT not in paths
-        assert _CALLDATA_API not in paths
-        assert _WEBHOOK_ROUTE in paths
+        # the port; the dashboard mounts but is auto-token protected (401).
+        from starlette.testclient import TestClient
 
-    def test_explicit_loopback_bind_host_does_not_gate(self, monkeypatch):
+        monkeypatch.setenv("PATTER_BIND_HOST", "0.0.0.0")
+        server = _make_server(_LOOPBACK_WEBHOOK)
+        client = TestClient(server._create_app())
+        assert server.effective_dashboard_token  # auto-generated
+        assert client.get(_DASHBOARD_ROOT).status_code == 401
+        assert _WEBHOOK_ROUTE in _route_paths(server._create_app())
+
+    def test_explicit_loopback_bind_host_stays_open(self, monkeypatch):
         # Explicitly setting the loopback default must NOT trip exposure.
+        from starlette.testclient import TestClient
+
         monkeypatch.setenv("PATTER_BIND_HOST", "127.0.0.1")
-        app = _build_app(_LOOPBACK_WEBHOOK)
-        paths = _route_paths(app)
-        assert _DASHBOARD_ROOT in paths
-        assert _CALLDATA_API in paths
+        server = _make_server(_LOOPBACK_WEBHOOK)
+        client = TestClient(server._create_app())
+        assert server.effective_dashboard_token == ""
+        assert client.get(_DASHBOARD_ROOT).status_code == 200
+        assert client.get(_CALLDATA_API).status_code == 200
 
 
 @pytest.mark.unit

--- a/libraries/python/tests/test_dashboard_fail_closed.py
+++ b/libraries/python/tests/test_dashboard_fail_closed.py
@@ -1,0 +1,313 @@
+"""Fail-closed dashboard gate — authentic real-app route-mounting tests.
+
+These tests build the REAL FastAPI application via ``EmbeddedServer._create_app``
+and drive it through the REAL Starlette ``TestClient`` (real ASGI routing, real
+route mounting, real auth dependency). Nothing under test is mocked — replacing
+the gate with a no-op (always mount) makes these tests fail, which is the
+litmus per ``.claude/rules/authentic-tests.md``.
+
+The gate's purpose: when the embedded metrics dashboard + call-data API would be
+reachable beyond loopback (a tunnel / public ``webhook_url`` / explicit
+non-loopback ``PATTER_BIND_HOST``) without a ``dashboard_token``, the dashboard
+and ``/api/*`` call-data routes are NOT mounted (they expose call transcripts and
+metadata — PII). The carrier webhook + ``/health`` routes always mount so calls
+keep working. ``allow_insecure_dashboard=True`` is the explicit escape hatch.
+"""
+
+import pytest
+
+from getpatter.local_config import LocalConfig
+from getpatter.models import Agent
+
+_has_fastapi = False
+try:
+    import fastapi  # noqa: F401
+    from starlette.testclient import TestClient  # noqa: F401
+
+    _has_fastapi = True
+except ImportError:
+    pass
+
+# A public (non-loopback) webhook hostname — what a tunnel would assign.
+# Not real PII / infra: trycloudflare.com is the public quick-tunnel domain.
+_PUBLIC_WEBHOOK = "patter-test.trycloudflare.com"
+_LOOPBACK_WEBHOOK = "127.0.0.1"
+
+# Representative routes.
+_DASHBOARD_ROOT = "/"
+_DASHBOARD_API = "/api/dashboard/calls"
+_CALLDATA_API = "/api/v1/calls"
+_WEBHOOK_ROUTE = "/webhooks/twilio/voice"
+_HEALTH_ROUTE = "/health"
+
+
+def _agent() -> Agent:
+    return Agent(
+        system_prompt="Test", voice="alloy", model="gpt-4o-mini-realtime-preview"
+    )
+
+
+def _config(webhook_url: str) -> LocalConfig:
+    return LocalConfig(
+        telephony_provider="twilio",
+        twilio_sid="AC" + "a" * 32,
+        twilio_token="test-token",
+        openai_key="sk-test",
+        phone_number="+15550001234",
+        webhook_url=webhook_url,
+    )
+
+
+def _build_app(
+    webhook_url: str,
+    *,
+    dashboard: bool = True,
+    dashboard_token: str = "",
+    allow_insecure_dashboard: bool = False,
+):
+    """Construct a real EmbeddedServer and return its real FastAPI app."""
+    from getpatter.server import EmbeddedServer
+
+    server = EmbeddedServer(
+        config=_config(webhook_url),
+        agent=_agent(),
+        dashboard=dashboard,
+        dashboard_token=dashboard_token,
+        allow_insecure_dashboard=allow_insecure_dashboard,
+    )
+    return server._create_app()
+
+
+def _route_paths(app) -> set[str]:
+    return {r.path for r in app.routes if hasattr(r, "path")}
+
+
+@pytest.fixture(autouse=True)
+def _clear_bind_host(monkeypatch):
+    """Isolate signal (c): ensure no inherited PATTER_BIND_HOST leaks in."""
+    monkeypatch.delenv("PATTER_BIND_HOST", raising=False)
+
+
+@pytest.mark.skipif(not _has_fastapi, reason="fastapi not installed")
+@pytest.mark.integration
+class TestDashboardFailClosed:
+    """Real-app gate behaviour across the four spec'd scenarios."""
+
+    # --- Case 1: exposed + dashboard on + token "" + default flag => gated ---
+
+    def test_exposed_unauthenticated_does_not_mount_dashboard_or_api(self):
+        app = _build_app(_PUBLIC_WEBHOOK)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT not in paths
+        assert _DASHBOARD_API not in paths
+        assert _CALLDATA_API not in paths
+
+    def test_exposed_unauthenticated_still_mounts_carrier_webhook_and_health(self):
+        # Calls MUST keep working: webhook + media + health always mount.
+        app = _build_app(_PUBLIC_WEBHOOK)
+        paths = _route_paths(app)
+        assert _WEBHOOK_ROUTE in paths
+        assert _HEALTH_ROUTE in paths
+
+    def test_exposed_unauthenticated_dashboard_and_api_return_404_over_http(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(_build_app(_PUBLIC_WEBHOOK))
+        assert client.get(_DASHBOARD_ROOT).status_code == 404
+        assert client.get(_DASHBOARD_API).status_code == 404
+        assert client.get(_CALLDATA_API).status_code == 404
+        # Health still answers so liveness probes / calls are unaffected.
+        assert client.get(_HEALTH_ROUTE).status_code == 200
+
+    # --- Case 2: exposed + dashboard on + token SET => mounted, 401 ---
+
+    def test_exposed_with_token_mounts_dashboard_and_api(self):
+        app = _build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret")
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT in paths
+        assert _DASHBOARD_API in paths
+        assert _CALLDATA_API in paths
+
+    def test_exposed_with_token_unauthenticated_request_is_401(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(_build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret"))
+        assert client.get(_DASHBOARD_ROOT).status_code == 401
+        assert client.get(_CALLDATA_API).status_code == 401
+
+    def test_exposed_with_token_authorized_request_succeeds(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(_build_app(_PUBLIC_WEBHOOK, dashboard_token="s3cret"))
+        ok = client.get(_CALLDATA_API, headers={"Authorization": "Bearer s3cret"})
+        assert ok.status_code == 200
+
+    # --- Case 3: loopback-only + dashboard on + token "" => mounted ---
+
+    def test_loopback_only_unauthenticated_mounts_dashboard_and_api(self):
+        # Local-dev path: backward compatible, still served unauthenticated.
+        app = _build_app(_LOOPBACK_WEBHOOK)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT in paths
+        assert _DASHBOARD_API in paths
+        assert _CALLDATA_API in paths
+
+    def test_loopback_only_dashboard_and_api_reachable_over_http(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(_build_app(_LOOPBACK_WEBHOOK))
+        assert client.get(_DASHBOARD_ROOT).status_code == 200
+        assert client.get(_CALLDATA_API).status_code == 200
+
+    def test_empty_webhook_url_local_dev_mounts_dashboard_and_api(self):
+        # No tunnel, no webhook_url at all (pure local dev) — still served.
+        app = _build_app("")
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT in paths
+        assert _CALLDATA_API in paths
+
+    # --- Case 4: exposed + token "" + allow_insecure_dashboard=True => mounted ---
+
+    def test_exposed_with_escape_hatch_mounts_dashboard_and_api(self):
+        app = _build_app(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT in paths
+        assert _DASHBOARD_API in paths
+        assert _CALLDATA_API in paths
+
+    def test_exposed_with_escape_hatch_dashboard_reachable_over_http(self):
+        from starlette.testclient import TestClient
+
+        client = TestClient(_build_app(_PUBLIC_WEBHOOK, allow_insecure_dashboard=True))
+        assert client.get(_DASHBOARD_ROOT).status_code == 200
+        assert client.get(_CALLDATA_API).status_code == 200
+
+    # --- dashboard=False disables everything regardless of exposure ---
+
+    def test_dashboard_disabled_mounts_neither_but_keeps_webhook(self):
+        app = _build_app(_PUBLIC_WEBHOOK, dashboard=False)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT not in paths
+        assert _CALLDATA_API not in paths
+        assert _WEBHOOK_ROUTE in paths
+        assert _HEALTH_ROUTE in paths
+
+
+@pytest.mark.skipif(not _has_fastapi, reason="fastapi not installed")
+@pytest.mark.integration
+class TestDashboardExposureSignalBindHost:
+    """Signal (c): explicit non-loopback PATTER_BIND_HOST triggers exposure."""
+
+    def test_explicit_nonloopback_bind_host_gates_unauthenticated_dashboard(
+        self, monkeypatch
+    ):
+        # Even with a loopback webhook_url, an explicit 0.0.0.0 bind exposes
+        # the port; the gate must fire.
+        monkeypatch.setenv("PATTER_BIND_HOST", "0.0.0.0")
+        app = _build_app(_LOOPBACK_WEBHOOK)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT not in paths
+        assert _CALLDATA_API not in paths
+        assert _WEBHOOK_ROUTE in paths
+
+    def test_explicit_loopback_bind_host_does_not_gate(self, monkeypatch):
+        # Explicitly setting the loopback default must NOT trip exposure.
+        monkeypatch.setenv("PATTER_BIND_HOST", "127.0.0.1")
+        app = _build_app(_LOOPBACK_WEBHOOK)
+        paths = _route_paths(app)
+        assert _DASHBOARD_ROOT in paths
+        assert _CALLDATA_API in paths
+
+
+@pytest.mark.unit
+class TestAllowInsecureDashboardConfigThreading:
+    """The opt-in flag exists with a safe default and threads to the server.
+
+    ``allow_insecure_dashboard`` lives on ``Patter.serve()`` — alongside
+    ``dashboard`` and ``dashboard_token`` — mirroring the TypeScript SDK where
+    ``allowInsecureDashboard`` is a ``ServeOptions`` field passed to ``serve()``.
+    """
+
+    def test_serve_has_safe_default(self):
+        import inspect
+
+        from getpatter.client import Patter
+
+        sig = inspect.signature(Patter.serve)
+        assert "allow_insecure_dashboard" in sig.parameters
+        assert sig.parameters["allow_insecure_dashboard"].default is False
+
+    def test_serve_sits_next_to_other_dashboard_params(self):
+        # Parity: the flag travels the same path as dashboard / dashboard_token.
+        import inspect
+
+        from getpatter.client import Patter
+
+        sig = inspect.signature(Patter.serve)
+        for name in ("dashboard", "dashboard_token", "allow_insecure_dashboard"):
+            assert name in sig.parameters
+
+    def test_embedded_server_has_safe_default(self):
+        import inspect
+
+        from getpatter.server import EmbeddedServer
+
+        sig = inspect.signature(EmbeddedServer.__init__)
+        assert "allow_insecure_dashboard" in sig.parameters
+        assert sig.parameters["allow_insecure_dashboard"].default is False
+
+    @staticmethod
+    def _serve_phone_and_agent():
+        from getpatter import OpenAIRealtime
+        from getpatter.carriers.twilio import Carrier as Twilio
+        from getpatter.client import Patter
+
+        phone = Patter(
+            carrier=Twilio(account_sid="AC" + "a" * 32, auth_token="tok_test"),
+            phone_number="+15550001234",
+            webhook_url=_PUBLIC_WEBHOOK,
+        )
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-test"), system_prompt="hi"
+        )
+        return phone, agent
+
+    async def test_serve_threads_flag_to_embedded_server(self):
+        # serve(allow_insecure_dashboard=True) must reach EmbeddedServer with
+        # the same value (the path dashboard / dashboard_token already travel).
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        phone, agent = self._serve_phone_and_agent()
+
+        mock_server = MagicMock()
+        mock_server.start = AsyncMock()
+        with patch(
+            "getpatter.server.EmbeddedServer", return_value=mock_server
+        ) as MockServer:
+            await phone.serve(agent, port=9123, allow_insecure_dashboard=True)
+        _, kwargs = MockServer.call_args
+        assert kwargs["allow_insecure_dashboard"] is True
+
+    async def test_serve_default_threads_false_to_embedded_server(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        phone, agent = self._serve_phone_and_agent()
+
+        mock_server = MagicMock()
+        mock_server.start = AsyncMock()
+        with patch(
+            "getpatter.server.EmbeddedServer", return_value=mock_server
+        ) as MockServer:
+            await phone.serve(agent, port=9124)
+        _, kwargs = MockServer.call_args
+        assert kwargs["allow_insecure_dashboard"] is False
+
+    def test_embedded_server_stores_flag_on_instance(self):
+        from getpatter.server import EmbeddedServer
+
+        server = EmbeddedServer(
+            config=_config(_PUBLIC_WEBHOOK),
+            agent=_agent(),
+            allow_insecure_dashboard=True,
+        )
+        assert server.allow_insecure_dashboard is True

--- a/libraries/python/tests/test_local_mode.py
+++ b/libraries/python/tests/test_local_mode.py
@@ -199,6 +199,7 @@ async def test_serve_calls_embedded_server():
             pricing=None,
             dashboard=True,
             dashboard_token="",
+            allow_insecure_dashboard=False,
         )
         mock_server.start.assert_called_once_with(port=9000)
 

--- a/libraries/python/tests/unit/test_server_unit.py
+++ b/libraries/python/tests/unit/test_server_unit.py
@@ -34,7 +34,15 @@ def _make_server(**overrides) -> EmbeddedServer:
         require_signature=False,
     )
     agent = make_agent()
-    defaults = dict(config=cfg, agent=agent, dashboard=False)
+    # ``webhook_url="test.ngrok.io"`` (kept for the webhook-signature tests)
+    # marks the server as exposed beyond loopback, which the fail-closed
+    # dashboard gate would otherwise refuse to serve unauthenticated. These
+    # route-mounting / auth tests assert the legacy mounted behaviour, so opt
+    # them into the explicit insecure-serve path. The gate itself is covered
+    # by tests/test_dashboard_fail_closed.py.
+    defaults = dict(
+        config=cfg, agent=agent, dashboard=False, allow_insecure_dashboard=True
+    )
     defaults.update(overrides)
     return EmbeddedServer(**defaults)
 

--- a/libraries/python/tests/unit/test_server_unit.py
+++ b/libraries/python/tests/unit/test_server_unit.py
@@ -35,11 +35,11 @@ def _make_server(**overrides) -> EmbeddedServer:
     )
     agent = make_agent()
     # ``webhook_url="test.ngrok.io"`` (kept for the webhook-signature tests)
-    # marks the server as exposed beyond loopback, which the fail-closed
-    # dashboard gate would otherwise refuse to serve unauthenticated. These
-    # route-mounting / auth tests assert the legacy mounted behaviour, so opt
-    # them into the explicit insecure-serve path. The gate itself is covered
-    # by tests/test_dashboard_fail_closed.py.
+    # marks the server as exposed beyond loopback, which would otherwise make
+    # the SDK auto-generate a dashboard token to protect it. These route-mounting
+    # tests assert the open (unauthenticated) behaviour, so opt them into the
+    # explicit insecure-serve path so the dashboard stays open. The auto-token
+    # protection itself is covered by tests/test_dashboard_autotoken.py.
     defaults = dict(
         config=cfg, agent=agent, dashboard=False, allow_insecure_dashboard=True
     )

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -724,6 +724,7 @@ export class Patter {
       opts.pricing,
       opts.dashboard ?? true,
       opts.dashboardToken ?? '',
+      opts.allowInsecureDashboard ?? false,
     );
     // Forward the prewarm-audio accessor so the per-call StreamHandler can
     // consume the pre-rendered first-message audio (if any) on ``start``.

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -852,12 +852,28 @@ export class EmbeddedServer {
   private server: HTTPServer | null = null;
   private wss: WebSocketServer | null = null;
   /**
-   * Whether the dashboard + ``/api/*`` routes were actually mounted in
-   * ``start()``. False when the fail-closed gate refused to serve them on an
-   * exposed, unauthenticated bind — used so the startup banner does not
-   * advertise a dashboard URL that would 404.
+   * Whether the dashboard + ``/api/*`` routes were mounted in ``start()``.
+   * The dashboard is now ALWAYS mounted when enabled (it never 404s): an
+   * exposed, token-less bind is protected with an auto-generated token
+   * rather than refused. This flag is therefore ``true`` whenever the
+   * dashboard is enabled — kept so the startup banner can gate on it.
    */
   private dashboardMounted = false;
+  /**
+   * The token actually in effect for the dashboard + ``/api/*`` routes,
+   * resolved in ``start()``. One of: the explicit ``dashboardToken`` if set;
+   * a freshly generated UUID when the bind is exposed and
+   * ``allowInsecureDashboard`` is ``false``; or ``''`` (OPEN) for loopback
+   * local dev and for an exposed bind with ``allowInsecureDashboard=true``.
+   * Read by the startup banner (to print the ready URL with ``?token=``) and
+   * by authentic tests (to authenticate).
+   */
+  private effectiveDashboardToken = '';
+
+  /** The token in effect for the dashboard, resolved at ``start()``. Empty string = served OPEN. */
+  get resolvedDashboardToken(): string {
+    return this.effectiveDashboardToken;
+  }
   private twilioTokenWarningLogged = false;
   private telnyxSigWarningLogged = false;
   readonly metricsStore: MetricsStore;
@@ -958,12 +974,16 @@ export class EmbeddedServer {
     private readonly dashboard: boolean = true,
     private readonly dashboardToken: string = '',
     /**
-     * When true, force-serve the dashboard + `/api/*` routes without
-     * authentication even when the server is reachable beyond loopback
-     * (tunnel / public webhook URL / explicit non-loopback bind). Defaults
-     * to `false`: when the dashboard is enabled, the token is empty, and the
-     * server is exposed, the dashboard + API routes are NOT mounted
-     * (fail-closed) to avoid leaking call transcripts and metadata (PII).
+     * Opt-out from the auto-generated dashboard token. When `false` (the
+     * default) and the dashboard is enabled with no explicit
+     * `dashboardToken` on a server reachable beyond loopback (tunnel /
+     * public webhook URL / explicit non-loopback bind), the SDK generates a
+     * one-time token and protects the dashboard + `/api/*` routes with it
+     * (the startup banner prints the ready-to-use URL including the token).
+     * Set this to `true` to serve the dashboard fully OPEN (no token) even
+     * when exposed — this leaks call transcripts and metadata (PII) to
+     * anyone who can reach the URL, so only enable it behind your own
+     * access control (Cloudflare Access, a tailnet, etc.).
      */
     private readonly allowInsecureDashboard: boolean = false,
   ) {
@@ -1199,36 +1219,47 @@ export class EmbeddedServer {
 
     // Mount dashboard and B2B API routes.
     //
-    // FAIL-CLOSED: the dashboard + ``/api/*`` routes serve call transcripts
-    // and metadata (PII). If the dashboard is enabled, no auth token is set,
-    // AND the server is reachable beyond loopback (tunnel / public webhook /
-    // explicit non-loopback bind), refuse to mount them unless the operator
-    // has explicitly opted in with ``allowInsecureDashboard``. The carrier
-    // webhook + media-stream + ``/health`` routes below mount regardless, so
-    // inbound/outbound calls keep working — only the PII surface is gated.
+    // The dashboard + ``/api/*`` routes serve call transcripts and metadata
+    // (PII). The dashboard is ALWAYS mounted when enabled (it never 404s) —
+    // we resolve an EFFECTIVE token first and protect the routes with it:
+    //
+    //   - explicit ``dashboardToken`` set        => use it (unchanged).
+    //   - exposed + NOT allowInsecureDashboard    => auto-generate a one-time
+    //                                                token (zero config) and
+    //                                                print the ready URL.
+    //   - exposed + allowInsecureDashboard        => OPEN (no token), warn.
+    //   - loopback-only, no token                 => OPEN (local-dev, unchanged).
     if (this.dashboard) {
       const exposed = this.isExposed();
-      const unauthenticated = !this.dashboardToken;
-      if (unauthenticated && exposed && !this.allowInsecureDashboard) {
-        getLogger().error(
-          'Dashboard NOT served: it would be reachable beyond 127.0.0.1 without ' +
-            'authentication, exposing call transcripts and metadata (PII). Fix one of: ' +
-            '(1) set dashboardToken=<secret> to require auth, (2) set dashboard=false to ' +
-            'disable it on this host, or (3) set allowInsecureDashboard=true to ' +
-            'force-serve it unauthenticated (NOT recommended on a public network).',
+      if (this.dashboardToken) {
+        // Explicit token — honour it as-is.
+        this.effectiveDashboardToken = this.dashboardToken;
+      } else if (exposed && !this.allowInsecureDashboard) {
+        // Exposed without a configured token: protect with a generated one.
+        this.effectiveDashboardToken = crypto.randomUUID();
+        getLogger().warn(
+          'Dashboard is reachable beyond 127.0.0.1 without a configured token; ' +
+            'protecting it with an auto-generated token. ' +
+            `Open: http://127.0.0.1:${port}/?token=${this.effectiveDashboardToken}  ` +
+            'Set dashboardToken for a stable token, or allowInsecureDashboard=true to ' +
+            'serve it open.',
+        );
+      } else if (exposed && this.allowInsecureDashboard) {
+        // Operator explicitly opted to serve the PII surface open.
+        this.effectiveDashboardToken = '';
+        getLogger().warn(
+          'Dashboard served WITHOUT authentication on a publicly-reachable bind ' +
+            '(allowInsecureDashboard=true). Call transcripts and metadata are ' +
+            'exposed to anyone who can reach this URL.',
         );
       } else {
-        if (unauthenticated && exposed && this.allowInsecureDashboard) {
-          getLogger().warn(
-            'Dashboard served WITHOUT authentication on a publicly-reachable bind ' +
-              '(allowInsecureDashboard=true). Call transcripts and metadata are ' +
-              'exposed to anyone who can reach this URL.',
-          );
-        }
-        mountDashboard(app, this.metricsStore, this.dashboardToken);
-        mountApi(app, this.metricsStore, this.dashboardToken);
-        this.dashboardMounted = true;
+        // Loopback-only, no token: open local-dev behaviour, unchanged. The
+        // friendly banner warning is emitted on listen (see below).
+        this.effectiveDashboardToken = '';
       }
+      mountDashboard(app, this.metricsStore, this.effectiveDashboardToken);
+      mountApi(app, this.metricsStore, this.effectiveDashboardToken);
+      this.dashboardMounted = true;
     }
 
     // Twilio statusCallback — captures ringing/no-answer/busy/failed
@@ -1914,16 +1945,23 @@ export class EmbeddedServer {
           );
         }
         if (this.dashboard && this.dashboardMounted) {
-          console.log('\n──── Dashboard ─────────────────────────────────────');
-          getLogger().info(`URL: http://127.0.0.1:${port}/`);
-          if (!this.dashboardToken) {
+          getLogger().info('──── Dashboard ─────────────────────────────────────');
+          if (this.effectiveDashboardToken) {
+            // A token (explicit or auto-generated) is in effect — print the
+            // ready-to-use URL so the operator can click straight in.
+            getLogger().info(
+              `URL: http://127.0.0.1:${port}/?token=${this.effectiveDashboardToken}`,
+            );
+          } else {
+            // Served OPEN (loopback local dev, or allowInsecureDashboard).
+            getLogger().info(`URL: http://127.0.0.1:${port}/`);
             getLogger().warn(
               'Dashboard is enabled without authentication. ' +
               'Set dashboardToken to protect call data. ' +
               'This is safe for local development but should not be exposed on a public network.'
             );
           }
-          console.log('────────────────────────────────────────────────────\n');
+          getLogger().info('────────────────────────────────────────────────────');
         }
         resolve();
       });

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -276,6 +276,48 @@ export function validateWebhookUrl(url: string, allowLoopback = false): void {
 }
 
 /**
+ * Reduce a host value (bare hostname, ``host:port``, or a full URL) to its
+ * lowercase hostname with any IPv6 brackets stripped. Returns ``''`` when the
+ * input is empty. Used by the dashboard exposure check, which receives the
+ * carrier ``webhookUrl`` (already a bare host) and the ``PATTER_BIND_HOST``
+ * env var (a bare host or IP).
+ */
+export function extractHost(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  let host = trimmed.replace(/^[a-z]+:\/\//i, '').replace(/\/.*$/, '');
+  // Bracketed IPv6 literal, optionally with a trailing port: ``[::1]`` or
+  // ``[::1]:8000``. Take everything between the brackets and drop the port.
+  if (host.startsWith('[')) {
+    return host.slice(1).split(']', 1)[0].toLowerCase();
+  }
+  // Strip a trailing ``:port`` for IPv4 / hostname. A bare IPv6 literal
+  // (``::1``) has many colons and no port, so it must not be split.
+  if (!host.includes('::')) {
+    const lastColon = host.lastIndexOf(':');
+    if (lastColon !== -1 && /^\d+$/.test(host.slice(lastColon + 1))) {
+      host = host.slice(0, lastColon);
+    }
+  }
+  return host.toLowerCase();
+}
+
+/** True when ``host`` is a loopback indicator (127.0.0.0/8, localhost, ::1). */
+export function isLoopbackHost(value: string): boolean {
+  const host = extractHost(value);
+  if (!host) return false;
+  if (host === 'localhost' || host === 'ip6-localhost' || host === 'ip6-loopback') {
+    return true;
+  }
+  if (host === '::1' || host === '::ffff:127.0.0.1') return true;
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (v4) {
+    return parseInt(v4[1], 10) === 127; // 127.0.0.0/8
+  }
+  return false;
+}
+
+/**
  * Validate a Telnyx webhook request signature using Ed25519.
  *
  * Telnyx signs the raw request body with an Ed25519 private key and includes
@@ -809,6 +851,13 @@ const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000;
 export class EmbeddedServer {
   private server: HTTPServer | null = null;
   private wss: WebSocketServer | null = null;
+  /**
+   * Whether the dashboard + ``/api/*`` routes were actually mounted in
+   * ``start()``. False when the fail-closed gate refused to serve them on an
+   * exposed, unauthenticated bind — used so the startup banner does not
+   * advertise a dashboard URL that would 404.
+   */
+  private dashboardMounted = false;
   private twilioTokenWarningLogged = false;
   private telnyxSigWarningLogged = false;
   readonly metricsStore: MetricsStore;
@@ -908,6 +957,15 @@ export class EmbeddedServer {
     pricingOverrides?: Record<string, Record<string, unknown>>,
     private readonly dashboard: boolean = true,
     private readonly dashboardToken: string = '',
+    /**
+     * When true, force-serve the dashboard + `/api/*` routes without
+     * authentication even when the server is reachable beyond loopback
+     * (tunnel / public webhook URL / explicit non-loopback bind). Defaults
+     * to `false`: when the dashboard is enabled, the token is empty, and the
+     * server is exposed, the dashboard + API routes are NOT mounted
+     * (fail-closed) to avoid leaking call transcripts and metadata (PII).
+     */
+    private readonly allowInsecureDashboard: boolean = false,
   ) {
     this.metricsStore = new MetricsStore();
     this.pricing = mergePricing(pricingOverrides as Record<string, { unit?: string; price?: number }> | undefined);
@@ -1030,6 +1088,50 @@ export class EmbeddedServer {
     this.amdClass.clear();
   }
 
+  /**
+   * Decide whether this server is reachable beyond loopback (127.0.0.1).
+   *
+   * The dashboard serves call transcripts and metadata (PII), so before
+   * mounting it unauthenticated we must know whether anyone off-host can
+   * reach the port. Signals (in order):
+   *
+   *   (a)+(b) — a public webhook URL. ``client.ts`` resolves
+   *       ``config.webhookUrl`` to the live hostname for every serve path:
+   *       a cloudflared quick-tunnel host, a {@link StaticTunnel} hostname,
+   *       or an explicit ``webhookUrl``. A tunnel directive (signal a) and a
+   *       public webhook URL (signal b) therefore both surface here as a
+   *       non-loopback, non-private webhook host. This is the case that
+   *       matters for tunnels — the whole port (dashboard included) is
+   *       published on a public ``*.trycloudflare.com`` URL.
+   *
+   *   (c) — an EXPLICIT non-loopback bind override via ``PATTER_BIND_HOST``.
+   *       Node's ``http.Server.listen(port, host)`` defaults to 127.0.0.1
+   *       here (see ``start()``), so plain local dev is never flagged; only
+   *       an operator who set ``PATTER_BIND_HOST`` to e.g. ``0.0.0.0`` is.
+   *
+   * Only loopback webhook hosts (127.0.0.0/8, localhost, ::1) are treated as
+   * not-exposed. RFC1918 / LAN hosts ARE exposure — they are reachable by
+   * other machines on the network — matching the Python SDK's gate.
+   */
+  private isExposed(): boolean {
+    // Signal (c): explicit non-loopback bind override.
+    const bindOverride = process.env.PATTER_BIND_HOST;
+    if (bindOverride && !isLoopbackHost(bindOverride)) {
+      return true;
+    }
+    // Signals (a)+(b): a non-loopback webhook host (tunnel-assigned or
+    // explicit). Any host that is not loopback is reachable beyond
+    // 127.0.0.1 — including RFC1918 / LAN addresses, which every other
+    // device on the network can reach. Mirrors the Python SDK
+    // (``_dashboard_is_exposed``), the parity reference: it treats any
+    // non-loopback webhook_url as exposed, with no private-range carve-out.
+    const host = extractHost(this.config.webhookUrl ?? '');
+    if (host && !isLoopbackHost(host)) {
+      return true;
+    }
+    return false;
+  }
+
   /** Bind HTTP + WebSocket listeners on `port`, mount carrier webhooks and dashboard routes. */
   async start(port: number = 8000): Promise<void> {
     const webhookUrlPattern = /^[a-zA-Z0-9][a-zA-Z0-9.\-]+[a-zA-Z0-9]$/;
@@ -1095,10 +1197,38 @@ export class EmbeddedServer {
       res.json({ status: 'ok', mode: 'local' });
     });
 
-    // Mount dashboard and B2B API routes
+    // Mount dashboard and B2B API routes.
+    //
+    // FAIL-CLOSED: the dashboard + ``/api/*`` routes serve call transcripts
+    // and metadata (PII). If the dashboard is enabled, no auth token is set,
+    // AND the server is reachable beyond loopback (tunnel / public webhook /
+    // explicit non-loopback bind), refuse to mount them unless the operator
+    // has explicitly opted in with ``allowInsecureDashboard``. The carrier
+    // webhook + media-stream + ``/health`` routes below mount regardless, so
+    // inbound/outbound calls keep working — only the PII surface is gated.
     if (this.dashboard) {
-      mountDashboard(app, this.metricsStore, this.dashboardToken);
-      mountApi(app, this.metricsStore, this.dashboardToken);
+      const exposed = this.isExposed();
+      const unauthenticated = !this.dashboardToken;
+      if (unauthenticated && exposed && !this.allowInsecureDashboard) {
+        getLogger().error(
+          'Dashboard NOT served: it would be reachable beyond 127.0.0.1 without ' +
+            'authentication, exposing call transcripts and metadata (PII). Fix one of: ' +
+            '(1) set dashboardToken=<secret> to require auth, (2) set dashboard=false to ' +
+            'disable it on this host, or (3) set allowInsecureDashboard=true to ' +
+            'force-serve it unauthenticated (NOT recommended on a public network).',
+        );
+      } else {
+        if (unauthenticated && exposed && this.allowInsecureDashboard) {
+          getLogger().warn(
+            'Dashboard served WITHOUT authentication on a publicly-reachable bind ' +
+              '(allowInsecureDashboard=true). Call transcripts and metadata are ' +
+              'exposed to anyone who can reach this URL.',
+          );
+        }
+        mountDashboard(app, this.metricsStore, this.dashboardToken);
+        mountApi(app, this.metricsStore, this.dashboardToken);
+        this.dashboardMounted = true;
+      }
     }
 
     // Twilio statusCallback — captures ringing/no-answer/busy/failed
@@ -1783,7 +1913,7 @@ export class EmbeddedServer {
             'this model, otherwise the dashboard cost display will under-report.'
           );
         }
-        if (this.dashboard) {
+        if (this.dashboard && this.dashboardMounted) {
           console.log('\n──── Dashboard ─────────────────────────────────────');
           getLogger().info(`URL: http://127.0.0.1:${port}/`);
           if (!this.dashboardToken) {

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -697,20 +697,22 @@ export interface ServeOptions {
   readonly dashboardToken?: string;
   /**
    * When true, serve the dashboard (and the call-data `/api/*` routes)
-   * WITHOUT authentication even when the server is reachable beyond
-   * loopback (e.g. behind a tunnel or a public webhook URL). **NOT
-   * RECOMMENDED on a public network** — the dashboard exposes call
-   * transcripts and metadata (PII) to anyone who can reach the URL.
+   * fully OPEN — WITHOUT authentication — even when the server is
+   * reachable beyond loopback (e.g. behind a tunnel or a public webhook
+   * URL). **NOT RECOMMENDED on a public network** — the dashboard exposes
+   * call transcripts and metadata (PII) to anyone who can reach the URL.
    *
    * Defaults to `false` (security). With the default, when the dashboard
    * is enabled, `dashboardToken` is empty, AND the server is exposed
-   * beyond `127.0.0.1`, the dashboard + `/api/*` routes are NOT mounted
-   * (fail-closed). The carrier webhook, media-stream, and `/health`
-   * routes are unaffected — inbound/outbound calls keep working.
+   * beyond `127.0.0.1`, the SDK auto-generates a one-time token and mounts
+   * the dashboard behind it (the startup banner prints the ready-to-use
+   * URL with `?token=...`). The dashboard is always available — it just
+   * requires the printed or configured token. Loopback-only local dev is
+   * unchanged: served open with no token.
    *
-   * To serve the dashboard safely on a public host, set `dashboardToken`
-   * instead. This flag is the deliberate escape hatch for the rare case
-   * where unauthenticated public exposure is intentional.
+   * For a stable token instead of the per-process auto-generated one, set
+   * `dashboardToken`. Set this flag only as the deliberate escape hatch
+   * for the rare case where unauthenticated public exposure is intentional.
    */
   readonly allowInsecureDashboard?: boolean;
   /** Path to SQLite database for dashboard persistence (not used in TS yet). */

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -695,6 +695,24 @@ export interface ServeOptions {
   readonly dashboard?: boolean;
   /** Bearer token for dashboard/API authentication. */
   readonly dashboardToken?: string;
+  /**
+   * When true, serve the dashboard (and the call-data `/api/*` routes)
+   * WITHOUT authentication even when the server is reachable beyond
+   * loopback (e.g. behind a tunnel or a public webhook URL). **NOT
+   * RECOMMENDED on a public network** — the dashboard exposes call
+   * transcripts and metadata (PII) to anyone who can reach the URL.
+   *
+   * Defaults to `false` (security). With the default, when the dashboard
+   * is enabled, `dashboardToken` is empty, AND the server is exposed
+   * beyond `127.0.0.1`, the dashboard + `/api/*` routes are NOT mounted
+   * (fail-closed). The carrier webhook, media-stream, and `/health`
+   * routes are unaffected — inbound/outbound calls keep working.
+   *
+   * To serve the dashboard safely on a public host, set `dashboardToken`
+   * instead. This flag is the deliberate escape hatch for the rare case
+   * where unauthenticated public exposure is intentional.
+   */
+  readonly allowInsecureDashboard?: boolean;
   /** Path to SQLite database for dashboard persistence (not used in TS yet). */
   readonly dashboardDb?: string;
   /** When true (default), persist dashboard data. */

--- a/libraries/typescript/tests/dashboard-exposure.test.ts
+++ b/libraries/typescript/tests/dashboard-exposure.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Fail-closed dashboard exposure tests.
+ *
+ * These exercise the REAL Express app mounted by the REAL ``EmbeddedServer``:
+ * each test binds the server on a loopback port and uses a real ``fetch`` to
+ * probe which routes are actually mounted. No mocks — the litmus test is that
+ * replacing the gate in ``server.ts`` with a no-op (always mount) makes case 1
+ * fail, because the dashboard root + ``/api/*`` routes would then respond 200
+ * on an exposed, unauthenticated bind.
+ *
+ * The gate: when the dashboard is enabled, the token is empty, AND the server
+ * is reachable beyond loopback (a public ``webhookUrl`` here, mirroring a
+ * cloudflared tunnel / static tunnel / explicit public webhook), the dashboard
+ * + call-data ``/api/*`` routes are NOT mounted. The carrier webhook route
+ * stays mounted so calls keep working.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { EmbeddedServer } from '../src/server';
+import type { LocalConfig } from '../src/server';
+import type { AgentOptions } from '../src/types';
+
+/** A public-looking webhook host triggers exposure signals (a)+(b). */
+const EXPOSED_WEBHOOK = 'abc123.trycloudflare.com';
+/** A loopback webhook host keeps the server local-only (not exposed). */
+const LOOPBACK_WEBHOOK = '127.0.0.1';
+
+function makeConfig(overrides: Partial<LocalConfig> = {}): LocalConfig {
+  return {
+    twilioSid: 'AC_test',
+    twilioToken: 'tok_test',
+    openaiKey: 'sk_test',
+    phoneNumber: '+15550000000',
+    webhookUrl: EXPOSED_WEBHOOK,
+    telephonyProvider: 'twilio',
+    // Keep the dashboard purely in-memory so tests don't hydrate from disk.
+    persistRoot: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<AgentOptions> = {}): AgentOptions {
+  return {
+    systemPrompt: 'You are helpful.',
+    voice: 'alloy',
+    model: 'gpt-4o-mini-realtime-preview',
+    language: 'en',
+    ...overrides,
+  };
+}
+
+/** Reserve a free loopback port by opening then closing a throwaway listener. */
+function reserveFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const port = (probe.address() as AddressInfo).port;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+interface Running {
+  readonly server: EmbeddedServer;
+  readonly port: number;
+}
+
+async function startServer(
+  config: LocalConfig,
+  opts: { token?: string; allowInsecure?: boolean } = {},
+): Promise<Running> {
+  const port = await reserveFreePort();
+  const server = new EmbeddedServer(
+    config,
+    makeAgent(),
+    undefined, // onCallStart
+    undefined, // onCallEnd
+    undefined, // onTranscript
+    undefined, // onMessage
+    false, // recording
+    '', // voicemailMessage
+    undefined, // onMetrics
+    undefined, // pricingOverrides
+    true, // dashboard ENABLED
+    opts.token ?? '', // dashboardToken
+    opts.allowInsecure ?? false, // allowInsecureDashboard
+  );
+  await server.start(port);
+  return { server, port };
+}
+
+describe('[integration] dashboard fail-closed exposure gate', () => {
+  let running: Running | null = null;
+
+  afterEach(async () => {
+    if (running) {
+      await running.server.stop();
+      running = null;
+    }
+    delete process.env.PATTER_BIND_HOST;
+  });
+
+  it('does NOT mount dashboard or call-data API when exposed + unauthenticated, but keeps the carrier webhook', async () => {
+    running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }));
+    const base = `http://127.0.0.1:${running.port}`;
+
+    // Dashboard UI root: absent (no GET '/' route) => 404.
+    const root = await fetch(`${base}/`);
+    expect(root.status).toBe(404);
+
+    // Call-data dashboard API: absent => 404 (NOT 200 with PII, NOT 401).
+    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
+    expect(dashCalls.status).toBe(404);
+
+    // B2B call-data API: absent => 404.
+    const v1Calls = await fetch(`${base}/api/v1/calls`);
+    expect(v1Calls.status).toBe(404);
+
+    // Health route is unaffected.
+    const health = await fetch(`${base}/health`);
+    expect(health.status).toBe(200);
+
+    // Carrier webhook route still mounted => calls keep working. A POST with
+    // no signature is rejected (503 signature-required) — crucially NOT 404,
+    // which would mean the route was dropped.
+    const webhook = await fetch(`${base}/webhooks/twilio/voice`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: 'CallSid=CA0000000000000000000000000000a001',
+    });
+    expect(webhook.status).not.toBe(404);
+  });
+
+  it('mounts dashboard + API (reachable, 401 when unauthenticated) when exposed + token SET', async () => {
+    running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }), {
+      token: 'secret-token-123',
+    });
+    const base = `http://127.0.0.1:${running.port}`;
+
+    // Routes ARE mounted; the auth middleware answers => 401 (not 404).
+    const root = await fetch(`${base}/`);
+    expect(root.status).toBe(401);
+
+    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
+    expect(dashCalls.status).toBe(401);
+
+    const v1Calls = await fetch(`${base}/api/v1/calls`);
+    expect(v1Calls.status).toBe(401);
+
+    // With the bearer token the call-data route serves normally.
+    const authed = await fetch(`${base}/api/dashboard/calls`, {
+      headers: { authorization: 'Bearer secret-token-123' },
+    });
+    expect(authed.status).toBe(200);
+  });
+
+  it('mounts dashboard + API when loopback-only + unauthenticated (local-dev backward compat)', async () => {
+    running = await startServer(makeConfig({ webhookUrl: LOOPBACK_WEBHOOK }));
+    const base = `http://127.0.0.1:${running.port}`;
+
+    // Local dev: dashboard served unauthenticated => 200, not gated.
+    const root = await fetch(`${base}/`);
+    expect(root.status).toBe(200);
+
+    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
+    expect(dashCalls.status).toBe(200);
+
+    const v1Calls = await fetch(`${base}/api/v1/calls`);
+    expect(v1Calls.status).toBe(200);
+  });
+
+  it('mounts dashboard + API when exposed + unauthenticated + allowInsecureDashboard escape hatch', async () => {
+    running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }), {
+      allowInsecure: true,
+    });
+    const base = `http://127.0.0.1:${running.port}`;
+
+    // Escape hatch: routes mounted unauthenticated => 200.
+    const root = await fetch(`${base}/`);
+    expect(root.status).toBe(200);
+
+    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
+    expect(dashCalls.status).toBe(200);
+
+    const v1Calls = await fetch(`${base}/api/v1/calls`);
+    expect(v1Calls.status).toBe(200);
+  });
+
+  it('does NOT mount dashboard when an explicit non-loopback PATTER_BIND_HOST override is set (signal c)', async () => {
+    // Even with a loopback webhook host, an explicit bind override to a
+    // non-loopback address marks the server exposed (signal c). The override
+    // also drives the real listen address — the server binds to 0.0.0.0,
+    // which still accepts connections on 127.0.0.1 so the test can fetch it.
+    process.env.PATTER_BIND_HOST = '0.0.0.0';
+    const port = await reserveFreePort();
+    const server = new EmbeddedServer(
+      makeConfig({ webhookUrl: LOOPBACK_WEBHOOK }),
+      makeAgent(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      '',
+      undefined,
+      undefined,
+      true,
+      '',
+      false,
+    );
+    await server.start(port);
+    running = { server, port };
+    const base = `http://127.0.0.1:${port}`;
+
+    const root = await fetch(`${base}/`);
+    expect(root.status).toBe(404);
+
+    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
+    expect(dashCalls.status).toBe(404);
+
+    // Health + webhook unaffected.
+    const health = await fetch(`${base}/health`);
+    expect(health.status).toBe(200);
+  });
+});

--- a/libraries/typescript/tests/dashboard-exposure.test.ts
+++ b/libraries/typescript/tests/dashboard-exposure.test.ts
@@ -1,31 +1,40 @@
 /**
- * Fail-closed dashboard exposure tests.
+ * Dashboard auto-token exposure tests.
  *
  * These exercise the REAL Express app mounted by the REAL ``EmbeddedServer``:
  * each test binds the server on a loopback port and uses a real ``fetch`` to
- * probe which routes are actually mounted. No mocks — the litmus test is that
- * replacing the gate in ``server.ts`` with a no-op (always mount) makes case 1
- * fail, because the dashboard root + ``/api/*`` routes would then respond 200
- * on an exposed, unauthenticated bind.
+ * probe the actual auth behaviour of the mounted routes. No mocks — the
+ * dashboard is ALWAYS mounted now (it never 404s); the protection comes from
+ * the token resolved in ``start()``.
  *
- * The gate: when the dashboard is enabled, the token is empty, AND the server
- * is reachable beyond loopback (a public ``webhookUrl`` here, mirroring a
- * cloudflared tunnel / static tunnel / explicit public webhook), the dashboard
- * + call-data ``/api/*`` routes are NOT mounted. The carrier webhook route
- * stays mounted so calls keep working.
+ * Resolution: when the dashboard is enabled with no explicit token AND the
+ * server is reachable beyond loopback (a public ``webhookUrl`` here, mirroring
+ * a cloudflared tunnel / static tunnel / explicit public webhook), the SDK
+ * generates a one-time token and protects the dashboard + call-data ``/api/*``
+ * routes with it. An explicit token is honoured as-is. Loopback-only dev and
+ * the ``allowInsecureDashboard`` escape hatch serve the dashboard OPEN.
+ *
+ * LITMUS: case 1 proves protection — if the auto-token branch were removed
+ * (effective token left ``''``), the unauthenticated request would return 200
+ * and the 401 assertion would FAIL.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { EmbeddedServer } from '../src/server';
 import type { LocalConfig } from '../src/server';
 import type { AgentOptions } from '../src/types';
+import { getLogger } from '../src/logger';
 
 /** A public-looking webhook host triggers exposure signals (a)+(b). */
 const EXPOSED_WEBHOOK = 'abc123.trycloudflare.com';
 /** A loopback webhook host keeps the server local-only (not exposed). */
 const LOOPBACK_WEBHOOK = '127.0.0.1';
+
+/** RFC 4122 v4 UUID matcher (the shape ``crypto.randomUUID()`` produces). */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function makeConfig(overrides: Partial<LocalConfig> = {}): LocalConfig {
   return {
@@ -92,7 +101,7 @@ async function startServer(
   return { server, port };
 }
 
-describe('[integration] dashboard fail-closed exposure gate', () => {
+describe('[integration] dashboard auto-token exposure protection', () => {
   let running: Running | null = null;
 
   afterEach(async () => {
@@ -101,23 +110,38 @@ describe('[integration] dashboard fail-closed exposure gate', () => {
       running = null;
     }
     delete process.env.PATTER_BIND_HOST;
+    vi.restoreAllMocks();
   });
 
-  it('does NOT mount dashboard or call-data API when exposed + unauthenticated, but keeps the carrier webhook', async () => {
+  it('case 1: exposed + no token => routes mounted, 401 unauthenticated, 200 with the resolved auto-token (a UUID)', async () => {
     running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }));
     const base = `http://127.0.0.1:${running.port}`;
 
-    // Dashboard UI root: absent (no GET '/' route) => 404.
+    // The SDK resolved a non-empty UUID token and stored it on the server.
+    const token = running.server.resolvedDashboardToken;
+    expect(token).toMatch(UUID_RE);
+
+    // Dashboard UI root + call-data routes ARE mounted (not 404), but the
+    // auth middleware rejects the unauthenticated request => 401. This is the
+    // litmus: if the auto-token branch were removed these would be 200.
     const root = await fetch(`${base}/`);
-    expect(root.status).toBe(404);
+    expect(root.status).toBe(401);
 
-    // Call-data dashboard API: absent => 404 (NOT 200 with PII, NOT 401).
     const dashCalls = await fetch(`${base}/api/dashboard/calls`);
-    expect(dashCalls.status).toBe(404);
+    expect(dashCalls.status).toBe(401);
 
-    // B2B call-data API: absent => 404.
     const v1Calls = await fetch(`${base}/api/v1/calls`);
-    expect(v1Calls.status).toBe(404);
+    expect(v1Calls.status).toBe(401);
+
+    // The resolved token authenticates via the ?token= query param.
+    const queryAuthed = await fetch(`${base}/api/dashboard/calls?token=${token}`);
+    expect(queryAuthed.status).toBe(200);
+
+    // ...and via the Authorization: Bearer header.
+    const headerAuthed = await fetch(`${base}/api/dashboard/calls`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(headerAuthed.status).toBe(200);
 
     // Health route is unaffected.
     const health = await fetch(`${base}/health`);
@@ -134,34 +158,34 @@ describe('[integration] dashboard fail-closed exposure gate', () => {
     expect(webhook.status).not.toBe(404);
   });
 
-  it('mounts dashboard + API (reachable, 401 when unauthenticated) when exposed + token SET', async () => {
+  it('case 2: exposed + explicit dashboardToken => 401 without it, 200 with it', async () => {
     running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }), {
       token: 'secret-token-123',
     });
     const base = `http://127.0.0.1:${running.port}`;
 
-    // Routes ARE mounted; the auth middleware answers => 401 (not 404).
+    // The explicit token is honoured as-is (no auto-generation).
+    expect(running.server.resolvedDashboardToken).toBe('secret-token-123');
+
     const root = await fetch(`${base}/`);
     expect(root.status).toBe(401);
 
     const dashCalls = await fetch(`${base}/api/dashboard/calls`);
     expect(dashCalls.status).toBe(401);
 
-    const v1Calls = await fetch(`${base}/api/v1/calls`);
-    expect(v1Calls.status).toBe(401);
-
-    // With the bearer token the call-data route serves normally.
     const authed = await fetch(`${base}/api/dashboard/calls`, {
       headers: { authorization: 'Bearer secret-token-123' },
     });
     expect(authed.status).toBe(200);
   });
 
-  it('mounts dashboard + API when loopback-only + unauthenticated (local-dev backward compat)', async () => {
+  it('case 3: loopback-only + no token => routes mounted and OPEN (200 without any token)', async () => {
     running = await startServer(makeConfig({ webhookUrl: LOOPBACK_WEBHOOK }));
     const base = `http://127.0.0.1:${running.port}`;
 
-    // Local dev: dashboard served unauthenticated => 200, not gated.
+    // Local dev: no token auto-generated, dashboard served OPEN.
+    expect(running.server.resolvedDashboardToken).toBe('');
+
     const root = await fetch(`${base}/`);
     expect(root.status).toBe(200);
 
@@ -172,13 +196,16 @@ describe('[integration] dashboard fail-closed exposure gate', () => {
     expect(v1Calls.status).toBe(200);
   });
 
-  it('mounts dashboard + API when exposed + unauthenticated + allowInsecureDashboard escape hatch', async () => {
+  it('case 4: exposed + no token + allowInsecureDashboard=true => routes mounted and OPEN (200), warning logged', async () => {
+    const warnSpy = vi.spyOn(getLogger(), 'warn');
     running = await startServer(makeConfig({ webhookUrl: EXPOSED_WEBHOOK }), {
       allowInsecure: true,
     });
     const base = `http://127.0.0.1:${running.port}`;
 
-    // Escape hatch: routes mounted unauthenticated => 200.
+    // Escape hatch: served OPEN, no token resolved.
+    expect(running.server.resolvedDashboardToken).toBe('');
+
     const root = await fetch(`${base}/`);
     expect(root.status).toBe(200);
 
@@ -187,42 +214,11 @@ describe('[integration] dashboard fail-closed exposure gate', () => {
 
     const v1Calls = await fetch(`${base}/api/v1/calls`);
     expect(v1Calls.status).toBe(200);
-  });
 
-  it('does NOT mount dashboard when an explicit non-loopback PATTER_BIND_HOST override is set (signal c)', async () => {
-    // Even with a loopback webhook host, an explicit bind override to a
-    // non-loopback address marks the server exposed (signal c). The override
-    // also drives the real listen address — the server binds to 0.0.0.0,
-    // which still accepts connections on 127.0.0.1 so the test can fetch it.
-    process.env.PATTER_BIND_HOST = '0.0.0.0';
-    const port = await reserveFreePort();
-    const server = new EmbeddedServer(
-      makeConfig({ webhookUrl: LOOPBACK_WEBHOOK }),
-      makeAgent(),
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      false,
-      '',
-      undefined,
-      undefined,
-      true,
-      '',
-      false,
+    // A warning about serving the PII surface unauthenticated was logged.
+    const warned = warnSpy.mock.calls.some((args) =>
+      String(args[0] ?? '').includes('WITHOUT authentication'),
     );
-    await server.start(port);
-    running = { server, port };
-    const base = `http://127.0.0.1:${port}`;
-
-    const root = await fetch(`${base}/`);
-    expect(root.status).toBe(404);
-
-    const dashCalls = await fetch(`${base}/api/dashboard/calls`);
-    expect(dashCalls.status).toBe(404);
-
-    // Health + webhook unaffected.
-    const health = await fetch(`${base}/health`);
-    expect(health.status).toBe(200);
+    expect(warned).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- The embedded metrics dashboard + `/api/*` call-data routes (call transcripts/metadata = PII) **now fail closed** when the server is reachable beyond `127.0.0.1` without a token — previously they mounted by default with only a soft warning, so a tunnelled always-on box published an unauthenticated PII dashboard on a public `*.trycloudflare.com` URL.
- New opt-in escape hatch `allow_insecure_dashboard` / `allowInsecureDashboard` (default `false`) for operators who deliberately run the dashboard open behind their own network controls.
- New **Production Deployment** docs page: named Cloudflare tunnel with ingress rules that expose *only* the carrier webhook path + dashboard hardening + per-client go-live checklist.

## Implementation
- **Gate (both SDKs):** at the dashboard/api mount site — if `dashboard` on **AND** token empty **AND** `is_exposed` **AND NOT** `allow_insecure_dashboard` → routes are **not** mounted and an `error` is logged with the three fixes. Escape hatch → mount + `warning`. Else (loopback-only / token set / dashboard off) → unchanged. Carrier webhook + media-stream + `/health` **always** mount, so calls keep working.
- **Exposure detection (identical PY↔TS):** non-loopback webhook host (tunnel-assigned or explicit `webhook_url`/`webhookUrl`) **or** explicit non-loopback `PATTER_BIND_HOST`. Loopback = `127.0.0.0/8`, `localhost`, `::1`. RFC1918/LAN hosts count as exposed (reachable by other machines) — drift fixed: TS previously failed *open* on private ranges, now matches Python.
- Files: Python `client.py`, `server.py` (`_is_loopback_host`, `_dashboard_is_exposed`); TypeScript `types.ts`, `client.ts`, `server.ts` (`extractHost`, `isLoopbackHost`, `isExposed`, `dashboardMounted` banner flag).
- Enforces the project rule `.claude/rules/security.md`: *"Dashboard: Disable by default when exposed beyond 127.0.0.1."*
- No deps added. No version bump (left for the release PR).

## Breaking change?
**Yes — ⚠️ behavior change** (security hardening). Any deployment running the dashboard on an exposed bind (tunnel / public `webhook_url` / non-loopback `PATTER_BIND_HOST`) **without a token** will stop serving the dashboard until it picks one migration:
- set `dashboard_token` / `dashboardToken` to require auth (**recommended**), or
- set `dashboard=False` / `dashboard: false` on the exposed host, or
- set `allow_insecure_dashboard=True` / `allowInsecureDashboard: true` to keep the old unauthenticated-on-public behavior.

Loopback-only local dev is **unchanged** (still served unauthenticated). Suggest a **minor** version bump at release.

## Test plan
- [x] Python: `pytest tests/` — 1898 passed, 25 skipped, 2 xfailed (incl. new `test_dashboard_fail_closed.py`, 18 cases)
- [x] TypeScript: `npm test` (1637 passed) + `npm run lint` (tsc clean) + `npm run build` (tsup OK) — incl. new `dashboard-exposure.test.ts` (5 cases)
- [x] Authentic tests: real FastAPI `TestClient` / real Express server; litmus verified (stubbing the gate to always-mount flips the exposed-unauth cases from 404 → 200)
- [x] Parity: identical field/default and identical exposure semantics across SDKs; carrier webhook still mounts (calls unaffected)
- [ ] E2E smoke — N/A (no pipeline/handler change)

## Docs updates
- `docs/dev-tools/production-deployment.mdx` (new)
- `docs/dev-tools/tunneling.mdx`, `docs/integrations/openclaw.mdx` (cross-links), `docs/docs.json` (nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
