### PR TITLE
fix(telephony): inbound + handoff metadata parity (Plivo extra_headers, Telnyx client_state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 ## Unreleased
 
+### Added
+
+- **Opt-in `client_state` / `clientState` on the programmatic transfer
+  surface (Telnyx).** `CallControl.transfer(number, client_state="…")` (Python)
+  and `bridge.transferCall(callId, number, { clientState: "…" })` (TypeScript)
+  now forward an opaque context string that Telnyx base64-encodes and echoes on
+  the transferred leg's subsequent webhooks — so call context can survive a
+  handoff. Previously the underlying `_telnyx_transfer` / `TelnyxBridge`
+  capability was unreachable (no public option fed it). Optional with no
+  default → the cold-transfer request body stays byte-identical for callers
+  that don't set it, and carriers without the capability (Twilio/Plivo) ignore
+  it. The LLM `transfer_call` tool schema is unchanged (an opaque state string
+  is a developer concern, not an LLM one). `libraries/python/getpatter/models.py`
+  (`CallControl.transfer`, `_invoke_transfer_fn`);
+  `libraries/typescript/src/types.ts` (`TransferCallOptions`),
+  `libraries/typescript/src/server.ts` (`TelnyxBridge.transferCall`).
+
+### Fixed
+
+- **Plivo `extra_headers` are now exposed to the agent prompt and
+  `on_call_start` (parity with Twilio's `<Parameter>` customParameters).**
+  Developer-supplied headers delivered on the Plivo `start` frame were parsed
+  only for caller/callee recovery and otherwise dropped — `resolve_agent_prompt`
+  and the `on_call_start` callback both received an empty `custom_params`, so
+  `{placeholder}` template variables sourced from inbound metadata never
+  resolved on Plivo calls. They are now parsed unconditionally and forwarded as
+  `custom_params` (internal `X-PH-caller`/`X-PH-callee` markers re-exposed as
+  `caller`/`callee`). The TypeScript Plivo bridge never read `extra_headers` at
+  all; it now passes the same `customParams` into `handleCallStart`.
+  `libraries/python/getpatter/telephony/plivo.py`;
+  `libraries/typescript/src/providers/plivo-adapter.ts` (new
+  `parsePlivoExtraHeaders` / `plivoInboundCustomParams`),
+  `libraries/typescript/src/server.ts`.
+
 ## 0.6.8 (2026-06-13)
 
 ### Added

--- a/libraries/python/getpatter/models.py
+++ b/libraries/python/getpatter/models.py
@@ -979,15 +979,19 @@ async def _invoke_transfer_fn(
     *,
     mode: str = "cold",
     summary: str = "",
+    client_state: str | None = None,
 ) -> dict | None:
     """Invoke a telephony ``transfer_fn`` with warm-transfer kwargs when its
     signature accepts them.
 
-    Cold mode ALWAYS calls ``transfer_fn(number)`` positionally — byte-
-    identical to the historical contract for every callable (carrier
-    closures default ``mode="cold"`` themselves). Warm mode passes
-    ``mode`` / ``summary`` keywords when the callable's signature accepts
-    them (or absorbs ``**kwargs``); the built-in per-carrier transfer
+    Cold mode calls ``transfer_fn(number)`` positionally — byte-identical to
+    the historical contract for every callable (carrier closures default
+    ``mode="cold"`` themselves). When an opt-in ``client_state`` is supplied
+    AND the callable's signature accepts it (Telnyx), it is forwarded as a
+    keyword; legacy ``(number)``-only callables (Twilio/Plivo) are still
+    invoked positionally, so the historical contract is preserved. Warm mode
+    passes ``mode`` / ``summary`` keywords when the callable's signature
+    accepts them (or absorbs ``**kwargs``); the built-in per-carrier transfer
     functions return either a result dict (``{"status": "transferring",
     ...}`` / ``{"error": ...}``) or ``None``. A ``mode="warm"`` request
     against a legacy callable that only declares ``(number)`` returns a
@@ -1000,6 +1004,17 @@ async def _invoke_transfer_fn(
     if transfer_fn is None:
         return {"error": "transfer is not available on this call"}
     if mode == "cold":
+        if client_state is not None:
+            try:
+                sig = inspect.signature(transfer_fn)
+                accepts_client_state = "client_state" in sig.parameters or any(
+                    p.kind is inspect.Parameter.VAR_KEYWORD
+                    for p in sig.parameters.values()
+                )
+            except (TypeError, ValueError):  # pragma: no cover - exotic callables
+                accepts_client_state = False
+            if accepts_client_state:
+                return await transfer_fn(number, client_state=client_state)
         return await transfer_fn(number)
     if mode != "warm":
         # Never silently coerce an unknown mode into a blind redirect — the
@@ -1076,7 +1091,12 @@ class CallControl:
         return self._transferred.is_set() or self._hung_up.is_set()
 
     async def transfer(
-        self, number: str, *, mode: Literal["cold", "warm"] = "cold", summary: str = ""
+        self,
+        number: str,
+        *,
+        mode: Literal["cold", "warm"] = "cold",
+        summary: str = "",
+        client_state: str | None = None,
     ) -> dict | None:
         """Transfer the call to another phone number (E.164 format).
 
@@ -1089,6 +1109,11 @@ class CallControl:
                 now; other carriers return an error envelope).
             summary: Warm mode only — short handoff summary announced to the
                 human agent before the caller is bridged.
+            client_state: Optional opaque context string carried onto the
+                transferred leg (Telnyx only — base64-encoded and echoed on
+                that leg's subsequent webhooks). Ignored by carriers that do
+                not support it (Twilio/Plivo), preserving the historical
+                cold-transfer contract.
 
         Returns:
             ``None`` for a cold transfer (legacy contract), or a result dict
@@ -1100,7 +1125,11 @@ class CallControl:
             logger.warning("transfer() not available for this provider mode")
             return None
         result = await _invoke_transfer_fn(
-            self._transfer_fn, number, mode=mode, summary=summary
+            self._transfer_fn,
+            number,
+            mode=mode,
+            summary=summary,
+            client_state=client_state,
         )
         if not (isinstance(result, dict) and result.get("error")):
             self._transferred.set()

--- a/libraries/python/getpatter/telephony/plivo.py
+++ b/libraries/python/getpatter/telephony/plivo.py
@@ -392,12 +392,24 @@ async def plivo_stream_bridge(
                 stream_id = start_data.get("streamId", "")
                 media_format = start_data.get("mediaFormat", {}) or {}
 
+                # Parse extra_headers once: caller / callee recovery + custom
+                # template variables. Plivo echoes the ``<Stream
+                # extraHeaders="...">`` payload back on the start frame.
+                hdrs = _parse_plivo_extra_headers(data.get("extra_headers", ""))
                 # Recover caller / callee: query string first (Plivo preserves
                 # it on the Stream URL), then the ``extra_headers`` fallback.
                 if not caller or not callee:
-                    hdrs = _parse_plivo_extra_headers(data.get("extra_headers", ""))
                     caller = caller or hdrs.get("X-PH-caller", "")
                     callee = callee or hdrs.get("X-PH-callee", "")
+                # Build custom_params from extra_headers — Plivo's metadata
+                # channel, mirroring Twilio's ``<Parameter>`` customParameters:
+                # developer-supplied headers become prompt template variables.
+                # The internal X-PH-caller / X-PH-callee markers are re-exposed
+                # under the canonical caller / callee keys (Twilio parity).
+                custom_params: dict = {"caller": caller, "callee": callee}
+                for _hk, _hv in hdrs.items():
+                    if _hk not in ("X-PH-caller", "X-PH-callee"):
+                        custom_params[_hk] = _hv
 
                 _mode = (
                     f"engine={getattr(agent, 'provider', 'unknown')}"
@@ -429,7 +441,7 @@ async def plivo_stream_bridge(
                             "caller": caller,
                             "callee": callee,
                             "direction": "inbound",
-                            "custom_params": {},
+                            "custom_params": custom_params,
                             "telephony_provider": "plivo",
                         }
                     )
@@ -451,7 +463,7 @@ async def plivo_stream_bridge(
                     except Exception as _exc:
                         logger.warning("Could not start recording: %s", _exc)
 
-                resolved_prompt = resolve_agent_prompt(agent, {})
+                resolved_prompt = resolve_agent_prompt(agent, custom_params)
                 provider = getattr(agent, "provider", "openai_realtime")
 
                 metrics = create_metrics_accumulator(
@@ -475,7 +487,9 @@ async def plivo_stream_bridge(
                 )
 
                 # --- Plivo-specific call control helpers ---
-                async def _plivo_transfer(number, *, mode: str = "cold", summary: str = ""):
+                async def _plivo_transfer(
+                    number, *, mode: str = "cold", summary: str = ""
+                ):
                     # ``mode="warm"`` is NOT yet implemented on Plivo — the
                     # MPC (multi-party call) flow needs participant-role
                     # coordination the bridge does not plumb today. A clear

--- a/libraries/python/tests/unit/test_plivo_handler_unit.py
+++ b/libraries/python/tests/unit/test_plivo_handler_unit.py
@@ -431,3 +431,70 @@ async def test_bridge_media_and_playedstream_and_dtmf(
     mock_handler.on_mark.assert_awaited_once_with("audio_1")
     mock_handler.on_dtmf.assert_awaited_once_with("7")
     assert "[DTMF: 7]" in on_transcript.call_args[0][0]["text"]
+
+
+def _start_message_with_headers(
+    extra_headers: str, call_id: str = "CU" + "a" * 30, stream_id: str = "ST1"
+) -> str:
+    """A Plivo ``start`` frame carrying the ``extra_headers`` field that Plivo
+    echoes back from the ``<Stream extraHeaders="...">`` TwiML attribute."""
+    return json.dumps(
+        {
+            "event": "start",
+            "start": {
+                "callId": call_id,
+                "streamId": stream_id,
+                "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000},
+            },
+            "extra_headers": extra_headers,
+        }
+    )
+
+
+@patch("getpatter.telephony.plivo.OpenAIRealtimeStreamHandler")
+@patch("getpatter.telephony.plivo.create_metrics_accumulator")
+@patch("getpatter.telephony.plivo.fetch_deepgram_cost", new_callable=AsyncMock)
+async def test_bridge_extra_headers_populate_custom_params_and_prompt(
+    mock_fetch_dg, mock_create_metrics, mock_handler_cls
+):
+    """Developer-supplied Plivo ``extra_headers`` must reach both the
+    ``on_call_start`` callback (as ``custom_params``) and the resolved system
+    prompt (as ``{placeholder}`` template variables) — parity with Twilio's
+    ``<Parameter>`` customParameters channel. ``resolve_agent_prompt`` is run
+    for real (it is the SDK's own template engine, not an external boundary)."""
+    from getpatter.telephony.plivo import plivo_stream_bridge
+
+    ws = _make_mock_ws(
+        [
+            _start_message_with_headers("customer_id=VIP42,ticket=T7"),
+            json.dumps({"event": "stop"}),
+        ]
+    )
+    mock_handler = AsyncMock()
+    mock_handler.audio_sender = None
+    mock_handler_cls.return_value = mock_handler
+    mock_create_metrics.return_value = MagicMock()
+    on_call_start = AsyncMock(return_value=None)
+
+    agent = make_agent(
+        provider="openai_realtime",
+        system_prompt="Greet {customer_id} about ticket {ticket}.",
+    )
+
+    await plivo_stream_bridge(
+        websocket=ws,
+        agent=agent,
+        openai_key="sk-test",
+        on_call_start=on_call_start,
+        on_call_end=AsyncMock(),
+    )
+
+    # on_call_start sees the parsed headers as custom_params (was {} before).
+    payload = on_call_start.call_args[0][0]
+    assert payload["custom_params"]["customer_id"] == "VIP42"
+    assert payload["custom_params"]["ticket"] == "T7"
+
+    # The resolved prompt substituted the header-derived template variables.
+    resolved = mock_handler_cls.call_args.kwargs["resolved_prompt"]
+    assert "VIP42" in resolved
+    assert "T7" in resolved

--- a/libraries/python/tests/unit/test_warm_transfer_unit.py
+++ b/libraries/python/tests/unit/test_warm_transfer_unit.py
@@ -21,7 +21,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from tests.conftest import make_agent
-from tests.unit.test_twilio_bridge_unit import _make_mock_ws, _start_message, _stop_message
+from tests.unit.test_twilio_bridge_unit import (
+    _make_mock_ws,
+    _start_message,
+    _stop_message,
+)
 
 CALL_SID = "CA" + "a" * 32
 ACCOUNT_SID = "AC" + "0" * 32
@@ -284,9 +288,7 @@ async def _capture_twilio_transfer_fn(**bridge_kwargs):
         patch("getpatter.telephony.twilio.OpenAIRealtimeStreamHandler") as handler_cls,
         patch("getpatter.telephony.twilio.create_metrics_accumulator") as metrics,
         patch("getpatter.telephony.twilio.resolve_agent_prompt", return_value="p"),
-        patch(
-            "getpatter.telephony.twilio.fetch_deepgram_cost", new_callable=AsyncMock
-        ),
+        patch("getpatter.telephony.twilio.fetch_deepgram_cost", new_callable=AsyncMock),
     ):
         handler = AsyncMock()
         handler.audio_sender = None
@@ -454,6 +456,76 @@ class TestTelnyxPlivoWarmUnsupported:
         http.post.assert_not_awaited()
 
 
+@pytest.mark.unit
+@pytest.mark.mocked
+class TestTelnyxClientStateTransfer:
+    """Telnyx cold transfer can carry an opt-in ``client_state`` that Telnyx
+    base64-encodes and echoes on the transferred leg's webhooks. Mocks ONLY
+    the carrier REST boundary (``httpx``)."""
+
+    async def _capture_telnyx_transfer_fn(self):
+        from getpatter.telephony.telnyx import telnyx_stream_bridge
+
+        ws = AsyncMock()
+        ws.accept = AsyncMock()
+        ws.query_params = {"caller": "+15551234567", "callee": "+15559876543"}
+        start = json.dumps(
+            {
+                "event": "start",
+                "stream_id": "s1",
+                "start": {"call_control_id": "cc-123", "media_format": {}},
+            }
+        )
+        stop = json.dumps({"event": "stop"})
+        ws.receive_text = AsyncMock(side_effect=[start, stop, Exception("stop")])
+        ws.send_text = AsyncMock()
+
+        with (
+            patch(
+                "getpatter.telephony.telnyx.OpenAIRealtimeStreamHandler"
+            ) as handler_cls,
+            patch("getpatter.telephony.telnyx.create_metrics_accumulator") as metrics,
+            patch("getpatter.telephony.telnyx.resolve_agent_prompt", return_value="p"),
+            patch(
+                "getpatter.telephony.telnyx.fetch_deepgram_cost",
+                new_callable=AsyncMock,
+            ),
+        ):
+            handler = AsyncMock()
+            handler.audio_sender = None
+            handler.stt = None
+            handler_cls.return_value = handler
+            metrics.return_value = MagicMock()
+            await telnyx_stream_bridge(
+                websocket=ws,
+                agent=make_agent(provider="openai_realtime"),
+                openai_key="sk-test",
+                telnyx_key="key-test",
+            )
+            return handler_cls.call_args.kwargs["transfer_fn"]
+
+    @pytest.mark.asyncio
+    async def test_cold_without_client_state_posts_bare_to(self) -> None:
+        transfer_fn = await self._capture_telnyx_transfer_fn()
+        http = _mock_http()
+        with patch("httpx.AsyncClient", return_value=http):
+            await transfer_fn("+15550001111")
+        assert http.post.await_count == 1
+        assert http.post.await_args_list[0].kwargs["json"] == {"to": "+15550001111"}
+
+    @pytest.mark.asyncio
+    async def test_cold_with_client_state_base64_encodes_into_body(self) -> None:
+        import base64
+
+        transfer_fn = await self._capture_telnyx_transfer_fn()
+        http = _mock_http()
+        with patch("httpx.AsyncClient", return_value=http):
+            await transfer_fn("+15550001111", client_state="customer_id=VIP42")
+        body = http.post.await_args_list[0].kwargs["json"]
+        assert body["to"] == "+15550001111"
+        assert base64.b64decode(body["client_state"]).decode() == "customer_id=VIP42"
+
+
 # ---------------------------------------------------------------------------
 # Pipeline built-in transfer handler — mode plumbing
 # ---------------------------------------------------------------------------
@@ -608,6 +680,41 @@ class TestCallControlTransferModes:
         control = _make_call_control(legacy)
         result = await control.transfer("+14155551234")
         assert result is None  # legacy contract
+        assert called == ["+14155551234"]
+        assert control.is_transferred is True
+
+    @pytest.mark.asyncio
+    async def test_cold_client_state_threaded_to_capable_fn(self) -> None:
+        """``client_state`` is forwarded on a cold transfer to a carrier fn
+        whose signature accepts it (Telnyx)."""
+        seen: list = []
+
+        async def capable(number, *, mode="cold", summary="", client_state=None):
+            seen.append((number, client_state))
+
+        control = _make_call_control(capable)
+        result = await control.transfer(
+            "+14155551234", client_state="customer_id=VIP42"
+        )
+        assert result is None  # cold contract
+        assert seen == [("+14155551234", "customer_id=VIP42")]
+        assert control.is_transferred is True
+
+    @pytest.mark.asyncio
+    async def test_cold_client_state_ignored_by_legacy_fn(self) -> None:
+        """A legacy ``(number)``-only carrier fn (Twilio/Plivo) must still be
+        called positionally when ``client_state`` is supplied — byte-identical
+        to the historical contract, no crash."""
+        called: list = []
+
+        async def legacy(number):
+            called.append(number)
+
+        control = _make_call_control(legacy)
+        result = await control.transfer(
+            "+14155551234", client_state="customer_id=VIP42"
+        )
+        assert result is None
         assert called == ["+14155551234"]
         assert control.is_transferred is True
 

--- a/libraries/typescript/src/providers/plivo-adapter.ts
+++ b/libraries/typescript/src/providers/plivo-adapter.ts
@@ -17,6 +17,71 @@ import { getLogger } from '../logger';
 const PLIVO_API_BASE = 'https://api.plivo.com/v1';
 
 /**
+ * Parse Plivo's ``extra_headers`` start-frame field into a record.
+ *
+ * Plivo echoes the ``<Stream extraHeaders="...">`` payload back on the
+ * ``start`` frame in one of several shapes. Port of Python's
+ * ``_parse_plivo_extra_headers``:
+ *   - JSON object — ``{"key": "value"}``
+ *   - Plivo brace form — ``{key: value, key2: value2}``
+ *   - Delimited pairs — ``k=v;k2=v2`` or ``k=v,k2=v2``
+ */
+export function parsePlivoExtraHeaders(raw: string): Record<string, string> {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return {};
+  const headers: Record<string, string> = {};
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const out: Record<string, string> = {};
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+          out[String(k)] = String(v);
+        }
+        return out;
+      }
+    } catch {
+      /* fall through to the brace form below */
+    }
+    const inner = trimmed.replace(/^\{+/, '').replace(/\}+$/, '');
+    for (const part of inner.split(',')) {
+      const idx = part.indexOf(':');
+      if (idx !== -1) {
+        headers[part.slice(0, idx).trim()] = part.slice(idx + 1).trim();
+      }
+    }
+    return headers;
+  }
+  for (const part of trimmed.replace(/;/g, ',').split(',')) {
+    const idx = part.indexOf('=');
+    if (idx !== -1) {
+      headers[part.slice(0, idx).trim()] = part.slice(idx + 1).trim();
+    }
+  }
+  return headers;
+}
+
+/**
+ * Build the inbound ``customParams`` for a Plivo call from its ``extra_headers``
+ * — Plivo's metadata channel, mirroring Twilio's ``<Parameter>``
+ * customParameters. Developer-supplied headers become prompt template
+ * variables; the internal ``X-PH-caller`` / ``X-PH-callee`` markers are
+ * re-exposed under the canonical ``caller`` / ``callee`` keys (Twilio parity).
+ */
+export function plivoInboundCustomParams(
+  extraHeadersRaw: string,
+  caller: string,
+  callee: string,
+): Record<string, string> {
+  const headers = parsePlivoExtraHeaders(extraHeadersRaw);
+  const params: Record<string, string> = { caller, callee };
+  for (const [k, v] of Object.entries(headers)) {
+    if (k !== 'X-PH-caller' && k !== 'X-PH-callee') params[k] = v;
+  }
+  return params;
+}
+
+/**
  * Speak a voicemail message on a machine-answered Plivo call, then hang up.
  *
  * Mirrors Python's ``handle_amd_result`` in ``telephony/plivo.py``. Uses

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -13,7 +13,7 @@ import type { TelemetryClient } from './telemetry/client';
 import { OpenAIRealtimeAdapter } from './providers/openai-realtime';
 import { OpenAIRealtime2Adapter } from './providers/openai-realtime-2';
 import { ElevenLabsConvAIAdapter } from './providers/elevenlabs-convai';
-import { PlivoAdapter, dropPlivoVoicemail } from './providers/plivo-adapter';
+import { PlivoAdapter, dropPlivoVoicemail, plivoInboundCustomParams } from './providers/plivo-adapter';
 import { TwilioAdapter } from './providers/twilio-adapter';
 import { PlivoBridge, classifyPlivoAmd, validatePlivoSignature } from './telephony/plivo';
 // Re-export so existing imports from './server' keep working after the
@@ -977,10 +977,17 @@ export class TelnyxBridge implements TelephonyBridge {
       return;
     }
     const telnyxKey = this.config.telnyxKey ?? '';
+    // Opt-in client_state: an opaque context string Telnyx base64-encodes and
+    // echoes on the transferred leg's subsequent webhooks. Omitted by default
+    // so the request body stays byte-identical to the historical contract.
+    const body: Record<string, string> = { to: toNumber };
+    if (options?.clientState) {
+      body.client_state = Buffer.from(options.clientState, 'utf-8').toString('base64');
+    }
     await fetch(`https://api.telnyx.com/v2/calls/${encodeURIComponent(callId)}/actions/transfer`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${telnyxKey}` },
-      body: JSON.stringify({ to: toNumber }),
+      body: JSON.stringify(body),
     });
     getLogger().info(`Telnyx call transferred to ${toNumber}`);
   }
@@ -3120,6 +3127,7 @@ export class EmbeddedServer {
         let data: {
           event?: string;
           start?: { callId?: string; streamId?: string; mediaFormat?: { encoding?: string; sampleRate?: number } };
+          extra_headers?: string;
           media?: { payload?: string };
           dtmf?: { digit?: string };
           name?: string;
@@ -3139,7 +3147,11 @@ export class EmbeddedServer {
           handler.setStreamSid(data.start?.streamId ?? '');
           const callId = data.start?.callId ?? '';
           if (callId) this.activeCallIds.set(ws, callId);
-          await handler.handleCallStart(callId);
+          // Plivo's extra_headers are the metadata channel mirroring Twilio's
+          // <Parameter> customParameters: developer-supplied headers become
+          // prompt template variables. Without this they were silently dropped.
+          const customParams = plivoInboundCustomParams(data.extra_headers ?? '', caller, callee);
+          await handler.handleCallStart(callId, customParams);
           // ``recording: true`` parity: Python's Plivo bridge starts the
           // recording here; the generic Twilio-credential-gated helper never
           // covered Plivo, so the flag silently no-op'd in TS.

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -326,6 +326,13 @@ export interface TransferCallOptions {
    * before the caller is bridged (who is calling and what they need).
    */
   readonly summary?: string;
+  /**
+   * Optional opaque context string carried onto the transferred leg
+   * (Telnyx only — base64-encoded and echoed on that leg's subsequent
+   * webhooks). Ignored by carriers that do not support it (Twilio/Plivo),
+   * preserving the historical cold-transfer contract.
+   */
+  readonly clientState?: string;
 }
 
 /**

--- a/libraries/typescript/tests/plivo.test.ts
+++ b/libraries/typescript/tests/plivo.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { PlivoBridge } from '../src/server';
 import type { LocalConfig } from '../src/server';
 import { Carrier as Plivo, validatePlivoSignature } from '../src/telephony/plivo';
-import { PlivoAdapter } from '../src/providers/plivo-adapter';
+import { PlivoAdapter, parsePlivoExtraHeaders, plivoInboundCustomParams } from '../src/providers/plivo-adapter';
 import crypto from 'node:crypto';
 import { DEFAULT_PRICING, calculateTelephonyCost } from '../src/pricing';
 
@@ -238,5 +238,66 @@ describe('Plivo pricing', () => {
   it('rounds partial minutes up like Twilio', () => {
     // 61 s → 2 minutes → 2 * 0.0055
     expect(calculateTelephonyCost('plivo', 61, DEFAULT_PRICING)).toBeCloseTo(0.011, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extra_headers → custom params (parity with Twilio <Parameter> channel)
+// ---------------------------------------------------------------------------
+
+describe('parsePlivoExtraHeaders', () => {
+  it('parses a JSON object', () => {
+    expect(parsePlivoExtraHeaders('{"customer_id":"VIP42","ticket":"T7"}')).toEqual({
+      customer_id: 'VIP42',
+      ticket: 'T7',
+    });
+  });
+
+  it('parses the Plivo brace form', () => {
+    expect(parsePlivoExtraHeaders('{customer_id: VIP42, ticket: T7}')).toEqual({
+      customer_id: 'VIP42',
+      ticket: 'T7',
+    });
+  });
+
+  it('parses delimited key=value pairs with , or ;', () => {
+    expect(parsePlivoExtraHeaders('customer_id=VIP42;ticket=T7')).toEqual({
+      customer_id: 'VIP42',
+      ticket: 'T7',
+    });
+  });
+
+  it('returns an empty record for blank input', () => {
+    expect(parsePlivoExtraHeaders('')).toEqual({});
+    expect(parsePlivoExtraHeaders('   ')).toEqual({});
+  });
+});
+
+describe('plivoInboundCustomParams', () => {
+  it('exposes developer headers as template variables alongside caller/callee', () => {
+    const params = plivoInboundCustomParams(
+      'customer_id=VIP42,ticket=T7',
+      '+15551234567',
+      '+15559876543',
+    );
+    expect(params).toEqual({
+      caller: '+15551234567',
+      callee: '+15559876543',
+      customer_id: 'VIP42',
+      ticket: 'T7',
+    });
+  });
+
+  it('drops the internal X-PH-caller/X-PH-callee markers (re-exposed as caller/callee)', () => {
+    const params = plivoInboundCustomParams(
+      'X-PH-caller=+15551234567,X-PH-callee=+15559876543,segment=gold',
+      '+15551234567',
+      '+15559876543',
+    );
+    expect(params).toEqual({
+      caller: '+15551234567',
+      callee: '+15559876543',
+      segment: 'gold',
+    });
   });
 });

--- a/libraries/typescript/tests/warm-transfer.mocked.test.ts
+++ b/libraries/typescript/tests/warm-transfer.mocked.test.ts
@@ -338,6 +338,22 @@ describe('[mocked] Telnyx / Plivo warm transfer unsupported', () => {
     const [url] = fetchSpy.mock.calls[0] as [string];
     expect(url).toBe('https://api.telnyx.com/v2/calls/cc-123/actions/transfer');
   });
+
+  it('TelnyxBridge cold transfer without clientState posts a bare { to } body', async () => {
+    const bridge = new TelnyxBridge(makeConfig({ telephonyProvider: 'telnyx', telnyxKey: 'key' }));
+    await bridge.transferCall('cc-123', '+15550001111');
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({ to: '+15550001111' });
+  });
+
+  it('TelnyxBridge cold transfer base64-encodes an opt-in clientState into the body', async () => {
+    const bridge = new TelnyxBridge(makeConfig({ telephonyProvider: 'telnyx', telnyxKey: 'key' }));
+    await bridge.transferCall('cc-123', '+15550001111', { clientState: 'customer_id=VIP42' });
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as { to: string; client_state?: string };
+    expect(body.to).toBe('+15550001111');
+    expect(Buffer.from(body.client_state ?? '', 'base64').toString('utf-8')).toBe('customer_id=VIP42');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes two SDK-parity bugs in how call context flows through the telephony layer: inbound metadata on Plivo, and context-on-handoff for Telnyx transfers.
- Both land in **both** SDKs (Python + TypeScript) with authentic tests.

## Implementation
- **Plivo `extra_headers` → prompt + `on_call_start` (Fixed).** Headers on the Plivo `start` frame were parsed only for caller/callee recovery and otherwise dropped, so `resolve_agent_prompt` and `on_call_start` both received an empty `custom_params` — `{placeholder}` variables sourced from inbound metadata never resolved on Plivo. Now parsed unconditionally and forwarded as `custom_params` (internal `X-PH-caller`/`X-PH-callee` markers re-exposed as `caller`/`callee`), matching Twilio's `<Parameter>` channel. The TypeScript Plivo bridge never read `extra_headers` at all; it now passes the same `customParams` into `handleCallStart`.
  - `libraries/python/getpatter/telephony/plivo.py`
  - `libraries/typescript/src/providers/plivo-adapter.ts` (new `parsePlivoExtraHeaders` / `plivoInboundCustomParams`), `libraries/typescript/src/server.ts`
- **Telnyx transfer `client_state` (Added, opt-in).** The capability existed at the adapter layer in both SDKs but was unreachable (no public option fed it). Exposed as an opt-in `client_state` / `clientState` on the programmatic transfer surface (`CallControl.transfer` / `TransferCallOptions` → `TelnyxBridge.transferCall`), base64-encoded into the transfer body so call context can survive a handoff. Optional with no default → the cold-transfer request body stays byte-identical for callers that don't set it; Twilio/Plivo ignore it; the LLM `transfer_call` tool schema is unchanged (an opaque state string is a developer concern, not an LLM one).
  - `libraries/python/getpatter/models.py` (`CallControl.transfer`, `_invoke_transfer_fn`)
  - `libraries/typescript/src/types.ts` (`TransferCallOptions`), `libraries/typescript/src/server.ts` (`TelnyxBridge.transferCall`)
- No dependencies added/removed.

## Breaking change?
No. Both changes are opt-in and backward compatible: Plivo behaviour only gains previously-dropped data; the new `clientState` transfer option is optional with no default, so the cold-transfer request body is byte-identical when unset.

## Test plan
- [x] Python: `pytest tests/` — 2664 passed, 8 skipped, 2 xfailed
- [x] TypeScript: `npm test` (2112 passed, 9 skipped) + `npm run lint` (clean) + `npm run build` (success)
- [ ] /parity-check clean
- [ ] E2E smoke (n/a — no pipeline/handler control-flow change)

Tests are authentic: real Plivo `start`-frame parsing, real prompt resolution, carrier REST mocked only at the `fetch`/`httpx` boundary. Added: `test_plivo_handler_unit.py`, `test_warm_transfer_unit.py` (Python); `plivo.test.ts`, `warm-transfer.mocked.test.ts` (TypeScript).

## Docs updates
N/A in this PR (the new opt-in `clientState` transfer option could get a one-line mention in the transfer docs as a follow-up).
