### PR TITLE
fix(telemetry): relay-cap batch chunking, XDG state-dir compliance, visible Python disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## Unreleased
 
+### Fixed
+
+- **Telemetry: large flushes are no longer truncated by the collector.** The
+  client buffers up to 256 events but the collector accepts at most 64 per
+  request — a busy session's flush could silently lose everything past the cap
+  (or the whole batch when oversized). Both SDKs now ship flushes in chunks of
+  ≤64 events per POST, on the async path and the exit-flush path.
+  `libraries/python/getpatter/telemetry/client.py`,
+  `libraries/typescript/src/telemetry/client.ts`.
+- **Telemetry: state files respect the XDG spec, and a persisted opt-out
+  survives environment changes.** With `XDG_STATE_HOME` set, the state files
+  (`install-id`, `version`, `first-run`, `telemetry-disabled`) were written into
+  the bare XDG root instead of an app subdirectory — colliding with other tools
+  and, worse, making a `getpatter telemetry disable` opt-out persisted under
+  `~/.getpatter/` go unhonored when the process later ran with XDG set (and vice
+  versa). Files now live in `$XDG_STATE_HOME/getpatter/`; a pre-existing legacy
+  id is migrated (no double-counted installs, mtime preserved for the install-age
+  bucket), a legacy opt-out marker keeps disabling telemetry, and a legacy
+  first-run marker is never re-emitted.
+  `libraries/python/getpatter/telemetry/install_id.py`,
+  `libraries/typescript/src/telemetry/install-id.ts`.
+- **Telemetry: the first-use disclosure is actually visible in Python.** The
+  one-time "anonymous telemetry is on" notice was emitted via `logging` at INFO
+  level, but the SDK attaches no handler — Python's last-resort handler only
+  shows WARNING and above, so a default install never saw the opt-out notice
+  (TypeScript already printed it via its console-backed logger). Python now
+  writes the disclosure straight to stderr, once per process, matching the
+  TypeScript behaviour and the OSS norm (Next.js/Astro).
+  `libraries/python/getpatter/telemetry/client.py`.
+
 ## 0.6.7 (2026-06-10)
 
 ### Fixed

--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -46,7 +46,8 @@ value is replaced with `other` before sending):
 
 The `run_id` is a fresh random value on every process start (it groups one run's
 events). The `install_id` is a random UUID generated **once** and stored in a small
-local file (`~/.getpatter/install-id`) so the maintainers can count unique active
+local file (`~/.getpatter/install-id`, or `$XDG_STATE_HOME/getpatter/install-id`
+when `XDG_STATE_HOME` is set) so the maintainers can count unique active
 installs over time — it is a random number, **not** tied to you or any PII, and is
 never derived from hardware (MAC address, hostname, serial numbers). Opting out
 never creates or reads this file. The collector drops the source IP on receipt.

--- a/libraries/python/getpatter/telemetry/client.py
+++ b/libraries/python/getpatter/telemetry/client.py
@@ -43,6 +43,9 @@ _TIMEOUT_S = 3.0
 _FLUSH_TIMEOUT_S = 2.0
 _ATEXIT_TIMEOUT_S = 0.25  # keep process-exit blocking minimal for short-lived runs
 _BUFFER_MAX = 256
+# The relay rejects batches larger than 64 events per request — a full buffer
+# must ship as multiple POSTs or events 65..256 silently vanish server-side.
+_MAX_EVENTS_PER_POST = 64
 
 # Module-level registry so a single ``atexit`` hook flushes every live client
 # without leaking one handler per instance. A ``WeakSet`` lets a client whose
@@ -70,15 +73,24 @@ def _show_notice_once() -> None:
     if _NOTICE_SHOWN:
         return
     _NOTICE_SHOWN = True
