### PR TITLE
chore(release): 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.6.6 (2026-06-10)
+
 ### Added
 
 - **`CustomLLM` — the canonical "Custom LLM" provider for any OpenAI-compatible endpoint.** One generic provider (the same engine the `HermesLLM` / `OpenClawLLM` presets subclass) now ships under the name the voice-AI ecosystem uses for this pattern: `from getpatter import CustomLLM` / `from getpatter.llm import custom` (Python) and `import { CustomLLM, custom } from "getpatter"` (TypeScript). Works with agent runtimes (Hermes, OpenClaw), keyless local gateways (Ollama, vLLM, LM Studio), or any service implementing `/chat/completions` with SSE streaming + tool calls — barge-in cancellation, long-turn filler, spoken error fallback, and cost attribution included. As part of this, the `session_key_from="caller_hash"` / `sessionKeyFrom: "caller_hash"` per-caller memory selector was hoisted from the Hermes preset into the generic provider, so ANY header-scoped runtime can enable cross-call per-caller memory (`patter-caller-<hash>`, never the raw number); the Hermes preset now delegates to it (behaviour unchanged). New `libraries/python/getpatter/llm/custom.py`, `libraries/typescript/src/llm/custom.ts`; `docs/python-sdk/llm.mdx`, `docs/typescript-sdk/llm.mdx`.

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -19,7 +19,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.5"
+version = "0.6.6"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Version bump **0.6.5 → 0.6.6** for npm and PyPI. Rolls the CHANGELOG `## Unreleased` block into `## 0.6.6 (2026-06-10)`.

**Headline: this release ships the anonymous opt-out usage telemetry** (schema v5) to both registries — it has been on `main` since PR #160 but never published. Also included since v0.6.5: `CustomLLM` (#165), `patter openclaw` CLI (#161), Hermes DX (#159), the carrier-buffered barge-in fix (#164), and the security-audit fix wave.

Four version files bumped: `libraries/python/getpatter/__init__.py`, `libraries/python/pyproject.toml`, `libraries/typescript/package.json`, `libraries/typescript/package-lock.json`.

## Test plan

- [x] `scripts/pr-validate.sh` — TypeScript install / lint (tsc) / tests (vitest) / build (tsup) all green
- [x] Python suite under 3.13 (uv venv): **2293 passed**, 27 skipped, 2 xfailed
- [x] `import getpatter` reports `0.6.6`
- [ ] After merge: tag `v0.6.6` → `release.yml` publishes to PyPI (trusted publisher) + npm

## Note for ops

`telemetry.getpatter.com` has **no DNS record** yet and no collector service was found in the org — the SDK client is fail-safe (events silently dropped), but telemetry data will not arrive until the collector is deployed and DNS is created.