### PR TITLE
chore(release): 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.6.7 (2026-06-10)
+
 ### Fixed
 
 - **Telemetry: fire-and-forget events no longer vanish before delivery.** Three

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -19,7 +19,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.6"
+version = "0.6.7"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

Version bump **0.6.6 → 0.6.7** for npm and PyPI. Rolls the CHANGELOG `## Unreleased` block into `## 0.6.7 (2026-06-10)`.

**Headline: the telemetry delivery fix wave (#167).** 0.6.6 shipped telemetry that *records* correctly but loses events in three ways before delivery (CLI events GC'd, close() killing the in-flight POST, in-flight flush stranding constructor/agent events). 0.6.7 makes delivery reliable and adds the Realtime model variant (`llm_model`) to `feature_used`.

Pairs with the collector going live at `telemetry.getpatter.com` — with both in place, telemetry is end-to-end operational.

## Test plan
- [x] `scripts/pr-validate.sh` — Python tests + security tests + TS lint/tests/build all green locally
- [ ] CI green on this PR
- [ ] After merge: tag `v0.6.7` → `release.yml` publishes to PyPI + npm