-    logger.info(
-        "Anonymous usage telemetry is on (no PII, no call content). Collected: "
-        "a random anonymous install id, SDK version, language, OS family, runtime "
-        "version, coarse feature flags, the composed stack (provider + model per "
-        "layer), tool counts, integration category, and per-call duration, latency, "
-        "cost, and error codes (no call content, no message text). "
-        "Disable with PATTER_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, or telemetry=False. "
-        "Details: https://docs.getpatter.com/telemetry"
-    )
+    # Written straight to stderr, not through logging: the SDK attaches no
+    # handler, so logging's WARNING-level lastResort would swallow an INFO
+    # disclosure — and the opt-out notice must be visible by default (it is
+    # what legitimises the opt-out model; Next.js/Astro print theirs too).
+    # The TS SDK's console-backed logger already shows it — this keeps parity.
+    try:
+        sys.stderr.write(
+            "[patter] Anonymous usage telemetry is on (no PII, no call content). "
+            "Collected: a random anonymous install id, SDK version, language, OS "
+            "family, runtime version, coarse feature flags, the composed stack "
+            "(provider + model per layer), tool counts, integration category, and "
+            "per-call duration, latency, cost, and error codes (no call content, "
+            "no message text). Disable with PATTER_TELEMETRY_DISABLED=1, "
+            "DO_NOT_TRACK=1, or telemetry=False. "
+            "Details: https://docs.getpatter.com/telemetry\n"
+        )
+    except Exception:
+        pass
 
 
 def _register_atexit() -> None:
@@ -237,11 +249,17 @@ class TelemetryClient:
         events = self._drain()
         try:
             http = self._ensure_http()
-            await http.post(self._endpoint, json=events)
+            # Ship in relay-sized chunks: a buffer larger than the relay's
+            # per-request cap would otherwise be silently truncated server-side.
+            for start in range(0, len(events), _MAX_EVENTS_PER_POST):
+                await http.post(
+                    self._endpoint, json=events[start : start + _MAX_EVENTS_PER_POST]
+                )
             # Status is ignored — telemetry is best-effort and never load-bearing.
         except Exception:
-            # Drop on any failure; do NOT requeue (avoids unbounded growth and
-            # keeps offline behaviour identical to online).
+            # Drop on any failure — including this flush's remaining chunks; do
+            # NOT requeue (avoids unbounded growth and keeps offline behaviour
+            # identical to online).
             logger.debug("telemetry flush failed", exc_info=True)
 
     def _ensure_http(self) -> Any:
@@ -260,6 +278,10 @@ class TelemetryClient:
             import httpx
 
             with httpx.Client(timeout=_ATEXIT_TIMEOUT_S) as client:
-                client.post(self._endpoint, json=events)
+                for start in range(0, len(events), _MAX_EVENTS_PER_POST):
+                    client.post(
+                        self._endpoint,
+                        json=events[start : start + _MAX_EVENTS_PER_POST],
+                    )
         except Exception:
             logger.debug("telemetry atexit flush failed", exc_info=True)

--- a/libraries/python/getpatter/telemetry/install_id.py
+++ b/libraries/python/getpatter/telemetry/install_id.py
@@ -36,11 +36,39 @@ def run_id() -> str:
     return _RUN_ID
 
 
+def _state_dir() -> Path:
+    """Directory holding the telemetry state files (overridable for tests).
+
+    Precedence: ``PATTER_TELEMETRY_STATE_DIR`` (used literally) →
+    ``$XDG_STATE_HOME/getpatter`` (the XDG spec requires an app subdirectory —
+    writing into the shared root collides with other tools) → ``~/.getpatter``.
+    """
+    override = os.getenv("PATTER_TELEMETRY_STATE_DIR")
+    if override:
+        return Path(override)
+    xdg = os.getenv("XDG_STATE_HOME")
+    if xdg:
+        return Path(xdg) / "getpatter"
+    return Path.home() / ".getpatter"
+
+
+def _legacy_state_dir() -> Path | None:
+    """Where pre-0.6.8 builds wrote state when ``XDG_STATE_HOME`` was set.
+
+    Those builds used the bare ``$XDG_STATE_HOME`` root (no ``getpatter/``
+    subdirectory). Existing installs must keep their id — and, critically, a
+    persisted opt-out must keep being honored — so the readers below fall back
+    to this location. ``None`` when no legacy location applies.
+    """
+    if os.getenv("PATTER_TELEMETRY_STATE_DIR"):
+        return None
+    xdg = os.getenv("XDG_STATE_HOME")
+    return Path(xdg) if xdg else None
+
+
 def _state_path() -> Path:
