### PR TITLE
fix: parity & bug-fix wave on the 0.6.6/0.6.7 features — EvalSession TS port, explicit-kwarg precedence, env-key path, telemetry chain guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Fixed
+
+- **Telemetry (TypeScript): a flush completing after `close()` began no longer
+  chains a detached delivery.** The post-flush chain in
+  `libraries/typescript/src/telemetry/client.ts` now stops once `close()` has
+  started (parity with Python's `not self._closed` guard): without it, an event
+  recorded during an in-flight POST could be picked up by a chained flush that
+  `close()` never awaited — a prompt process exit then killed that POST mid-air.
+  `close()` now always drains later-buffered events itself before resolving.
+  Added the previously missing regression tests (both SDKs) for the
+  "event recorded during an in-flight flush is chained, not stranded" 0.6.7 fix.
+
 ## 0.6.7 (2026-06-10)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@
 
 ### Fixed
 
+- **`provider="openai_realtime"` now honours `OPENAI_API_KEY` from the
+  environment — and the env key actually reaches the call path.** Python's
+  validation rejected the provider-string path unless the key was on the
+  config, even though its own error message promised "or set OPENAI_API_KEY in
+  the environment" (the engine markers already env-fallback). TypeScript
+  accepted the env var at validation but then dialed with an empty
+  `localConfig.openaiKey` — a dead call at connect time instead of a clear
+  error. Both SDKs now backfill the local config from the environment when the
+  provider-string path has no configured key, and reject with the same message
+  when no key exists anywhere. Caught by running the cross-SDK parity suite
+  with `OPENAI_API_KEY` set. `libraries/python/getpatter/client.py`,
+  `libraries/typescript/src/client.ts`.
 - **Python: an explicit `voice=` / `model=` on `agent()` now always wins over
   the `engine=` marker — even when the value equals the documented default.**
   The kwargs moved to sentinel defaults (`voice: str | None = None`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ### Fixed
 
+- **Python: an explicit `voice=` / `model=` on `agent()` now always wins over
+  the `engine=` marker — even when the value equals the documented default.**
+  The kwargs moved to sentinel defaults (`voice: str | None = None`,
+  `model: str | None = None`) so "explicit `gpt-realtime-mini`" is
+  distinguishable from "unset": previously
+  `agent(model="gpt-realtime-mini", engine=OpenAIRealtime(model="gpt-realtime-2"))`
+  silently ran (and reported in telemetry) the engine's model, while the same
+  call in TypeScript ran the explicit one. Resolution is now
+  explicit → engine → default in both SDKs (TS was already correct). Calls
+  that omit `voice=`/`model=` see zero change.
+  `libraries/python/getpatter/client.py`.
 - **Telemetry (TypeScript): a flush completing after `close()` began no longer
   chains a detached delivery.** The post-flush chain in
   `libraries/typescript/src/telemetry/client.ts` now stops once `close()` has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ### Added
 
+- **TypeScript: `EvalSession` — the eval harness now has full parity with
+  Python.** `import { EvalSession, expect, ScriptedLLMProvider } from
+  "getpatter"` constructs a REAL pipeline-mode `StreamHandler` and injects user
+  turns through the live-call path (transcript commit → dispatch → `LLMLoop` →
+  tool executor → sentence chunker → TTS), faking only the paid/external
+  boundary (`FakeAudioSender`/`FakeSTT`/`FakeTTS` + a deterministic
+  `ScriptedLLMProvider` or any real `LLMProvider`). `await session.userSays("…")`
+  returns a readonly `TurnResult` (`agentText`, `toolCalls`, `historySnapshot`,
+  `interrupted`, `metricsTurn`); `expect(result)` adds chainable
+  `.toolCalled(name, argsSubset?)` / `.noToolCalled()` / `.agentTextContains(…)`
+  plus async `.judge(llmJudge, { intent })`. `EvalCase` gains optional
+  `agent`/`llmProvider` routing through the session (the legacy reply-factory
+  path is unchanged), and `getpatter eval run <suite>` replaces the CLI stub
+  (exit codes 0/1/2, JSON report, `--agent module:export` loader). Defaults and
+  report rows are byte-compatible with Python's. New
+  `libraries/typescript/src/evals/`; `src/cli.ts`, `src/index.ts`.
+
 - **Python: `barge_in_mode` / `barge_in_confirm_ms` are now `Patter.agent()`
   keywords** (TypeScript parity — `AgentOptions` already exposed `bargeInMode` /
   `bargeInConfirmMs`). Previously they existed only as `Agent` dataclass fields,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+### Added
+
+- **Python: `barge_in_mode` / `barge_in_confirm_ms` are now `Patter.agent()`
+  keywords** (TypeScript parity — `AgentOptions` already exposed `bargeInMode` /
+  `bargeInConfirmMs`). Previously they existed only as `Agent` dataclass fields,
+  forcing callers through `dataclasses.replace(...)` on the returned agent.
+  Same defaults (`"cancel"` / `1500`); invalid modes are rejected with a
+  `ValueError`. Opt-in — existing calls are unaffected.
+  `libraries/python/getpatter/client.py`.
+
 ### Fixed
 
 - **Python: an explicit `voice=` / `model=` on `agent()` now always wins over

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,42 @@
+# Patter Examples
+
+Runnable examples for both SDKs. Each example ships as a Python / TypeScript
+pair with identical behavior.
+
+Run the Python examples with `pip install getpatter` + `python <file>.py`,
+and the TypeScript examples with `npm install getpatter` + `npx tsx <file>.ts`.
+Each file's header comment lists the environment variables it needs
+(`TWILIO_ACCOUNT_SID`, `OPENAI_API_KEY`, ...).
+
+## Getting started
+
+| Example | Files | What it shows |
+|---------|-------|---------------|
+| Basic inbound | [`basic-inbound.py`](./basic-inbound.py) / [`basic-inbound.ts`](./basic-inbound.ts) | Answer incoming calls with OpenAI Realtime. |
+| Basic outbound | [`basic-outbound.py`](./basic-outbound.py) / [`basic-outbound.ts`](./basic-outbound.ts) | Place an outbound call. |
+| Local agent | [`local-agent.py`](./local-agent.py) / [`local-agent.ts`](./local-agent.ts) | Run the embedded server in local mode. |
+
+## Voice & conversation
+
+| Example | Files | What it shows |
+|---------|-------|---------------|
+| Custom voice | [`custom-voice.py`](./custom-voice.py) / [`custom-voice.ts`](./custom-voice.ts) | Pick voices and TTS providers. |
+| Dynamic variables | [`dynamic-variables.py`](./dynamic-variables.py) / [`dynamic-variables.ts`](./dynamic-variables.ts) | Template variables in the system prompt. |
+| Conversation history | [`conversation-history.py`](./conversation-history.py) / [`conversation-history.ts`](./conversation-history.ts) | Access the per-call transcript history. |
+| Pipeline custom agent | [`pipeline-custom-agent.py`](./pipeline-custom-agent.py) / [`pipeline-custom-agent.ts`](./pipeline-custom-agent.ts) | Bring your own LLM in pipeline mode. |
+
+## Turn-taking & latency (pipeline mode)
+
+| Example | Files | What it shows |
+|---------|-------|---------------|
+| Pause-resume barge-in | [`pause-resume-barge-in.py`](./pause-resume-barge-in.py) / [`pause-resume-barge-in.ts`](./pause-resume-barge-in.ts) | `barge_in_mode="pause_resume"` — pause TTS on interruption and resume after coughs / line noise instead of cancelling the turn. |
+| Preemptive generation | [`preemptive-generation.py`](./preemptive-generation.py) / [`preemptive-generation.ts`](./preemptive-generation.ts) | `preemptive_generation=True` — start LLM+TTS on a confident interim transcript and release the audio when the final matches. |
+| Smart-turn detection | [`smart-turn-detection.py`](./smart-turn-detection.py) / [`smart-turn-detection.ts`](./smart-turn-detection.ts) | `turn_detector=SmartTurnDetector.load(...)` — semantic end-of-utterance detection so mid-sentence pauses don't cut the caller off. |
+
+## Telephony features
+
+| Example | Files | What it shows |
+|---------|-------|---------------|
+| Tool calling | [`tool-calling.py`](./tool-calling.py) / [`tool-calling.ts`](./tool-calling.ts) | Define tools the agent can invoke mid-call. |
+| Call transfer | [`call-transfer.py`](./call-transfer.py) / [`call-transfer.ts`](./call-transfer.ts) | Escalate to a human with the built-in `transfer_call` tool. |
+| Recording + AMD | [`recording-amd.py`](./recording-amd.py) / [`recording-amd.ts`](./recording-amd.ts) | Carrier-side call recording and answering machine detection. |

--- a/docs/examples/pause-resume-barge-in.py
+++ b/docs/examples/pause-resume-barge-in.py
@@ -1,0 +1,38 @@
+"""Pause-and-resume barge-in — survive coughs and line noise (pipeline mode).
+
+With barge_in_mode="pause_resume", a VAD speech_start during the agent's turn
+PAUSES playback instead of cancelling it. If a committed final transcript
+confirms a real interruption within barge_in_confirm_ms, the turn is cancelled
+as usual; if the window expires with no transcript (a cough, background
+noise), the agent resumes from the first sentence the caller had not fully
+heard — without re-billing TTS.
+"""
+import asyncio
+
+from getpatter import Patter, Twilio, DeepgramSTT, OpenAILLM, ElevenLabsTTS
+
+
+async def main():
+    phone = Patter(
+        carrier=Twilio(),                               # TWILIO_* from env
+        phone_number="+15550001234",
+        webhook_url="xxx.ngrok-free.dev",
+    )
+
+    agent = phone.agent(
+        stt=DeepgramSTT(),                              # DEEPGRAM_API_KEY from env
+        llm=OpenAILLM(),                                # OPENAI_API_KEY from env
+        tts=ElevenLabsTTS(voice_id="aria"),             # ELEVENLABS_API_KEY from env
+        system_prompt="You are a patient customer-support agent for Acme Corp. "
+                      "Answer thoroughly — callers can interrupt you at any time.",
+        first_message="Hi! Thanks for calling Acme. How can I help you today?",
+        barge_in_mode="pause_resume",  # default "cancel": kill the turn on speech_start
+        barge_in_confirm_ms=1500,      # default 1500 — resume TTS if no final
+                                       # transcript confirms within this window
+    )
+
+    print("Listening for calls...")
+    await phone.serve(agent=agent, port=8000)
+
+
+asyncio.run(main())

--- a/docs/examples/pause-resume-barge-in.ts
+++ b/docs/examples/pause-resume-barge-in.ts
@@ -1,0 +1,37 @@
+/**
+ * Pause-and-resume barge-in — survive coughs and line noise (pipeline mode).
+ *
+ * With bargeInMode: 'pause_resume', a VAD speech_start during the agent's turn
+ * PAUSES playback instead of cancelling it. If a committed final transcript
+ * confirms a real interruption within bargeInConfirmMs, the turn is cancelled
+ * as usual; if the window expires with no transcript (a cough, background
+ * noise), the agent resumes from the first sentence the caller had not fully
+ * heard — without re-billing TTS.
+ */
+import { Patter, Twilio, DeepgramSTT, OpenAILLM, ElevenLabsTTS } from "getpatter";
+
+async function main() {
+  const phone = new Patter({
+    carrier: new Twilio(),                              // TWILIO_* from env
+    phoneNumber: "+15550001234",
+    webhookUrl: "xxx.ngrok-free.dev",
+  });
+
+  const agent = phone.agent({
+    stt: new DeepgramSTT(),                             // DEEPGRAM_API_KEY from env
+    llm: new OpenAILLM(),                               // OPENAI_API_KEY from env
+    tts: new ElevenLabsTTS({ voiceId: "aria" }),        // ELEVENLABS_API_KEY from env
+    systemPrompt:
+      "You are a patient customer-support agent for Acme Corp. " +
+      "Answer thoroughly — callers can interrupt you at any time.",
+    firstMessage: "Hi! Thanks for calling Acme. How can I help you today?",
+    bargeInMode: "pause_resume", // default 'cancel': kill the turn on speech_start
+    bargeInConfirmMs: 1500,      // default 1500 — resume TTS if no final
+                                 // transcript confirms within this window
+  });
+
+  console.log("Listening for calls...");
+  await phone.serve({ agent, port: 8000 });
+}
+
+main().catch(console.error);

--- a/docs/examples/preemptive-generation.py
+++ b/docs/examples/preemptive-generation.py
@@ -1,0 +1,39 @@
+"""Preemptive generation — pay LLM+TTS latency during the caller's own pause.
+
+Pipeline mode with the built-in LLM loop only. With preemptive_generation=True
+the SDK starts the LLM (and sentence-chunked TTS synthesis) EARLY on a
+confident interim transcript — one that ends with sentence-final punctuation,
+or that has been unchanged for preemptive_min_stable_ms — holding the audio in
+memory. If the final transcript matches the speculated interim, the buffered
+audio is released to the carrier immediately; if it differs, the speculation
+is discarded silently and the turn dispatches normally on the final.
+"""
+import asyncio
+
+from getpatter import Patter, Twilio, DeepgramSTT, OpenAILLM, ElevenLabsTTS
+
+
+async def main():
+    phone = Patter(
+        carrier=Twilio(),                               # TWILIO_* from env
+        phone_number="+15550001234",
+        webhook_url="xxx.ngrok-free.dev",
+    )
+
+    agent = phone.agent(
+        stt=DeepgramSTT(),                              # DEEPGRAM_API_KEY from env
+        llm=OpenAILLM(),                                # OPENAI_API_KEY from env
+        tts=ElevenLabsTTS(voice_id="aria"),             # ELEVENLABS_API_KEY from env
+        system_prompt="You are a quick, friendly assistant for Acme Corp. "
+                      "Keep replies short.",
+        first_message="Hi! Thanks for calling Acme. How can I help?",
+        preemptive_generation=True,    # default False — opt in to speculation
+        preemptive_min_stable_ms=300,  # default 300 — interim without sentence-final
+                                       # punctuation must hold steady this long
+    )
+
+    print("Listening for calls...")
+    await phone.serve(agent=agent, port=8000)
+
+
+asyncio.run(main())

--- a/docs/examples/preemptive-generation.ts
+++ b/docs/examples/preemptive-generation.ts
@@ -1,0 +1,37 @@
+/**
+ * Preemptive generation — pay LLM+TTS latency during the caller's own pause.
+ *
+ * Pipeline mode with the built-in LLM loop only. With preemptiveGeneration:
+ * true the SDK starts the LLM (and sentence-chunked TTS synthesis) EARLY on a
+ * confident interim transcript — one that ends with sentence-final
+ * punctuation, or that has been unchanged for preemptiveMinStableMs — holding
+ * the audio in memory. If the final transcript matches the speculated interim,
+ * the buffered audio is released to the carrier immediately; if it differs,
+ * the speculation is discarded silently and the turn dispatches normally.
+ */
+import { Patter, Twilio, DeepgramSTT, OpenAILLM, ElevenLabsTTS } from "getpatter";
+
+async function main() {
+  const phone = new Patter({
+    carrier: new Twilio(),                              // TWILIO_* from env
+    phoneNumber: "+15550001234",
+    webhookUrl: "xxx.ngrok-free.dev",
+  });
+
+  const agent = phone.agent({
+    stt: new DeepgramSTT(),                             // DEEPGRAM_API_KEY from env
+    llm: new OpenAILLM(),                               // OPENAI_API_KEY from env
+    tts: new ElevenLabsTTS({ voiceId: "aria" }),        // ELEVENLABS_API_KEY from env
+    systemPrompt:
+      "You are a quick, friendly assistant for Acme Corp. Keep replies short.",
+    firstMessage: "Hi! Thanks for calling Acme. How can I help?",
+    preemptiveGeneration: true,  // default false — opt in to speculation
+    preemptiveMinStableMs: 300,  // default 300 — interim without sentence-final
+                                 // punctuation must hold steady this long
+  });
+
+  console.log("Listening for calls...");
+  await phone.serve({ agent, port: 8000 });
+}
+
+main().catch(console.error);

--- a/docs/examples/smart-turn-detection.py
+++ b/docs/examples/smart-turn-detection.py
@@ -1,0 +1,55 @@
+"""Semantic end-of-utterance detection with smart-turn v3 (pipeline mode).
+
+A VAD only knows WHETHER the caller is making sound; smart-turn looks at the
+prosody of the last few seconds of speech and predicts whether the caller has
+FINISHED their turn or is merely pausing mid-sentence ("My phone number is…").
+The pipeline defers the turn until the model agrees the caller is done,
+holding for at most max_semantic_hold_ms so a turn can never hang.
+
+Setup:
+    pip install "getpatter[turn-detector]"
+    # Download a smart-turn-v3 ONNX file (~30 MB, NOT bundled with the SDK)
+    # from https://huggingface.co/pipecat-ai/smart-turn-v3 then either:
+    export PATTER_SMART_TURN_MODEL=/path/to/smart-turn-v3.0.onnx
+    # ...or pass model_path= to SmartTurnDetector.load() below.
+"""
+import asyncio
+
+from getpatter import (
+    Patter,
+    Twilio,
+    DeepgramSTT,
+    OpenAILLM,
+    ElevenLabsTTS,
+    SmartTurnDetector,
+)
+
+
+async def main():
+    phone = Patter(
+        carrier=Twilio(),                               # TWILIO_* from env
+        phone_number="+15550001234",
+        webhook_url="xxx.ngrok-free.dev",
+    )
+
+    # Reads PATTER_SMART_TURN_MODEL; or pass model_path="/path/to/model.onnx".
+    # threshold=0.5 is the default end-of-turn probability cutoff.
+    detector = SmartTurnDetector.load()
+
+    agent = phone.agent(
+        stt=DeepgramSTT(),                              # DEEPGRAM_API_KEY from env
+        llm=OpenAILLM(),                                # OPENAI_API_KEY from env
+        tts=ElevenLabsTTS(voice_id="aria"),             # ELEVENLABS_API_KEY from env
+        system_prompt="You are a receptionist for Acme Corp. Collect the "
+                      "caller's name and phone number, then confirm them back.",
+        first_message="Hi! Thanks for calling Acme. Who am I speaking with?",
+        turn_detector=detector,
+        max_semantic_hold_ms=1200,  # default 1200 — max wait while the model
+                                    # keeps predicting "incomplete"
+    )
+
+    print("Listening for calls...")
+    await phone.serve(agent=agent, port=8000)
+
+
+asyncio.run(main())

--- a/docs/examples/smart-turn-detection.ts
+++ b/docs/examples/smart-turn-detection.ts
@@ -1,0 +1,54 @@
+/**
+ * Semantic end-of-utterance detection with smart-turn v3 (pipeline mode).
+ *
+ * A VAD only knows WHETHER the caller is making sound; smart-turn looks at
+ * the prosody of the last few seconds of speech and predicts whether the
+ * caller has FINISHED their turn or is merely pausing mid-sentence ("My phone
+ * number is…"). The pipeline defers the turn until the model agrees the
+ * caller is done, holding for at most maxSemanticHoldMs so a turn never hangs.
+ *
+ * Setup:
+ *   npm install getpatter          # onnxruntime-node ships as an optional dep
+ *   # Download a smart-turn-v3 ONNX file (~30 MB, NOT bundled with the SDK)
+ *   # from https://huggingface.co/pipecat-ai/smart-turn-v3 then either:
+ *   export PATTER_SMART_TURN_MODEL=/path/to/smart-turn-v3.0.onnx
+ *   # ...or pass modelPath to SmartTurnDetector.load() below.
+ */
+import {
+  Patter,
+  Twilio,
+  DeepgramSTT,
+  OpenAILLM,
+  ElevenLabsTTS,
+  SmartTurnDetector,
+} from "getpatter";
+
+async function main() {
+  const phone = new Patter({
+    carrier: new Twilio(),                              // TWILIO_* from env
+    phoneNumber: "+15550001234",
+    webhookUrl: "xxx.ngrok-free.dev",
+  });
+
+  // Reads PATTER_SMART_TURN_MODEL; or pass { modelPath: "/path/to/model.onnx" }.
+  // threshold: 0.5 is the default end-of-turn probability cutoff.
+  const detector = await SmartTurnDetector.load();
+
+  const agent = phone.agent({
+    stt: new DeepgramSTT(),                             // DEEPGRAM_API_KEY from env
+    llm: new OpenAILLM(),                               // OPENAI_API_KEY from env
+    tts: new ElevenLabsTTS({ voiceId: "aria" }),        // ELEVENLABS_API_KEY from env
+    systemPrompt:
+      "You are a receptionist for Acme Corp. Collect the caller's name and " +
+      "phone number, then confirm them back.",
+    firstMessage: "Hi! Thanks for calling Acme. Who am I speaking with?",
+    turnDetector: detector,
+    maxSemanticHoldMs: 1200, // default 1200 — max wait while the model
+                             // keeps predicting "incomplete"
+  });
+
+  console.log("Listening for calls...");
+  await phone.serve({ agent, port: 8000 });
+}
+
+main().catch(console.error);

--- a/docs/python-sdk/events.mdx
+++ b/docs/python-sdk/events.mdx
@@ -72,6 +72,7 @@ async def on_call_end(event):
 | `ended_at` | `float` | Unix timestamp when the call ended (e.g. `1710489601.234`). |
 | `transcript` | `list[dict]` | Full conversation transcript. Each entry has `role` (`"user"` or `"assistant"`) and `text`. |
 | `metrics` | `CallMetrics \| None` | Call metrics with cost and latency breakdowns. `None` if metrics collection failed. See [Metrics & Cost Tracking](/python-sdk/metrics). |
+| `recording_path` | `str \| None` | Path to the local stereo WAV. Only present when `local_recording` was enabled on `serve()`; `None` if finalizing the file failed. See [Local Recording](/python-sdk/features#local-recording-carrier-neutral). |
 
 ---
 

--- a/docs/python-sdk/features.mdx
+++ b/docs/python-sdk/features.mdx
@@ -33,6 +33,39 @@ for record in recordings:
     print(record.sid, record.duration)
 ```
 
+### Local Recording (Carrier-Neutral)
+
+`local_recording` records each call **on your own machine**, with no carrier API involved. The SDK taps the audio already flowing through the per-call stream handler and writes an interleaved stereo WAV — **left channel = caller, right channel = agent** — as PCM16 at 16 kHz. μ-law 8 kHz carrier audio is upsampled and 24 kHz Realtime audio is downsampled, so the output format is the same on every carrier and engine mode.
+
+```python
+await phone.serve(agent, local_recording=True)
+
+# Or pass a directory string to choose where the WAVs go:
+await phone.serve(agent, local_recording="/var/recordings")
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `local_recording` | `bool \| str` | `False` | SDK-side stereo WAV recording (left = caller, right = agent, PCM16 16 kHz). Pass a directory string to set the output directory. Works on every carrier (Twilio, Telnyx, Plivo) and engine mode. |
+
+Where the file lands:
+
+1. Directory string → `<dir>/<call_id>.wav`.
+2. [Call logging](/python-sdk/call-logging) enabled → `<call_log_dir>/recording.wav`, next to `metadata.json` and `transcript.jsonl` (so it is covered by the same `PATTER_LOG_RETENTION_DAYS` cleanup).
+3. Otherwise → `./recordings/<call_id>.wav` under the current working directory.
+
+The final path is surfaced as `recording_path` in the [`on_call_end`](/python-sdk/events#on_call_end) payload and persisted in the call-log `metadata.json`:
+
+```python
+async def on_call_end(event):
+    if event.get("recording_path"):
+        print(f"Recording saved: {event['recording_path']}")
+```
+
+<Note>
+  The WAV header is finalized on **every** teardown path — including abnormal carrier WebSocket drops — so a truncated call still yields a playable file. `local_recording` is independent of the carrier-side `recording` flag: both can be enabled on the same call.
+</Note>
+
 ---
 
 ## Answering Machine Detection (AMD)

--- a/docs/python-sdk/local-mode.mdx
+++ b/docs/python-sdk/local-mode.mdx
@@ -66,6 +66,7 @@ await phone.serve(agent, port=8000)
 | `agent` | `Agent` | *required* | The agent configuration to use for all calls. Create with `phone.agent()`. |
 | `port` | `int` | `8000` | TCP port to bind to (1-65535). |
 | `recording` | `bool` | `False` | Enable call recording via the Twilio Recordings API. |
+| `local_recording` | `bool \| str` | `False` | Carrier-neutral SDK-side recording: stereo WAV per call (left = caller, right = agent, PCM16 16 kHz). Pass a directory string to set the output directory. See [Local Recording](/python-sdk/features#local-recording-carrier-neutral). |
 | `on_call_start` | `Callable \| None` | `None` | Async callback fired when a call connects. |
 | `on_call_end` | `Callable \| None` | `None` | Async callback fired when a call ends. |
 | `on_transcript` | `Callable \| None` | `None` | Async callback fired for each utterance. |

--- a/docs/python-sdk/reference.mdx
+++ b/docs/python-sdk/reference.mdx
@@ -107,6 +107,7 @@ async def serve(
     agent: Agent,
     port: int = 8000,
     recording: bool = False,
+    local_recording: bool | str = False,
     on_call_start: Callable[[dict], Awaitable[None]] | None = None,
     on_call_end: Callable[[dict], Awaitable[None]] | None = None,
     on_transcript: Callable[[dict], Awaitable[None]] | None = None,
@@ -120,6 +121,8 @@ async def serve(
 ```
 
 Start the embedded server. Blocks until stopped.
+
+`local_recording` enables carrier-neutral SDK-side recording: an interleaved stereo WAV (left = caller, right = agent, PCM16 16 kHz) written incrementally per call. Pass a directory string to choose the output directory. The final path is surfaced as `recording_path` in the `on_call_end` payload. Independent of the carrier-side `recording` flag. See [Local Recording](/python-sdk/features#local-recording-carrier-neutral).
 
 ---
 

--- a/docs/typescript-sdk/events.mdx
+++ b/docs/typescript-sdk/events.mdx
@@ -87,6 +87,8 @@ await phone.serve({
   caller: string;        // Caller phone number (E.164)
   callee: string;        // Callee phone number (E.164)
   ended_at: number;      // Unix timestamp in seconds (fractional)
+  recording_path?: string | null;  // Local stereo WAV path; only present when
+                                   // localRecording was enabled on serve()
   transcript: Array<{
     role: string;        // "user" or "assistant"
     text: string;        // Transcript text

--- a/docs/typescript-sdk/features.mdx
+++ b/docs/typescript-sdk/features.mdx
@@ -28,6 +28,45 @@ await phone.serve({
 
 The SDK sets up a `/webhooks/twilio/recording` endpoint to receive recording status callbacks. Recording URLs are logged to the console when they become available.
 
+### Local Recording (Carrier-Neutral)
+
+`localRecording` records each call **on your own machine**, with no carrier API involved. The SDK taps the audio already flowing through the per-call stream handler and writes an interleaved stereo WAV — **left channel = caller, right channel = agent** — as PCM16 at 16 kHz. μ-law 8 kHz carrier audio is upsampled and 24 kHz Realtime audio is downsampled, so the output format is the same on every carrier and engine mode.
+
+```typescript
+await phone.serve({ agent, localRecording: true });
+
+// Or pass a directory string to choose where the WAVs go:
+await phone.serve({ agent, localRecording: "/var/recordings" });
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `localRecording` | `boolean \| string` | `false` | SDK-side stereo WAV recording (left = caller, right = agent, PCM16 16 kHz). Pass a directory string to set the output directory. Works on every carrier (Twilio, Telnyx, Plivo) and engine mode. |
+
+Where the file lands:
+
+1. Directory string → `<dir>/<call_id>.wav`.
+2. [Call logging](/typescript-sdk/call-logging) enabled → `<call_log_dir>/recording.wav`, next to `metadata.json` and `transcript.jsonl` (so it is covered by the same `PATTER_LOG_RETENTION_DAYS` cleanup).
+3. Otherwise → `./recordings/<call_id>.wav` under the current working directory.
+
+The final path is surfaced as `recording_path` in the [`onCallEnd`](/typescript-sdk/events#oncallend) payload and persisted in the call-log `metadata.json`:
+
+```typescript
+await phone.serve({
+  agent,
+  localRecording: true,
+  onCallEnd: async (data) => {
+    if (data.recording_path) {
+      console.log(`Recording saved: ${data.recording_path}`);
+    }
+  },
+});
+```
+
+<Note>
+  The WAV header is finalized on **every** teardown path — including abnormal carrier WebSocket drops — so a truncated call still yields a playable file. `localRecording` is independent of the carrier-side `recording` flag: both can be enabled on the same call.
+</Note>
+
 ## Answering Machine Detection (AMD)
 
 Detect voicemail systems on outbound calls and optionally leave a message. AMD is available with Twilio only.

--- a/docs/typescript-sdk/local-mode.mdx
+++ b/docs/typescript-sdk/local-mode.mdx
@@ -41,6 +41,7 @@ await phone.serve({ agent, port: 8000 });
 | `onMessage` | `(data) => Promise<string>` | No | — | Pipeline mode only. Receives user transcript, returns response text. Can also be a URL string for remote webhook/WebSocket integration. |
 | `onMetrics` | `(data) => Promise<void>` | No | — | Called after each conversational turn with per-turn latency and cost metrics. |
 | `recording` | `boolean` | No | `false` | Enable call recording (Twilio only). |
+| `localRecording` | `boolean \| string` | No | `false` | Carrier-neutral SDK-side recording: stereo WAV per call (left = caller, right = agent, PCM16 16 kHz). Pass a directory string to set the output directory. See [Local Recording](/typescript-sdk/features#local-recording-carrier-neutral). |
 | `voicemailMessage` | `string` | No | — | Default voicemail message for AMD. |
 | `pricing` | `Record<string, Record<string, unknown>>` | No | — | Custom pricing overrides for cost calculation. |
 | `dashboard` | `boolean` | No | `true` | When `true`, serve a dashboard UI at `/dashboard`. |

--- a/docs/typescript-sdk/reference.mdx
+++ b/docs/typescript-sdk/reference.mdx
@@ -254,6 +254,7 @@ interface ServeOptions {
   onMessage?: PipelineMessageHandler | string;
   onMetrics?: (data: Record<string, unknown>) => Promise<void>;
   recording?: boolean;
+  localRecording?: boolean | string;  // SDK-side stereo WAV recording; string = output directory
   voicemailMessage?: string;
   pricing?: Record<string, Record<string, unknown>>;
   dashboard?: boolean;
@@ -263,6 +264,8 @@ interface ServeOptions {
   manageWebhook?: boolean;  // default true; ignored when tunnel: true
 }
 ```
+
+`localRecording` enables carrier-neutral SDK-side recording: an interleaved stereo WAV (left = caller, right = agent, PCM16 16 kHz) written incrementally per call. Pass a directory string to choose the output directory. The final path is surfaced as `recording_path` in the `onCallEnd` payload. Independent of the carrier-side `recording` flag. See [Local Recording](/typescript-sdk/features#local-recording-carrier-neutral).
 
 ### LocalCallOptions
 

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1965,11 +1965,23 @@ class Patter:
             provider in ("openai_realtime", "openai_realtime_2")
             and not self._local_config.openai_key
         ):
-            raise ValueError(
-                "OpenAI Realtime mode requires an OpenAI API key. Pass "
-                "engine=OpenAIRealtime(api_key='sk-...') or set OPENAI_API_KEY "
-                "in the environment."
-            )
+            # The provider= string path has no engine marker to carry the key —
+            # honour OPENAI_API_KEY from the environment (the error message has
+            # always promised it, TS accepts it, and the engine markers already
+            # env-fallback). Backfill the local config so the CALL PATH uses the
+            # key too — accepting here but dialing with an empty key later
+            # would be a dead call instead of a clear error.
+            _env_openai_key = os.environ.get("OPENAI_API_KEY", "")
+            if _env_openai_key:
+                self._local_config = replace(
+                    self._local_config, openai_key=_env_openai_key
+                )
+            else:
+                raise ValueError(
+                    "OpenAI Realtime mode requires an OpenAI API key. Pass "
+                    "engine=OpenAIRealtime(api_key='sk-...') or set OPENAI_API_KEY "
+                    "in the environment."
+                )
 
         if provider == "pipeline":
             if stt_resolved is None:

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1670,8 +1670,8 @@ class Patter:
     def agent(
         self,
         system_prompt: str,
-        voice: str = "alloy",
-        model: str = "gpt-realtime-mini",
+        voice: str | None = None,
+        model: str | None = None,
         language: str = "en",
         first_message: str = "",
         llm_error_message: str | None = None,
@@ -1720,8 +1720,12 @@ class Patter:
 
         Args:
             system_prompt: Instructions for the AI agent.
-            voice: TTS voice name (e.g. ``"alloy"``, ``"echo"``).
-            model: OpenAI Realtime model ID.
+            voice: TTS voice name (e.g. ``"alloy"``, ``"echo"``). When omitted,
+                the ``engine=`` marker's voice applies (default ``"alloy"``);
+                an explicit value always wins over the engine.
+            model: OpenAI Realtime model ID. When omitted, the ``engine=``
+                marker's model applies (default ``"gpt-realtime-mini"``); an
+                explicit value always wins over the engine.
             language: BCP-47 language code, e.g. ``"en"``.
             first_message: If set, the agent speaks this immediately on connect.
             long_turn_message: Pipeline mode only. Opt-in short filler spoken
@@ -1785,9 +1789,11 @@ class Patter:
             # Realtime has no composed stack, so the model variant is the whole
             # story — resolve it the same way the engine unpacking below does
             # (an explicit model= kwarg wins; otherwise the engine's model).
-            _rt_model = model
-            if _rt_model == "gpt-realtime-mini" and getattr(engine, "model", None):
-                _rt_model = engine.model
+            _rt_model = (
+                model
+                if model is not None
+                else (getattr(engine, "model", None) or "gpt-realtime-mini")
+            )
             _stack = {**_stack, "llm_model": model_token("openai", _rt_model)}
         _feature_key = (
             _family + "|" + ",".join(f"{k}={v}" for k, v in sorted(_stack.items()))
@@ -1890,12 +1896,13 @@ class Patter:
                 )
             engine_kind, engine_fields = self._unpack_engine(engine)
             provider = engine_kind
-            # Engine-supplied voice/model win over the method defaults, but we
-            # let any *explicit* voice=/model= kwarg pass through unchanged —
-            # users sometimes pass the engine AND a specific voice.
-            if voice == "alloy" and engine_fields.get("voice"):
+            # Engine-supplied voice/model fill the slots the caller left unset
+            # (sentinel ``None``); an *explicit* voice=/model= kwarg always
+            # wins — even when its value equals the documented default.
+            # Mirrors TS ``opts.model ?? engineModel ?? default``.
+            if voice is None and engine_fields.get("voice"):
                 voice = engine_fields["voice"]
-            if model == "gpt-realtime-mini" and engine_fields.get("model"):
+            if model is None and engine_fields.get("model"):
                 model = engine_fields["model"]
             if engine_kind in ("openai_realtime", "openai_realtime_2"):
                 openai_engine_key = engine_fields.get("api_key", "")
@@ -2044,6 +2051,14 @@ class Patter:
                     "handoff_to tool is only injected in Realtime and Pipeline "
                     "modes and will be ignored for this agent."
                 )
+
+        # Apply the documented defaults to slots neither the caller nor an
+        # engine marker filled (sentinel ``None`` distinguishes "unset" from an
+        # explicit value equal to the default).
+        if voice is None:
+            voice = "alloy"
+        if model is None:
+            model = "gpt-realtime-mini"
 
         return Agent(
             system_prompt=system_prompt,

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1690,6 +1690,8 @@ class Patter:
         audio_filter: AudioFilter | None = None,
         background_audio: BackgroundAudioPlayer | None = None,
         barge_in_threshold_ms: int = 300,
+        barge_in_mode: str = "cancel",
+        barge_in_confirm_ms: int = 1500,
         aggressive_first_flush: bool = False,
         disable_phone_preamble: bool = False,
         echo_cancellation: bool = False,
@@ -1879,6 +1881,15 @@ class Patter:
                     + ", ".join(_valid_providers)
                     + f". Got: {provider!r}"
                 )
+
+        # --- Validate barge_in_mode (parity with TS ``bargeInMode`` union) ---
+        _valid_barge_in_modes = ("cancel", "pause_resume")
+        if barge_in_mode not in _valid_barge_in_modes:
+            raise ValueError(
+                "barge_in_mode must be one of: "
+                + ", ".join(_valid_barge_in_modes)
+                + f". Got: {barge_in_mode!r}"
+            )
 
         # --- Engine dispatch ---
         openai_engine_key: str = ""
@@ -2085,6 +2096,8 @@ class Patter:
             audio_filter=audio_filter,
             background_audio=background_audio,
             barge_in_threshold_ms=barge_in_threshold_ms,
+            barge_in_mode=barge_in_mode,
+            barge_in_confirm_ms=barge_in_confirm_ms,
             aggressive_first_flush=aggressive_first_flush,
             disable_phone_preamble=disable_phone_preamble,
             echo_cancellation=echo_cancellation,

--- a/libraries/python/getpatter/evals/assertions.py
+++ b/libraries/python/getpatter/evals/assertions.py
@@ -1,6 +1,6 @@
 """Fluent assertions for :class:`~getpatter.evals.session.TurnResult`.
 
-LiveKit-style chainable expectations against the outcome of one real
+Chainable expectations against the outcome of one real
 pipeline turn driven by :class:`~getpatter.evals.session.EvalSession`::
 
     from getpatter.evals.assertions import expect

--- a/libraries/python/getpatter/evals/session.py
+++ b/libraries/python/getpatter/evals/session.py
@@ -57,7 +57,7 @@ Notes
   built-in :class:`~getpatter.services.llm_loop.LLMLoop` path.
 * ``TurnResult.agent_text`` is what the caller HEARD (post-guardrail,
   post-hook, post-text-transform sentences handed to TTS), which is the
-  LiveKit-style observable. ``history_snapshot`` mirrors the dashboard
+  caller-side observable. ``history_snapshot`` mirrors the dashboard
   conversation history, where the streaming path records the raw LLM text.
 """
 

--- a/libraries/python/getpatter/llm/custom.py
+++ b/libraries/python/getpatter/llm/custom.py
@@ -1,7 +1,7 @@
 """Custom LLM — point Patter's pipeline at ANY OpenAI-compatible endpoint.
 
-The industry-standard "Custom LLM" pattern (the same concept ElevenLabs
-Agents, Retell, and Vapi expose under that name): Patter owns the phone leg
+The industry-standard "Custom LLM" pattern (the name the voice-AI
+ecosystem uses for this concept): Patter owns the phone leg
 — carrier, STT, turn-taking, barge-in, TTS — and POSTs each conversation
 turn to YOUR ``/chat/completions`` endpoint. That endpoint can be:
 

--- a/libraries/python/getpatter/models.py
+++ b/libraries/python/getpatter/models.py
@@ -654,7 +654,7 @@ class Agent:
     #   - ``"cancel"`` (default): today's behaviour — the in-flight turn is
     #     cancelled immediately (or marked pending when
     #     ``barge_in_strategies`` are configured).
-    #   - ``"pause_resume"`` (LiveKit-style false-interruption handling):
+    #   - ``"pause_resume"`` (false-interruption handling):
     #     output is PAUSED immediately — the carrier buffer is cleared and
     #     no further TTS audio is sent — while the LLM stream and the TTS
     #     provider stream stay alive (tokens buffer as sentences,
@@ -712,7 +712,7 @@ class Agent:
     # paid during the user's own end-of-utterance silence); if it differs,
     # the speculation is discarded silently and the turn dispatches normally
     # on the final. History and metrics record exactly one turn either way.
-    # Same pattern as LiveKit Agents' ``preemptive_generation``. Default
+    # The standard voice-AI "preemptive generation" pattern. Default
     # ``False`` — every turn waits for the final transcript, as today.
     preemptive_generation: bool = False
     # Interim-stability window (ms) for preemptive generation: an interim

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -4882,7 +4882,7 @@ class PipelineStreamHandler(StreamHandler):
 
     # ---------------------------------------------------------------
     # Pause-and-resume false-interruption handling (barge_in_mode =
-    # "pause_resume"). LiveKit-style: PAUSE output on VAD speech_start,
+    # "pause_resume"): PAUSE output on VAD speech_start,
     # KILL on a committed final transcript within the confirm window,
     # RESUME from the first not-fully-heard sentence otherwise.
     # ---------------------------------------------------------------
@@ -5459,8 +5459,7 @@ class PipelineStreamHandler(StreamHandler):
     # ------------------------------------------------------------------
     # PREEMPTIVE GENERATION (opt-in) — speculative dispatch on a confident
     # interim transcript; commit-or-discard at end of utterance. Mirrors TS
-    # ``noteInterimTranscript`` / ``tryReleaseSpeculation`` and LiveKit's
-    # ``preemptive_generation``.
+    # ``noteInterimTranscript`` / ``tryReleaseSpeculation``.
     # ------------------------------------------------------------------
 
     def _can_speculate(self) -> bool:
@@ -7191,7 +7190,7 @@ class PipelineStreamHandler(StreamHandler):
                 last["text"] = text
 
     def _maybe_truncate_completed_turn_history(self) -> None:
-        """LiveKit-style "heard prefix" semantics for a barge-in that lands
+        """Heard-prefix semantics for a barge-in that lands
         AFTER the turn completed, while the carrier is still playing the
         buffered tail.
 

--- a/libraries/python/getpatter/telephony/telnyx.py
+++ b/libraries/python/getpatter/telephony/telnyx.py
@@ -46,12 +46,6 @@ _DTMF_DEFAULT_DURATION_MS = 250
 _SIP_URI_RE = re.compile(r"^sips?:[^\s@]+(@[^\s]+)?$", re.IGNORECASE)
 
 
-# TODO: TS equivalent — mirror the pause-digit set (``w``/``W``) in
-# ``libraries/typescript/src/server.ts`` ``TELNYX_DTMF_ALLOWED`` (Team 8).
-# Telnyx ``send_dtmf`` accepts ``w`` / ``W`` as a pause character (500 ms
-# wait per Telnyx docs) alongside DTMF digits and A-D letters.
-
-
 async def handle_amd_result(
     *,
     call_control_id: str,

--- a/libraries/python/tests/test_telemetry.py
+++ b/libraries/python/tests/test_telemetry.py
@@ -228,6 +228,87 @@ async def test_aclose_awaits_in_flight_flush_started_by_record(enabled, collecto
     assert [e["event"] for e in collector.events] == ["cli_command"]
 
 
+class _GatedCollector(_Collector):
+    """A real collector that holds its FIRST response until released.
+
+    Lets a test pin the "event recorded while a flush POST is in flight"
+    window deterministically: the first POST blocks server-side, the test
+    records a second event, then releases the gate.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_request_started = threading.Event()
+        self._gate = threading.Event()
+        self._held_one = False
+
+    def release(self) -> None:
+        self._gate.set()
+
+    def start(self) -> None:
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 (stdlib name)
+                length = int(self.headers.get("Content-Length", "0") or 0)
+                body = self.rfile.read(length)
+                hold = not collector._held_one
+                collector._held_one = True
+                collector.first_request_started.set()
+                if hold:
+                    collector._gate.wait(timeout=5.0)
+                try:
+                    collector.requests.append(json.loads(body))
+                except Exception:
+                    collector.requests.append(body)
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, *args: object) -> None:  # silence
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+
+@pytest.fixture
+def gated_collector():
+    c = _GatedCollector()
+    c.start()
+    yield c
+    c.release()  # never leave the handler thread blocked
+    c.stop()
+
+
+async def test_event_recorded_during_in_flight_flush_is_chained(
+    enabled, gated_collector
+):
+    """An event recorded *while* a flush POST is in flight must not strand in
+    the buffer: the completing flush chains another one (regression: ``record``
+    saw the live flush task and skipped scheduling, so constructor-time events
+    shadowed agent-time events until ``aclose``/process exit).
+
+    Pinned WITHOUT calling ``aclose`` — delivery must happen on its own.
+    """
+    client = TelemetryClient(sdk_version="0.6.7", endpoint=gated_collector.url)
+    client.record("cli_command", cli_command="dashboard")
+
+    # Wait until the first POST is genuinely in flight (held by the server).
+    await asyncio.to_thread(gated_collector.first_request_started.wait, 5.0)
+    client.record("first_run")  # lands in the buffer; no flush is scheduled
+    gated_collector.release()
+
+    await _wait_for(gated_collector, 2)
+    assert sorted(e["event"] for e in gated_collector.events) == [
+        "cli_command",
+        "first_run",
+    ]
+    # Two separate POSTs: the second was chained by the completing first flush.
+    assert len(gated_collector.requests) == 2
+    await client.aclose()
+
+
 # --- disabled paths: zero egress -------------------------------------------
 
 

--- a/libraries/python/tests/test_validation_guardrails.py
+++ b/libraries/python/tests/test_validation_guardrails.py
@@ -134,8 +134,11 @@ def test_agent_pipeline_requires_stt_instance():
         phone.agent(system_prompt="test", tts=ElevenLabsTTS(api_key="el"))
 
 
-def test_agent_openai_realtime_requires_openai_key():
+def test_agent_openai_realtime_requires_openai_key(monkeypatch):
     """openai_realtime provider without openai_key raises ValueError."""
+    # "Without any openai_key" includes the environment — the provider path
+    # honours OPENAI_API_KEY since the env-backfill fix.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     # Build a Patter without any openai_key, and call agent() without an engine
     # so the default provider picks up openai_realtime without a key.
     phone = Patter(

--- a/libraries/python/tests/unit/test_client_unit.py
+++ b/libraries/python/tests/unit/test_client_unit.py
@@ -212,7 +212,12 @@ class TestAgentFactory:
         assert agent.disable_phone_preamble is True
         assert agent.echo_cancellation is True
 
-    def test_agent_openai_realtime_requires_key(self) -> None:
+    def test_agent_openai_realtime_requires_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # "No openai key anywhere" includes the environment — the provider
+        # path honours OPENAI_API_KEY since the env-backfill fix.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         client = _local_phone()
         # No engine and no openai key anywhere → should raise.
         with pytest.raises(ValueError, match="OpenAI"):

--- a/libraries/python/tests/unit/test_new_client_api.py
+++ b/libraries/python/tests/unit/test_new_client_api.py
@@ -437,3 +437,51 @@ class TestEngineModelVoiceMerge:
         )
         assert agent.voice == "alloy"
         assert agent.model == "gpt-realtime-mini"
+
+
+class TestAgentFactoryBargeInKwargs:
+    """``barge_in_mode`` / ``barge_in_confirm_ms`` are factory kwargs (TS parity).
+
+    TypeScript ``AgentOptions`` exposes ``bargeInMode`` / ``bargeInConfirmMs``;
+    the Python factory must accept the same knobs instead of forcing callers
+    through ``dataclasses.replace`` on the returned Agent.
+    """
+
+    def _phone(self) -> Patter:
+        return Patter(
+            carrier=Twilio(account_sid="AC", auth_token="tok"),
+            phone_number="+15550001234",
+            webhook_url="abc.ngrok.io",
+        )
+
+    def test_factory_passes_barge_in_mode_and_confirm_ms(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            system_prompt="hi",
+            stt=deepgram_stt.STT(api_key="dg_test"),
+            tts=elevenlabs_tts.TTS(api_key="el_test"),
+            barge_in_mode="pause_resume",
+            barge_in_confirm_ms=900,
+        )
+        assert agent.barge_in_mode == "pause_resume"
+        assert agent.barge_in_confirm_ms == 900
+
+    def test_factory_defaults_match_dataclass(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            system_prompt="hi",
+            stt=deepgram_stt.STT(api_key="dg_test"),
+            tts=elevenlabs_tts.TTS(api_key="el_test"),
+        )
+        assert agent.barge_in_mode == "cancel"
+        assert agent.barge_in_confirm_ms == 1500
+
+    def test_invalid_barge_in_mode_rejected(self) -> None:
+        phone = self._phone()
+        with pytest.raises(ValueError, match="barge_in_mode"):
+            phone.agent(
+                system_prompt="hi",
+                stt=deepgram_stt.STT(api_key="dg_test"),
+                tts=elevenlabs_tts.TTS(api_key="el_test"),
+                barge_in_mode="silence",
+            )

--- a/libraries/python/tests/unit/test_new_client_api.py
+++ b/libraries/python/tests/unit/test_new_client_api.py
@@ -356,3 +356,84 @@ class TestQuickstartSmoke:
         assert agent.provider == "openai_realtime"
         assert phone._local_config.twilio_sid == "AC_env"
         assert phone._local_config.openai_key == "sk-env"
+
+
+# ---------------------------------------------------------------------------
+# Engine voice/model merge precedence
+# ---------------------------------------------------------------------------
+
+
+class TestEngineModelVoiceMerge:
+    """Explicit kwargs > engine marker > defaults.
+
+    Mirrors the TypeScript resolution ``opts.model ?? engineModel ??
+    "gpt-realtime-mini"`` (and the same for voice): an explicit ``model=`` /
+    ``voice=`` kwarg always wins, even when its value equals the documented
+    default — the engine fills the slot only when the kwarg is omitted.
+    """
+
+    def _phone(self) -> Patter:
+        return Patter(
+            carrier=Twilio(account_sid="AC", auth_token="tok"),
+            phone_number="+15550001234",
+            webhook_url="abc.ngrok.io",
+        )
+
+    def test_explicit_model_wins_over_engine_model(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-engine", model="gpt-realtime-2"),
+            system_prompt="hi",
+            model="gpt-realtime-mini",
+        )
+        assert agent.model == "gpt-realtime-mini"
+
+    def test_engine_model_fills_unset_kwarg(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-engine", model="gpt-realtime-2"),
+            system_prompt="hi",
+        )
+        assert agent.model == "gpt-realtime-2"
+
+    def test_explicit_voice_wins_over_engine_voice(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-engine", voice="nova"),
+            system_prompt="hi",
+            voice="alloy",
+        )
+        assert agent.voice == "alloy"
+
+    def test_engine_voice_fills_unset_kwarg(self) -> None:
+        phone = self._phone()
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-engine", voice="nova"),
+            system_prompt="hi",
+        )
+        assert agent.voice == "nova"
+
+    def test_defaults_without_engine_or_kwargs(self) -> None:
+        """Old-shape call (no voice=/model=) keeps today's documented defaults.
+
+        Pipeline mode: no engine marker touches the slots, so the sentinel
+        fallback must land on ``"alloy"`` / ``"gpt-realtime-mini"`` unchanged.
+        """
+        phone = self._phone()
+        agent = phone.agent(
+            system_prompt="hi",
+            stt=deepgram_stt.STT(api_key="dg_test"),
+            tts=elevenlabs_tts.TTS(api_key="el_test"),
+        )
+        assert agent.voice == "alloy"
+        assert agent.model == "gpt-realtime-mini"
+
+    def test_defaults_with_bare_engine(self) -> None:
+        """Engine constructed with its own defaults yields the same defaults."""
+        phone = self._phone()
+        agent = phone.agent(
+            engine=OpenAIRealtime(api_key="sk-engine"),
+            system_prompt="hi",
+        )
+        assert agent.voice == "alloy"
+        assert agent.model == "gpt-realtime-mini"

--- a/libraries/python/tests/unit/test_new_client_api.py
+++ b/libraries/python/tests/unit/test_new_client_api.py
@@ -485,3 +485,36 @@ class TestAgentFactoryBargeInKwargs:
                 tts=elevenlabs_tts.TTS(api_key="el_test"),
                 barge_in_mode="silence",
             )
+
+
+class TestProviderRealtimeEnvKey:
+    """``provider="openai_realtime"`` honours ``OPENAI_API_KEY`` from the env.
+
+    The error message has always promised "or set OPENAI_API_KEY in the
+    environment" and TypeScript accepts the env var — Python must too, AND the
+    key must be backfilled into the local config so the call path actually
+    uses it (accepting at validation but dialing with an empty key would be a
+    dead call).
+    """
+
+    def _phone(self) -> Patter:
+        return Patter(
+            carrier=Twilio(account_sid="AC", auth_token="tok"),
+            phone_number="+15550001234",
+            webhook_url="abc.ngrok.io",
+        )
+
+    def test_env_key_accepted_and_backfilled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        phone = self._phone()
+        agent = phone.agent(system_prompt="hi", provider="openai_realtime")
+        assert agent.provider == "openai_realtime"
+        assert phone._local_config.openai_key == "sk-env"
+
+    def test_no_key_anywhere_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        phone = self._phone()
+        with pytest.raises(ValueError, match="OpenAI API key"):
+            phone.agent(system_prompt="hi", provider="openai_realtime")

--- a/libraries/typescript/src/cli.ts
+++ b/libraries/typescript/src/cli.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   npx getpatter dashboard [--port 8000]
- *   npx getpatter eval                        (stub — evals are Python-only today)
+ *   npx getpatter eval run <suite> [--agent module:export] [--output report.json]
  *   npx getpatter telemetry [status|disable|enable]
  */
 
@@ -102,14 +102,101 @@ function parseArgs(argv: string[]): { port: number } {
   return { port };
 }
 
-function printEvalStub(): void {
-  console.log(
-    'Evaluations are not yet available in the TypeScript SDK.\n' +
-      'Use the Python SDK instead:\n\n' +
-      '  pip install getpatter\n' +
-      '  patter eval --help\n\n' +
-      'See https://github.com/PatterAI/Patter for docs.',
-  );
+/**
+ * `getpatter eval run <suite>` — run an evaluation suite. Mirrors the
+ * Python `patter eval run` CLI (same flags, same report shape, same exit
+ * codes: 0 all passed, 1 failures, 2 usage).
+ */
+async function runEvalCommand(args: string[]): Promise<number> {
+  if (args[0] !== 'run' || !args[1]) {
+    console.log('Usage: getpatter eval run <suite> [--agent module:export]');
+    console.log('       [--judge-model gpt-4o-mini] [--pass-threshold 0.7] [--output report.json]');
+    return 2;
+  }
+  const suitePath = args[1];
+  let agentSpec = '';
+  let judgeModel = 'gpt-4o-mini';
+  let passThreshold = 0.7;
+  let output = '';
+  for (let i = 2; i < args.length; i++) {
+    const flag = args[i];
+    const value = args[i + 1];
+    if (flag === '--agent' && value !== undefined) {
+      agentSpec = value;
+      i++;
+    } else if (flag === '--judge-model' && value !== undefined) {
+      judgeModel = value;
+      i++;
+    } else if (flag === '--pass-threshold' && value !== undefined) {
+      passThreshold = Number.parseFloat(value);
+      i++;
+    } else if (flag === '--output' && value !== undefined) {
+      output = value;
+      i++;
+    } else {
+      console.log(`Unknown eval option: ${flag}`);
+      return 2;
+    }
+  }
+
+  const { EvalRunner, LLMJudge, loadSuite } = await import('./evals');
+  const suite = await loadSuite(suitePath);
+  const judge = new LLMJudge({ model: judgeModel, passThreshold });
+  const runner = new EvalRunner({ judge });
+
+  const factory = await loadAgentFactory(agentSpec);
+  const results = await runner.run(suite, factory);
+  const report = runner.report(suite, results);
+
+  if (output) {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(output, report, 'utf-8');
+    console.log(`Wrote report to ${output}`);
+  } else {
+    console.log(report);
+  }
+
+  const total = results.length;
+  const passed = results.filter((r) => r.judge.passed).length;
+  console.error(`\n${passed}/${total} cases passed`);
+  return passed === total ? 0 : 1;
+}
+
+/**
+ * Resolve a ``module:export`` string to an agent factory.
+ *
+ * Falls back to an echo-style mock agent when no factory is provided — lets
+ * developers sanity-check their suite shape before wiring the real agent.
+ */
+async function loadAgentFactory(
+  spec: string,
+): Promise<() => (text: string) => Promise<string>> {
+  if (!spec) {
+    const echo = async (text: string): Promise<string> => `echo: ${text}`;
+    return () => echo;
+  }
+  const sep = spec.lastIndexOf(':');
+  if (sep <= 0) {
+    throw new Error("--agent must be of the form 'module-or-path:exportName'");
+  }
+  const modulePath = spec.slice(0, sep);
+  const exportName = spec.slice(sep + 1);
+  const { pathToFileURL } = await import('node:url');
+  const { resolve } = await import('node:path');
+  const { existsSync } = await import('node:fs');
+  // File paths (./agent.mjs, ../x.js, absolute) are resolved against cwd;
+  // anything else is treated as a bare module specifier.
+  const looksLikePath =
+    modulePath.startsWith('.') || modulePath.startsWith('/') || existsSync(modulePath);
+  const specifier = looksLikePath
+    ? pathToFileURL(resolve(modulePath)).href
+    : modulePath;
+  const mod = (await import(specifier)) as Record<string, unknown>;
+  const target = mod[exportName] ?? (mod.default as Record<string, unknown> | undefined)?.[exportName];
+  if (typeof target !== 'function') {
+    throw new Error(`--agent target ${JSON.stringify(spec)} is not callable`);
+  }
+  return target as () => (text: string) => Promise<string>;
 }
 
 function printHermesStub(): void {
@@ -151,8 +238,12 @@ async function main(): Promise<void> {
 
   if (command === 'eval') {
     await emitCliCommand('eval');
-    printEvalStub();
-    process.exit(0);
+    try {
+      process.exit(await runEvalCommand(process.argv.slice(3)));
+    } catch (err) {
+      console.error(`eval failed: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
   }
   if (command === 'hermes') {
     printHermesStub();
@@ -165,7 +256,7 @@ async function main(): Promise<void> {
   if (command !== 'dashboard') {
     await emitCliCommand(command ? 'other' : 'none');
     console.log('Usage: getpatter dashboard [--port 8000]');
-    console.log('       getpatter eval          (stub — use Python SDK for evals)');
+    console.log('       getpatter eval run <suite> [--agent module:export] [--output report.json]');
     console.log('       getpatter hermes        (stub — use Python SDK for the wizard)');
     console.log('       getpatter openclaw      (stub — use Python SDK for the wizard)');
     console.log('       getpatter telemetry [status|disable|enable]');

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -737,14 +737,21 @@ export class Patter {
     if (
       working.provider === 'openai_realtime' &&
       !working.engine &&
-      !this.localConfig.openaiKey &&
-      !process.env.OPENAI_API_KEY
+      !this.localConfig.openaiKey
     ) {
-      throw new Error(
-        "OpenAI Realtime mode requires an OpenAI API key. Pass " +
-          "engine: new OpenAIRealtime({ apiKey: 'sk-...' }) or set " +
-          'OPENAI_API_KEY in the environment.',
-      );
+      const envKey = process.env.OPENAI_API_KEY;
+      if (envKey) {
+        // Backfill the local config so the CALL PATH uses the env key too —
+        // accepting here but dialing with an empty key later would be a dead
+        // call instead of a clear error (parity with Python).
+        this.localConfig = { ...this.localConfig, openaiKey: envKey };
+      } else {
+        throw new Error(
+          "OpenAI Realtime mode requires an OpenAI API key. Pass " +
+            "engine: new OpenAIRealtime({ apiKey: 'sk-...' }) or set " +
+            'OPENAI_API_KEY in the environment.',
+        );
+      }
     }
 
     // The consult tool is injected only in Realtime and Pipeline modes;

--- a/libraries/typescript/src/evals/assertions.ts
+++ b/libraries/typescript/src/evals/assertions.ts
@@ -1,0 +1,234 @@
+/**
+ * Fluent assertions for {@link TurnResult}.
+ *
+ * Chainable expectations against the outcome of one real pipeline turn
+ * driven by {@link EvalSession}:
+ *
+ * ```ts
+ * const result = await session.userSays('book me a table for two');
+ * expect(result)
+ *   .toolCalled('book_table', { partySize: 2 })
+ *   .agentTextContains('booked');
+ *
+ * // Semantic check via the LLMJudge (async, ends the chain):
+ * await expect(result).judge(new LLMJudge(), {
+ *   intent: 'The agent confirms the booking and offers help.',
+ * });
+ * ```
+ *
+ * Every failed expectation throws Node's ``AssertionError`` with the
+ * observed values, so plain vitest reports are actionable without extra
+ * plumbing. Mirrors the Python `getpatter.evals.assertions` module.
+ */
+
+import { AssertionError } from 'node:assert';
+import { getLogger } from '../logger';
+import type { EvalCase, JudgeResult } from './case';
+import type { LLMJudge } from './llm-judge';
+import { historyTranscript } from './session';
+import type { TurnResult } from './session';
+
+/** Wrap a {@link TurnResult} in a chainable expectation object. */
+export function expect(result: TurnResult): TurnExpectation {
+  return new TurnExpectation(result);
+}
+
+/** Deep structural equality for the non-object branch of {@link isSubset}. */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (
+    a !== null &&
+    b !== null &&
+    typeof a === 'object' &&
+    typeof b === 'object' &&
+    !Array.isArray(a) &&
+    !Array.isArray(b)
+  ) {
+    const ak = Object.keys(a as Record<string, unknown>);
+    const bk = Object.keys(b as Record<string, unknown>);
+    return (
+      ak.length === bk.length &&
+      ak.every((k) =>
+        deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+      )
+    );
+  }
+  return false;
+}
+
+/**
+ * True when ``subset`` is recursively contained in ``actual``.
+ *
+ * Plain objects match when every key in ``subset`` exists in ``actual`` and
+ * its value matches recursively; every other type (including arrays)
+ * matches by deep equality — same semantics as the Python helper.
+ */
+function isSubset(subset: unknown, actual: unknown): boolean {
+  if (subset !== null && typeof subset === 'object' && !Array.isArray(subset)) {
+    if (actual === null || typeof actual !== 'object' || Array.isArray(actual)) {
+      return false;
+    }
+    const actualRecord = actual as Record<string, unknown>;
+    return Object.entries(subset as Record<string, unknown>).every(
+      ([key, value]) => key in actualRecord && isSubset(value, actualRecord[key]),
+    );
+  }
+  return deepEqual(subset, actual);
+}
+
+/** Options for {@link TurnExpectation.agentTextContains}. */
+export interface AgentTextContainsOptions {
+  /** Compare needles case-sensitively. Default: false (Python parity). */
+  readonly caseSensitive?: boolean;
+}
+
+/** Chainable assertions over one turn. See {@link expect}. */
+export class TurnExpectation {
+  private readonly turnResult: TurnResult;
+
+  constructor(result: TurnResult) {
+    this.turnResult = result;
+  }
+
+  /** The wrapped {@link TurnResult} (escape hatch for ad-hoc asserts). */
+  get result(): TurnResult {
+    return this.turnResult;
+  }
+
+  // -- tools -----------------------------------------------------------------
+
+  /**
+   * Assert that tool ``name`` ran this turn.
+   *
+   * ``argsSubset`` (optional) must be recursively contained in the args of
+   * at least one matching invocation — extra argument keys are allowed,
+   * listed keys must match exactly.
+   */
+  toolCalled(name: string, argsSubset?: Record<string, unknown>): TurnExpectation {
+    const matches = this.turnResult.toolCalls.filter((tc) => tc.name === name);
+    if (matches.length === 0) {
+      const called = this.turnResult.toolCalls.map((tc) => tc.name);
+      throw new AssertionError({
+        message:
+          `expected tool ${JSON.stringify(name)} to be called this turn; ` +
+          `tools called: ${called.length > 0 ? JSON.stringify(called) : 'none'}`,
+      });
+    }
+    if (argsSubset !== undefined && !matches.some((tc) => isSubset(argsSubset, tc.arguments))) {
+      throw new AssertionError({
+        message:
+          `tool ${JSON.stringify(name)} was called, but no invocation matched ` +
+          `argsSubset=${JSON.stringify(argsSubset)}; observed args: ` +
+          JSON.stringify(matches.map((tc) => tc.arguments)),
+      });
+    }
+    return this;
+  }
+
+  /** Assert that no tool ran this turn (or that ``name`` did not). */
+  noToolCalled(name?: string): TurnExpectation {
+    if (name === undefined) {
+      if (this.turnResult.toolCalls.length > 0) {
+        throw new AssertionError({
+          message:
+            'expected no tool calls this turn; tools called: ' +
+            JSON.stringify(this.turnResult.toolCalls.map((tc) => tc.name)),
+        });
+      }
+      return this;
+    }
+    const offenders = this.turnResult.toolCalls.filter((tc) => tc.name === name);
+    if (offenders.length > 0) {
+      throw new AssertionError({
+        message:
+          `expected tool ${JSON.stringify(name)} NOT to be called this turn; ` +
+          `it ran ${offenders.length} time(s) with args ` +
+          JSON.stringify(offenders.map((tc) => tc.arguments)),
+      });
+    }
+    return this;
+  }
+
+  // -- text ------------------------------------------------------------------
+
+  /**
+   * Assert that every needle appears in the spoken agent text.
+   *
+   * Variadic form is case-insensitive (Python default); pass an array plus
+   * an options object for ``caseSensitive: true``.
+   */
+  agentTextContains(...needles: string[]): TurnExpectation;
+  agentTextContains(
+    needles: string | ReadonlyArray<string>,
+    options?: AgentTextContainsOptions,
+  ): TurnExpectation;
+  agentTextContains(
+    first: string | ReadonlyArray<string>,
+    ...rest: Array<string | AgentTextContainsOptions | undefined>
+  ): TurnExpectation {
+    let needles: string[];
+    let caseSensitive = false;
+    if (Array.isArray(first)) {
+      needles = [...first];
+      const options = rest[0] as AgentTextContainsOptions | undefined;
+      caseSensitive = options?.caseSensitive ?? false;
+    } else {
+      needles = [first as string, ...(rest as string[])].filter(
+        (n): n is string => typeof n === 'string',
+      );
+    }
+    const haystack = this.turnResult.agentText;
+    const cmpHaystack = caseSensitive ? haystack : haystack.toLowerCase();
+    const missing = needles.filter(
+      (n) => !cmpHaystack.includes(caseSensitive ? n : n.toLowerCase()),
+    );
+    if (missing.length > 0) {
+      throw new AssertionError({
+        message:
+          `agent text is missing ${JSON.stringify(missing)}; agent said: ` +
+          JSON.stringify(haystack),
+      });
+    }
+    return this;
+  }
+
+  // -- semantic judge ----------------------------------------------------------
+
+  /**
+   * Score this turn against ``intent`` with the LLM judge.
+   *
+   * Builds a synthetic {@link EvalCase} whose ``expectedBehavior`` is
+   * ``intent`` and judges the turn's full history snapshot. Throws
+   * ``AssertionError`` when the judge fails the turn; returns the
+   * {@link JudgeResult} otherwise (chain-ending, async).
+   */
+  async judge(
+    llmJudge: LLMJudge,
+    options: { readonly intent: string; readonly rubric?: string },
+  ): Promise<JudgeResult> {
+    const { intent, rubric } = options;
+    const evalCase: EvalCase = {
+      name: 'inline-judge',
+      turns: [],
+      expectedBehavior: intent,
+      rubric: rubric ?? `Pass when the agent's behavior matches: ${intent}`,
+    };
+    const transcript = historyTranscript(this.turnResult.historySnapshot);
+    const verdict = await llmJudge.judgeCase(evalCase, transcript);
+    getLogger().info(
+      `judge intent=${JSON.stringify(intent)} score=${verdict.score.toFixed(2)} passed=${verdict.passed}`,
+    );
+    if (!verdict.passed) {
+      throw new AssertionError({
+        message:
+          `LLM judge failed the turn (score=${verdict.score.toFixed(2)}): ` +
+          `${verdict.reasoning} — intent was ${JSON.stringify(intent)}; agent said ` +
+          JSON.stringify(this.turnResult.agentText),
+      });
+    }
+    return verdict;
+  }
+}

--- a/libraries/typescript/src/evals/case.ts
+++ b/libraries/typescript/src/evals/case.ts
@@ -1,0 +1,90 @@
+/**
+ * Eval case data model.
+ *
+ * An {@link EvalCase} is a scripted scenario: a sequence of user turns, an
+ * expected-behavior description, and a rubric used by the judge LLM.
+ *
+ * Designed to be loaded from a YAML/JSON suite file — see
+ * {@link loadSuite} in `runner.ts`. Mirrors the Python
+ * `getpatter.evals.case` module (frozen dataclasses → readonly interfaces).
+ */
+
+import type { AgentOptions } from '../types';
+import type { LLMProvider } from '../llm-loop';
+
+/** A single user utterance in a scripted conversation. */
+export interface EvalTurn {
+  readonly user: string;
+  /**
+   * Optional substrings the agent's reply should contain — used as a cheap
+   * pre-filter (logged, never fatal) before invoking the LLM judge.
+   */
+  readonly expectedContains?: ReadonlyArray<string>;
+}
+
+/** A complete evaluation scenario. */
+export interface EvalCase {
+  readonly name: string;
+  readonly turns: ReadonlyArray<EvalTurn>;
+  readonly expectedBehavior: string;
+  readonly rubric: string;
+  /** Optional metadata for reporting/filtering. */
+  readonly tags?: ReadonlyArray<string>;
+  /**
+   * Optional first-message the agent should emit before any user turn.
+   * On the real-pipeline path (``agent`` set) it overrides the agent's own
+   * ``firstMessage`` so the REAL handler speaks it; on the legacy
+   * ``reply()`` path it is prepended to the transcript display-only.
+   */
+  readonly firstMessage?: string;
+  /**
+   * Optional REAL-pipeline target. When ``agent`` is set, the runner drives
+   * the case through {@link EvalSession} — the real `StreamHandler`
+   * pipeline call loop (tools, hooks, guardrails, history) — instead of the
+   * legacy ``reply()``-callable factory. ``llmProvider`` optionally
+   * overrides ``agent.llm`` (e.g. a {@link ScriptedLLMProvider} for CI).
+   * Both default to ``undefined`` so existing suites are unaffected.
+   */
+  readonly agent?: AgentOptions;
+  readonly llmProvider?: LLMProvider;
+}
+
+/** The judge's verdict on one case. */
+export interface JudgeResult {
+  /** Score in [0.0, 1.0]. */
+  readonly score: number;
+  readonly passed: boolean;
+  readonly reasoning: string;
+}
+
+/** One line of a judge-facing transcript. */
+export interface TranscriptEntry {
+  readonly role: string;
+  readonly text: string;
+}
+
+/** The result of running a single {@link EvalCase}. */
+export interface EvalResult {
+  readonly caseName: string;
+  readonly transcript: ReadonlyArray<TranscriptEntry>;
+  readonly judge: JudgeResult;
+  readonly durationS: number;
+  readonly error: string | null;
+}
+
+/**
+ * Render an {@link EvalResult} as the JSON-report row shape — mirrors the
+ * Python `EvalResult.to_dict()` (snake_case keys, stable across SDKs so CI
+ * artefacts are interchangeable).
+ */
+export function evalResultToDict(result: EvalResult): Record<string, unknown> {
+  return {
+    case: result.caseName,
+    score: result.judge.score,
+    passed: result.judge.passed,
+    reasoning: result.judge.reasoning,
+    transcript: result.transcript.map((t) => ({ role: t.role, text: t.text })),
+    duration_s: Math.round(result.durationS * 1000) / 1000,
+    error: result.error,
+  };
+}

--- a/libraries/typescript/src/evals/fakes.ts
+++ b/libraries/typescript/src/evals/fakes.ts
@@ -1,0 +1,223 @@
+/**
+ * Eval-harness fakes — the ONLY mocked boundary of {@link EvalSession}.
+ *
+ * Everything inward of these (transcript commit filters, barge-in state
+ * machine, LLM loop, tool executor, hooks, guardrails, sentence chunking,
+ * metrics) is the REAL pipeline code. The fakes stand in for the
+ * paid/external surfaces a live call touches: the telephony carrier
+ * (audio sender), the STT socket, and the TTS socket.
+ */
+
+import type { WebSocket as WSWebSocket } from 'ws';
+import type { TelephonyBridge } from '../stream-handler';
+import type {
+  AgentOptions,
+  CarrierKind,
+  TransferCallOptions,
+  TransferCallResult,
+  VADEvent,
+  VADProvider,
+} from '../types';
+import type { STTAdapter, STTTranscriptCallback, TTSAdapter } from '../provider-factory';
+import { ErrorCode, PatterError } from '../errors';
+import { getLogger } from '../logger';
+
+/** Minimal carrier-WebSocket stub (the carrier socket is an external boundary). */
+export function makeFakeCarrierWs(): WSWebSocket {
+  const noop = (): void => undefined;
+  return {
+    send: noop,
+    close: noop,
+    on: noop,
+    once: noop,
+    removeListener: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    readyState: 1,
+    OPEN: 1,
+  } as unknown as WSWebSocket;
+}
+
+/**
+ * Records every carrier-bound audio operation; auto-acks marks.
+ *
+ * The TS analogue of the carrier boundary is the {@link TelephonyBridge}, so
+ * this fake implements it directly. ``sentAudio`` collects the decoded wire
+ * chunks handed to the carrier, ``clears`` counts ``sendClear`` calls
+ * (barge-in flushes), ``marks`` records mark names, ``endedCalls`` /
+ * ``transfers`` record call-control invocations. When attached to a handler,
+ * each ``sendMark`` is echoed back through ``handler.onMark`` so mark-gated
+ * pacing never deadlocks.
+ */
+export class FakeAudioSender implements TelephonyBridge {
+  readonly label = 'Eval';
+  // The metrics/dashboard tag for the faked carrier — mirrors Python's
+  // ``telephony_provider="eval"``. No pricing row exists for 'eval', so
+  // telephony cost is always 0. The cast is deliberate: CarrierKind
+  // enumerates real carriers and the harness is not one.
+  readonly telephonyProvider = 'eval' as CarrierKind;
+  readonly inputWireFormat = 'pcm_16000' as const;
+
+  readonly sentAudio: Buffer[] = [];
+  readonly marks: string[] = [];
+  readonly endedCalls: string[] = [];
+  readonly transfers: Array<{ readonly callId: string; readonly toNumber: string }> = [];
+  clears = 0;
+
+  private handler: { onMark(markName: string): Promise<void> } | null = null;
+  private sttFactory: (() => STTAdapter | null) | null = null;
+
+  /** Wire the auto-ack loopback for ``sendMark`` → ``onMark``. */
+  attachHandler(handler: { onMark(markName: string): Promise<void> }): void {
+    this.handler = handler;
+  }
+
+  /** Wire the STT instance ``createStt`` should hand to the handler. */
+  attachSttFactory(factory: () => STTAdapter | null): void {
+    this.sttFactory = factory;
+  }
+
+  sendAudio(_ws: WSWebSocket, audioBase64: string, _streamSid: string): void {
+    this.sentAudio.push(Buffer.from(audioBase64, 'base64'));
+  }
+
+  sendMark(_ws: WSWebSocket, markName: string, _streamSid: string): void {
+    this.marks.push(markName);
+    if (this.handler !== null) {
+      // Echo the ack — resolves any pending-mark waiter the handler
+      // registered just before this call. Fire-and-forget: the bridge
+      // contract is synchronous and onMark never throws in practice.
+      void this.handler.onMark(markName).catch((err) => {
+        getLogger().debug(`FakeAudioSender mark ack failed: ${String(err)}`);
+      });
+    }
+  }
+
+  sendClear(_ws: WSWebSocket, _streamSid: string): void {
+    this.clears += 1;
+  }
+
+  async transferCall(
+    callId: string,
+    toNumber: string,
+    _options?: TransferCallOptions,
+  ): Promise<TransferCallResult | void> {
+    this.transfers.push({ callId, toNumber });
+  }
+
+  async endCall(callId: string, _ws: WSWebSocket): Promise<void> {
+    this.endedCalls.push(callId);
+  }
+
+  async createStt(_agent: AgentOptions): Promise<STTAdapter | null> {
+    return this.sttFactory ? this.sttFactory() : null;
+  }
+
+  async queryTelephonyCost(): Promise<void> {
+    // Faked carrier — no cost to query.
+  }
+}
+
+/**
+ * Callback-backed STT double feeding the handler's REAL transcript path.
+ *
+ * The harness pushes finalised transcripts via {@link FakeSTT.pushFinal};
+ * the handler consumes them through the same ``onTranscript`` callback a
+ * live Deepgram adapter drives, so ``handleBargeIn`` → ``commitTranscript``
+ * → ``dispatchTurn`` run exactly as on a real call. ``pushFinal`` resolves
+ * once the handler's transcript drain loop has fully processed the
+ * transcript (i.e. the dispatch task for it — if any — has been created),
+ * which is what {@link EvalSession.userSays} awaits before grabbing the
+ * dispatch task.
+ */
+export class FakeSTT implements STTAdapter {
+  readonly sentAudio: Buffer[] = [];
+  connected = false;
+  closed = false;
+
+  private callback: STTTranscriptCallback | null = null;
+
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  sendAudio(pcm: Buffer): void {
+    this.sentAudio.push(pcm);
+  }
+
+  onTranscript(cb: STTTranscriptCallback): void {
+    this.callback = cb;
+  }
+
+  /** Inject one final transcript through the handler's real receive path. */
+  async pushFinal(text: string): Promise<void> {
+    if (this.closed) {
+      throw new PatterError(
+        'FakeSTT is closed — the EvalSession was already cleaned up',
+        { code: ErrorCode.CONFIG },
+      );
+    }
+    if (this.callback === null) {
+      throw new PatterError(
+        'FakeSTT has no transcript consumer — the handler is not started',
+        { code: ErrorCode.CONFIG },
+      );
+    }
+    await this.callback({ text, isFinal: true, confidence: 1.0 });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+/**
+ * TTS double: records the text it is asked to speak, yields silence.
+ *
+ * The default chunk is 320 bytes of PCM16 @ 16 kHz (10 ms of silence) so the
+ * handler's playback-backlog accounting stays in the sub-frame range and a
+ * following turn is never misclassified as a barge-in against a phantom
+ * carrier backlog. ``closed`` flips when the handler's teardown invokes
+ * ``cancelActiveStream`` (the TS TTS adapters are per-request — teardown
+ * cancels the active stream rather than closing a connection).
+ */
+export class FakeTTS implements TTSAdapter {
+  readonly spoken: string[] = [];
+  closed = false;
+
+  private readonly chunk: Buffer;
+
+  constructor(chunk: Buffer = Buffer.alloc(320)) {
+    this.chunk = chunk;
+  }
+
+  async *synthesizeStream(text: string): AsyncIterable<Buffer> {
+    this.spoken.push(text);
+    yield this.chunk;
+  }
+
+  /** Invoked by the handler's real teardown (``handleStop``). */
+  cancelActiveStream(): void {
+    this.closed = true;
+  }
+}
+
+/**
+ * No-op VAD injected when the agent has none — prevents the real start path
+ * from auto-loading SileroVAD (ONNX model) in deterministic eval runs.
+ * Never consulted in practice: the session injects transcripts directly and
+ * feeds no audio frames.
+ */
+export class NoopVad implements VADProvider {
+  async processFrame(_pcmChunk: Buffer, _sampleRate: number): Promise<VADEvent | null> {
+    return null;
+  }
+
+  reset(): void {
+    // No per-utterance state.
+  }
+
+  async close(): Promise<void> {
+    // Nothing to release.
+  }
+}

--- a/libraries/typescript/src/evals/index.ts
+++ b/libraries/typescript/src/evals/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Patter evaluation framework — mirrors Python `getpatter.evals`.
+ *
+ * Primitives:
+ * - {@link EvalCase} — declarative description of a test case
+ * - {@link EvalRunner} — drives one or more cases
+ * - {@link LLMJudge} — uses an LLM to score a transcript against a rubric
+ *
+ * Real-pipeline harness (drives an actual pipeline `StreamHandler` — tools,
+ * hooks, guardrails, barge-in state machine, history — with fake telephony /
+ * STT / TTS at the boundary):
+ * - {@link EvalSession} — `await EvalSession.create({ agent, llmProvider })`
+ *   then `await session.userSays('hi')` / `await session.close()`
+ * - {@link ScriptedLLMProvider} (+ {@link textTurn} / {@link toolCallTurn})
+ *   — deterministic LLM for CI
+ * - {@link expect} — chainable assertions over a {@link TurnResult}
+ *   (`toolCalled`, `noToolCalled`, `agentTextContains`, async `judge`)
+ */
+
+export type {
+  EvalCase,
+  EvalResult,
+  EvalTurn,
+  JudgeResult,
+  TranscriptEntry,
+} from './case';
+export { evalResultToDict } from './case';
+export { LLMJudge } from './llm-judge';
+export type { JudgeBackend, LLMJudgeOptions } from './llm-judge';
+export { EvalRunner, loadSuite } from './runner';
+export type { AgentCallable, AgentFactory, EvalRunnerOptions, EvalSuite } from './runner';
+export { FakeAudioSender, FakeSTT, FakeTTS } from './fakes';
+export { ScriptedLLMProvider, textTurn, toolCallTurn } from './scripted-llm';
+export type { ScriptedLLMCall } from './scripted-llm';
+export { EvalSession, historyTranscript } from './session';
+export type { EvalSessionOptions, ToolCallRecord, TurnResult } from './session';
+export { expect, TurnExpectation } from './assertions';
+export type { AgentTextContainsOptions } from './assertions';

--- a/libraries/typescript/src/evals/llm-judge.ts
+++ b/libraries/typescript/src/evals/llm-judge.ts
@@ -1,0 +1,154 @@
+/**
+ * LLM-as-judge scoring for eval cases.
+ *
+ * Mirrors the Python `getpatter.evals.llm_judge` module. The judge is
+ * intentionally provider-specific (OpenAI chat completions) because
+ * reliability of structured JSON output matters more than provider
+ * flexibility for evals. Callers who need a different backend can implement
+ * a {@link JudgeBackend} and inject it via the ``backend`` option.
+ */
+
+import { getLogger } from '../logger';
+import type { EvalCase, JudgeResult, TranscriptEntry } from './case';
+
+const JUDGE_SYSTEM =
+  'You are a strict but fair evaluator of voice-AI agents. ' +
+  'You will be given: (1) the expected behavior for the agent, (2) a rubric, ' +
+  '(3) a transcript of the conversation. ' +
+  'Return a JSON object with exactly three keys:\n' +
+  '  - "score": float between 0.0 and 1.0\n' +
+  '  - "passed": boolean (true when score >= threshold)\n' +
+  '  - "reasoning": short string explaining the score\n' +
+  'Do not return any text outside the JSON object.';
+
+/** Pluggable judge backend — anything exposing ``judge(prompt)``. */
+export interface JudgeBackend {
+  judge(prompt: string): Promise<string>;
+}
+
+/** Options for {@link LLMJudge}. Defaults match the Python SDK byte-for-byte. */
+export interface LLMJudgeOptions {
+  /** Model the judge should use. Default: ``gpt-4o-mini``. */
+  readonly model?: string;
+  /** OpenAI API key. Falls back to ``OPENAI_API_KEY`` when unset. */
+  readonly apiKey?: string;
+  /** Score threshold for a pass. Default: ``0.7``. */
+  readonly passThreshold?: number;
+  /** Test/alternative backend — any object exposing ``judge(prompt)``. */
+  readonly backend?: JudgeBackend;
+}
+
+/** Scores conversation transcripts against a rubric via an OpenAI model. */
+export class LLMJudge {
+  readonly model: string;
+  readonly passThreshold: number;
+  private readonly apiKey?: string;
+  private readonly backend?: JudgeBackend;
+
+  constructor(options: LLMJudgeOptions = {}) {
+    this.model = options.model ?? 'gpt-4o-mini';
+    this.apiKey = options.apiKey;
+    this.passThreshold = options.passThreshold ?? 0.7;
+    this.backend = options.backend;
+  }
+
+  /** Return a {@link JudgeResult} for the given transcript. */
+  async judgeCase(
+    evalCase: EvalCase,
+    transcript: ReadonlyArray<TranscriptEntry>,
+  ): Promise<JudgeResult> {
+    const prompt = this.buildPrompt(evalCase, transcript);
+    const raw = this.backend
+      ? await this.backend.judge(prompt)
+      : await this.callOpenAI(prompt);
+    return this.parse(raw);
+  }
+
+  private buildPrompt(
+    evalCase: EvalCase,
+    transcript: ReadonlyArray<TranscriptEntry>,
+  ): string {
+    const lines = [
+      `EXPECTED BEHAVIOR: ${evalCase.expectedBehavior}`,
+      `RUBRIC: ${evalCase.rubric}`,
+      `PASS THRESHOLD: ${this.passThreshold}`,
+      'TRANSCRIPT:',
+    ];
+    for (const turn of transcript) {
+      lines.push(`  ${turn.role || '?'}: ${turn.text ?? ''}`);
+    }
+    return lines.join('\n');
+  }
+
+  /** Call OpenAI chat completions directly over fetch (no SDK dependency). */
+  private async callOpenAI(prompt: string): Promise<string> {
+    const apiKey = this.apiKey || process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        'LLMJudge requires an OpenAI API key. ' +
+          'Set OPENAI_API_KEY or pass apiKey to the LLMJudge constructor.',
+      );
+    }
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          { role: 'system', content: JUDGE_SYSTEM },
+          { role: 'user', content: prompt },
+        ],
+        response_format: { type: 'json_object' },
+        temperature: 0.0,
+      }),
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`LLMJudge OpenAI call failed: ${response.status} ${errText.slice(0, 200)}`);
+    }
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string | null } }>;
+    };
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      // A 200 without choices (error envelope, empty completion) would
+      // otherwise silently parse as a zero-score fail — surface it instead.
+      throw new Error(
+        `LLMJudge response had no choices/content: ${JSON.stringify(data).slice(0, 200)}`,
+      );
+    }
+    return content;
+  }
+
+  /** Parse the judge's JSON — tolerant of extra whitespace / code fences. */
+  private parse(raw: string): JudgeResult {
+    let text = raw.trim();
+    // Strip a leading fence if the model added one despite json_object mode.
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+    }
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      getLogger().warn(`LLMJudge: invalid JSON, defaulting to fail: ${JSON.stringify(raw)}`);
+      return {
+        score: 0.0,
+        passed: false,
+        reasoning: `Judge returned invalid JSON: ${raw.slice(0, 200)}`,
+      };
+    }
+    const scoreRaw = Number(data.score ?? 0.0);
+    let score = Number.isFinite(scoreRaw) ? scoreRaw : 0.0;
+    score = Math.max(0.0, Math.min(1.0, score));
+    // Verdict is computed LOCALLY from the score: trusting the judge's
+    // self-reported ``passed`` let a hallucinated ``passed: true`` with
+    // ``score: 0.2`` record a pass.
+    const passed = score >= this.passThreshold;
+    const reasoning = String(data.reasoning ?? '');
+    return { score, passed, reasoning };
+  }
+}

--- a/libraries/typescript/src/evals/runner.ts
+++ b/libraries/typescript/src/evals/runner.ts
@@ -1,0 +1,337 @@
+/**
+ * Eval runner — executes an {@link EvalSuite} against a scripted agent.
+ *
+ * Two execution paths per case (mirrors the Python `getpatter.evals.runner`):
+ *
+ * - **Legacy** (default): the caller supplies an ``agentFactory`` returning
+ *   an async ``reply(text) => string`` callable — no SDK machinery involved.
+ * - **Real pipeline**: when an {@link EvalCase} carries ``agent`` (an
+ *   {@link AgentOptions}, optionally with ``llmProvider``), the runner
+ *   drives the case through {@link EvalSession} — the real `StreamHandler`
+ *   pipeline call loop with tools, hooks, guardrails, and history handling.
+ *
+ * ```ts
+ * const evalCase: EvalCase = {
+ *   name: 'books a table',
+ *   turns: [{ user: 'table for two at eight' }],
+ *   expectedBehavior: 'Agent books and confirms the table.',
+ *   rubric: 'Pass if a booking is confirmed.',
+ *   agent: myAgent,                              // real agent under test
+ *   llmProvider: new ScriptedLLMProvider([...]), // or a real provider
+ * };
+ * const results = await new EvalRunner({ judge }).run({ name: 's', cases: [evalCase] });
+ * ```
+ */
+
+import { readFile } from 'node:fs/promises';
+import { extname, basename } from 'node:path';
+import { getLogger } from '../logger';
+import type { EvalCase, EvalResult, EvalTurn, TranscriptEntry } from './case';
+import { evalResultToDict } from './case';
+import { LLMJudge } from './llm-judge';
+
+/**
+ * An agent callable receives one user turn and returns the agent's final
+ * text response. This decouples the runner from the real Patter Agent
+ * wiring and lets callers plug in any chat-completions client or mock.
+ */
+export type AgentCallable = (text: string) => Promise<string>;
+/** A factory takes no arguments and returns an {@link AgentCallable}. */
+export type AgentFactory = () => AgentCallable | Promise<AgentCallable>;
+
+/** A named collection of {@link EvalCase} to run together. */
+export interface EvalSuite {
+  readonly name: string;
+  readonly cases: ReadonlyArray<EvalCase>;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** Options for {@link EvalRunner}. */
+export interface EvalRunnerOptions {
+  /** Judge used to score each case. Default: ``new LLMJudge()``. */
+  readonly judge?: LLMJudge;
+}
+
+/** Drives one or more cases against an agent and produces a JSON report. */
+export class EvalRunner {
+  readonly judge: LLMJudge;
+
+  constructor(options: EvalRunnerOptions = {}) {
+    this.judge = options.judge ?? new LLMJudge();
+  }
+
+  /**
+   * Run every case in ``suite`` sequentially.
+   *
+   * ``agentFactory`` is required only for cases that do NOT carry their own
+   * ``agent`` (the legacy ``reply()`` path).
+   */
+  async run(suite: EvalSuite, agentFactory?: AgentFactory): Promise<EvalResult[]> {
+    const results: EvalResult[] = [];
+    for (const evalCase of suite.cases) {
+      results.push(await this.runCase(evalCase, agentFactory));
+    }
+    return results;
+  }
+
+  /**
+   * Run a single case and return its {@link EvalResult}.
+   *
+   * Routes through the real-pipeline {@link EvalSession} when
+   * ``evalCase.agent`` is set; otherwise uses the legacy ``reply()``-callable
+   * ``agentFactory`` (unchanged behaviour).
+   */
+  async runCase(evalCase: EvalCase, agentFactory?: AgentFactory): Promise<EvalResult> {
+    const start = Date.now();
+    const transcript: TranscriptEntry[] = [];
+    let error: string | null = null;
+
+    try {
+      if (evalCase.agent !== undefined) {
+        await this.runTurnsWithSession(evalCase, transcript);
+      } else {
+        if (agentFactory === undefined) {
+          throw new Error(
+            `case ${JSON.stringify(evalCase.name)} has no agent and no agentFactory was supplied`,
+          );
+        }
+        await this.runTurnsWithReply(evalCase, agentFactory, transcript);
+      }
+    } catch (exc) {
+      error = formatError(exc);
+      getLogger().error(`eval case=${JSON.stringify(evalCase.name)} raised: ${error}`);
+    }
+
+    // If we failed to produce any transcript, skip the judge.
+    if (error !== null && transcript.length === 0) {
+      return {
+        caseName: evalCase.name,
+        transcript,
+        judge: { score: 0.0, passed: false, reasoning: error },
+        durationS: (Date.now() - start) / 1000,
+        error,
+      };
+    }
+
+    let judgeResult;
+    try {
+      judgeResult = await this.judge.judgeCase(evalCase, transcript);
+    } catch (exc) {
+      // One transient judge failure (429, timeout, missing key) must not
+      // abort the WHOLE suite, discarding every completed case.
+      const judgeError = `judge error: ${exc instanceof Error ? exc.message : String(exc)}`;
+      return {
+        caseName: evalCase.name,
+        transcript,
+        judge: { score: 0.0, passed: false, reasoning: judgeError },
+        durationS: (Date.now() - start) / 1000,
+        error: judgeError,
+      };
+    }
+    return {
+      caseName: evalCase.name,
+      transcript,
+      judge: judgeResult,
+      durationS: (Date.now() - start) / 1000,
+      error,
+    };
+  }
+
+  /**
+   * Legacy path — drives the case against a ``reply()`` callable.
+   *
+   * Appends into ``transcript`` in place so a mid-case exception still
+   * leaves the partial transcript for the judge (existing semantics).
+   */
+  private async runTurnsWithReply(
+    evalCase: EvalCase,
+    agentFactory: AgentFactory,
+    transcript: TranscriptEntry[],
+  ): Promise<void> {
+    // Factories that return a promise are awaited (Python parity with
+    // awaitable factories).
+    const agent = await agentFactory();
+
+    if (evalCase.firstMessage) {
+      transcript.push({ role: 'agent', text: evalCase.firstMessage });
+    }
+
+    for (const turn of evalCase.turns) {
+      transcript.push({ role: 'user', text: turn.user });
+      const reply = typeof agent === 'function' ? await agent(turn.user) : '';
+      transcript.push({ role: 'agent', text: reply || '' });
+      logMissingExpected(evalCase, turn, reply || '');
+    }
+  }
+
+  /**
+   * Real-pipeline path — drives the case through {@link EvalSession}.
+   *
+   * The agent's REAL handler emits its own ``firstMessage`` (a
+   * ``evalCase.firstMessage`` overrides the agent's), tools/hooks/guardrails
+   * run for real, and the transcript mirrors what the pipeline actually
+   * said. Appends into ``transcript`` in place (partial-on-error, same as
+   * the legacy path).
+   */
+  private async runTurnsWithSession(
+    evalCase: EvalCase,
+    transcript: TranscriptEntry[],
+  ): Promise<void> {
+    // Local import keeps the runner light for the CLI — the session module
+    // pulls in the stream handler.
+    const { EvalSession } = await import('./session');
+
+    if (!evalCase.agent) {
+      throw new Error(`case ${JSON.stringify(evalCase.name)} has no agent — use the reply-factory path`);
+    }
+    let agent = evalCase.agent;
+    if (evalCase.firstMessage) {
+      agent = { ...agent, firstMessage: evalCase.firstMessage };
+    }
+
+    const session = await EvalSession.create({
+      agent,
+      llmProvider: evalCase.llmProvider,
+    });
+    try {
+      if (agent.firstMessage) {
+        transcript.push({ role: 'agent', text: agent.firstMessage });
+      }
+      for (const turn of evalCase.turns) {
+        transcript.push({ role: 'user', text: turn.user });
+        const result = await session.userSays(turn.user);
+        transcript.push({ role: 'agent', text: result.agentText });
+        logMissingExpected(evalCase, turn, result.agentText);
+      }
+    } finally {
+      await session.close();
+    }
+  }
+
+  /** Render a JSON report suitable for CI artefacts. */
+  report(suite: EvalSuite, results: ReadonlyArray<EvalResult>): string {
+    const total = results.length;
+    const passed = results.filter((r) => r.judge.passed).length;
+    const payload = {
+      suite: suite.name,
+      total,
+      passed,
+      failed: total - passed,
+      pass_rate: total > 0 ? passed / total : 0.0,
+      cases: results.map((r) => evalResultToDict(r)),
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+}
+
+function formatError(exc: unknown): string {
+  if (exc instanceof Error) {
+    return `${exc.name}: ${exc.message}`;
+  }
+  return String(exc);
+}
+
+/**
+ * Cheap pre-filter — if a required substring is missing we still let the
+ * judge decide, but log for easier debugging.
+ */
+function logMissingExpected(evalCase: EvalCase, turn: EvalTurn, reply: string): void {
+  for (const needle of turn.expectedContains ?? []) {
+    if (!reply.toLowerCase().includes(needle.toLowerCase())) {
+      getLogger().info(
+        `case=${JSON.stringify(evalCase.name)} expectedContains=${JSON.stringify(needle)} missing in reply`,
+      );
+    }
+  }
+}
+
+/**
+ * Load a suite from YAML or JSON.
+ *
+ * Schema (YAML):
+ *
+ * ```yaml
+ * name: "customer support v1"
+ * cases:
+ *   - name: "greeting is warm"
+ *     expected_behavior: "Agent greets the caller warmly and asks how it can help."
+ *     rubric: "Pass if reply contains a greeting and an open-ended question."
+ *     turns:
+ *       - user: "hi"
+ * ```
+ *
+ * Suite files use snake_case keys (shared byte-for-byte with the Python
+ * SDK so one suite file drives both); camelCase aliases are also accepted.
+ */
+export async function loadSuite(path: string): Promise<EvalSuite> {
+  const text = await readFile(path, 'utf-8');
+  const ext = extname(path).toLowerCase();
+  let data: unknown;
+  if (ext === '.yaml' || ext === '.yml') {
+    let yaml: { parse(src: string): unknown };
+    try {
+      // Optional dependency (parity with Python's `getpatter[evals]` pyyaml
+      // extra) — resolved through a variable specifier so the SDK compiles
+      // and ships without it; JSON suites need nothing extra.
+      const moduleName = 'yaml';
+      yaml = (await import(moduleName)) as { parse(src: string): unknown };
+    } catch {
+      throw new Error(
+        "Loading YAML suites requires the optional 'yaml' package. " +
+          'Install with: npm install yaml — or use a JSON suite file.',
+      );
+    }
+    data = yaml.parse(text);
+  } else {
+    data = JSON.parse(text);
+  }
+
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`Eval suite ${path} must be a mapping, got ${typeOf(data)}`);
+  }
+  const record = data as Record<string, unknown>;
+
+  const casesRaw = record.cases ?? [];
+  if (!Array.isArray(casesRaw)) {
+    throw new Error(`Eval suite ${path}: 'cases' must be a list`);
+  }
+
+  const cases: EvalCase[] = casesRaw.map((c, i) => {
+    if (c === null || typeof c !== 'object' || Array.isArray(c)) {
+      throw new Error(`Eval suite ${path}: case ${i} must be a mapping`);
+    }
+    const caseRecord = c as Record<string, unknown>;
+    const turnsRaw = caseRecord.turns ?? [];
+    const turns: EvalTurn[] = (Array.isArray(turnsRaw) ? turnsRaw : [])
+      .filter((t): t is Record<string, unknown> => t !== null && typeof t === 'object')
+      .map((t) => ({
+        user: String(t.user ?? ''),
+        expectedContains: toStringArray(t.expected_contains ?? t.expectedContains),
+      }));
+    return {
+      name: String(caseRecord.name ?? `case_${i}`),
+      turns,
+      expectedBehavior: String(caseRecord.expected_behavior ?? caseRecord.expectedBehavior ?? ''),
+      rubric: String(caseRecord.rubric ?? ''),
+      tags: toStringArray(caseRecord.tags),
+      firstMessage: String(caseRecord.first_message ?? caseRecord.firstMessage ?? ''),
+    };
+  });
+
+  return {
+    name: String(record.name ?? basename(path, extname(path))),
+    cases,
+    metadata: (record.metadata as Record<string, unknown> | undefined) ?? {},
+  };
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((v) => String(v));
+}
+
+function typeOf(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}

--- a/libraries/typescript/src/evals/scripted-llm.ts
+++ b/libraries/typescript/src/evals/scripted-llm.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministic scripted LLM provider for CI evals.
+ *
+ * The fourth fake-able boundary of {@link EvalSession}: instead of a paid
+ * model API, a {@link ScriptedLLMProvider} replays pre-scripted streaming
+ * chunks through the REAL {@link LLMLoop} — tool dispatch, history
+ * threading, usage accounting, and abort handling all run for real.
+ */
+
+import type { LLMChunk, LLMProvider, LLMStreamOptions } from '../llm-loop';
+
+/** Build one scripted assistant turn that streams ``text`` then usage. */
+export function textTurn(
+  text: string,
+  options: { readonly inputTokens?: number; readonly outputTokens?: number } = {},
+): LLMChunk[] {
+  return [
+    { type: 'text', content: text },
+    {
+      type: 'usage',
+      inputTokens: options.inputTokens ?? 8,
+      outputTokens: options.outputTokens ?? 8,
+    },
+  ];
+}
+
+/**
+ * Build one scripted turn that emits a single complete tool call.
+ *
+ * The {@link LLMLoop} executes the tool via the real ``DefaultToolExecutor``
+ * and re-submits — so a tool scenario needs a follow-up scripted turn
+ * (usually {@link textTurn}) for the post-tool-result response.
+ */
+export function toolCallTurn(
+  name: string,
+  args?: Record<string, unknown>,
+  options: { readonly callId?: string } = {},
+): LLMChunk[] {
+  return [
+    {
+      type: 'tool_call',
+      index: 0,
+      id: options.callId ?? 'call_1',
+      name,
+      arguments: JSON.stringify(args ?? {}),
+    },
+    { type: 'usage', inputTokens: 8, outputTokens: 4 },
+  ];
+}
+
+/** One recorded {@link ScriptedLLMProvider.stream} request. */
+export interface ScriptedLLMCall {
+  readonly messages: Array<Record<string, unknown>>;
+  readonly tools: Array<Record<string, unknown>> | null;
+  readonly callId: string | null;
+}
+
+/**
+ * Deterministic {@link LLMProvider}.
+ *
+ * Pops one scripted chunk-list per ``stream()`` call (i.e. per LLM-loop
+ * iteration — a tool-call turn consumes one script for the call and one for
+ * the post-result response). Records every request's ``messages`` and
+ * ``tools`` in {@link ScriptedLLMProvider.calls} so tests can assert exactly
+ * what the real pipeline sent to the model. Honours the per-turn abort
+ * signal between chunks like a well-behaved provider.
+ */
+export class ScriptedLLMProvider implements LLMProvider {
+  /** Stable pricing/dashboard key (no real pricing entry — cost is 0). */
+  static readonly providerKey = 'scripted';
+
+  readonly calls: ScriptedLLMCall[] = [];
+  private readonly scripts: LLMChunk[][];
+
+  constructor(turns?: ReadonlyArray<ReadonlyArray<LLMChunk>>) {
+    this.scripts = (turns ?? []).map((chunks) => chunks.map((c) => ({ ...c })));
+  }
+
+  /** Append another scripted turn (chunk list) to the script queue. */
+  addTurn(chunks: ReadonlyArray<LLMChunk>): void {
+    this.scripts.push(chunks.map((c) => ({ ...c })));
+  }
+
+  async *stream(
+    messages: Array<Record<string, unknown>>,
+    tools?: Array<Record<string, unknown>> | null,
+    opts?: LLMStreamOptions,
+  ): AsyncGenerator<LLMChunk, void, unknown> {
+    this.calls.push({
+      messages: messages.map((m) => ({ ...m })),
+      tools: tools ? tools.map((t) => ({ ...t })) : null,
+      callId: opts?.callId ?? null,
+    });
+    const script = this.scripts.shift();
+    if (script === undefined) {
+      yield { type: 'done' };
+      return;
+    }
+    for (const chunk of script) {
+      if (opts?.signal?.aborted) return;
+      yield { ...chunk };
+    }
+  }
+}

--- a/libraries/typescript/src/evals/session.ts
+++ b/libraries/typescript/src/evals/session.ts
@@ -1,0 +1,566 @@
+/**
+ * Eval session — drives the REAL pipeline call loop, no telephony required.
+ *
+ * Unlike the legacy ``reply()``-callable path in `runner.ts` (which never
+ * touches the SDK), {@link EvalSession} constructs a real
+ * {@link StreamHandler} in pipeline mode and injects user turns through the
+ * exact same path a live phone call uses:
+ *
+ * ``FakeSTT → onTranscript → handleBargeIn → commitTranscript →
+ * dispatchTurn → LLMLoop (real DefaultToolExecutor, hooks, guardrails) →
+ * SentenceChunker → FakeTTS → FakeAudioSender``
+ *
+ * so tool calling, pipeline hooks, guardrail replacement,
+ * dedup/hallucination filtering, history handling, metrics, and the
+ * turn-taking state machine are all exercised for real. Only the
+ * paid/external boundary is faked: the telephony bridge (audio sender), the
+ * STT socket, the TTS socket, and — optionally — the LLM (a deterministic
+ * {@link ScriptedLLMProvider} for CI, or any real {@link LLMProvider} for
+ * live evals). See `fakes.ts` / `scripted-llm.ts`.
+ *
+ * Lifecycle (TS idiom — no async context managers in JS):
+ *
+ * ```ts
+ * const session = await EvalSession.create({ agent, llmProvider });
+ * try {
+ *   const result = await session.userSays('where is my order?');
+ *   expect(result)
+ *     .toolCalled('lookup_order', { orderId: 'A1' })
+ *     .agentTextContains('tomorrow');
+ * } finally {
+ *   await session.close();
+ * }
+ * ```
+ *
+ * ``EvalSession.create()`` = ``new EvalSession(options)`` + ``await
+ * session.start()``; ``close()`` runs the handler's real teardown
+ * (``handleStop``) and is idempotent. Always pair ``create`` with a
+ * ``finally { await session.close() }`` so fakes and timers are released
+ * even when an assertion throws.
+ *
+ * Notes
+ * -----
+ * - ``agent.stt`` / ``agent.tts`` configs are ignored (replaced by the
+ *   fakes); ``agent.provider`` is forced to ``'pipeline'``.
+ * - ``onMessage``-style agents are not supported — the session targets the
+ *   built-in {@link LLMLoop} path.
+ * - ``TurnResult.agentText`` is what the caller HEARD (post-guardrail,
+ *   post-hook, post-text-transform sentences handed to TTS).
+ *   ``historySnapshot`` mirrors the dashboard conversation history, where
+ *   the streaming path records the raw LLM text.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { StreamHandler } from '../stream-handler';
+import type { StreamHandlerDeps } from '../stream-handler';
+import { MetricsStore } from '../dashboard/store';
+import { RemoteMessageHandler } from '../remote-message';
+import { sanitizeVariables, resolveVariables } from '../server';
+import type { AgentOptions } from '../types';
+import type { LLMProvider } from '../llm-loop';
+import type { TurnMetrics } from '../metrics';
+import type { HistoryEntry } from '../handler-utils';
+import { ErrorCode, PatterConfigError, PatterError } from '../errors';
+import { getLogger } from '../logger';
+import type { TranscriptEntry } from './case';
+import { FakeAudioSender, FakeSTT, FakeTTS, NoopVad, makeFakeCarrierWs } from './fakes';
+
+// ---------------------------------------------------------------------------
+// Result shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * One tool invocation observed through the handler's tool-event path.
+ *
+ * ``args`` is the parsed-JSON object the {@link LLMLoop} handed to the real
+ * ``DefaultToolExecutor``; ``result`` is the executor's string return value
+ * (``null`` only for hand-built records). Caller-immutable by convention.
+ */
+export interface ToolCallRecord {
+  readonly name: string;
+  readonly arguments: Readonly<Record<string, unknown>>;
+  readonly result: string | null;
+}
+
+/**
+ * The observable outcome of one {@link EvalSession.userSays} turn.
+ *
+ * - ``userText`` — the injected user utterance.
+ * - ``agentText`` — what the caller heard this turn: the sentences handed to
+ *   TTS after guardrails / hooks / text transforms, joined by a single
+ *   space. Falls back to the assistant history entry when no TTS sentence
+ *   was produced (e.g. the turn was cut short before synthesis).
+ * - ``toolCalls`` — tool invocations recorded via the handler's tool-event
+ *   path (``LLMLoop`` ``onToolCall`` → ``recordToolCall``), in execution
+ *   order.
+ * - ``historySnapshot`` — the handler's full conversation history right
+ *   after the turn settled (``role`` / ``text`` / ``timestamp`` entries,
+ *   including ``role: 'tool'`` timeline entries).
+ * - ``interrupted`` — true when the turn was cut short (barge-in cancel,
+ *   hook veto, or an LLM error that interrupted the turn) — derived from
+ *   the handler's ``turn_ended`` events carrying ``[interrupted]``.
+ * - ``metricsTurn`` — the {@link TurnMetrics} emitted for this turn via the
+ *   handler's ``onMetrics`` callback, or ``null`` when the turn did not
+ *   complete normally (vetoed / interrupted).
+ */
+export interface TurnResult {
+  readonly userText: string;
+  readonly agentText: string;
+  readonly toolCalls: ReadonlyArray<ToolCallRecord>;
+  readonly historySnapshot: ReadonlyArray<HistoryEntry>;
+  readonly interrupted: boolean;
+  readonly metricsTurn: TurnMetrics | null;
+}
+
+/**
+ * Render a conversation history in the judge transcript shape
+ * (``[{ role: 'user'|'agent'|'tool', text }]`` — assistant → agent).
+ * Shared by {@link EvalSession.transcript} and the assertion ``judge``.
+ */
+export function historyTranscript(
+  history: ReadonlyArray<{ readonly role: string; readonly text: string }>,
+): TranscriptEntry[] {
+  return history.map((entry) => ({
+    role: entry.role === 'assistant' ? 'agent' : String(entry.role ?? 'user'),
+    text: String(entry.text ?? ''),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// EvalSession
+// ---------------------------------------------------------------------------
+
+/**
+ * The handler internals the harness reads/wires. The same private surface
+ * the SDK's own unit suites exercise via casts — the harness observes the
+ * REAL handler, it never replaces any of it.
+ */
+interface HandlerInternals {
+  llmLoop: {
+    setOnToolCall(
+      cb?: (name: string, args: Record<string, unknown>, result: string) => Promise<void>,
+    ): void;
+  } | null;
+  dispatchTask: Promise<void> | null;
+  firstMessageTask: Promise<void> | null;
+  lastCommitText: string;
+  lastCommitAt: number;
+  llmAbort: AbortController | null;
+  history: { entries: HistoryEntry[] };
+  recordToolCall(
+    name: string,
+    args: Record<string, unknown>,
+    result: string,
+  ): Promise<void>;
+}
+
+/** Options for {@link EvalSession}. Defaults match the Python SDK. */
+export interface EvalSessionOptions {
+  /**
+   * The agent under test. Its ``stt`` / ``tts`` configs are replaced by
+   * fakes and ``provider`` is forced to ``'pipeline'``; everything else
+   * (tools, guardrails, hooks, text transforms, firstMessage, variables,
+   * ...) is live.
+   */
+  readonly agent: AgentOptions;
+  /**
+   * Optional LLM provider override. Defaults to ``agent.llm``. Pass a
+   * {@link ScriptedLLMProvider} for deterministic CI evals or a real
+   * provider for live evals.
+   */
+  readonly llmProvider?: LLMProvider;
+  /**
+   * Legacy fallback — when neither ``llmProvider`` nor ``agent.llm`` is
+   * set, the built-in OpenAI provider is built from this key (live evals
+   * only; never use in CI).
+   */
+  readonly openaiKey?: string;
+  /** Call identity threaded through the handler, tools' call context, and metrics. */
+  readonly callId?: string;
+  readonly caller?: string;
+  readonly callee?: string;
+  /**
+   * Optional per-call variables resolved into the system prompt exactly
+   * like ``phone.call({ customParams })``.
+   */
+  readonly customParams?: Readonly<Record<string, string>>;
+  /**
+   * Per-turn ceiling in seconds for {@link EvalSession.userSays} (LLM +
+   * tools + TTS). Generous default (60) for live providers; scripted
+   * providers finish in milliseconds.
+   */
+  readonly turnTimeoutS?: number;
+}
+
+/** Race ``promise`` against a timeout; the loser's timer is always cleared. */
+async function awaitWithTimeout(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<'ok' | 'timeout'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => 'ok' as const),
+      new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Harness around a real pipeline-mode {@link StreamHandler}.
+ *
+ * See the module docstring for usage. Construction is cheap; the handler is
+ * built and started in {@link EvalSession.start} (``EvalSession.create``
+ * calls it).
+ */
+export class EvalSession {
+  readonly callId: string;
+  readonly caller: string;
+  readonly callee: string;
+
+  /** The faked carrier boundary — records audio / clears / marks. */
+  readonly audioSender = new FakeAudioSender();
+  /** The faked STT boundary — inject transcripts via the session, not directly. */
+  readonly stt = new FakeSTT();
+  /** The faked TTS boundary — ``spoken`` records every synthesised sentence. */
+  readonly tts = new FakeTTS();
+  /**
+   * Every payload the handler fired through ``onTranscript`` — user /
+   * assistant / tool events, in emission order.
+   */
+  readonly transcriptEvents: Array<Record<string, unknown>> = [];
+
+  private readonly sourceAgent: AgentOptions;
+  private readonly llmProvider?: LLMProvider;
+  private readonly openaiKey: string;
+  private readonly customParams?: Readonly<Record<string, string>>;
+  private readonly turnTimeoutS: number;
+
+  private streamHandler: StreamHandler | null = null;
+  private readonly toolCalls: ToolCallRecord[] = [];
+  private readonly metricsTurns: TurnMetrics[] = [];
+  private interruptedTurns = 0;
+  private offTurnEnded: (() => void) | null = null;
+  private started = false;
+  private closed = false;
+
+  constructor(options: EvalSessionOptions) {
+    if (!options || !options.agent) {
+      throw new PatterConfigError('EvalSession requires an agent');
+    }
+    this.sourceAgent = options.agent;
+    this.llmProvider = options.llmProvider;
+    this.openaiKey = options.openaiKey ?? '';
+    this.callId = options.callId ?? `eval_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+    this.caller = options.caller ?? '+15550000001';
+    this.callee = options.callee ?? '+15550000002';
+    this.customParams = options.customParams;
+    this.turnTimeoutS = options.turnTimeoutS ?? 60.0;
+  }
+
+  /** Build AND start a session — the canonical entry point. */
+  static async create(options: EvalSessionOptions): Promise<EvalSession> {
+    const session = new EvalSession(options);
+    await session.start();
+    return session;
+  }
+
+  // -- lifecycle ------------------------------------------------------------
+
+  /** Build and start the real handler (idempotent). */
+  async start(): Promise<void> {
+    if (this.started) return;
+
+    const evalAgent = this.buildEvalAgent();
+    if (evalAgent.llm == null && !this.openaiKey) {
+      throw new PatterConfigError(
+        'EvalSession needs an LLM: pass llmProvider (e.g. a ' +
+          'ScriptedLLMProvider for CI), set agent.llm, or supply ' +
+          'openaiKey for the built-in OpenAI provider.',
+      );
+    }
+
+    this.audioSender.attachSttFactory(() => this.stt);
+    const deps: StreamHandlerDeps = {
+      config: this.openaiKey ? { openaiKey: this.openaiKey } : {},
+      agent: evalAgent,
+      bridge: this.audioSender,
+      metricsStore: new MetricsStore(),
+      pricing: null,
+      remoteHandler: new RemoteMessageHandler(),
+      recording: false,
+      onTranscript: async (data) => {
+        this.transcriptEvents.push(data);
+      },
+      onMetrics: async (data) => {
+        const turn = data.turn as TurnMetrics | undefined;
+        if (turn != null) this.metricsTurns.push(turn);
+      },
+      // Pipeline mode never builds a Realtime/ConvAI adapter; loud guard in
+      // case a future refactor routes the eval agent elsewhere.
+      buildAIAdapter: () => {
+        throw new PatterConfigError('EvalSession supports pipeline mode only');
+      },
+      sanitizeVariables,
+      resolveVariables,
+    };
+
+    const handler = new StreamHandler(deps, makeFakeCarrierWs(), this.caller, this.callee);
+    const internals = handler as unknown as HandlerInternals;
+    this.audioSender.attachHandler(handler);
+    handler.setStreamSid('eval');
+    // Interruption observability: the accumulator emits ``turn_ended`` with
+    // ``agent_text: '[interrupted]'`` whenever a turn is cut short (barge-in
+    // cancel, hook veto, LLM error) — the public analogue of Python's
+    // ``_last_response_interrupted`` flag.
+    this.offTurnEnded = handler.addObserver<{ turn?: TurnMetrics }>((payload) => {
+      if (payload?.turn?.agent_text === '[interrupted]') this.interruptedTurns += 1;
+    }, 'turn_ended');
+
+    this.streamHandler = handler;
+    try {
+      // The REAL start path: initPipeline connects the FakeSTT, plays
+      // ``firstMessage`` through the FakeTTS, builds the real LLMLoop +
+      // DefaultToolExecutor, and installs the transcript handler.
+      await handler.handleCallStart(this.callId, { ...(this.customParams ?? {}) });
+      // The greeting runs as a tracked background task on the live path;
+      // settle it here so ``tts.spoken`` / history are stable when the
+      // first userSays lands (parity with the Python harness, where
+      // ``start()`` returns after the greeting played).
+      if (internals.firstMessageTask) await internals.firstMessageTask;
+      if (internals.llmLoop == null) {
+        throw new PatterConfigError(
+          'EvalSession could not build the LLM loop — the agent has ' +
+            'onMessage-style wiring or no usable LLM provider.',
+        );
+      }
+      // Observe tool executions through the handler's tool-event path:
+      // keep the handler's own transcript-timeline behaviour (role='tool'
+      // history entries + onTranscript events) and additionally record
+      // structured ToolCallRecords for assertions.
+      internals.llmLoop.setOnToolCall(async (name, args, result) => {
+        await internals.recordToolCall(name, args, result);
+        this.toolCalls.push({ name, arguments: { ...(args ?? {}) }, result });
+      });
+    } catch (err) {
+      // ``create()`` callers never reach their ``finally`` when start
+      // throws — tear down here.
+      try {
+        await handler.handleStop();
+      } catch {
+        /* best-effort teardown */
+      }
+      this.offTurnEnded?.();
+      this.offTurnEnded = null;
+      this.streamHandler = null;
+      throw err;
+    }
+    this.started = true;
+  }
+
+  /** Run the handler's real teardown (``handleStop``). Idempotent. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.offTurnEnded?.();
+    this.offTurnEnded = null;
+    const handler = this.streamHandler;
+    if (handler === null) return;
+    await handler.handleStop();
+  }
+
+  // -- turn driving -----------------------------------------------------------
+
+  /**
+   * Inject one final user transcript and await the full agent turn.
+   *
+   * The transcript flows through the handler's real receive path — barge-in
+   * handling, dedup/hallucination filtering, hooks, the LLM loop with real
+   * tool execution, guardrails, sentence chunking, and TTS — exactly as on
+   * a live call. Returns once the turn's dispatch task settles.
+   *
+   * Throws:
+   * - ``PatterError`` (``INPUT_VALIDATION``) — the REAL pipeline dropped
+   *   the transcript (duplicate within the 2 s throttle window, known STT
+   *   hallucination, or empty text) — same behaviour as a live call.
+   * - ``PatterError`` (``TIMEOUT``) — the turn did not settle within
+   *   ``timeoutS`` (default: the session's ``turnTimeoutS``).
+   */
+  async userSays(text: string, options: { readonly timeoutS?: number } = {}): Promise<TurnResult> {
+    if (!this.started || this.streamHandler === null) {
+      throw new PatterError(
+        'EvalSession is not started — use `await EvalSession.create(...)`',
+        { code: ErrorCode.CONFIG },
+      );
+    }
+    if (this.closed) {
+      throw new PatterError('EvalSession is closed', { code: ErrorCode.CONFIG });
+    }
+    const timeoutS = options.timeoutS ?? this.turnTimeoutS;
+    const timeoutMs = timeoutS * 1000;
+    const internals = this.streamHandler as unknown as HandlerInternals;
+
+    // Per-turn snapshots — everything new after the turn belongs to it.
+    const historyLen = internals.history.entries.length;
+    const toolsLen = this.toolCalls.length;
+    const spokenLen = this.tts.spoken.length;
+    const turnsLen = this.metricsTurns.length;
+    const interruptedLen = this.interruptedTurns;
+    // Commit detection: ``commitTranscript`` stamps these exactly when a
+    // final transcript is accepted (the dispatch promise nulls itself on
+    // settle, so it cannot serve as the commit signal).
+    const commitTextBefore = internals.lastCommitText;
+    const commitAtBefore = internals.lastCommitAt;
+
+    // ``pushFinal`` resolves once the handler's transcript drain loop has
+    // fully processed this transcript (dispatch-task creation included).
+    const consumed = await awaitWithTimeout(this.stt.pushFinal(text), timeoutMs);
+    if (consumed === 'timeout') {
+      throw new PatterError(
+        `user turn ${JSON.stringify(text)} was not consumed by the STT ` +
+          `transcript loop within ${timeoutS}s — a hook or the previous ` +
+          'turn may be hung (check logs)',
+        { code: ErrorCode.TIMEOUT },
+      );
+    }
+
+    const committed =
+      internals.lastCommitText !== commitTextBefore ||
+      internals.lastCommitAt !== commitAtBefore;
+    if (!committed) {
+      throw new PatterError(
+        `user turn ${JSON.stringify(text)} was dropped by the pipeline's ` +
+          'commit filter (duplicate within 2s, known STT hallucination, or ' +
+          'empty) — exactly as it would be on a live call. Vary the text ' +
+          'between turns or split the case.',
+        { code: ErrorCode.INPUT_VALIDATION },
+      );
+    }
+
+    // The dispatch promise nulls itself when the turn settles — a null here
+    // means the turn already finished (or was vetoed before dispatch).
+    const dispatch = internals.dispatchTask;
+    if (dispatch !== null) {
+      const settled = await awaitWithTimeout(dispatch, timeoutMs);
+      if (settled === 'timeout') {
+        // Abort the in-flight LLM stream so the hung turn unwinds instead
+        // of leaking into the next one (JS promises are not cancellable).
+        try {
+          internals.llmAbort?.abort();
+        } catch {
+          /* defensive */
+        }
+        // Await the aborted task's unwinding (bounded) before throwing so a
+        // following close() cannot race a still-running dispatch through the
+        // fakes' teardown — mirrors Python's cancel-then-await.
+        await Promise.race([
+          dispatch.catch(() => undefined),
+          new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
+        ]);
+        throw new PatterError(
+          `agent turn for ${JSON.stringify(text)} did not settle within ${timeoutS}s`,
+          { code: ErrorCode.TIMEOUT },
+        );
+      }
+    }
+
+    return this.buildTurnResult(text, { historyLen, toolsLen, spokenLen, turnsLen, interruptedLen });
+  }
+
+  // -- convenience accessors ----------------------------------------------------
+
+  /** The live {@link StreamHandler} (``null`` before ``start``). */
+  get handler(): StreamHandler | null {
+    return this.streamHandler;
+  }
+
+  /** Current conversation history (shallow copies of the entries). */
+  get history(): HistoryEntry[] {
+    if (this.streamHandler === null) return [];
+    const internals = this.streamHandler as unknown as HandlerInternals;
+    return internals.history.entries.map((e) => ({ ...e }));
+  }
+
+  /** Full-session transcript in the judge shape (assistant → agent). */
+  transcript(): TranscriptEntry[] {
+    return historyTranscript(this.history);
+  }
+
+  // -- internals --------------------------------------------------------------
+
+  /** Return the agent reshaped for harness execution. */
+  private buildEvalAgent(): AgentOptions {
+    const agent = this.sourceAgent;
+    const overrides: Record<string, unknown> = {};
+    // Unlike Python (whose handler is pipeline-only), the TS handler
+    // defaults to realtime when ``provider`` is unset — force pipeline.
+    if (agent.provider !== 'pipeline') {
+      overrides.provider = 'pipeline';
+    }
+    if (agent.engine !== undefined) {
+      getLogger().info('EvalSession: agent.engine ignored — the harness runs pipeline mode');
+      overrides.engine = undefined;
+    }
+    if (agent.stt !== undefined) {
+      getLogger().info(
+        'EvalSession: agent.stt config ignored — transcripts are injected directly',
+      );
+    }
+    // The real init path reads STT from the bridge (FakeSTT) and TTS from
+    // ``agent.tts`` — install the fake there.
+    overrides.stt = undefined;
+    if (agent.tts !== undefined) {
+      getLogger().info('EvalSession: agent.tts config replaced by FakeTTS');
+    }
+    overrides.tts = this.tts;
+    if (this.llmProvider !== undefined) {
+      overrides.llm = this.llmProvider;
+    }
+    // Without this, the real start path would try to auto-load SileroVAD
+    // (ONNX model) — pointless here since the session feeds no audio frames.
+    if (agent.vad === undefined) {
+      overrides.vad = new NoopVad();
+    }
+    return { ...agent, ...overrides } as AgentOptions;
+  }
+
+  private buildTurnResult(
+    userText: string,
+    snapshot: {
+      readonly historyLen: number;
+      readonly toolsLen: number;
+      readonly spokenLen: number;
+      readonly turnsLen: number;
+      readonly interruptedLen: number;
+    },
+  ): TurnResult {
+    const internals = this.streamHandler as unknown as HandlerInternals;
+    const spoken = this.tts.spoken.slice(snapshot.spokenLen);
+    const fullHistory = internals.history.entries.map((e) => ({ ...e }));
+    const newHistory = fullHistory.slice(snapshot.historyLen);
+    // ``agentText`` is what the caller HEARD; when no TTS output was
+    // produced this turn (cut short pre-synthesis / empty reply) fall back
+    // to the assistant history entry, if any.
+    const agentText =
+      spoken.length > 0
+        ? spoken.join(' ')
+        : newHistory
+            .filter((e) => e.role === 'assistant')
+            .map((e) => e.text)
+            .join(' ');
+    const newTurns = this.metricsTurns.slice(snapshot.turnsLen);
+    return {
+      userText,
+      agentText,
+      toolCalls: this.toolCalls.slice(snapshot.toolsLen),
+      historySnapshot: fullHistory,
+      interrupted: this.interruptedTurns > snapshot.interruptedLen,
+      metricsTurn: newTurns.length > 0 ? newTurns[newTurns.length - 1] : null,
+    };
+  }
+}

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -366,6 +366,44 @@ export {
   TelnyxTTSSampleRate,
 } from "./providers/telnyx-tts";
 
+// Evaluation framework — declarative eval cases, an LLM judge, the
+// real-pipeline EvalSession harness, and chainable turn assertions.
+// Mirrors Python `getpatter.evals` (run via `getpatter eval run <suite>`).
+export {
+  EvalRunner,
+  EvalSession,
+  FakeAudioSender,
+  FakeSTT,
+  FakeTTS,
+  LLMJudge,
+  ScriptedLLMProvider,
+  TurnExpectation,
+  evalResultToDict,
+  expect,
+  historyTranscript,
+  loadSuite,
+  textTurn,
+  toolCallTurn,
+} from "./evals";
+export type {
+  AgentCallable,
+  AgentFactory,
+  AgentTextContainsOptions,
+  EvalCase,
+  EvalResult,
+  EvalRunnerOptions,
+  EvalSessionOptions,
+  EvalSuite,
+  EvalTurn,
+  JudgeBackend,
+  JudgeResult,
+  LLMJudgeOptions,
+  ScriptedLLMCall,
+  ToolCallRecord,
+  TranscriptEntry,
+  TurnResult,
+} from "./evals";
+
 // Observability — OTel-compatible tracing (optional peer dep).
 export {
   initTracing,

--- a/libraries/typescript/src/llm/custom.ts
+++ b/libraries/typescript/src/llm/custom.ts
@@ -1,8 +1,8 @@
 /**
  * Custom LLM — point Patter's pipeline at ANY OpenAI-compatible endpoint.
  *
- * The industry-standard "Custom LLM" pattern (the same concept ElevenLabs
- * Agents, Retell, and Vapi expose under that name): Patter owns the phone leg
+ * The industry-standard "Custom LLM" pattern (the name the voice-AI
+ * ecosystem uses for this concept): Patter owns the phone leg
  * — carrier, STT, turn-taking, barge-in, TTS — and POSTs each conversation
  * turn to YOUR ``/chat/completions`` endpoint. That endpoint can be:
  *

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -1509,10 +1509,8 @@ export class StreamHandler {
       }
     }
     this.inboundAudioRing = [];
-    // [DIAG-2026-05-05] INFO so we can see in stdout whether the ring flush
-    // is feeding STT bleed-only audio that produces phantom transcripts.
-    getLogger().info(
-      `[DIAG] Flushed ${replayed} pre-barge-in frame(s) (~${replayed * 20} ms) to STT`,
+    getLogger().debug(
+      `Flushed ${replayed} pre-barge-in frame(s) (~${replayed * 20} ms) to STT`,
     );
   }
   /**
@@ -3579,11 +3577,6 @@ export class StreamHandler {
   }
 
   private async processTranscript(transcript: STTTranscript): Promise<void> {
-    // [DIAG-2026-05-05] Temporary INFO logging to diagnose post-barge-in
-    // empty/phantom transcripts. Remove once root cause is understood.
-    getLogger().info(
-      `[DIAG] processTranscript text=${JSON.stringify((transcript.text ?? '').slice(0, 60))} isFinal=${transcript.isFinal} speechFinal=${transcript.speechFinal} isSpeaking=${this.isSpeaking}`,
-    );
     // Function-scope barge-in flag — set either by the upfront barge-in
     // check, or by the TTS loops downstream when ``isSpeaking`` flips mid-
     // synthesis. Prevents recordTurnComplete double-counting a half-spoken
@@ -3626,10 +3619,6 @@ export class StreamHandler {
     }
 
     const label = this.deps.bridge.label;
-    // [DIAG-2026-05-05] Temporary INFO. Remove once root cause known.
-    getLogger().info(
-      `[DIAG] processTranscript COMMITTED → LLM (${label} pipeline): ${sanitizeLogValue(transcript.text.slice(0, 80))}`,
-    );
     getLogger().debug(`User (${label} pipeline): ${sanitizeLogValue(transcript.text)}`);
 
     // A final transcript committed — interim-stability tracking for this

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -825,7 +825,7 @@ export class StreamHandler {
   /**
    * Pause-and-resume false-interruption handling (opt-in
    * ``agent.bargeInMode: 'pause_resume'``; default ``'cancel'`` keeps
-   * today's behaviour byte-identical). LiveKit-style: PAUSE output on
+   * today's behaviour byte-identical): PAUSE output on
    * VAD speech_start (carrier cleared, sends gated on ``outputPaused``),
    * KILL on a committed final transcript within ``bargeInConfirmMs``,
    * RESUME from the first not-fully-heard sentence otherwise. Mirrors
@@ -1166,7 +1166,7 @@ export class StreamHandler {
   }
 
   /**
-   * LiveKit-style "heard prefix" semantics for a barge-in that lands AFTER
+   * Heard-prefix semantics for a barge-in that lands AFTER
    * the turn completed, while the carrier is still playing the buffered
    * tail.
    *
@@ -4116,7 +4116,7 @@ export class StreamHandler {
 
   // ---------------------------------------------------------------------------
   // Pause-and-resume false-interruption handling (bargeInMode: 'pause_resume').
-  // LiveKit-style: PAUSE output on VAD speech_start, KILL on a committed final
+  // PAUSE output on VAD speech_start, KILL on a committed final
   // transcript within the confirm window, RESUME from the first
   // not-fully-heard sentence otherwise. Mirrors Python `_start_pause_resume`.
   // ---------------------------------------------------------------------------
@@ -4526,8 +4526,7 @@ export class StreamHandler {
   // ---------------------------------------------------------------------------
   // PREEMPTIVE GENERATION (opt-in) — speculative dispatch on a confident
   // interim transcript; commit-or-discard at end of utterance. Mirrors Python
-  // ``_note_interim_transcript`` / ``_try_release_speculation`` and LiveKit's
-  // ``preemptive_generation``.
+  // ``_note_interim_transcript`` / ``_try_release_speculation``.
   // ---------------------------------------------------------------------------
 
   /**

--- a/libraries/typescript/src/telemetry/client.ts
+++ b/libraries/typescript/src/telemetry/client.ts
@@ -177,8 +177,11 @@ export class TelemetryClient {
       this.inflight = null;
       // Events recorded while the POST was in flight are sitting in the buffer
       // with no flush scheduled (record() saw `inflight` and skipped) — chain
-      // another flush or they strand until close()/process exit.
-      if (this.buffer.length > 0) this.scheduleFlush();
+      // another flush or they strand until close()/process exit. Never chain
+      // after close() began: close() awaits the in-flight flush and then drains
+      // the buffer itself — a chained flush here would detach from close() and
+      // die mid-air on a prompt process exit (mirrors Python's `not _closed`).
+      if (this.buffer.length > 0 && !this.closed) this.scheduleFlush();
     });
     void this.inflight;
   }

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -801,7 +801,7 @@ export interface AgentOptions {
    * - ``'cancel'`` (default): today's behaviour — the in-flight turn is
    *   cancelled immediately (or marked pending when
    *   ``bargeInStrategies`` are configured).
-   * - ``'pause_resume'`` (LiveKit-style false-interruption handling):
+   * - ``'pause_resume'`` (false-interruption handling):
    *   output is PAUSED immediately — the carrier buffer is cleared and
    *   no further TTS audio is sent — while the LLM stream and the TTS
    *   provider stream stay alive (tokens buffer as sentences,
@@ -869,7 +869,7 @@ export interface AgentOptions {
    * paid during the user's own end-of-utterance silence); if it differs,
    * the speculation is discarded silently and the turn dispatches normally
    * on the final. History and metrics record exactly one turn either way.
-   * Same pattern as LiveKit Agents' ``preemptive_generation``. Default:
+   * The standard voice-AI "preemptive generation" pattern. Default:
    * ``false`` — every turn waits for the final transcript, as today.
    * Mirrors Python ``preemptive_generation``.
    */

--- a/libraries/typescript/tests/telemetry.test.ts
+++ b/libraries/typescript/tests/telemetry.test.ts
@@ -134,6 +134,84 @@ async function waitFor(collector: Collector, n: number, timeoutMs = 2000): Promi
   }
 }
 
+/**
+ * A real collector that holds its FIRST response until released — lets a test
+ * pin the "event recorded while a flush POST is in flight" window
+ * deterministically. Test-local lifecycle: always release() before stop().
+ */
+class GatedCollector {
+  requests: unknown[] = [];
+  private server!: Server;
+  private heldOne = false;
+  private gateResolve!: () => void;
+  private readonly gate = new Promise<void>((r) => {
+    this.gateResolve = r;
+  });
+  private firstStartedResolve!: () => void;
+  readonly firstRequestStarted = new Promise<void>((r) => {
+    this.firstStartedResolve = r;
+  });
+
+  release(): void {
+    this.gateResolve();
+  }
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        const hold = !this.heldOne;
+        this.heldOne = true;
+        this.firstStartedResolve();
+        const respond = (): void => {
+          try {
+            this.requests.push(JSON.parse(Buffer.concat(chunks).toString()));
+          } catch {
+            this.requests.push(null);
+          }
+          res.statusCode = 204;
+          res.end();
+        };
+        if (hold) void this.gate.then(respond);
+        else respond();
+      });
+    });
+    await new Promise<void>((resolve) =>
+      this.server.listen(0, '127.0.0.1', () => resolve()),
+    );
+  }
+
+  get url(): string {
+    const addr = this.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    return `http://127.0.0.1:${port}/v1/ingest`;
+  }
+
+  get events(): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    for (const batch of this.requests) {
+      if (Array.isArray(batch)) out.push(...(batch as Array<Record<string, unknown>>));
+    }
+    return out;
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
+async function waitForEvents(
+  c: { events: Array<Record<string, unknown>> },
+  n: number,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (c.events.length < n && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
 let collector: Collector;
 
 beforeEach(async () => {
@@ -216,6 +294,58 @@ describe('[integration] telemetry — enabled path', () => {
     await client.close();
 
     expect(collector.events.map((e) => e.event)).toEqual(['cli_command']);
+  });
+
+  it('an event recorded during an in-flight flush is chained, not stranded', async () => {
+    // Regression: record() saw `inflight` and skipped scheduling, so an event
+    // recorded while a flush POST was in flight sat in the buffer with no
+    // flush scheduled — constructor-time events shadowed agent-time events
+    // until close()/process exit. Pinned WITHOUT calling close(): delivery
+    // must happen on its own via the chained flush.
+    enableTelemetryEnv();
+    const gated = new GatedCollector();
+    await gated.start();
+    try {
+      const client = new TelemetryClient({ sdkVersion: '0.6.7', endpoint: gated.url });
+      client.record('cli_command', { cli_command: 'dashboard' });
+      await gated.firstRequestStarted; // first POST genuinely in flight (held)
+      client.record('first_run'); // buffered; no flush scheduled
+      gated.release();
+
+      await waitForEvents(gated, 2);
+      expect(gated.events.map((e) => e.event).sort()).toEqual(['cli_command', 'first_run']);
+      // Two separate POSTs: the second was chained by the completing first flush.
+      expect(gated.requests).toHaveLength(2);
+      await client.close();
+    } finally {
+      gated.release();
+      await gated.stop();
+    }
+  });
+
+  it('close() during an in-flight flush delivers later-buffered events before resolving', async () => {
+    // Pins the `!this.closed` chain guard (parity with Python's `not _closed`):
+    // without it, the completing in-flight flush chains a DETACHED flush for
+    // the second event, close()'s own flush sees an empty buffer and resolves
+    // early, and a prompt process exit kills the detached POST mid-air.
+    enableTelemetryEnv();
+    const gated = new GatedCollector();
+    await gated.start();
+    try {
+      const client = new TelemetryClient({ sdkVersion: '0.6.7', endpoint: gated.url });
+      client.record('cli_command', { cli_command: 'dashboard' });
+      await gated.firstRequestStarted;
+      client.record('first_run'); // buffered behind the in-flight POST
+      const closing = client.close();
+      gated.release();
+      await closing;
+
+      // By the time close() resolves, BOTH events must have been delivered.
+      expect(gated.events.map((e) => e.event).sort()).toEqual(['cli_command', 'first_run']);
+    } finally {
+      gated.release();
+      await gated.stop();
+    }
   });
 
   it('drops denylisted dimensions', async () => {

--- a/libraries/typescript/tests/unit/eval-assertions.test.ts
+++ b/libraries/typescript/tests/unit/eval-assertions.test.ts
@@ -1,0 +1,137 @@
+/**
+ * [unit] Eval assertion helpers (``src/evals/assertions.ts``).
+ *
+ * Mirrors Python ``tests/unit/test_eval_assertions.py``. These exercise
+ * ``expect`` against hand-built ``TurnResult`` objects — the end-to-end
+ * pairing with a real session lives in ``eval-session.test.ts``. The
+ * ``judge`` helper reuses the real ``LLMJudge`` with an injected fake
+ * backend (no network).
+ */
+import { describe, it, expect } from 'vitest';
+import { LLMJudge } from '../../src/evals';
+import { expect as expectTurn } from '../../src/evals';
+import type { JudgeBackend, ToolCallRecord, TurnResult } from '../../src/evals';
+
+function makeResult(
+  overrides: {
+    agentText?: string;
+    toolCalls?: ToolCallRecord[];
+    history?: Array<{ role: string; text: string; timestamp: number }>;
+  } = {},
+): TurnResult {
+  return {
+    userText: 'book a table',
+    agentText: overrides.agentText ?? 'Booked your table for two.',
+    toolCalls: overrides.toolCalls ?? [],
+    historySnapshot: overrides.history ?? [],
+    interrupted: false,
+    metricsTurn: null,
+  };
+}
+
+class FakeJudgeBackend implements JudgeBackend {
+  readonly prompts: string[] = [];
+  constructor(private readonly payload: Record<string, unknown>) {}
+  async judge(prompt: string): Promise<string> {
+    this.prompts.push(prompt);
+    return JSON.stringify(this.payload);
+  }
+}
+
+describe('[unit] eval assertions', () => {
+  it('toolCalled passes and chains', () => {
+    const record: ToolCallRecord = {
+      name: 'book_table',
+      arguments: { partySize: 2, time: '20:00' },
+      result: '{"ok": true}',
+    };
+    const result = makeResult({ toolCalls: [record] });
+    const chained = expectTurn(result)
+      .toolCalled('book_table')
+      .toolCalled('book_table', { partySize: 2 })
+      .agentTextContains('booked', 'table');
+    expect(chained.result).toBe(result);
+  });
+
+  it('toolCalled fails with observed tools in the message', () => {
+    const result = makeResult({
+      toolCalls: [{ name: 'other_tool', arguments: {}, result: null }],
+    });
+    expect(() => expectTurn(result).toolCalled('book_table')).toThrow(/other_tool/);
+  });
+
+  it('toolCalled argsSubset mismatch fails', () => {
+    const record: ToolCallRecord = { name: 'book_table', arguments: { partySize: 4 }, result: null };
+    expect(() =>
+      expectTurn(makeResult({ toolCalls: [record] })).toolCalled('book_table', {
+        partySize: 2,
+      }),
+    ).toThrow(/partySize/);
+  });
+
+  it('toolCalled argsSubset is recursive', () => {
+    const record: ToolCallRecord = {
+      name: 'update',
+      arguments: { customer: { id: 'c1', tier: 'gold' }, notify: true },
+      result: null,
+    };
+    expectTurn(makeResult({ toolCalls: [record] })).toolCalled('update', {
+      customer: { id: 'c1' },
+    });
+    expect(() =>
+      expectTurn(makeResult({ toolCalls: [record] })).toolCalled('update', {
+        customer: { id: 'nope' },
+      }),
+    ).toThrow();
+  });
+
+  it('noToolCalled passes and fails', () => {
+    expectTurn(makeResult()).noToolCalled();
+    const busy = makeResult({ toolCalls: [{ name: 't', arguments: {}, result: null }] });
+    expect(() => expectTurn(busy).noToolCalled()).toThrow(/no tool calls/);
+    // Named variant: only the named tool is forbidden.
+    expectTurn(busy).noToolCalled('other');
+    expect(() => expectTurn(busy).noToolCalled('t')).toThrow();
+  });
+
+  it('agentTextContains handles case sensitivity', () => {
+    const result = makeResult({ agentText: 'Your Table is Booked.' });
+    expectTurn(result).agentTextContains('table is booked');
+    expect(() =>
+      expectTurn(result).agentTextContains(['table is booked'], { caseSensitive: true }),
+    ).toThrow(/missing/);
+  });
+
+  it('judge passes and returns the verdict', async () => {
+    const backend = new FakeJudgeBackend({
+      score: 0.9,
+      passed: true,
+      reasoning: 'confirms the booking',
+    });
+    const judge = new LLMJudge({ backend });
+    const history = [
+      { role: 'user', text: 'book a table', timestamp: 1 },
+      { role: 'assistant', text: 'Booked your table for two.', timestamp: 2 },
+    ];
+    const verdict = await expectTurn(makeResult({ history })).judge(judge, {
+      intent: 'The agent confirms the booking.',
+    });
+    expect(verdict.passed).toBe(true);
+    expect(verdict.score).toBeCloseTo(0.9);
+    // The judge saw the turn transcript with assistant mapped to 'agent'.
+    expect(backend.prompts[0]).toContain('agent: Booked your table for two.');
+    expect(backend.prompts[0]).toContain('The agent confirms the booking.');
+  });
+
+  it('judge failure raises with the reasoning in the message', async () => {
+    const backend = new FakeJudgeBackend({
+      score: 0.2,
+      passed: false,
+      reasoning: 'never confirmed',
+    });
+    const judge = new LLMJudge({ backend });
+    await expect(
+      expectTurn(makeResult()).judge(judge, { intent: 'Booking is confirmed.' }),
+    ).rejects.toThrow(/never confirmed/);
+  });
+});

--- a/libraries/typescript/tests/unit/eval-runner-session.test.ts
+++ b/libraries/typescript/tests/unit/eval-runner-session.test.ts
@@ -1,0 +1,179 @@
+/**
+ * [unit] EvalRunner ↔ EvalSession integration (real pipeline, scripted LLM).
+ *
+ * Mirrors Python ``tests/unit/test_eval_runner_session.py``. Verifies that
+ * an ``EvalCase`` carrying ``agent`` / ``llmProvider`` is routed through the
+ * real pipeline ``StreamHandler`` harness, while the legacy
+ * ``reply()``-factory path keeps working unchanged — including both
+ * flavours mixed in one suite.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  EvalRunner,
+  LLMJudge,
+  ScriptedLLMProvider,
+  textTurn,
+  toolCallTurn,
+} from '../../src/evals';
+import type { EvalCase, JudgeBackend } from '../../src/evals';
+import { tool } from '../../src/public-api';
+import type { AgentOptions } from '../../src/types';
+
+class FakeJudgeBackend implements JudgeBackend {
+  readonly prompts: string[] = [];
+  constructor(private readonly payload: Record<string, unknown>) {}
+  async judge(prompt: string): Promise<string> {
+    this.prompts.push(prompt);
+    return JSON.stringify(this.payload);
+  }
+}
+
+function passingJudge(): { judge: LLMJudge; backend: FakeJudgeBackend } {
+  const backend = new FakeJudgeBackend({ score: 1.0, passed: true, reasoning: 'ok' });
+  return { judge: new LLMJudge({ backend }), backend };
+}
+
+describe('[unit] EvalRunner with real-pipeline cases', () => {
+  it('drives the real pipeline for a case that carries an agent', async () => {
+    const toolRan: Array<Record<string, unknown>> = [];
+
+    const agent: AgentOptions = {
+      systemPrompt: 'You are a support agent.',
+      provider: 'pipeline',
+      tools: [
+        tool({
+          name: 'cancel_order',
+          description: 'Cancel an order',
+          parameters: {
+            type: 'object',
+            properties: { order_id: { type: 'string' } },
+          },
+          handler: async (args) => {
+            toolRan.push(args);
+            return JSON.stringify({ cancelled: true });
+          },
+        }),
+      ],
+    };
+    const provider = new ScriptedLLMProvider([
+      toolCallTurn('cancel_order', { order_id: 'A-1' }),
+      textTurn('Done — order A-1 is cancelled.'),
+    ]);
+    const evalCase: EvalCase = {
+      name: 'cancels the order',
+      turns: [{ user: 'please cancel order A-1' }],
+      expectedBehavior: 'Agent cancels the order and confirms.',
+      rubric: 'Pass when the cancellation is confirmed.',
+      firstMessage: 'Hi, you have reached support.',
+      agent,
+      llmProvider: provider,
+    };
+    const { judge, backend } = passingJudge();
+    const runner = new EvalRunner({ judge });
+
+    // No agentFactory needed — the case carries its own real agent.
+    const results = await runner.run({ name: 's', cases: [evalCase] });
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.error).toBeNull();
+    expect(result.judge.passed).toBe(true);
+    // The REAL pipeline executed the tool through the real executor.
+    expect(toolRan).toEqual([{ order_id: 'A-1' }]);
+    // Transcript: case.firstMessage (spoken by the REAL start path) +
+    // the user turn + what the agent actually said.
+    expect(result.transcript[0]).toEqual({
+      role: 'agent',
+      text: 'Hi, you have reached support.',
+    });
+    expect(result.transcript[1]).toEqual({
+      role: 'user',
+      text: 'please cancel order A-1',
+    });
+    expect(result.transcript[2].role).toBe('agent');
+    expect(result.transcript[2].text).toContain('cancelled');
+    // The judge saw the real transcript.
+    expect(backend.prompts[0]).toContain('order A-1 is cancelled');
+
+    // Report shape is unchanged.
+    const report = JSON.parse(
+      runner.report({ name: 's', cases: [evalCase] }, results),
+    ) as Record<string, unknown>;
+    expect(report.passed).toBe(1);
+  });
+
+  it('mixes legacy and session cases in one suite', async () => {
+    const agent: AgentOptions = { systemPrompt: 'hi', provider: 'pipeline' };
+    const sessionCase: EvalCase = {
+      name: 'real-pipeline',
+      turns: [{ user: 'ping' }],
+      expectedBehavior: '',
+      rubric: '',
+      agent,
+      llmProvider: new ScriptedLLMProvider([textTurn('pong from pipeline')]),
+    };
+    const legacyCase: EvalCase = {
+      name: 'legacy-reply',
+      turns: [{ user: 'ping' }],
+      expectedBehavior: '',
+      rubric: '',
+    };
+
+    const reply = async (text: string): Promise<string> => `echo:${text}`;
+
+    const { judge } = passingJudge();
+    const runner = new EvalRunner({ judge });
+    const results = await runner.run(
+      { name: 'mixed', cases: [sessionCase, legacyCase] },
+      () => reply,
+    );
+
+    expect(results.map((r) => r.caseName)).toEqual(['real-pipeline', 'legacy-reply']);
+    expect(results[0].transcript[results[0].transcript.length - 1].text).toBe(
+      'pong from pipeline',
+    );
+    expect(results[1].transcript[results[1].transcript.length - 1].text).toBe('echo:ping');
+    expect(results.every((r) => r.error === null)).toBe(true);
+  });
+
+  it('requires a factory for legacy cases', async () => {
+    const legacyCase: EvalCase = {
+      name: 'needs-factory',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: '',
+      rubric: '',
+    };
+    const { judge } = passingJudge();
+    const runner = new EvalRunner({ judge });
+    const results = await runner.run({ name: 's', cases: [legacyCase] });
+    expect(results[0].error).not.toBeNull();
+    expect(results[0].error).toContain('agentFactory');
+  });
+
+  it('records an error on a mid-case failure but judges the partial transcript', async () => {
+    // A failure mid-case keeps the partial transcript and reports the error
+    // — same contract as the legacy path.
+    const agent: AgentOptions = { systemPrompt: 'hi', provider: 'pipeline' };
+    const evalCase: EvalCase = {
+      name: 'dup-turn',
+      // The second identical turn is dropped by the REAL commit filter,
+      // which the session surfaces as an error.
+      turns: [{ user: 'same text' }, { user: 'same text' }],
+      expectedBehavior: '',
+      rubric: '',
+      agent,
+      llmProvider: new ScriptedLLMProvider([textTurn('first'), textTurn('second')]),
+    };
+    const { judge } = passingJudge();
+    const runner = new EvalRunner({ judge });
+    const results = await runner.run({ name: 's', cases: [evalCase] });
+    const result = results[0];
+    expect(result.error).not.toBeNull();
+    expect(result.error).toContain('commit filter');
+    // Partial transcript from before the failure is preserved for the judge.
+    expect(result.transcript).toContainEqual({ role: 'user', text: 'same text' });
+    expect(result.transcript.some((t) => t.role === 'agent' && t.text === 'first')).toBe(
+      true,
+    );
+  });
+});

--- a/libraries/typescript/tests/unit/eval-session.test.ts
+++ b/libraries/typescript/tests/unit/eval-session.test.ts
@@ -1,0 +1,404 @@
+/**
+ * [unit] Real-pipeline eval harness (``src/evals/session.ts``).
+ *
+ * Mirrors Python ``tests/unit/test_eval_session.py``. These tests drive an
+ * ACTUAL pipeline ``StreamHandler`` — the real transcript receive path,
+ * ``handleBargeIn`` / ``commitTranscript`` / ``dispatchTurn``, the real
+ * ``LLMLoop`` with the real ``DefaultToolExecutor``, guardrails, sentence
+ * chunking, and metrics — with only the paid/external boundary faked
+ * (telephony bridge, STT/TTS adapters, and a scripted LLM provider).
+ * No network anywhere.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  EvalSession,
+  ScriptedLLMProvider,
+  textTurn,
+  toolCallTurn,
+} from '../../src/evals';
+import { expect as expectTurn } from '../../src/evals';
+import { ErrorCode, PatterConfigError, PatterError } from '../../src/errors';
+import { tool, guardrail } from '../../src/public-api';
+import type { AgentOptions } from '../../src/types';
+
+function makeAgent(overrides: Partial<AgentOptions> = {}): AgentOptions {
+  return {
+    systemPrompt: 'You are a concise test agent.',
+    provider: 'pipeline',
+    firstMessage: '',
+    ...overrides,
+  };
+}
+
+async function expectPatterError(
+  promise: Promise<unknown>,
+  code: (typeof ErrorCode)[keyof typeof ErrorCode],
+): Promise<PatterError> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(PatterError);
+    expect((err as PatterError).code).toBe(code);
+    return err as PatterError;
+  }
+  throw new Error(`expected PatterError(${code}) but nothing was thrown`);
+}
+
+// ---------------------------------------------------------------------------
+// (a) Tool-call case — the REAL DefaultToolExecutor runs a local handler
+// ---------------------------------------------------------------------------
+
+describe('[unit] EvalSession — real pipeline harness', () => {
+  it('tool call runs the real tool executor and is assertable', async () => {
+    const handlerCalls: Array<
+      [Record<string, unknown>, Record<string, unknown>]
+    > = [];
+
+    const agent = makeAgent({
+      tools: [
+        tool({
+          name: 'get_weather',
+          description: 'Get the weather for a city',
+          parameters: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+          },
+          handler: async (args, callContext) => {
+            handlerCalls.push([args, callContext]);
+            return JSON.stringify({ forecast: 'sunny', city: args.city });
+          },
+        }),
+      ],
+    });
+    const provider = new ScriptedLLMProvider([
+      toolCallTurn('get_weather', { city: 'Paris' }),
+      textTurn('It is sunny in Paris today.'),
+    ]);
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let result;
+    try {
+      result = await s.userSays("what's the weather in paris?");
+    } finally {
+      await s.close();
+    }
+
+    // Chainable assertion helpers.
+    expectTurn(result)
+      .toolCalled('get_weather', { city: 'Paris' })
+      .agentTextContains('sunny in Paris');
+
+    // The REAL DefaultToolExecutor invoked the local handler with the real
+    // call context (call_id / caller / callee threaded by the handler).
+    expect(handlerCalls).toHaveLength(1);
+    const [args, callContext] = handlerCalls[0];
+    expect(args).toEqual({ city: 'Paris' });
+    expect(callContext.call_id).toBe(s.callId);
+    expect(callContext.caller).toBe(s.caller);
+
+    // The recorded ToolCallRecord carries the executor's result string.
+    expect(result.toolCalls).toHaveLength(1);
+    const record = result.toolCalls[0];
+    expect(record.name).toBe('get_weather');
+    expect(JSON.parse(record.result ?? '')).toEqual({ forecast: 'sunny', city: 'Paris' });
+
+    // The tool result was fed back to the model: the provider's second call
+    // contains the assistant tool_calls message + the role='tool' result.
+    expect(provider.calls).toHaveLength(2);
+    const second = provider.calls[1].messages;
+    const toolMsgs = second.filter((m) => m.role === 'tool');
+    expect(toolMsgs).toHaveLength(1);
+    expect(String(toolMsgs[0].content)).toContain('sunny');
+
+    // The handler's tool-event path also surfaced role='tool' entries into
+    // the conversation history (dashboard timeline parity).
+    const toolHistory = result.historySnapshot.filter((e) => e.role === 'tool');
+    expect(toolHistory.some((e) => e.text.includes('get_weather'))).toBe(true);
+
+    // And the model saw the tool schema (not the handler) via the LLM loop.
+    const toolsSent = provider.calls[0].tools;
+    expect(toolsSent).not.toBeNull();
+    const fn = (toolsSent![0] as { function: Record<string, unknown> }).function;
+    expect(fn.name).toBe('get_weather');
+    expect('handler' in fn).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // (b) Multi-turn — history accumulates through the real handler exactly once
+  // -------------------------------------------------------------------------
+
+  it('multi-turn history accumulates without duplicates', async () => {
+    const provider = new ScriptedLLMProvider([
+      textTurn('First reply.'),
+      textTurn('Second reply.'),
+    ]);
+    const agent = makeAgent();
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let r1, r2;
+    try {
+      r1 = await s.userSays('tell me a joke');
+      r2 = await s.userSays('explain that joke');
+    } finally {
+      await s.close();
+    }
+
+    expect(r1.agentText).toBe('First reply.');
+    expect(r2.agentText).toBe('Second reply.');
+
+    // History snapshot after turn 2: both exchanges, in order, exactly once.
+    const rolesTexts = r2.historySnapshot.map((e) => [e.role, e.text]);
+    expect(rolesTexts).toEqual([
+      ['user', 'tell me a joke'],
+      ['assistant', 'First reply.'],
+      ['user', 'explain that joke'],
+      ['assistant', 'Second reply.'],
+    ]);
+
+    // What the provider actually received on turn 2 — the history snapshot
+    // handed to LLMLoop.run EXCLUDES the current user turn, and
+    // buildMessages appends userText exactly once, so every turn (including
+    // the current one) reaches the provider exactly once and in order. This
+    // is the cross-SDK contract; a regression re-introducing the old
+    // trailing duplicate of the current user message must fail here.
+    const msgs = provider.calls[1].messages;
+    expect(msgs[0].role).toBe('system');
+    expect(msgs.slice(1).map((m) => [m.role, m.content])).toEqual([
+      ['user', 'tell me a joke'],
+      ['assistant', 'First reply.'],
+      ['user', 'explain that joke'],
+    ]);
+    // No entry is ever duplicated.
+    expect(msgs.filter((m) => m.content === 'tell me a joke')).toHaveLength(1);
+    expect(msgs.filter((m) => m.content === 'First reply.')).toHaveLength(1);
+    expect(msgs.filter((m) => m.content === 'explain that joke')).toHaveLength(1);
+  });
+
+  it('firstMessage flows through the real start path', async () => {
+    const provider = new ScriptedLLMProvider([textTurn('Sure thing.')]);
+    const agent = makeAgent({ firstMessage: 'Hello, thanks for calling!' });
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let result;
+    try {
+      // The REAL start path spoke the greeting through the fake TTS,
+      // billed it, and pushed it into history.
+      expect(s.tts.spoken).toEqual(['Hello, thanks for calling!']);
+      expect(s.history[0].role).toBe('assistant');
+      expect(s.history[0].text).toBe('Hello, thanks for calling!');
+      expect(s.audioSender.sentAudio.length).toBeGreaterThanOrEqual(1);
+
+      result = await s.userSays('hi, I need help');
+    } finally {
+      await s.close();
+    }
+
+    // The greeting is part of the LLM context on the first user turn.
+    const msgs = provider.calls[0].messages;
+    expect([msgs[1].role, msgs[1].content]).toEqual([
+      'assistant',
+      'Hello, thanks for calling!',
+    ]);
+    expect(result.historySnapshot[0].text).toBe('Hello, thanks for calling!');
+  });
+
+  // -------------------------------------------------------------------------
+  // (c) Guardrail replacement is observable in agentText
+  // -------------------------------------------------------------------------
+
+  it('guardrail replacement is observable in agentText', async () => {
+    const provider = new ScriptedLLMProvider([
+      textTurn('The secret password is swordfish.'),
+    ]);
+    const agent = makeAgent({
+      guardrails: [
+        guardrail({
+          name: 'no-secrets',
+          blockedTerms: ['swordfish'],
+          replacement: 'I cannot share that information.',
+        }),
+      ],
+    });
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let result, spoken;
+    try {
+      result = await s.userSays('what is the secret password?');
+      spoken = [...s.tts.spoken];
+    } finally {
+      await s.close();
+    }
+
+    // agentText reflects what the caller HEARD: the guardrail replacement.
+    expectTurn(result).agentTextContains('cannot share that information');
+    expect(result.agentText).not.toContain('swordfish');
+    // The raw sentence never reached TTS.
+    expect(spoken).toEqual(['I cannot share that information.']);
+    // Pipeline-streaming history keeps the RAW LLM text (existing handler
+    // behaviour, mirrored from the live path) — documented on TurnResult.
+    const assistantEntries = result.historySnapshot.filter(
+      (e) => e.role === 'assistant',
+    );
+    expect(assistantEntries[assistantEntries.length - 1].text).toBe(
+      'The secret password is swordfish.',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // (d) close() runs the handler's real teardown
+  // -------------------------------------------------------------------------
+
+  it('close() tears the fakes down through the real handler teardown', async () => {
+    const provider = new ScriptedLLMProvider([
+      textTurn('Reply one.'),
+      textTurn('Reply two.'),
+    ]);
+    const agent = makeAgent({ firstMessage: 'Hi!' });
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    try {
+      await s.userSays('first question');
+      await s.userSays('second question');
+    } finally {
+      await s.close();
+    }
+
+    // The fakes were closed through the handler's real handleStop().
+    expect(s.stt.closed).toBe(true);
+    expect(s.tts.closed).toBe(true);
+    // close() is idempotent.
+    await s.close();
+    // A closed session refuses further turns, loudly.
+    await expectPatterError(s.userSays('hello again'), ErrorCode.CONFIG);
+  });
+
+  it('teardown runs when the body raises (try/finally pattern)', async () => {
+    const provider = new ScriptedLLMProvider([textTurn('ok')]);
+    const agent = makeAgent();
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let raised = false;
+    try {
+      throw new Error('boom');
+    } catch (err) {
+      raised = true;
+      expect((err as Error).message).toBe('boom');
+    } finally {
+      await s.close();
+    }
+    expect(raised).toBe(true);
+    expect(s.stt.closed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Real commit-path filters apply (dedup / hallucination), loudly
+  // -------------------------------------------------------------------------
+
+  it('a duplicate transcript is dropped by the real commit filter', async () => {
+    const provider = new ScriptedLLMProvider([textTurn('Once.'), textTurn('Twice.')]);
+    const agent = makeAgent();
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    try {
+      await s.userSays('repeat after me');
+      // The REAL ``commitTranscript`` dedup throttle drops an identical
+      // final within 2 s — exactly as on a live call. The harness surfaces
+      // that as a loud, typed error instead of a silent no-op turn.
+      await expectPatterError(s.userSays('repeat after me'), ErrorCode.INPUT_VALIDATION);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('an STT hallucination is dropped by the real commit filter', async () => {
+    const provider = new ScriptedLLMProvider([textTurn('unused')]);
+    const agent = makeAgent();
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    try {
+      await expectPatterError(
+        s.userSays('thank you for watching'),
+        ErrorCode.INPUT_VALIDATION,
+      );
+    } finally {
+      await s.close();
+    }
+    expect(provider.calls).toEqual([]); // never reached the LLM
+  });
+
+  // -------------------------------------------------------------------------
+  // Metrics / transcript-event observability
+  // -------------------------------------------------------------------------
+
+  it('metrics turn and transcript events are captured', async () => {
+    const provider = new ScriptedLLMProvider([textTurn('All sorted.')]);
+    const agent = makeAgent();
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let result;
+    try {
+      result = await s.userSays('sort it out');
+    } finally {
+      await s.close();
+    }
+
+    const turn = result.metricsTurn;
+    expect(turn).not.toBeNull();
+    expect(turn!.user_text).toBe('sort it out');
+    expect(turn!.agent_text).toBe('All sorted.');
+    expect(turn!.latency).toBeDefined();
+    expect(result.interrupted).toBe(false);
+
+    // onTranscript fired for both roles through the real handler.
+    const roles = s.transcriptEvents.map((e) => e.role);
+    expect(roles).toContain('user');
+    expect(roles).toContain('assistant');
+    const userEvents = s.transcriptEvents.filter((e) => e.role === 'user');
+    expect(userEvents[0].text).toBe('sort it out');
+    expect(userEvents[0].call_id).toBe(s.callId);
+  });
+
+  it('hooks run on the real path (afterTranscribe rewrites before the LLM)', async () => {
+    // afterTranscribe rewrites the user text before the LLM sees it —
+    // proof the real PipelineHookExecutor path is exercised.
+    const provider = new ScriptedLLMProvider([textTurn('Noted.')]);
+    const agent = makeAgent({
+      hooks: {
+        afterTranscribe: (text) => text.replace('4111-1111', '[card]'),
+      },
+    });
+
+    const s = await EvalSession.create({ agent, llmProvider: provider });
+    let result;
+    try {
+      result = await s.userSays('my card is 4111-1111');
+    } finally {
+      await s.close();
+    }
+
+    const msgs = provider.calls[0].messages;
+    const userContents = msgs
+      .filter((m) => m.role === 'user')
+      .map((m) => String(m.content));
+    expect(userContents.length).toBeGreaterThan(0);
+    expect(userContents.every((c) => c.includes('[card]'))).toBe(true);
+    expect(userContents.every((c) => !c.includes('4111-1111'))).toBe(true);
+    // History carries the redacted text too (what the LLM actually saw).
+    expect(result.historySnapshot[0].text).toBe('my card is [card]');
+  });
+
+  // -------------------------------------------------------------------------
+  // Configuration errors are loud and typed
+  // -------------------------------------------------------------------------
+
+  it('a session without an LLM raises a config error', async () => {
+    const agent = makeAgent();
+    await expect(EvalSession.create({ agent })).rejects.toBeInstanceOf(PatterConfigError);
+  });
+
+  it('userSays before start raises', async () => {
+    const agent = makeAgent();
+    const session = new EvalSession({ agent, llmProvider: new ScriptedLLMProvider() });
+    await expectPatterError(session.userSays('hello'), ErrorCode.CONFIG);
+  });
+});

--- a/libraries/typescript/tests/unit/evals.test.ts
+++ b/libraries/typescript/tests/unit/evals.test.ts
@@ -1,0 +1,240 @@
+/**
+ * [unit] Patter evals framework — judge parsing, legacy runner, suite loading.
+ *
+ * Mirrors Python ``tests/test_evals.py``. The judge BACKEND is a canned test
+ * double (the judge's only external boundary is a paid OpenAI call);
+ * everything else — prompt building, JSON parsing, score clamping, the
+ * runner loop, report rendering, suite loading — is real code.
+ */
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import {
+  EvalRunner,
+  LLMJudge,
+  loadSuite,
+} from '../../src/evals';
+import type { EvalCase, EvalSuite, JudgeBackend } from '../../src/evals';
+
+class FakeBackend implements JudgeBackend {
+  calls = 0;
+  constructor(private readonly payload: Record<string, unknown>) {}
+  async judge(_prompt: string): Promise<string> {
+    this.calls += 1;
+    return JSON.stringify(this.payload);
+  }
+}
+
+describe('[unit] LLMJudge', () => {
+  it('parses score and reasoning', async () => {
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 0.9, passed: true, reasoning: 'great' }),
+    });
+    const evalCase: EvalCase = {
+      name: 'test',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: 'reply politely',
+      rubric: 'pass if polite',
+    };
+    const result = await judge.judgeCase(evalCase, [{ role: 'user', text: 'hi' }]);
+    expect(result.score).toBeCloseTo(0.9);
+    expect(result.passed).toBe(true);
+    expect(result.reasoning).toBe('great');
+  });
+
+  it('tolerates code fences', async () => {
+    const fenced = '```json\n{"score": 0.5, "passed": false, "reasoning": "meh"}\n```';
+    const judge = new LLMJudge({
+      backend: { judge: async () => fenced },
+    });
+    const evalCase: EvalCase = { name: 't', turns: [], expectedBehavior: '', rubric: '' };
+    const result = await judge.judgeCase(evalCase, []);
+    expect(result.score).toBeCloseTo(0.5);
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails safely on invalid JSON', async () => {
+    const judge = new LLMJudge({
+      backend: { judge: async () => 'not json at all' },
+    });
+    const evalCase: EvalCase = { name: 't', turns: [], expectedBehavior: '', rubric: '' };
+    const result = await judge.judgeCase(evalCase, []);
+    expect(result.score).toBe(0.0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('clamps score to the unit range', async () => {
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 1.5, passed: true, reasoning: '' }),
+    });
+    const evalCase: EvalCase = { name: 't', turns: [], expectedBehavior: '', rubric: '' };
+    const result = await judge.judgeCase(evalCase, []);
+    expect(result.score).toBe(1.0);
+  });
+
+  it('computes the verdict locally from the score, not the self-report', async () => {
+    // A hallucinated `passed: true` with a failing score must NOT pass.
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 0.2, passed: true, reasoning: 'hallucinated pass' }),
+    });
+    const evalCase: EvalCase = { name: 't', turns: [], expectedBehavior: '', rubric: '' };
+    const result = await judge.judgeCase(evalCase, []);
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('[unit] EvalRunner (legacy reply path)', () => {
+  it('end-to-end produces transcript and report', async () => {
+    const evalCase: EvalCase = {
+      name: 'greeting',
+      turns: [{ user: 'hello' }, { user: 'how are you?' }],
+      expectedBehavior: 'greet and respond',
+      rubric: 'pass if reply is non-empty',
+      firstMessage: 'Hi, how can I help?',
+    };
+    const suite: EvalSuite = { name: 'demo', cases: [evalCase] };
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 1.0, passed: true, reasoning: 'looks good' }),
+    });
+    const runner = new EvalRunner({ judge });
+
+    const reply = async (text: string): Promise<string> => `echo:${text}`;
+    const results = await runner.run(suite, () => reply);
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.caseName).toBe('greeting');
+    expect(result.judge.passed).toBe(true);
+    // transcript: firstMessage (agent) + user + agent + user + agent = 5.
+    expect(result.transcript).toHaveLength(5);
+    expect(result.transcript[0]).toEqual({ role: 'agent', text: 'Hi, how can I help?' });
+    expect(result.transcript[1]).toEqual({ role: 'user', text: 'hello' });
+    expect(result.transcript[2].role).toBe('agent');
+    expect(result.transcript[2].text).toBe('echo:hello');
+
+    // Report should be valid JSON and contain pass-rate.
+    const report = JSON.parse(runner.report(suite, results)) as Record<string, unknown>;
+    expect(report.suite).toBe('demo');
+    expect(report.total).toBe(1);
+    expect(report.passed).toBe(1);
+    expect(report.pass_rate).toBe(1.0);
+  });
+
+  it('handles an agent exception and records the error', async () => {
+    const evalCase: EvalCase = {
+      name: 'boom',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: '',
+      rubric: '',
+    };
+    const suite: EvalSuite = { name: 's', cases: [evalCase] };
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 0, passed: false, reasoning: '' }),
+    });
+    const runner = new EvalRunner({ judge });
+
+    const broken = async (_: string): Promise<string> => {
+      throw new Error('agent died');
+    };
+    const results = await runner.run(suite, () => broken);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].error).not.toBeNull();
+    expect(results[0].error).toContain('agent died');
+    expect(results[0].judge.passed).toBe(false);
+  });
+
+  it('survives a judge failure without aborting the suite', async () => {
+    const evalCase: EvalCase = {
+      name: 'judge-blip',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: '',
+      rubric: '',
+    };
+    const judge = new LLMJudge({
+      backend: {
+        judge: async () => {
+          throw new Error('429 too many requests');
+        },
+      },
+    });
+    const runner = new EvalRunner({ judge });
+    const results = await runner.run(
+      { name: 's', cases: [evalCase] },
+      () => async (text: string) => `echo:${text}`,
+    );
+    expect(results[0].judge.passed).toBe(false);
+    expect(results[0].error).toContain('judge error');
+  });
+});
+
+describe('[unit] loadSuite', () => {
+  it('loads a JSON suite', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'patter-evals-'));
+    const src = join(dir, 'suite.json');
+    await writeFile(
+      src,
+      JSON.stringify({
+        name: 'json-suite',
+        cases: [
+          {
+            name: 't1',
+            expected_behavior: 'b',
+            rubric: 'r',
+            turns: [{ user: 'hey' }],
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    const suite = await loadSuite(src);
+    expect(suite.name).toBe('json-suite');
+    expect(suite.cases[0].turns[0].user).toBe('hey');
+    expect(suite.cases[0].expectedBehavior).toBe('b');
+  });
+
+  it('loads a YAML suite (skipped when the optional yaml package is missing)', async (ctx) => {
+    const yamlModule = 'yaml';
+    const hasYaml = await import(yamlModule).then(
+      () => true,
+      () => false,
+    );
+    if (!hasYaml) {
+      ctx.skip();
+      return;
+    }
+    const dir = await mkdtemp(join(tmpdir(), 'patter-evals-'));
+    const src = join(dir, 'suite.yaml');
+    await writeFile(
+      src,
+      [
+        'name: test-suite',
+        'cases:',
+        '  - name: greeting',
+        '    expected_behavior: greet',
+        '    rubric: pass if greeting',
+        '    turns:',
+        '      - user: hi',
+        '        expected_contains: [hello, hi]',
+        '    tags: [smoke]',
+      ].join('\n'),
+      'utf-8',
+    );
+    const suite = await loadSuite(src);
+    expect(suite.name).toBe('test-suite');
+    expect(suite.cases).toHaveLength(1);
+    const c = suite.cases[0];
+    expect(c.name).toBe('greeting');
+    expect(c.turns[0].user).toBe('hi');
+    expect(c.turns[0].expectedContains).toEqual(['hello', 'hi']);
+    expect(c.tags).toEqual(['smoke']);
+  });
+
+  it('rejects a non-mapping suite', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'patter-evals-'));
+    const src = join(dir, 'bad.json');
+    await writeFile(src, JSON.stringify([1, 2, 3]), 'utf-8');
+    await expect(loadSuite(src)).rejects.toThrow(/must be a mapping/);
+  });
+});

