### PR TITLE
chore(release): 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.6.8 (2026-06-13)
+
 ### Added
 
 - **TypeScript: `EvalSession` — the eval harness now has full parity with
@@ -26,8 +28,6 @@
   Same defaults (`"cancel"` / `1500`); invalid modes are rejected with a
   `ValueError`. Opt-in — existing calls are unaffected.
   `libraries/python/getpatter/client.py`.
-
-### Added
 
 - **Telemetry: `call_uid` — a random per-call correlation id (schema v7).**
   `call_started` and `call_completed` of the same call now carry the same

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -20,7 +20,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.7"
+version = "0.6.8"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- Release **0.6.8** of both SDKs (Python `getpatter` on PyPI, TypeScript `getpatter` on npm).
- Bumps the four version literals and rolls the `CHANGELOG.md` `## Unreleased` block into `## 0.6.8 (2026-06-13)`.
- No code changes — every feature/fix shipping in 0.6.8 already landed on `main` via its own reviewed PR (#169, #172, #173, #175, #176, #178).

## Implementation
- Version bump (all four must move together, per the release rule):
  - `libraries/python/getpatter/__init__.py` -> `0.6.8`
  - `libraries/python/pyproject.toml` -> `0.6.8`
  - `libraries/typescript/package.json` -> `0.6.8`
  - `libraries/typescript/package-lock.json` -> `0.6.8` (root + `packages[""]`)
- `CHANGELOG.md`: `## Unreleased` -> `## 0.6.8 (2026-06-13)`, fresh empty `## Unreleased` on top, consolidated the two adjacent `### Added` groups into one.
- No deps added/removed.

### What ships in 0.6.8 (since v0.6.7)
- Multi-agent handoff, local recording, preemptive generation, semantic EOU + review-wave fixes across both SDKs (#169)
- Parity & bug-fix wave on the 0.6.6/0.6.7 features — `EvalSession` TS port, explicit-kwarg precedence, env-key path, telemetry chain guard (#172)
- Telemetry: relay-cap batch chunking, XDG state-dir compliance, visible Python disclosure (#173)
- Telemetry: `hermes`/`openclaw` CLI usage now visible (schema v6) (#175)
- Telemetry: `call_completed` delivered before process exit via `drain()` in `disconnect()` (#176)
- Telemetry: `call_uid` random per-call correlation id (schema v7) (#178)

## Breaking change?
No. All additions are opt-in; telemetry schema bumps (v6/v7) are backward-compatible (off-shape values coerced/dropped server-side, never breaking).

## Test plan
- [ ] Python: `pytest tests/` (CI: 3.11 / 3.12 / 3.13)
- [ ] TypeScript: `npm test` + `npm run lint` + `npm run build` (CI: Node 20 / 22)
- [ ] /parity-check clean
- [ ] E2E + security suites green

Bump-only commit (no source changes); CI is the authoritative gate. After merge: tag `v0.6.8` on `main` to trigger the automated release workflow (PyPI via OIDC, npm via token).

## Docs updates
- N/A (per-feature docs landed in their own PRs; this PR is version metadata + changelog only)