-    """Where the persisted install id lives (overridable for tests/sandboxes)."""
-    base = os.getenv("PATTER_TELEMETRY_STATE_DIR") or os.getenv("XDG_STATE_HOME")
-    root = Path(base) if base else Path.home() / ".getpatter"
-    return root / "install-id"
+    """Where the persisted install id lives."""
+    return _state_dir() / "install-id"
 
 
 def install_id() -> str:
@@ -61,6 +89,26 @@ def install_id() -> str:
             return _install_id
     except OSError:
         pass
+
+    legacy_dir = _legacy_state_dir()
+    if legacy_dir is not None:
+        legacy = legacy_dir / "install-id"
+        try:
+            existing = legacy.read_text(encoding="utf-8").strip()
+        except OSError:
+            existing = ""
+        if _HEX32.match(existing):
+            # Migrate the pre-0.6.8 id so the install keeps counting as one,
+            # preserving the file mtime that feeds days_since_install_bucket.
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(existing, encoding="utf-8")
+                stat = legacy.stat()
+                os.utime(path, (stat.st_atime, stat.st_mtime))
+            except OSError:
+                pass
+            _install_id = existing
+            return _install_id
 
     new_id = uuid.uuid4().hex
     try:
@@ -86,6 +134,13 @@ def previous_version(current: str) -> str:
         prev = path.read_text(encoding="utf-8").strip()
     except OSError:
         prev = ""
+    if not prev:
+        legacy_dir = _legacy_state_dir()
+        if legacy_dir is not None:
+            try:
+                prev = (legacy_dir / "version").read_text(encoding="utf-8").strip()
+            except OSError:
+                prev = ""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(current, encoding="utf-8")
@@ -126,6 +181,13 @@ def is_first_run() -> bool:
             return False
     except OSError:
         return False
+    legacy_dir = _legacy_state_dir()
+    if legacy_dir is not None:
+        try:
+            if (legacy_dir / "first-run").exists():
+                return False  # pre-0.6.8 marker — never re-emit first_run
+        except OSError:
+            return False
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("1", encoding="utf-8")
@@ -142,10 +204,20 @@ def is_opted_out() -> bool:
     """Whether a persisted opt-out marker exists (``getpatter telemetry disable``).
 
     Read-only — never writes, so checking consent never touches the filesystem.
+    Also honors a marker written by pre-0.6.8 builds into the bare
+    ``$XDG_STATE_HOME`` root: an opt-out must survive the state-dir move.
     Mirrors ``isOptedOut`` in ``install-id.ts``.
     """
     try:
-        return _opt_out_path().exists()
+        if _opt_out_path().exists():
+            return True
+    except OSError:
+        pass
+    legacy_dir = _legacy_state_dir()
+    if legacy_dir is None:
+        return False
+    try:
+        return (legacy_dir / "telemetry-disabled").exists()
     except OSError:
         return False
 
@@ -166,3 +238,11 @@ def set_opt_out(disabled: bool) -> None:
             path.unlink()
         except FileNotFoundError:
             pass
+        # Also clear a pre-0.6.8 marker in the bare $XDG_STATE_HOME root —
+        # is_opted_out honors it, so leaving it behind would pin telemetry off.
+        legacy_dir = _legacy_state_dir()
+        if legacy_dir is not None:
+            try:
+                (legacy_dir / "telemetry-disabled").unlink()
+            except FileNotFoundError:
+                pass

--- a/libraries/python/tests/test_telemetry.py
+++ b/libraries/python/tests/test_telemetry.py
@@ -529,7 +529,9 @@ async def test_server_wiring_emits_call_completed(enabled, collector):
     from getpatter.models import CallMetrics, CostBreakdown, LatencyBreakdown
 
     server = _telemetry_server(collector)
