### PR TITLE
chore(release): 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.6.5 (2026-06-05)
+
 ### Added
 
 - **`llm_error_message` / `llmErrorMessage` — opt-in spoken fallback when the

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -19,7 +19,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.4"
+version = "0.6.5"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
Version bump to **0.6.5** — releases the agent-as-primary-LLM work merged in #157.

## Implementation
- Bumps all three canonical version files to `0.6.5`: `libraries/python/getpatter/__init__.py`, `libraries/python/pyproject.toml`, `libraries/typescript/package.json` (+ `package-lock.json`).
- Rolls the CHANGELOG `## Unreleased` block into `## 0.6.5 (2026-06-05)` and opens a fresh empty `## Unreleased`.

## Release contents (already on `main` via #157)
- `OpenAICompatibleLLM` / `HermesLLM` / `OpenClawLLM` pipeline-mode providers (Python + TypeScript parity) — Patter as a voice shell in front of an OpenAI-compatible agent runtime.
- Opt-in session continuity: Hermes `X-Hermes-Session-Id` (per call) + optional `X-Hermes-Session-Key` (memory scope) headers; OpenClaw `user` + `x-openclaw-session-key`.
- Opt-in `llm_error_message` / `llmErrorMessage` spoken fallback on LLM-stream error (gateway down / timeout).
- Backward-compat `call_id` introspection guard so custom providers without `call_id`/`**kwargs` don't break.

## Breaking change?
No — version bump only, no source changes.

## Test plan
- [x] No code change in this PR; CI re-runs the full Python + TypeScript suites on the bump (verifies the lockfile/package.json version sync).

## Docs updates
N/A — docs shipped in #157.

## Release steps after merge
Tag `v0.6.5` on `main` → `.github/workflows/release.yml` publishes to PyPI (OIDC) + npm. Tag is pushed only after this PR merges.