--- a/libraries/typescript/tests/unit/new-client-api.test.ts
+++ b/libraries/typescript/tests/unit/new-client-api.test.ts
@@ -238,6 +238,37 @@ describe('phone.agent({ tools / guardrails })', () => {
 });
 
 // ---------------------------------------------------------------------------
+// provider: 'openai_realtime' — OPENAI_API_KEY env handling
+// ---------------------------------------------------------------------------
+
+describe("phone.agent({ provider: 'openai_realtime' }) — env key", () => {
+  function makeKeylessPhone(): Patter {
+    return new Patter({
+      carrier: new Twilio({ accountSid: 'AC_test', authToken: 'tok' }),
+      phoneNumber: '+15550001234',
+    });
+  }
+
+  it('accepts OPENAI_API_KEY from the env AND backfills the local config', () => {
+    // Accepting at validation but dialing with an empty key later would be a
+    // dead call — the env key must reach the call path (parity with Python).
+    process.env.OPENAI_API_KEY = 'sk-env';
+    const phone = makeKeylessPhone();
+    const agent = phone.agent({ provider: 'openai_realtime', systemPrompt: 'hi' });
+    expect(agent.provider).toBe('openai_realtime');
+    const cfg = (phone as unknown as { localConfig: { openaiKey?: string } }).localConfig;
+    expect(cfg.openaiKey).toBe('sk-env');
+  });
+
+  it('rejects when no key is configured anywhere', () => {
+    const phone = makeKeylessPhone();
+    expect(() => phone.agent({ provider: 'openai_realtime', systemPrompt: 'hi' })).toThrow(
+      /OpenAI API key/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tunnel
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Consolidation pass on the already-shipped 0.6.6/0.6.7 feature wave: close Python⇄TypeScript parity gaps, fix bugs, and harden integration — no new feature surface beyond parity.
- Biggest item: **EvalSession ported to TypeScript** (the last big parity gap) — a real-pipeline eval harness driving the actual `StreamHandler`, with chainable assertions, scripted LLM provider, and an unstubbed `getpatter eval` CLI.
- Plus five targeted fixes: explicit `voice=`/`model=` precedence over engine markers (Python), `OPENAI_API_KEY` env handling on the provider-string path (both SDKs — TS had a latent dead-call), a telemetry close/chain race guard (TS), `barge_in_mode`/`barge_in_confirm_ms` exposed on the Python `agent()` factory, and missing regression tests for the 0.6.7 telemetry delivery fix.

## Implementation
- **EvalSession TS** (`src/evals/`): `EvalSession` constructs a real pipeline-mode `StreamHandler` and injects turns through the live-call path; fakes only at the STT/TTS/audio-sender/LLM boundary. `expect()` assertions, `LLMJudge`, `EvalCase.agent`/`llmProvider` routing, JSON/YAML suite loader, CLI `eval run` with exit codes 0/1/2. Field names, defaults, and report rows byte-compatible with Python. Reviewed post-port: `arguments` field parity, bounded await of aborted dispatch before timeout throw, crypto-based call ids, judge response guard.
- **Explicit-kwarg precedence (Python)**: `voice`/`model` moved to sentinel `None` defaults so explicit values — even equal to the documented default — win over `engine=` marker values (mirrors TS `??` resolution). Telemetry model resolution updated consistently.
- **Env-key path (both SDKs)**: `provider="openai_realtime"` with no configured key now backfills `OPENAI_API_KEY` from the environment into the local config so the call path actually uses it. Python previously rejected despite its error message promising env support; TS accepted at validation but dialed with an empty key.
- **Telemetry (TS)**: the post-flush chain now stops once `close()` has begun (parity with Python's `not _closed`); added the missing regression tests in both SDKs for the 0.6.7 "event recorded during an in-flight flush" fix, using a gated real HTTP collector.
- **Python factory parity**: `barge_in_mode` / `barge_in_confirm_ms` as `agent()` keywords with validation (were dataclass-only).
- **Hygiene**: removed leftover temporary DIAG INFO instrumentation from the TS stream handler; scrubbed external-project references from source comments; dropped a stale DTMF TODO.
- **Docs**: `local_recording`/`localRecording` documented across both SDK doc trees (8 pages); runnable examples added for pause-resume barge-in, preemptive generation, and smart-turn semantic EOU (both languages) + examples index.

## Breaking change?
No. Two edge-case behavior corrections, both documented under `## Unreleased` → Fixed:
- explicit `model="gpt-realtime-mini"` + engine with a different model now runs the explicit model in Python (previously the engine's — TS already did this);
- `provider="openai_realtime"` with only an env key is now accepted in Python (previously rejected) and actually works in TS (previously dead call).

## Test plan
- [x] Python: `pytest tests/` — 2648 passed, 8 skipped, 2 xfailed
- [x] TypeScript: `npm test` (2096 passed, 9 skipped) + `npm run lint` + `npm run build`
- [x] Cross-SDK parity suite: 10/10 — verified both with and without `OPENAI_API_KEY` in the env (the env-set run is what caught the env-key divergence)
- [x] New regression tests RED-verified against reverted fixes (telemetry chain, kwarg precedence)
- [ ] E2E smoke: not required (no pipeline/handler behavior change beyond the eval harness, which is test-infrastructure)

## Docs updates
- `docs/python-sdk/{features,reference,local-mode,events}.mdx`, `docs/typescript-sdk/{features,reference,local-mode,events}.mdx` (local recording)
- `docs/examples/`: `pause-resume-barge-in.{py,ts}`, `preemptive-generation.{py,ts}`, `smart-turn-detection.{py,ts}`, `README.md` index