-    _start, on_call_end, _metrics, _transcript_line, _transcript = server._wrap_callbacks()
+    _start, on_call_end, _metrics, _transcript_line, _transcript = (
+        server._wrap_callbacks()
+    )
     metrics = CallMetrics(
         call_id="CAx",
         duration_seconds=73.0,
@@ -945,7 +947,9 @@ def test_direction_on_call_completed():
         def record(self, name, **dims):
             recorded.append(dims)
 
-    cm.record_call_completed(_Sink(), outcome="failed", carrier="telnyx", direction="outbound")
+    cm.record_call_completed(
+        _Sink(), outcome="failed", carrier="telnyx", direction="outbound"
+    )
     assert recorded[0]["direction"] == "outbound"
 
 
@@ -955,6 +959,107 @@ def test_is_first_run_is_idempotent(monkeypatch, tmp_path):
     monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", str(tmp_path))
     assert iid.is_first_run() is True  # first call marks it
     assert iid.is_first_run() is False  # every later call
+
+
+# --- state-dir hardening + visible disclosure + relay-cap chunking (0.6.8) ----
+
+
+def test_xdg_state_home_uses_getpatter_subdir(monkeypatch, tmp_path):
+    """XDG spec: state files live in an app subdirectory, never the shared root."""
+    from getpatter.telemetry import install_id as iid
+
+    monkeypatch.delenv("PATTER_TELEMETRY_STATE_DIR", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    iid._install_id = None
+    first = iid.install_id()
+    assert (tmp_path / "getpatter" / "install-id").read_text().strip() == first
+    assert not (tmp_path / "install-id").exists()
+
+
+def test_xdg_legacy_install_id_migrates(monkeypatch, tmp_path):
+    """A pre-0.6.8 id in the bare XDG root is kept (no double-counted install)
+    and migrated into the subdirectory."""
+    from getpatter.telemetry import install_id as iid
+
+    monkeypatch.delenv("PATTER_TELEMETRY_STATE_DIR", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    legacy_id = "ab" * 16
+    (tmp_path / "install-id").write_text(legacy_id)
+    iid._install_id = None
+    assert iid.install_id() == legacy_id
+    assert (tmp_path / "getpatter" / "install-id").read_text().strip() == legacy_id
+
+
+def test_xdg_legacy_opt_out_still_honored(monkeypatch, tmp_path):
+    """An opt-out persisted by a pre-0.6.8 build (bare XDG root) must keep
+    disabling telemetry after the state-dir move — consent survives upgrades."""
+    from getpatter.telemetry import install_id as iid
+    from getpatter.telemetry.consent import is_enabled
+
+    monkeypatch.setattr("getpatter.telemetry.consent.is_ci", lambda: False)
+    monkeypatch.setattr("getpatter.telemetry.consent.is_test", lambda: False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_STATE_DIR", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    (tmp_path / "telemetry-disabled").write_text("1")  # pre-0.6.8 marker
+    assert iid.is_opted_out() is True
+    assert is_enabled() is False
+    iid.set_opt_out(False)  # re-enable must clear the legacy marker too
+    assert iid.is_opted_out() is False
+    assert is_enabled() is True
+
+
+def test_xdg_legacy_first_run_not_reemitted(monkeypatch, tmp_path):
+    from getpatter.telemetry import install_id as iid
+
+    monkeypatch.delenv("PATTER_TELEMETRY_STATE_DIR", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    (tmp_path / "first-run").write_text("1")  # pre-0.6.8 marker
+    assert iid.is_first_run() is False
+
+
+def test_first_use_notice_is_visible_on_stderr(enabled, collector, monkeypatch, capsys):
+    """The opt-out disclosure must be visible by default. The SDK attaches no
+    logging handler, so a logger.info-only notice is invisible (lastResort shows
+    WARNING+) — it goes straight to stderr, once per process."""
+    from getpatter.telemetry import client as client_mod
+
+    monkeypatch.setattr(client_mod, "_NOTICE_SHOWN", False)
+    TelemetryClient(sdk_version="0.6.7", endpoint=collector.url)
+    err = capsys.readouterr().err
+    assert "Anonymous usage telemetry is on" in err
+    assert "docs.getpatter.com/telemetry" in err
+    # Once per process: a second client does not repeat it.
+    TelemetryClient(sdk_version="0.6.7", endpoint=collector.url)
+    assert "Anonymous usage telemetry" not in capsys.readouterr().err
+
+
+async def test_flush_chunks_large_buffers_to_relay_cap(enabled, collector):
+    """The relay rejects >64 events per request — a large flush must ship as
+    multiple POSTs, never one oversized batch (which the relay drops/truncates)."""
+    client = TelemetryClient(sdk_version="0.6.7", endpoint=collector.url)
+    for _ in range(100):
+        client.record("cli_command", cli_command="dashboard")
+    await _wait_for(collector, 100)
+    await client.aclose()
+
+    assert len(collector.events) == 100  # nothing truncated
+    batches = [len(b) for b in collector.requests if isinstance(b, list)]
+    assert batches and max(batches) <= 64
+
+
+def test_flush_sync_chunks_large_buffers(enabled, collector):
+    """The synchronous atexit path applies the same relay-cap chunking."""
+    client = TelemetryClient(sdk_version="0.6.7", endpoint=collector.url)
+    for _ in range(70):
+        client.record("cli_command", cli_command="eval")
+    client._flush_sync()
+
+    assert len(collector.events) == 70
+    batches = [len(b) for b in collector.requests if isinstance(b, list)]
+    assert batches and max(batches) <= 64
 
 
 def test_persisted_opt_out_disables_consent(monkeypatch, tmp_path):

--- a/libraries/typescript/src/telemetry/client.ts
+++ b/libraries/typescript/src/telemetry/client.ts
@@ -26,6 +26,9 @@ export const DEFAULT_ENDPOINT = 'https://telemetry.getpatter.com/v1/ingest';
 
 const TIMEOUT_MS = 3000;
 const BUFFER_MAX = 256;
+// The relay rejects batches larger than 64 events per request — a full buffer
+// must ship as multiple POSTs or events 65..256 silently vanish server-side.
+const MAX_EVENTS_PER_POST = 64;
 
 let noticeShown = false;
 // WeakRefs so a client whose owning `Patter` was discarded is garbage-collected
@@ -188,22 +191,29 @@ export class TelemetryClient {
     const events = this.buffer.splice(0, this.buffer.length);
     pendingFlush.delete(this); // nothing buffered — GC may reclaim us again
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-    (timer as { unref?: () => void }).unref?.();
     try {
-      await fetch(this.endpoint, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(events),
-        signal: controller.signal,
-      });
-      // Status ignored — telemetry is best-effort and never load-bearing.
+      // Ship in relay-sized chunks: a buffer larger than the relay's
+      // per-request cap would otherwise be silently truncated server-side.
+      for (let start = 0; start < events.length; start += MAX_EVENTS_PER_POST) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+        (timer as { unref?: () => void }).unref?.();
+        try {
+          await fetch(this.endpoint, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(events.slice(start, start + MAX_EVENTS_PER_POST)),
+            signal: controller.signal,
+          });
+          // Status ignored — telemetry is best-effort and never load-bearing.
+        } finally {
+          clearTimeout(timer);
+        }
+      }
     } catch (err) {
-      // Drop on any failure; do NOT requeue (keeps offline behaviour identical).
+      // Drop on any failure — including this flush's remaining chunks; do NOT
+      // requeue (keeps offline behaviour identical).
       getLogger().debug('telemetry flush failed', err);
-    } finally {
-      clearTimeout(timer);
     }
   }
 }

--- a/libraries/typescript/src/telemetry/install-id.ts
+++ b/libraries/typescript/src/telemetry/install-id.ts
@@ -30,10 +30,34 @@ export function runId(): string {
   return RUN_ID;
 }
 
+/**
+ * Directory holding the telemetry state files (overridable for tests).
+ * Precedence: `PATTER_TELEMETRY_STATE_DIR` (used literally) →
+ * `$XDG_STATE_HOME/getpatter` (the XDG spec requires an app subdirectory —
+ * writing into the shared root collides with other tools) → `~/.getpatter`.
+ */
+function stateDir(): string {
+  const override = process.env.PATTER_TELEMETRY_STATE_DIR;
+  if (override && override.length > 0) return override;
+  const xdg = process.env.XDG_STATE_HOME;
+  if (xdg && xdg.length > 0) return path.join(xdg, 'getpatter');
+  return path.join(os.homedir(), '.getpatter');
+}
+
+/**
+ * Where pre-0.6.8 builds wrote state when `XDG_STATE_HOME` was set: the bare
+ * `$XDG_STATE_HOME` root (no `getpatter/` subdirectory). Existing installs must
+ * keep their id — and, critically, a persisted opt-out must keep being honored —
+ * so the readers below fall back here. `null` when no legacy location applies.
+ */
+function legacyStateDir(): string | null {
+  if (process.env.PATTER_TELEMETRY_STATE_DIR) return null;
+  const xdg = process.env.XDG_STATE_HOME;
+  return xdg && xdg.length > 0 ? xdg : null;
+}
+
 function statePath(): string {
-  const base = process.env.PATTER_TELEMETRY_STATE_DIR || process.env.XDG_STATE_HOME;
-  const root = base && base.length > 0 ? base : path.join(os.homedir(), '.getpatter');
-  return path.join(root, 'install-id');
+  return path.join(stateDir(), 'install-id');
 }
 
 /**
@@ -52,6 +76,31 @@ export function installId(): string {
     }
   } catch {
     // not present / unreadable — fall through to create one
+  }
+
+  const legacyDir = legacyStateDir();
+  if (legacyDir !== null) {
+    const legacy = path.join(legacyDir, 'install-id');
+    let existing = '';
+    try {
+      existing = fs.readFileSync(legacy, 'utf8').trim();
+    } catch {
+      existing = '';
+    }
+    if (HEX32.test(existing)) {
+      // Migrate the pre-0.6.8 id so the install keeps counting as one,
+      // preserving the file mtime that feeds daysSinceInstallBucket.
+      try {
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, existing, 'utf8');
+        const stat = fs.statSync(legacy);
+        fs.utimesSync(p, stat.atime, stat.mtime);
+      } catch {
+        /* best-effort */
+      }
+      cachedInstallId = existing;
+      return cachedInstallId;
+    }
   }
 
   const newId = randomUUID().replace(/-/g, '');
@@ -81,6 +130,16 @@ export function previousVersion(current: string): string {
     prev = fs.readFileSync(p, 'utf8').trim();
   } catch {
     prev = '';
+  }
+  if (prev === '') {
+    const legacyDir = legacyStateDir();
+    if (legacyDir !== null) {
+      try {
+        prev = fs.readFileSync(path.join(legacyDir, 'version'), 'utf8').trim();
+      } catch {
+        prev = '';
+      }
+    }
   }
   try {
     fs.mkdirSync(path.dirname(p), { recursive: true });
@@ -125,6 +184,15 @@ export function isFirstRun(): boolean {
   } catch {
     return false;
   }
+  const legacyDir = legacyStateDir();
+  if (legacyDir !== null) {
+    try {
+      // A pre-0.6.8 marker in the bare XDG root — never re-emit first_run.
+      if (fs.existsSync(path.join(legacyDir, 'first-run'))) return false;
+    } catch {
+      return false;
+    }
+  }
   try {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, '1', 'utf8');
@@ -144,7 +212,16 @@ function optOutPath(): string {
  */
 export function isOptedOut(): boolean {
   try {
-    return fs.existsSync(optOutPath());
+    if (fs.existsSync(optOutPath())) return true;
+  } catch {
+    /* fall through to the legacy check */
+  }
+  // Honor a marker written by pre-0.6.8 builds into the bare $XDG_STATE_HOME
+  // root: an opt-out must survive the state-dir move.
+  const legacyDir = legacyStateDir();
+  if (legacyDir === null) return false;
+  try {
+    return fs.existsSync(path.join(legacyDir, 'telemetry-disabled'));
   } catch {
     return false;
   }
@@ -165,6 +242,16 @@ export function setOptOut(disabled: boolean): void {
       fs.unlinkSync(p);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    // Also clear a pre-0.6.8 marker in the bare $XDG_STATE_HOME root —
+    // isOptedOut honors it, so leaving it behind would pin telemetry off.
+    const legacyDir = legacyStateDir();
+    if (legacyDir !== null) {
+      try {
+        fs.unlinkSync(path.join(legacyDir, 'telemetry-disabled'));
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
     }
   }
 }

--- a/libraries/typescript/tests/telemetry.test.ts
+++ b/libraries/typescript/tests/telemetry.test.ts
@@ -707,6 +707,88 @@ describe('[unit] deploy-shape + upgrade funnel (schema v4)', () => {
   });
 });
 
+describe('[unit] state-dir hardening (XDG subdir + legacy migration, 0.6.8)', () => {
+  let savedStateDir: string | undefined;
+  let savedXdg: string | undefined;
+
+  beforeEach(() => {
+    savedStateDir = process.env.PATTER_TELEMETRY_STATE_DIR;
+    savedXdg = process.env.XDG_STATE_HOME;
+  });
+  afterEach(() => {
+    if (savedStateDir === undefined) delete process.env.PATTER_TELEMETRY_STATE_DIR;
+    else process.env.PATTER_TELEMETRY_STATE_DIR = savedStateDir;
+    if (savedXdg === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = savedXdg;
+    vi.resetModules();
+  });
+
+  it('uses the getpatter subdirectory under XDG_STATE_HOME, never the shared root', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-xdg-'));
+    delete process.env.PATTER_TELEMETRY_STATE_DIR;
+    process.env.XDG_STATE_HOME = dir;
+    vi.resetModules();
+    const mod = await import('../src/telemetry/install-id');
+    const id = mod.installId();
+    expect(fs.readFileSync(path.join(dir, 'getpatter', 'install-id'), 'utf8').trim()).toBe(id);
+    expect(fs.existsSync(path.join(dir, 'install-id'))).toBe(false);
+  });
+
+  it('keeps and migrates a pre-0.6.8 install id from the bare XDG root', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-xdg-legacy-'));
+    delete process.env.PATTER_TELEMETRY_STATE_DIR;
+    process.env.XDG_STATE_HOME = dir;
+    const legacyId = 'ab'.repeat(16);
+    fs.writeFileSync(path.join(dir, 'install-id'), legacyId, 'utf8');
+    vi.resetModules();
+    const mod = await import('../src/telemetry/install-id');
+    expect(mod.installId()).toBe(legacyId); // no double-counted install
+    expect(
+      fs.readFileSync(path.join(dir, 'getpatter', 'install-id'), 'utf8').trim(),
+    ).toBe(legacyId);
+  });
+
+  it('honors a pre-0.6.8 opt-out marker in the bare XDG root; re-enable clears it', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-xdg-opt-'));
+    delete process.env.PATTER_TELEMETRY_STATE_DIR;
+    process.env.XDG_STATE_HOME = dir;
+    fs.writeFileSync(path.join(dir, 'telemetry-disabled'), '1', 'utf8');
+    vi.resetModules();
+    const mod = await import('../src/telemetry/install-id');
+    expect(mod.isOptedOut()).toBe(true); // consent survives the state-dir move
+    mod.setOptOut(false);
+    expect(mod.isOptedOut()).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'telemetry-disabled'))).toBe(false);
+  });
+
+  it('never re-emits first_run when the pre-0.6.8 marker exists', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-xdg-fr-'));
+    delete process.env.PATTER_TELEMETRY_STATE_DIR;
+    process.env.XDG_STATE_HOME = dir;
+    fs.writeFileSync(path.join(dir, 'first-run'), '1', 'utf8');
+    vi.resetModules();
+    const mod = await import('../src/telemetry/install-id');
+    expect(mod.isFirstRun()).toBe(false);
+  });
+});
+
+describe('[integration] telemetry — relay-cap chunking (0.6.8)', () => {
+  it('chunks a large flush to ≤64 events per POST, delivering everything', async () => {
+    enableTelemetryEnv();
+    const client = new TelemetryClient({ sdkVersion: '0.6.7', endpoint: collector.url });
+    for (let i = 0; i < 100; i++) client.record('cli_command', { cli_command: 'dashboard' });
+    await waitFor(collector, 100);
+    await client.close();
+
+    expect(collector.events).toHaveLength(100); // nothing truncated
+    const sizes = collector.requests
+      .filter((b): b is unknown[] => Array.isArray(b))
+      .map((b) => b.length);
+    expect(sizes.length).toBeGreaterThan(1);
+    expect(Math.max(...sizes)).toBeLessThanOrEqual(64);
+  });
+});
+
 describe('[unit] CLI usage + first-run + call funnel + opt-out (schema v5)', () => {
   it('is on schema v5', () => {
     expect(SCHEMA_VERSION).toBe(5);


### PR DESCRIPTION
## Summary
- Hardens the telemetry client in both SDKs against three issues surfaced by a best-practice audit of the live pipeline: flush batches larger than the collector's 64-event cap were silently truncated server-side; state files violated the XDG spec (written into the bare `$XDG_STATE_HOME` root) and a persisted opt-out could go unhonored across environment changes; the one-time Python disclosure notice was invisible by default.
- No new public API surface — behavior fixes only, identical in Python and TypeScript.

## Implementation
- **Relay-cap chunking** (`telemetry/client.py`, `telemetry/client.ts`): flushes now ship in chunks of ≤64 events per POST on both the async path and the exit-flush path (`_flush_sync` / chained flush). On failure the remaining chunks are dropped, never requeued — offline behavior stays identical to online.
- **XDG state dir** (`telemetry/install_id.py`, `telemetry/install-id.ts`): state files (`install-id`, `version`, `first-run`, `telemetry-disabled`) now live in `$XDG_STATE_HOME/getpatter/` (spec-compliant app subdirectory). The pre-existing legacy location (bare XDG root) is migrate-read: the install id is kept and migrated (mtime preserved so the install-age bucket survives), a legacy opt-out marker keeps disabling telemetry (and `telemetry enable` clears it), and a legacy first-run marker is never re-emitted. `PATTER_TELEMETRY_STATE_DIR` remains literal.
- **Visible Python disclosure** (`telemetry/client.py`): the one-time "anonymous telemetry is on" notice is written straight to stderr — it was previously `logging.info` with no handler attached, which Python's last-resort handler (WARNING+) swallows, so default installs never saw the opt-out notice. Matches the TypeScript console-backed behavior and the OSS norm (Next.js/Astro).
- 7 new Python tests + 5 new TypeScript tests (real local HTTP collector, real filesystem, no mocks beyond the network boundary per `authentic-tests.md`).
- Includes a merge of `main` (post-#172); the telemetry chain-guard from #172 and these changes touch disjoint regions and merged cleanly.

## Breaking change?
No. Paths only move when `XDG_STATE_HOME` is set, with full migrate-read of the legacy location; all other behavior is additive hardening.

## Test plan
- [x] Python: `pytest tests/` — 2655 passed (post-merge)
- [x] TypeScript: `npm test` (2101 passed) + `npm run lint` + `npm run build` (post-merge)
- [x] Parity: fixes implemented byte-equivalent in both SDKs, mirrored tests
- [ ] E2E smoke — N/A (no pipeline/handler changes)

## Docs updates
- `docs/telemetry.mdx` — install-id storage path now documents the XDG location