### PR TITLE
feat(telemetry): activation + reliability signals (schema v8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 ## Unreleased
 
+### Added
+
+- **Telemetry: `config_incomplete` — activation-blocker signal.** A new event
+  emitted at most once per `Patter` instance when required runtime config is
+  missing so the instance/agent cannot proceed. It carries a single coarse enum
+  dimension `missing` (`carrier_credentials` / `llm_key` / `engine_config` /
+  `other`) naming *what* is absent — never the key value, env var name, carrier
+  credentials, or any PII. Emitted immediately before the existing validation
+  error at each blocker site: a carrier with no phone number (and, in TypeScript,
+  a missing `phoneNumber` / `carrier`) → `carrier_credentials`; OpenAI Realtime
+  mode with no API key → `llm_key`; an incomplete pipeline/engine config (Python
+  pipeline with no STT; TypeScript unknown-engine and invalid-provider) →
+  `engine_config`. Fire-and-forget: it can never throw into, block, or alter the
+  call/control flow — the original error propagates unchanged. In the
+  never-sampled set, so it is always delivered when telemetry is enabled and
+  emits nothing on opt-out. `libraries/python/getpatter/client.py`,
+  `libraries/typescript/src/client.ts`. Parity across both SDKs.
+
+- **`PATTER_TELEMETRY_SAMPLE` — client-side downsampling of high-frequency call
+  telemetry.** New env var, a float in `[0, 1]` read once at telemetry-client
+  construction (Python `getpatter/telemetry/env.py` `sample_rate()` /
+  `getpatter/telemetry/client.py`; TypeScript `src/telemetry/env.ts`
+  `sampleRate()` / `src/telemetry/client.ts`). Defaults to `1.0` (no sampling —
+  every event kept); a missing, empty, non-numeric, `< 0`, or `> 1` value fails
+  safe back to `1.0` and never raises, so a misconfigured env can never silently
+  drop data. The gate applies ONLY to the high-frequency `call_started` /
+  `call_completed` events; `first_run`, `config_incomplete`, `sdk_initialized`,
+  `cli_command`, `feature_used`, `agent_configured`, and any error
+  `call_completed` (`outcome == "error"` or an `error_code` present) are always
+  delivered regardless of rate. The keep/drop decision is **deterministic per
+  run** — derived from a SHA-256 hash of the per-process `run_id` — so a whole
+  run consistently keeps or drops its sampleable call events rather than flipping
+  a per-event coin (which would bias short runs). When a sampled call event is
+  kept at a rate `< 1.0`, the event carries a `sample_rate` dimension so
+  analytics can extrapolate true volume with weight `1 / sample_rate`; at rate
+  `1.0` no `sample_rate` is stamped (payloads stay lean). Lets future
+  high-volume installs cut telemetry egress without losing extrapolation
+  accuracy. Opt-in, additive, parity across both SDKs.
+
+- **Telemetry: per-stage latency on `call_completed`.** The existing
+  `call_completed` event now carries up to four whole-millisecond latency dims
+  read straight off the per-call metrics accumulator (`CallMetrics.latency_p95`,
+  the same source as `latency_ms`): `stt_latency_ms` (`LatencyBreakdown.stt_ms`),
+  `llm_ttft_ms` (`llm_ttft_ms`), `tts_first_byte_ms` (`tts_ms`), and
+  `eou_latency_ms` (`endpoint_ms`). Read-only — no new audio-path
+  instrumentation. A dim is omitted (never sent as `0`) when its stage didn't
+  run, so realtime/convai engines naturally drop `stt_latency_ms` /
+  `tts_first_byte_ms`. `libraries/python/getpatter/telemetry/call_metrics.py`,
+  `libraries/typescript/src/telemetry/call-metrics.ts`.
+
+- **Telemetry: `error_layer` + `disconnect_reason` on `call_completed`.**
+  `error_layer` (`stt`/`llm`/`tts`/`carrier`/`config`/`internal`/`none`/`other`)
+  is derived deterministically from the existing `CallMetrics.error_code` (never
+  the message); `none` on a clean completion. `disconnect_reason`
+  (`error`/`timeout`/`no_answer`/`busy`/`completed`/`other`) is derived from the
+  terminal outcome plus the error code. These populate the previously
+  under-filled error taxonomy from state already known at call end.
+  `libraries/python/getpatter/telemetry/call_metrics.py`,
+  `libraries/typescript/src/telemetry/call-metrics.ts`.
+
+- **Telemetry: `time_to_first_call_bucket` on `call_started` and
+  `call_completed`.** A coarse activation-funnel band
+  (`lt_1h`/`1h_1d`/`1d_7d`/`gt_7d`/`unknown`) computed from the install-id file
+  mtime via a new public `install_age_seconds()` / `installAgeSeconds()` helper
+  (`getpatter/telemetry/install_id.py` / `src/telemetry/install-id.ts`), reusing
+  the same mtime seam as `days_since_install_bucket`. Read-only and best-effort —
+  `unknown` on a read-only / unreadable filesystem.
+
+### Changed
+
+- **Telemetry `SCHEMA_VERSION` bumped 7 → 8** for the new `config_incomplete`
+  event, the per-stage latency / `error_layer` / `disconnect_reason` /
+  `time_to_first_call_bucket` dimensions, and the `sample_rate` dimension added
+  by client-side sampling. The relay applies version-appropriate validation off
+  this number, so it moves in lockstep across both SDKs
+  (`libraries/python/getpatter/telemetry/events.py`,
+  `libraries/typescript/src/telemetry/events.ts`). No payload a v7 consumer
+  understood was removed or renamed — all changes are additive.
+
 ## 0.6.8 (2026-06-13)
 
 ### Added

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -405,9 +405,22 @@ class Patter:
             plivo_auth_id = carrier_creds["auth_id"]
             plivo_auth_token = carrier_creds["auth_token"]
 
+        # --- Anonymous usage telemetry (opt-out, default ON) ---
+        # Constructed BEFORE the activation-blocker validation below so the
+        # ``config_incomplete`` signal can be emitted on the failing path. Separate
+        # from getpatter.observability (user-facing OTel). Fire-and-forget and
+        # fail-safe: it can never block or break a call. Disable with
+        # PATTER_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, or telemetry=False.
+        self._telemetry = _build_telemetry_client(telemetry)
+        self._telemetry_seen_engines: set[str] = set()
+        self._telemetry_seen_agent_shapes: set[tuple] = set()
+        # Activation-blocker signal is emitted at most once per instance.
+        self._telemetry_config_incomplete_emitted = False
+
         # --- Local mode validation (only when a carrier is provided) ---
         if carrier_kind is not None:
             if not phone_number:
+                self._record_config_incomplete("carrier_credentials")
                 raise ValueError(
                     "Local mode requires phone_number (e.g., phone_number='+15550001234')."
                 )
@@ -426,13 +439,9 @@ class Patter:
             persist_root=_resolve_persist_root(persist),
         )
 
-        # --- Anonymous usage telemetry (opt-out, default ON) ---
-        # Separate from getpatter.observability (user-facing OTel). Fire-and-forget
-        # and fail-safe: it can never block or break a call. Disable with
-        # PATTER_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, or telemetry=False.
-        self._telemetry = _build_telemetry_client(telemetry)
-        self._telemetry_seen_engines: set[str] = set()
-        self._telemetry_seen_agent_shapes: set[tuple] = set()
+        # The telemetry client + dedup state were constructed above (before the
+        # activation-blocker validation) so ``config_incomplete`` could be emitted
+        # on the failing path. Here we emit the normal startup events.
         # Environment dims only when telemetry is ENABLED: the helper's
         # ``previous_version`` probe writes ``~/.getpatter/version`` (and
         # ``days_since_install_bucket`` mkdirs the state root), violating the
@@ -1211,7 +1220,11 @@ class Patter:
             "_prewarmed_conn_tasks",
         ):
             mapping = getattr(self, attr, None)
-            if isinstance(mapping, dict) and old_id in mapping and new_id not in mapping:
+            if (
+                isinstance(mapping, dict)
+                and old_id in mapping
+                and new_id not in mapping
+            ):
                 mapping[new_id] = mapping.pop(old_id)
 
     def pop_prewarmed_connections(self, call_id: str) -> dict[str, Any] | None:
@@ -1667,6 +1680,26 @@ class Patter:
             f"or None; got {type(tts).__name__}"
         )
 
+    def _record_config_incomplete(self, missing: str) -> None:
+        """Emit the activation-blocker ``config_incomplete`` signal, at most once.
+
+        Fire-and-forget: this records the coarse ``missing`` category right before
+        a validation ``raise`` and then lets that error propagate unchanged. It
+        NEVER throws and NEVER alters control flow. Deduped per instance so a retry
+        loop or a second ``agent()`` call on the same Patter cannot double-emit.
+        Only the allowlisted enum leaves the process — never the key value, env var
+        name, carrier credentials, or any PII. ``config_incomplete`` is in the
+        never-sampled set, so the telemetry client always delivers it.
+        """
+        try:
+            if self._telemetry_config_incomplete_emitted:
+                return
+            self._telemetry_config_incomplete_emitted = True
+            self._telemetry.record("config_incomplete", missing=missing)
+        except Exception:
+            # Telemetry must never break construction or agent setup.
+            pass
+
     def agent(
         self,
         system_prompt: str,
@@ -1977,6 +2010,7 @@ class Patter:
                     self._local_config, openai_key=_env_openai_key
                 )
             else:
+                self._record_config_incomplete("llm_key")
                 raise ValueError(
                     "OpenAI Realtime mode requires an OpenAI API key. Pass "
                     "engine=OpenAIRealtime(api_key='sk-...') or set OPENAI_API_KEY "
@@ -1985,6 +2019,7 @@ class Patter:
 
         if provider == "pipeline":
             if stt_resolved is None:
+                self._record_config_incomplete("engine_config")
                 raise ValueError(
                     "Pipeline mode requires an STT provider instance. "
                     "Pass stt=DeepgramSTT(api_key='...') (or another supported "

--- a/libraries/python/getpatter/telemetry/call_metrics.py
+++ b/libraries/python/getpatter/telemetry/call_metrics.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from getpatter.telemetry.install_id import install_age_seconds
+
 
 def _engine_from_mode(mode: str | None) -> str:
     if mode in ("openai_realtime", "openai_realtime_2"):
@@ -84,6 +86,115 @@ def _latency_ms(metrics: Any) -> float | None:
     return getattr(p95, "agent_response_ms", None) if p95 is not None else None
 
 
+def _whole_ms(value: Any) -> int | None:
+    """Coerce a millisecond latency to a whole non-negative int, or ``None``.
+
+    ``None`` when the source is absent OR ``0`` (a stage that did not run — e.g.
+    realtime/convai have no separate STT/TTS span, so those breakdown fields
+    stay ``0.0`` and are omitted rather than reported as a false zero).
+    """
+    if value is None:
+        return None
+    try:
+        ms = max(0, int(round(float(value))))
+    except (TypeError, ValueError):
+        return None
+    return ms if ms > 0 else None
+
+
+def _per_stage_latencies(metrics: Any) -> dict[str, int]:
+    """Read the per-stage latency breakdown off the existing p95 accumulator.
+
+    Read-only — no new audio-path instrumentation. Maps the
+    ``LatencyBreakdown`` fields onto the wire dims, omitting any stage whose
+    source is ``None`` or ``0`` (stage did not run). Same source object as
+    ``latency_ms`` (``metrics.latency_p95``).
+    """
+    p95 = getattr(metrics, "latency_p95", None)
+    if p95 is None:
+        return {}
+    mapping = {
+        "stt_latency_ms": getattr(p95, "stt_ms", None),
+        "llm_ttft_ms": getattr(p95, "llm_ttft_ms", None),
+        "tts_first_byte_ms": getattr(p95, "tts_ms", None),
+        "eou_latency_ms": getattr(p95, "endpoint_ms", None),
+    }
+    out: dict[str, int] = {}
+    for key, raw in mapping.items():
+        whole = _whole_ms(raw)
+        if whole is not None:
+            out[key] = whole
+    return out
+
+
+# Coarse, deterministic error_code -> error_layer mapping. NEVER the message;
+# the layer is inferred only from the structured code. ``provider_error`` is not
+# attributable to a specific stage from the code alone, so it maps to ``other``.
+# Keep byte-for-byte identical to ``ERROR_LAYER_BY_CODE`` in ``call-metrics.ts``.
+_ERROR_LAYER_BY_CODE: dict[str, str] = {
+    "auth": "llm",
+    "rate_limit": "llm",
+    "timeout": "llm",
+    "provider_error": "other",
+    "connection": "other",
+    "webhook_verification": "carrier",
+    "provision": "carrier",
+    "config": "config",
+    "input_validation": "config",
+    "internal": "internal",
+}
+
+
+def _error_layer(error_code: str) -> str:
+    """Map a terminal ``error_code`` to its coarse originating layer.
+
+    ``"none"`` on a clean completion (no code); the value allowlist coerces
+    anything off the enum to ``"other"``.
+    """
+    if not error_code:
+        return "none"
+    return _ERROR_LAYER_BY_CODE.get(error_code, "other")
+
+
+def _disconnect_reason(outcome: str, error_code: str) -> str:
+    """Map the terminal outcome (+ error_code) to a coarse disconnect reason.
+
+    Derived only from already-known state. ``hangup_local`` / ``hangup_remote``
+    are NOT set here because the hanging-up side is not reliably known on this
+    path; clean ends collapse to ``completed`` and the value allowlist coerces
+    anything off-list to ``other``. Keep identical to ``disconnectReason`` in
+    ``call-metrics.ts``.
+    """
+    if outcome == "no_answer":
+        return "no_answer"
+    if outcome == "busy":
+        return "busy"
+    if outcome == "error":
+        return "timeout" if error_code == "timeout" else "error"
+    if outcome == "failed":
+        return "timeout" if error_code == "timeout" else "error"
+    if outcome == "completed":
+        return "completed"
+    return "other"
+
+
+def _time_to_first_call_bucket(age_seconds: float | None) -> str:
+    """Bucket the install age (seconds) into a coarse time-to-first-call band.
+
+    ``unknown`` when the age can't be read. Keep boundaries byte-for-byte
+    identical to ``timeToFirstCallBucket`` in ``call-metrics.ts``.
+    """
+    if age_seconds is None:
+        return "unknown"
+    if age_seconds < 3600:
+        return "lt_1h"
+    if age_seconds < 86400:
+        return "1h_1d"
+    if age_seconds < 604800:
+        return "1d_7d"
+    return "gt_7d"
+
+
 def record_call_started(
     telemetry: Any,
     *,
@@ -114,6 +225,10 @@ def record_call_started(
             dims["direction"] = d
         if call_uid is not None:
             dims["call_uid"] = call_uid
+        # F4: how long after install this call fires (coarse bucket).
+        dims["time_to_first_call_bucket"] = _time_to_first_call_bucket(
+            install_age_seconds()
+        )
         telemetry.record("call_started", **dims)
     except Exception:
         pass
@@ -166,6 +281,9 @@ def record_call_completed(
             turns = getattr(metrics, "turns", None)
             if turns is not None:
                 dims["turn_count_bucket"] = _turn_count_bucket(len(turns))
+            # F2: per-stage latency, read-only off the same p95 breakdown as
+            # latency_ms. Each dim is omitted when its stage didn't run.
+            dims.update(_per_stage_latencies(metrics))
             # A connected call that ended with a terminal error: surface the code
             # and flip the outcome to "error" (the value allowlist coerces an
             # unknown code to "other").
@@ -173,8 +291,24 @@ def record_call_completed(
             if error_code:
                 dims["error_code"] = error_code
                 dims["outcome"] = "error"
+            # F3: coarse error layer + disconnect reason, derived deterministically
+            # from the (now-final) outcome and error_code. error_layer is "none"
+            # on a clean completion.
+            dims["error_layer"] = _error_layer(error_code)
+            dims["disconnect_reason"] = _disconnect_reason(dims["outcome"], error_code)
         elif carrier is not None:
             dims["carrier"] = _carrier_family(carrier)
+            # F3: non-connected failures (no_answer/busy/failed) carry no metrics,
+            # so there is no error_code — map the disconnect reason from the
+            # outcome alone; error_layer stays "carrier" only when the carrier
+            # itself failed (outcome "failed"), else "none".
+            dims["error_layer"] = "carrier" if outcome == "failed" else "none"
+            dims["disconnect_reason"] = _disconnect_reason(outcome, "")
+        # F4: how long after install this call fires (coarse bucket) — on both
+        # call_started and call_completed for the activation-funnel join.
+        dims["time_to_first_call_bucket"] = _time_to_first_call_bucket(
+            install_age_seconds()
+        )
         telemetry.record(
             "call_completed", **{k: v for k, v in dims.items() if v is not None}
         )

--- a/libraries/python/getpatter/telemetry/client.py
+++ b/libraries/python/getpatter/telemetry/client.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import hashlib
 import json
 import logging
 import os
@@ -32,8 +33,13 @@ from collections import deque
 from typing import Any
 
 from getpatter.telemetry.consent import is_enabled
-from getpatter.telemetry.env import is_truthy
-from getpatter.telemetry.events import build_event
+from getpatter.telemetry.env import is_truthy, sample_rate
+from getpatter.telemetry.events import (
+    EVENT_CALL_COMPLETED,
+    EVENT_CALL_STARTED,
+    build_event,
+)
+from getpatter.telemetry.install_id import run_id
 
 logger = logging.getLogger("getpatter.telemetry")
 
@@ -50,6 +56,30 @@ _BUFFER_MAX = 256
 # The relay rejects batches larger than 64 events per request — a full buffer
 # must ship as multiple POSTs or events 65..256 silently vanish server-side.
 _MAX_EVENTS_PER_POST = 64
+
+# The ONLY events the client-side sampling gate may drop. Everything else
+# (first_run, config_incomplete, sdk_initialized, cli_command, feature_used,
+# agent_configured) is always delivered — those are low-frequency activation /
+# usage signals, never high-volume call traffic. An *error* call_completed is
+# also force-kept (see ``_keep_event``) so error rates stay unbiased.
+_SAMPLEABLE_EVENTS = frozenset({EVENT_CALL_STARTED, EVENT_CALL_COMPLETED})
+
+
+def _run_keep_ratio() -> float:
+    """A stable per-run value in ``[0, 1)`` derived from this process's run id.
+
+    Hashing the run id (constant for the process) makes the keep/drop decision
+    DETERMINISTIC PER RUN: the whole run consistently keeps or drops its
+    sampleable call events rather than flipping a per-event coin — which would
+    bias short runs (a 3-call run at rate=0.5 could keep 0 or 3 by luck). Any
+    failure degrades to ``0.0`` so the caller keeps the event (fail safe).
+    """
+    try:
+        digest = hashlib.sha256(run_id().encode("utf-8")).hexdigest()[:8]
+        return int(digest, 16) / 0xFFFFFFFF
+    except Exception:  # pragma: no cover — hashing a str never realistically fails
+        return 0.0
+
 
 # Module-level registry so a single ``atexit`` hook flushes every live client
 # without leaking one handler per instance. A ``WeakSet`` lets a client whose
@@ -136,6 +166,18 @@ class TelemetryClient:
         self._http: Any = None  # httpx.AsyncClient, lazily created
         self._closed = False
 
+        # Client-side sampling gate (computed ONCE at construction):
+        #   * ``_sample_rate`` — the effective rate in ``[0, 1]`` from the env.
+        #   * ``_keep_sampled`` — the deterministic per-run keep/drop decision for
+        #     the high-frequency call events. Because the seed is the run id
+        #     (constant for the process) the whole run consistently keeps or
+        #     drops them — never a per-event coin flip. ``rate >= 1.0`` always
+        #     keeps. See ``_run_keep_ratio`` and ``record``.
+        self._sample_rate = sample_rate()
+        self._keep_sampled = (
+            self._sample_rate >= 1.0 or _run_keep_ratio() < self._sample_rate
+        )
+
         if self._enabled and not self._debug:
             _show_notice_once()
             _register_atexit()
@@ -148,9 +190,34 @@ class TelemetryClient:
     # -- public API ----------------------------------------------------------
 
     def record(self, name: str, **dimensions: Any) -> None:
-        """Enqueue an event. Fire-and-forget; never raises, never blocks."""
+        """Enqueue an event. Fire-and-forget; never raises, never blocks.
+
+        Applies the client-side sampling gate (see ``__init__``): only the
+        high-frequency ``call_started`` / ``call_completed`` events may be
+        dropped, and only when this run's deterministic decision says so. An
+        error ``call_completed`` (``outcome == "error"`` or an ``error_code``
+        present) is ALWAYS kept so error rates stay unbiased. A kept sampled
+        event carries ``sample_rate`` so analytics can extrapolate (weight
+        ``1/sample_rate``). All other events bypass the gate entirely.
+        """
         if not self._enabled or self._closed:
             return
+
+        # -- sampling gate (high-frequency call events only) -----------------
+        if name in _SAMPLEABLE_EVENTS and self._sample_rate < 1.0:
+            # Force-keep error call_completed events regardless of rate — error
+            # rates would be biased if errors were sampled like clean calls.
+            is_error = name == EVENT_CALL_COMPLETED and (
+                dimensions.get("outcome") == "error" or "error_code" in dimensions
+            )
+            if not self._keep_sampled and not is_error:
+                return  # sampled out for this run
+            # Kept (by the run decision or because it's an error): stamp the rate
+            # so analytics can extrapolate (weight = 1/rate). ``build_event``
+            # keeps it (the Schema phase added sample_rate to the numeric
+            # allowlist). Stamped only when rate < 1.0 to keep payloads lean.
+            dimensions = {**dimensions, "sample_rate": self._sample_rate}
+
         try:
             event = build_event(
                 name, sdk_version=self._sdk_version, dimensions=dimensions

--- a/libraries/python/getpatter/telemetry/env.py
+++ b/libraries/python/getpatter/telemetry/env.py
@@ -45,6 +45,33 @@ def is_truthy(value: str | None) -> bool:
     }
 
 
+def sample_rate() -> float:
+    """Client-side sampling rate for high-frequency call events, in ``[0, 1]``.
+
+    Read from ``PATTER_TELEMETRY_SAMPLE`` and clamped to ``[0, 1]``. Defaults to
+    ``1.0`` (no sampling — every event kept) when the var is unset, empty,
+    non-numeric, ``< 0``, or ``> 1``. Fail-safe: this never raises — a bad value
+    degrades to ``1.0`` so a misconfigured env can never silently drop data.
+
+    Only the high-frequency ``call_started`` / ``call_completed`` events are
+    gated by this rate (see :class:`TelemetryClient`); activation and error
+    events are always delivered regardless. Mirrors ``sampleRate`` in ``env.ts``.
+    """
+    raw = os.getenv("PATTER_TELEMETRY_SAMPLE")
+    if raw is None:
+        return 1.0
+    try:
+        rate = float(raw.strip())
+    except (TypeError, ValueError):
+        return 1.0
+    # NaN/inf or out of range → fail safe to 1.0 (keep everything). A value of
+    # exactly 0.0 is honored (drop all sampleable events); only invalid input
+    # degrades to the no-sampling default.
+    if rate != rate or rate < 0.0 or rate > 1.0:
+        return 1.0
+    return rate
+
+
 def is_ci() -> bool:
     """True when running under a recognised CI provider."""
     return any(is_truthy(os.getenv(name)) for name in _CI_ENV_VARS)

--- a/libraries/python/getpatter/telemetry/events.py
+++ b/libraries/python/getpatter/telemetry/events.py
@@ -30,7 +30,7 @@ from getpatter.telemetry.env import is_ci, is_test
 from getpatter.telemetry.install_id import install_id, run_id
 from getpatter.telemetry.stack import STACK_VENDORS
 
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 # --- Event names (the only values the ``event`` field may take) -------------
 EVENT_SDK_INITIALIZED = "sdk_initialized"
@@ -40,6 +40,9 @@ EVENT_FEATURE_USED = "feature_used"
 EVENT_AGENT_CONFIGURED = "agent_configured"
 EVENT_CALL_STARTED = "call_started"
 EVENT_CALL_COMPLETED = "call_completed"
+# Activation-blocker signal: emitted once when required runtime config is missing
+# so the instance cannot proceed. In the NEVER-sampled set (always delivered).
+EVENT_CONFIG_INCOMPLETE = "config_incomplete"
 
 _ALLOWED_EVENTS = frozenset(
     {
@@ -50,6 +53,7 @@ _ALLOWED_EVENTS = frozenset(
         EVENT_AGENT_CONFIGURED,
         EVENT_CALL_STARTED,
         EVENT_CALL_COMPLETED,
+        EVENT_CONFIG_INCOMPLETE,
     }
 )
 
@@ -126,6 +130,34 @@ DIMENSION_VALUES: dict[str, frozenset[str]] = {
     "turn_detection": frozenset({"default", "custom", "none"}),
     # call_completed: how many conversational turns the call had.
     "turn_count_bucket": frozenset({"0", "1", "2_3", "4_6", "7_12", "13_plus"}),
+    # config_incomplete: coarse category of the absent required runtime config
+    # blocking activation. Never the key value, env var name, or any PII.
+    "missing": frozenset({"carrier_credentials", "llm_key", "engine_config", "other"}),
+    # call_completed: which layer the terminal error originated in (derived from
+    # CallMetrics.error_code/outcome). "none" when the call ended cleanly.
+    "error_layer": frozenset(
+        {"stt", "llm", "tts", "carrier", "config", "internal", "none", "other"}
+    ),
+    # call_completed: coarse reason the call ended (derived from terminal
+    # outcome/error/AMD state). hangup_local/hangup_remote only when the side is
+    # reliably known; else fall back to completed (clean end) or other.
+    "disconnect_reason": frozenset(
+        {
+            "hangup_local",
+            "hangup_remote",
+            "error",
+            "timeout",
+            "no_answer",
+            "busy",
+            "completed",
+            "other",
+        }
+    ),
+    # call_started / call_completed: coarse age of the install at call time
+    # (install-id file mtime vs now). "unknown" when the timestamp can't be read.
+    "time_to_first_call_bucket": frozenset(
+        {"lt_1h", "1h_1d", "1d_7d", "gt_7d", "unknown"}
+    ),
 }
 
 # Dimensions that may accompany an event. Enum dimensions are the keys of
@@ -133,8 +165,23 @@ DIMENSION_VALUES: dict[str, frozenset[str]] = {
 # ``latency_ms`` (raw milliseconds) and ``duration_seconds`` (raw seconds) are
 # operational metrics — the coarse-bucket privacy posture (which exists for cost
 # and for names) does not apply to them, so they are sent at full resolution.
+# The per-stage call_completed latencies (``stt_latency_ms``, ``llm_ttft_ms``,
+# ``tts_first_byte_ms``, ``eou_latency_ms``) are read off the existing
+# CallMetrics LatencyBreakdown — whole ints, omitted when the stage didn't run.
+# ``sample_rate`` is the client-side sampling rate in (0,1] for high-frequency
+# call events (analytics weight = 1/sample_rate).
 _NUMERIC_DIMENSIONS = frozenset(
-    {"builtin_tool_count", "latency_ms", "duration_seconds", "cost_usd"}
+    {
+        "builtin_tool_count",
+        "latency_ms",
+        "duration_seconds",
+        "cost_usd",
+        "stt_latency_ms",
+        "llm_ttft_ms",
+        "tts_first_byte_ms",
+        "eou_latency_ms",
+        "sample_rate",
+    }
 )
 # feature_used (pipeline): the sanitized per-layer model token, e.g.
 # ``deepgram-nova-3`` / ``anthropic-claude-haiku-4-5``. NOT a closed enum — the

--- a/libraries/python/getpatter/telemetry/install_id.py
+++ b/libraries/python/getpatter/telemetry/install_id.py
@@ -165,6 +165,21 @@ def days_since_install_bucket() -> str:
     return "30_plus"
 
 
+def install_age_seconds() -> float | None:
+    """Seconds since this install was created, from the install-id file mtime.
+
+    Reuses the same mtime seam as :func:`days_since_install_bucket`. Returns
+    ``None`` on an unreadable / read-only filesystem (the caller buckets that to
+    ``"unknown"``). Best-effort and never raises. Mirrors ``installAgeSeconds``
+    in ``install-id.ts``.
+    """
+    try:
+        mtime = _state_path().stat().st_mtime
+    except OSError:
+        return None
+    return max(0.0, time.time() - mtime)
+
+
 def is_first_run() -> bool:
     """Return ``True`` exactly once per install — on the run that first marks it.
 

--- a/libraries/python/tests/test_telemetry.py
+++ b/libraries/python/tests/test_telemetry.py
@@ -121,7 +121,7 @@ async def test_event_reaches_collector_when_enabled(enabled, collector):
     assert event["sdk"] == "python"
     assert event["sdk_version"] == "0.6.3"
     assert event["runtime"] == "cpython"
-    assert event["schema_version"] == 7
+    assert event["schema_version"] == 8
     assert event["engine"] == "realtime"
     assert event["provider"] == "openai"
     assert event["carrier"] == "twilio"
@@ -963,20 +963,18 @@ def test_build_event_v4_bool_enum_and_version_dims():
 # --- CLI usage + first-run + call funnel + persisted opt-out (schema v6) ------
 
 
-def test_schema_version_is_7():
+def test_schema_version_is_8():
     from getpatter.telemetry import SCHEMA_VERSION
 
-    assert SCHEMA_VERSION == 7
-    assert build_event("first_run", sdk_version="0.6.5")["schema_version"] == 7
+    assert SCHEMA_VERSION == 8
+    assert build_event("first_run", sdk_version="0.6.5")["schema_version"] == 8
 
 
 def test_call_uid_kept_only_when_hex32():
     # A well-formed random correlation id (32 lowercase hex) survives; every
     # off-shape value is DROPPED (key absent), never coerced to "other".
     good = "a" * 32
-    ev = build_event(
-        "call_started", sdk_version="0.6.5", dimensions={"call_uid": good}
-    )
+    ev = build_event("call_started", sdk_version="0.6.5", dimensions={"call_uid": good})
     assert ev["call_uid"] == good
 
     for bad in ("not-a-uid", "A" * 32, "a" * 31, "a" * 33, 123, True):

--- a/libraries/python/tests/test_telemetry_call_stages.py
+++ b/libraries/python/tests/test_telemetry_call_stages.py
@@ -1,0 +1,340 @@
+"""Authentic tests for the per-stage / error / time-to-first-call call dims.
+
+Covers telemetry workstream F2 (per-stage latency), F3 (error_layer +
+disconnect_reason), and F4 (time_to_first_call_bucket) on the shared
+``call_started`` / ``call_completed`` emit path.
+
+These exercise the REAL builders in ``getpatter.telemetry.call_metrics`` against
+REAL ``CallMetrics`` / ``LatencyBreakdown`` / ``CostBreakdown`` model objects.
+Only the outermost boundary — the telemetry client's ``record`` sink — is a
+local capture double (no HTTP, no env), so every dimension assertion checks the
+dict the builder actually produced. Nothing here mocks the code under test.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from getpatter.models import (
+    CallMetrics,
+    CostBreakdown,
+    LatencyBreakdown,
+)
+from getpatter.telemetry import call_metrics
+from getpatter.telemetry import install_id as install_id_mod
+from getpatter.telemetry.call_metrics import (
+    record_call_completed,
+    record_call_started,
+)
+
+
+class CaptureTelemetry:
+    """Capture double for the telemetry sink — the only mocked surface.
+
+    Mirrors ``TelemetryClient.record(name, **dimensions)`` and stores each call
+    so a test can assert the real, fully-built dimension dict.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, dict[str, Any]]] = []
+
+    def record(self, name: str, **dimensions: Any) -> None:
+        self.records.append((name, dict(dimensions)))
+
+
+def _metrics(
+    *,
+    provider_mode: str,
+    latency: LatencyBreakdown,
+    error_code: str = "",
+    duration_seconds: float = 12.0,
+    telephony_provider: str = "twilio",
+    llm_provider: str = "",
+) -> CallMetrics:
+    """Build a real CallMetrics object with a known p95 latency breakdown."""
+    return CallMetrics(
+        call_id="ca-test",
+        duration_seconds=duration_seconds,
+        turns=(),
+        cost=CostBreakdown(total=0.06),
+        latency_avg=latency,
+        latency_p95=latency,
+        provider_mode=provider_mode,
+        telephony_provider=telephony_provider,
+        llm_provider=llm_provider,
+        error_code=error_code,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# F2 — per-stage latency                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_pipeline_call_emits_four_per_stage_latencies_as_whole_ints() -> None:
+    cap = CaptureTelemetry()
+    latency = LatencyBreakdown(
+        stt_ms=120.4,
+        tts_ms=88.9,
+        llm_ttft_ms=305.5,
+        endpoint_ms=42.2,
+        agent_response_ms=436.0,
+    )
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(
+            provider_mode="pipeline", latency=latency, llm_provider="cerebras"
+        ),
+    )
+
+    assert len(cap.records) == 1
+    name, dims = cap.records[0]
+    assert name == "call_completed"
+    # Rounded to whole ints, never the float.
+    assert dims["stt_latency_ms"] == 120
+    assert dims["tts_first_byte_ms"] == 89
+    assert dims["llm_ttft_ms"] == 306
+    assert dims["eou_latency_ms"] == 42
+    assert all(
+        isinstance(dims[k], int)
+        for k in (
+            "stt_latency_ms",
+            "tts_first_byte_ms",
+            "llm_ttft_ms",
+            "eou_latency_ms",
+        )
+    )
+
+
+def test_realtime_call_omits_stt_and_tts_stage_dims() -> None:
+    """Realtime has no separate STT/TTS span — stt_ms/tts_ms stay 0, so those
+    dims are omitted entirely (never sent as a misleading 0)."""
+    cap = CaptureTelemetry()
+    # Realtime: stt_ms / tts_ms are 0 (no separate stage); only the fused
+    # endpoint + ttft are meaningful.
+    latency = LatencyBreakdown(
+        stt_ms=0.0,
+        tts_ms=0.0,
+        llm_ttft_ms=210.0,
+        endpoint_ms=30.0,
+    )
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(provider_mode="openai_realtime", latency=latency),
+    )
+
+    _, dims = cap.records[0]
+    assert "stt_latency_ms" not in dims
+    assert "tts_first_byte_ms" not in dims
+    assert dims["llm_ttft_ms"] == 210
+    assert dims["eou_latency_ms"] == 30
+
+
+def test_absent_optional_stage_is_omitted_not_zero() -> None:
+    """A ``None`` optional stage (llm_ttft/endpoint) is omitted, not coerced."""
+    cap = CaptureTelemetry()
+    latency = LatencyBreakdown(stt_ms=100.0, tts_ms=50.0)  # ttft/endpoint default None
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(provider_mode="pipeline", latency=latency),
+    )
+
+    _, dims = cap.records[0]
+    assert dims["stt_latency_ms"] == 100
+    assert dims["tts_first_byte_ms"] == 50
+    assert "llm_ttft_ms" not in dims
+    assert "eou_latency_ms" not in dims
+
+
+# --------------------------------------------------------------------------- #
+# F3 — error_layer + disconnect_reason                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_clean_completion_maps_to_error_layer_none_and_disconnect_completed() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(provider_mode="pipeline", latency=LatencyBreakdown()),
+    )
+    _, dims = cap.records[0]
+    assert dims["error_layer"] == "none"
+    assert dims["disconnect_reason"] == "completed"
+    assert dims["outcome"] == "completed"
+
+
+def test_llm_auth_error_maps_to_llm_layer_and_error_disconnect() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(
+            provider_mode="pipeline", latency=LatencyBreakdown(), error_code="auth"
+        ),
+    )
+    _, dims = cap.records[0]
+    # Connected call with a terminal error flips the outcome to "error".
+    assert dims["outcome"] == "error"
+    assert dims["error_code"] == "auth"
+    assert dims["error_layer"] == "llm"
+    assert dims["disconnect_reason"] == "error"
+
+
+def test_timeout_error_maps_disconnect_to_timeout() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(
+            provider_mode="pipeline", latency=LatencyBreakdown(), error_code="timeout"
+        ),
+    )
+    _, dims = cap.records[0]
+    assert dims["error_layer"] == "llm"
+    assert dims["disconnect_reason"] == "timeout"
+
+
+def test_webhook_verification_error_maps_to_carrier_layer() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(
+            provider_mode="pipeline",
+            latency=LatencyBreakdown(),
+            error_code="webhook_verification",
+        ),
+    )
+    _, dims = cap.records[0]
+    assert dims["error_layer"] == "carrier"
+
+
+def test_provider_error_maps_to_other_layer() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(
+        cap,
+        outcome="completed",
+        metrics=_metrics(
+            provider_mode="pipeline",
+            latency=LatencyBreakdown(),
+            error_code="provider_error",
+        ),
+    )
+    _, dims = cap.records[0]
+    assert dims["error_layer"] == "other"
+    assert dims["disconnect_reason"] == "error"
+
+
+def test_no_answer_failure_maps_disconnect_no_answer_and_layer_none() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(cap, outcome="no_answer", carrier="twilio")
+    _, dims = cap.records[0]
+    assert dims["outcome"] == "no_answer"
+    assert dims["disconnect_reason"] == "no_answer"
+    assert dims["error_layer"] == "none"
+
+
+def test_busy_failure_maps_disconnect_busy() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(cap, outcome="busy", carrier="telnyx")
+    _, dims = cap.records[0]
+    assert dims["disconnect_reason"] == "busy"
+    assert dims["error_layer"] == "none"
+
+
+def test_carrier_failed_maps_disconnect_error_and_layer_carrier() -> None:
+    cap = CaptureTelemetry()
+    record_call_completed(cap, outcome="failed", carrier="twilio")
+    _, dims = cap.records[0]
+    assert dims["disconnect_reason"] == "error"
+    assert dims["error_layer"] == "carrier"
+
+
+# --------------------------------------------------------------------------- #
+# F4 — time_to_first_call_bucket (both events)                                #
+# --------------------------------------------------------------------------- #
+
+
+def _set_install_mtime(state_dir: str, age_seconds: float) -> None:
+    """Create a real install-id file whose mtime is ``age_seconds`` old."""
+    os.makedirs(state_dir, exist_ok=True)
+    path = os.path.join(state_dir, "install-id")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("0" * 32)
+    import time as _time
+
+    when = _time.time() - age_seconds
+    os.utime(path, (when, when))
+
+
+def test_time_to_first_call_bucket_on_started_and_completed(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    state_dir = str(tmp_path / "state")
+    monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", state_dir)
+    # Reset the cached install id so the new state dir is honored.
+    monkeypatch.setattr(install_id_mod, "_install_id", None, raising=False)
+
+    # A 30-minute-old install → lt_1h on both events.
+    _set_install_mtime(state_dir, age_seconds=30 * 60)
+
+    started = CaptureTelemetry()
+    record_call_started(started, provider_mode="pipeline", telephony_provider="twilio")
+    completed = CaptureTelemetry()
+    record_call_completed(
+        completed,
+        outcome="completed",
+        metrics=_metrics(provider_mode="pipeline", latency=LatencyBreakdown()),
+    )
+
+    assert started.records[0][1]["time_to_first_call_bucket"] == "lt_1h"
+    assert completed.records[0][1]["time_to_first_call_bucket"] == "lt_1h"
+
+
+def test_time_to_first_call_bucket_boundaries(tmp_path: Any, monkeypatch: Any) -> None:
+    state_dir = str(tmp_path / "state")
+    monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", state_dir)
+
+    cases = [
+        (60, "lt_1h"),
+        (3600 + 1, "1h_1d"),
+        (86400 + 1, "1d_7d"),
+        (604800 + 1, "gt_7d"),
+    ]
+    for age, expected in cases:
+        _set_install_mtime(state_dir, age_seconds=age)
+        cap = CaptureTelemetry()
+        record_call_started(cap, provider_mode="pipeline")
+        assert cap.records[0][1]["time_to_first_call_bucket"] == expected
+
+
+def test_time_to_first_call_bucket_unknown_when_state_unreadable(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    # Point the state dir at a path with no install-id file → mtime unreadable.
+    monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", str(tmp_path / "does-not-exist"))
+    cap = CaptureTelemetry()
+    record_call_started(cap, provider_mode="pipeline")
+    assert cap.records[0][1]["time_to_first_call_bucket"] == "unknown"
+
+
+def test_install_age_seconds_reads_mtime(tmp_path: Any, monkeypatch: Any) -> None:
+    state_dir = str(tmp_path / "state")
+    monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", state_dir)
+    _set_install_mtime(state_dir, age_seconds=7200)
+    age = install_id_mod.install_age_seconds()
+    assert age is not None
+    assert 7000 <= age <= 7400  # ~2h, allow scheduling slack
+
+
+def test_builders_never_raise_with_telemetry_none() -> None:
+    # Fire-and-forget contract: None sink is a no-op, never throws.
+    record_call_started(None, provider_mode="pipeline")
+    record_call_completed(None, outcome="completed")
+    # Reference call_metrics module to keep the import meaningful.
+    assert hasattr(call_metrics, "record_call_completed")

--- a/libraries/python/tests/test_telemetry_config_incomplete.py
+++ b/libraries/python/tests/test_telemetry_config_incomplete.py
@@ -1,0 +1,228 @@
+"""Authentic tests for the ``config_incomplete`` activation-blocker signal (F1).
+
+The real ``Patter`` client runs its real credential/engine validation. The only
+substituted surface is the telemetry client's outbound boundary: a capturing
+double records every ``record(name, **dims)`` call into a list (mirroring the
+allowed mock surface in ``.claude/rules/authentic-tests.md`` — the telemetry
+client is the last hop to the network). Everything from ``Patter.__init__`` /
+``Patter.agent`` inward — the ``_record_config_incomplete`` dedupe, the
+validation, and the ``raise`` — is exercised for real.
+
+Each test asserts that the blocking validation BOTH emits exactly one
+``config_incomplete`` event with the correct coarse ``missing`` enum AND still
+raises the original error unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from getpatter import DeepgramSTT, Patter, Twilio
+
+
+class _CaptureTelemetry:
+    """Stands in for ``TelemetryClient`` at the outbound boundary only.
+
+    Reports ``enabled`` truthfully (so the enabled-vs-opt-out behaviour is real)
+    and appends each recorded event to ``calls`` instead of POSTing it. The
+    ``record`` signature matches the real client: ``record(name, **dimensions)``.
+    """
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def record(self, name: str, **dimensions: Any) -> None:
+        # Mirror the real client: a disabled client drops every event.
+        if not self.enabled:
+            return
+        self.calls.append((name, dict(dimensions)))
+
+    # No-op lifecycle hooks the client exercises elsewhere — never relevant here.
+    def flush_pending(self) -> None:  # pragma: no cover - not hit by these tests
+        pass
+
+    async def drain(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        pass
+
+    async def aclose(self) -> None:  # pragma: no cover
+        pass
+
+
+def _config_incomplete(cap: _CaptureTelemetry) -> list[dict[str, Any]]:
+    return [dims for name, dims in cap.calls if name == "config_incomplete"]
+
+
+@pytest.fixture
+def install_capture(monkeypatch):
+    """Make ``Patter`` build an enabled capturing telemetry client.
+
+    Returns the most-recently-built capture instance via a one-element holder so a
+    test can inspect what the real validation path recorded.
+    """
+    holder: dict[str, _CaptureTelemetry] = {}
+
+    def _build(flag: bool | None) -> _CaptureTelemetry:
+        # Honour the opt-out flag exactly like the real client: telemetry=False
+        # yields a disabled client. (Env-based opt-out is covered separately.)
+        cap = _CaptureTelemetry(enabled=flag is not False)
+        holder["client"] = cap
+        return cap
+
+    monkeypatch.setattr("getpatter.client._build_telemetry_client", _build)
+    return holder
+
+
+# --- (1) missing carrier credentials (constructor) --------------------------
+
+
+def test_missing_phone_number_emits_carrier_credentials_and_still_raises(
+    install_capture,
+):
+    with pytest.raises(ValueError, match="phone_number"):
+        Patter(carrier=Twilio(account_sid="AC", auth_token="tk"), webhook_url="x")
+
+    cap = install_capture["client"]
+    events = _config_incomplete(cap)
+    assert len(events) == 1
+    assert events[0] == {"missing": "carrier_credentials"}
+
+
+# --- (2) missing LLM / engine key (agent) -----------------------------------
+
+
+def test_missing_openai_key_emits_llm_key_and_still_raises(
+    install_capture, monkeypatch
+):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    phone = Patter(
+        carrier=Twilio(account_sid="AC", auth_token="tk"),
+        phone_number="+15550000000",
+    )
+    cap = install_capture["client"]
+    # Construction itself must not have emitted the activation-blocker signal.
+    assert _config_incomplete(cap) == []
+
+    # Default provider is openai_realtime → requires a key we have not supplied.
+    with pytest.raises(
+        ValueError, match="OpenAI Realtime mode requires an OpenAI API key"
+    ):
+        phone.agent("You are a helpful assistant.")
+
+    events = _config_incomplete(cap)
+    assert len(events) == 1
+    assert events[0] == {"missing": "llm_key"}
+
+
+# --- (3) incomplete pipeline / engine config (agent) ------------------------
+
+
+def test_pipeline_without_stt_emits_engine_config_and_still_raises(install_capture):
+    phone = Patter(
+        carrier=Twilio(account_sid="AC", auth_token="tk"),
+        phone_number="+15550000000",
+    )
+    cap = install_capture["client"]
+
+    with pytest.raises(ValueError, match="Pipeline mode requires an STT provider"):
+        phone.agent("You are a helpful assistant.", provider="pipeline")
+
+    events = _config_incomplete(cap)
+    assert len(events) == 1
+    assert events[0] == {"missing": "engine_config"}
+
+
+# --- opt-out emits nothing ---------------------------------------------------
+
+
+def test_opt_out_flag_emits_no_config_incomplete(install_capture):
+    with pytest.raises(ValueError, match="phone_number"):
+        Patter(
+            carrier=Twilio(account_sid="AC", auth_token="tk"),
+            webhook_url="x",
+            telemetry=False,
+        )
+
+    cap = install_capture["client"]
+    assert cap.enabled is False
+    # A disabled real client drops record() — the capture double mirrors that by
+    # being constructed disabled; the activation path still ran but emitted nothing
+    # observable on the wire. The dedupe flag flips, but no event leaves.
+    assert _config_incomplete(cap) == []
+
+
+def test_opt_out_env_var_emits_no_config_incomplete(monkeypatch):
+    """With the real ``TelemetryClient`` and PATTER_TELEMETRY_DISABLED=1, the
+    activation-blocker validation must not enqueue any event."""
+    monkeypatch.setenv("PATTER_TELEMETRY_DISABLED", "1")
+    monkeypatch.delenv("PATTER_TELEMETRY_DEBUG", raising=False)
+
+    with pytest.raises(ValueError, match="phone_number"):
+        phone = Patter(
+            carrier=Twilio(account_sid="AC", auth_token="tk"), webhook_url="x"
+        )
+        del phone  # pragma: no cover - never reached, the constructor raises
+
+    # The real client is disabled by the env var; nothing buffered. We assert via
+    # the public ``enabled`` flag on a separately-built client under the same env.
+    from getpatter.client import _build_telemetry_client
+
+    real = _build_telemetry_client(None)
+    assert real.enabled is False
+
+
+# --- emitted at most once per instance --------------------------------------
+
+
+def test_config_incomplete_emitted_at_most_once_per_instance(
+    install_capture, monkeypatch
+):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    phone = Patter(
+        carrier=Twilio(account_sid="AC", auth_token="tk"),
+        phone_number="+15550000000",
+    )
+    cap = install_capture["client"]
+
+    # First failing agent() call emits once.
+    with pytest.raises(ValueError):
+        phone.agent("prompt one")
+    # A retry / a second agent() call on the SAME instance must NOT double-emit.
+    with pytest.raises(ValueError):
+        phone.agent("prompt two")
+    with pytest.raises(ValueError):
+        phone.agent("prompt three", provider="pipeline")
+
+    events = _config_incomplete(cap)
+    assert len(events) == 1
+    assert events[0] == {"missing": "llm_key"}
+
+
+# --- a fully-valid agent never emits the activation-blocker signal -----------
+
+
+def test_valid_realtime_agent_emits_no_config_incomplete(install_capture, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-not-a-real-key")
+    phone = Patter(
+        carrier=Twilio(account_sid="AC", auth_token="tk"),
+        phone_number="+15550000000",
+    )
+    cap = install_capture["client"]
+    phone.agent("You are a helpful assistant.")
+    assert _config_incomplete(cap) == []
+
+
+def test_valid_pipeline_agent_with_stt_emits_no_config_incomplete(install_capture):
+    phone = Patter(
+        carrier=Twilio(account_sid="AC", auth_token="tk"),
+        phone_number="+15550000000",
+    )
+    cap = install_capture["client"]
+    phone.agent(
+        "You are a helpful assistant.",
+        provider="pipeline",
+        stt=DeepgramSTT(api_key="dg-test"),
+    )
+    assert _config_incomplete(cap) == []

--- a/libraries/python/tests/test_telemetry_sampling.py
+++ b/libraries/python/tests/test_telemetry_sampling.py
@@ -1,0 +1,345 @@
+"""Authentic tests for the client-side telemetry sampling gate (F4).
+
+A real local HTTP collector (stdlib ``http.server`` in a background thread)
+captures what the SDK actually sends over a real ``httpx`` POST. The sampling
+decision, the per-run hash of ``run_id``, the ``sample_rate`` stamping, the
+payload builder, and the network egress are all REAL — only the CI/test
+*environment detection* is neutralised (so the enabled path runs inside pytest)
+and the network boundary is local. ``run_id`` is the only thing pinned to a
+fixed value per test, because the keep/drop decision is deterministic per run
+and the test needs to exercise both the kept and the dropped branch.
+
+Mirrors ``libraries/typescript/tests/telemetry-sampling.test.ts``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from getpatter.telemetry import client as client_mod
+from getpatter.telemetry.client import TelemetryClient, _run_keep_ratio
+from getpatter.telemetry.env import sample_rate
+
+# Two fixed run ids whose SHA-256-derived ratio straddles 0.5, so at rate=0.5
+# one run KEEPS its sampleable call events and the other DROPS them. Computed
+# from the real ``_run_keep_ratio`` formula (asserted below, not trusted blind).
+_KEEP_RUN_ID = "run00000000000000000000000000000000"  # ratio ~0.031 -> keep @0.5
+_DROP_RUN_ID = "run00000000000000000000000000000003"  # ratio ~0.742 -> drop @0.5
+
+
+class _Collector:
+    """A real local HTTP server that records POSTed JSON bodies."""
+
+    def __init__(self) -> None:
+        self.requests: list[object] = []
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def url(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[0], self._server.server_address[1]
+        return f"http://127.0.0.1:{port}/v1/ingest"
+
+    @property
+    def events(self) -> list[dict]:
+        out: list[dict] = []
+        for batch in self.requests:
+            if isinstance(batch, list):
+                out.extend(batch)
+        return out
+
+    def event_names(self) -> list[str]:
+        return [e["event"] for e in self.events]
+
+    def start(self) -> None:
+        collector = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 (stdlib name)
+                length = int(self.headers.get("Content-Length", "0") or 0)
+                body = self.rfile.read(length)
+                try:
+                    collector.requests.append(json.loads(body))
+                except Exception:
+                    collector.requests.append(body)
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, *args: object) -> None:  # silence
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+
+
+@pytest.fixture
+def collector():
+    c = _Collector()
+    c.start()
+    yield c
+    c.stop()
+
+
+@pytest.fixture
+def enabled(monkeypatch, tmp_path):
+    """Neutralise CI/test detection, isolate the state dir, clear disablers → ON."""
+    monkeypatch.setattr("getpatter.telemetry.consent.is_ci", lambda: False)
+    monkeypatch.setattr("getpatter.telemetry.consent.is_test", lambda: False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_DEBUG", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_ENDPOINT", raising=False)
+    monkeypatch.delenv("PATTER_TELEMETRY_SAMPLE", raising=False)
+    monkeypatch.setenv("PATTER_TELEMETRY_STATE_DIR", str(tmp_path / "getpatter-state"))
+
+
+def _pin_run_id(monkeypatch, run_id: str) -> None:
+    """Pin the per-run sampling seed. ``record``/``__init__`` read ``run_id`` via
+    the client module's imported symbol; ``build_event`` reads its own (the run_id
+    *field* on the wire is irrelevant to the gate)."""
+    monkeypatch.setattr(client_mod, "run_id", lambda: run_id)
+
+
+async def _wait_for(collector: _Collector, n: int, timeout: float = 2.0) -> None:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while len(collector.events) < n and loop.time() < deadline:
+        await asyncio.sleep(0.01)
+
+
+# --- the seed fixtures are real (the formula is the source of truth) ---------
+
+
+def test_seed_run_ids_straddle_half():
+    """Guard the fixtures: the two pinned run ids really do keep/drop at 0.5."""
+    assert _run_keep_ratio_for(_KEEP_RUN_ID) < 0.5
+    assert _run_keep_ratio_for(_DROP_RUN_ID) >= 0.5
+
+
+def _run_keep_ratio_for(run_id: str) -> float:
+    import hashlib
+
+    return int(hashlib.sha256(run_id.encode()).hexdigest()[:8], 16) / 0xFFFFFFFF
+
+
+# --- env: sample_rate() parsing + clamping + fail-safe ----------------------
+
+
+def test_sample_rate_defaults_to_one_when_unset(monkeypatch):
+    monkeypatch.delenv("PATTER_TELEMETRY_SAMPLE", raising=False)
+    assert sample_rate() == 1.0
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0", 0.0),
+        ("0.0", 0.0),
+        ("0.5", 0.5),
+        ("1", 1.0),
+        ("1.0", 1.0),
+        ("  0.25  ", 0.25),  # surrounding whitespace tolerated
+    ],
+)
+def test_sample_rate_parses_valid_values(monkeypatch, raw, expected):
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", raw)
+    assert sample_rate() == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "abc", "0.5x", "-0.1", "-1", "2", "1.5", "10", "nan", "inf", "-inf"],
+)
+def test_sample_rate_malformed_or_out_of_range_degrades_to_one(monkeypatch, raw):
+    # Fail safe: anything not a clean float in [0, 1] keeps everything (1.0).
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", raw)
+    assert sample_rate() == 1.0
+
+
+def test_sample_rate_never_raises(monkeypatch):
+    for raw in ["", "garbage", "NaN", "1e9999", "+-+"]:
+        monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", raw)
+        sample_rate()  # must not raise
+
+
+# --- rate = 0: call events dropped; activation/error events still delivered --
+
+
+async def test_rate_zero_drops_call_events_keeps_activation_and_errors(
+    enabled, collector, monkeypatch
+):
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "0")
+    # run id is irrelevant at rate 0 (keep_sampled is always False), but pin it
+    # for a stable test.
+    _pin_run_id(monkeypatch, _KEEP_RUN_ID)
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+
+    # High-frequency call events: dropped.
+    client.record("call_started", engine="realtime", carrier="twilio")
+    client.record("call_completed", outcome="completed", carrier="twilio")
+
+    # NEVER-sampled events: always delivered, even at rate 0.
+    client.record("first_run")
+    client.record("config_incomplete", missing="carrier_credentials")
+    client.record("sdk_initialized", engine="realtime")
+
+    # An ERROR call_completed is force-kept regardless of rate (unbiased errors).
+    client.record(
+        "call_completed", outcome="error", error_code="provider_error", carrier="twilio"
+    )
+
+    await _wait_for(collector, 4)
+    await client.aclose()
+
+    names = sorted(collector.event_names())
+    # Two clean call events dropped; everything else delivered.
+    assert names == [
+        "call_completed",  # the error one
+        "config_incomplete",
+        "first_run",
+        "sdk_initialized",
+    ]
+    # The single surviving call_completed is the error one and carries sample_rate.
+    err = next(e for e in collector.events if e["event"] == "call_completed")
+    assert err["outcome"] == "error"
+    assert err["error_code"] == "provider_error"
+    assert err["sample_rate"] == 0.0
+
+
+async def test_rate_zero_error_via_error_code_only_is_kept(
+    enabled, collector, monkeypatch
+):
+    # An error_code key alone (outcome may still be "completed") forces a keep.
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "0")
+    _pin_run_id(monkeypatch, _KEEP_RUN_ID)
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    client.record("call_completed", outcome="completed", error_code="timeout")
+    client.record("call_started", engine="realtime")  # dropped
+    await _wait_for(collector, 1)
+    await client.aclose()
+
+    assert collector.event_names() == ["call_completed"]
+    assert collector.events[0]["error_code"] == "timeout"
+
+
+# --- rate = 0.5: deterministic keep vs drop + sample_rate stamping -----------
+
+
+async def test_rate_half_kept_run_delivers_call_events_with_sample_rate(
+    enabled, collector, monkeypatch
+):
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "0.5")
+    _pin_run_id(monkeypatch, _KEEP_RUN_ID)  # ratio < 0.5 -> this run KEEPS
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    assert client._keep_sampled is True
+    assert client._sample_rate == 0.5
+
+    client.record("call_started", engine="realtime", carrier="twilio")
+    client.record("call_completed", outcome="completed", carrier="twilio")
+    await _wait_for(collector, 2)
+    await client.aclose()
+
+    assert sorted(collector.event_names()) == ["call_completed", "call_started"]
+    # Both kept sampled events carry the rate so analytics can weight by 1/rate.
+    for e in collector.events:
+        assert e["sample_rate"] == 0.5
+
+
+async def test_rate_half_dropped_run_drops_clean_call_events(
+    enabled, collector, monkeypatch
+):
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "0.5")
+    _pin_run_id(monkeypatch, _DROP_RUN_ID)  # ratio >= 0.5 -> this run DROPS
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    assert client._keep_sampled is False
+
+    client.record("call_started", engine="realtime")
+    client.record("call_completed", outcome="completed")
+    # first_run still passes; an error call_completed still passes.
+    client.record("first_run")
+    client.record("call_completed", outcome="error", error_code="auth")
+    await _wait_for(collector, 2)
+    await client.aclose()
+
+    assert sorted(collector.event_names()) == ["call_completed", "first_run"]
+    err = next(e for e in collector.events if e["event"] == "call_completed")
+    assert err["outcome"] == "error"
+    assert err["sample_rate"] == 0.5  # force-kept error still carries the rate
+
+
+async def test_rate_half_decision_is_stable_across_repeated_records(
+    enabled, collector, monkeypatch
+):
+    """Determinism: the SAME run id yields the SAME keep/drop decision for every
+    record call within the process — not a per-event coin flip."""
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "0.5")
+    _pin_run_id(monkeypatch, _DROP_RUN_ID)  # this run drops sampleable events
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+
+    for _ in range(20):
+        client.record("call_started", engine="realtime")
+    await asyncio.sleep(0.1)
+    await client.aclose()
+
+    # All 20 dropped — consistently, never a stray keep.
+    assert collector.events == []
+
+    # And a fresh client in the same run (same pinned run id) makes the SAME call.
+    client2 = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    assert client2._keep_sampled is False
+
+
+# --- unset / rate >= 1: no sampling, no stamping ----------------------------
+
+
+async def test_unset_keeps_everything_without_sample_rate(
+    enabled, collector, monkeypatch
+):
+    monkeypatch.delenv("PATTER_TELEMETRY_SAMPLE", raising=False)
+    _pin_run_id(monkeypatch, _DROP_RUN_ID)  # would drop IF sampling were active
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    assert client._sample_rate == 1.0
+    assert client._keep_sampled is True
+
+    client.record("call_started", engine="realtime")
+    client.record("call_completed", outcome="completed")
+    await _wait_for(collector, 2)
+    await client.aclose()
+
+    assert sorted(collector.event_names()) == ["call_completed", "call_started"]
+    # Payloads stay lean at rate 1.0 — no sample_rate stamped.
+    for e in collector.events:
+        assert "sample_rate" not in e
+
+
+async def test_malformed_value_degrades_to_keep_all(enabled, collector, monkeypatch):
+    monkeypatch.setenv("PATTER_TELEMETRY_SAMPLE", "garbage")
+    _pin_run_id(monkeypatch, _DROP_RUN_ID)
+    client = TelemetryClient(sdk_version="0.6.8", endpoint=collector.url)
+    assert client._sample_rate == 1.0  # fail safe
+
+    client.record("call_started", engine="realtime")
+    client.record("call_completed", outcome="completed")
+    await _wait_for(collector, 2)
+    await client.aclose()
+
+    assert sorted(collector.event_names()) == ["call_completed", "call_started"]
+    for e in collector.events:
+        assert "sample_rate" not in e
+
+
+def test_run_keep_ratio_is_in_unit_interval():
+    r = _run_keep_ratio()
+    assert 0.0 <= r < 1.0001

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -289,6 +289,8 @@ export class Patter {
   private readonly telemetry: TelemetryClient;
   private readonly telemetrySeenEngines = new Set<string>();
   private readonly telemetrySeenAgentShapes = new Set<string>();
+  /** Activation-blocker signal is emitted at most once per instance. */
+  private telemetryConfigIncompleteEmitted = false;
 
   /**
    * Pre-rendered first-message TTS audio per outbound call_id. Populated
@@ -486,10 +488,22 @@ export class Patter {
       );
     }
 
+    // --- Anonymous usage telemetry (opt-out, default ON) ---
+    // Constructed BEFORE the activation-blocker validation below so the
+    // `config_incomplete` signal can be emitted on the failing path. Separate
+    // from ./observability (user-facing OTel). Fail-safe fire-and-forget.
+    // Disable with PATTER_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, or telemetry: false.
+    this.telemetry = new TelemetryClient({
+      sdkVersion: VERSION,
+      flag: options.telemetry,
+    });
+
     if (!options.phoneNumber) {
+      this.recordConfigIncomplete('carrier_credentials');
       throw new Error('Local mode requires phoneNumber');
     }
     if (!options.carrier) {
+      this.recordConfigIncomplete('carrier_credentials');
       throw new Error(
         'Local mode requires a `carrier` instance. ' +
           'Pass `carrier: new Twilio({...})`, `carrier: new Telnyx({...})` or ' +
@@ -528,13 +542,9 @@ export class Patter {
       persistRoot: resolvePersistRoot(options.persist),
     };
 
-    // --- Anonymous usage telemetry (opt-out, default ON) ---
-    // Separate from ./observability (user-facing OTel). Fail-safe fire-and-forget.
-    // Disable with PATTER_TELEMETRY_DISABLED=1, DO_NOT_TRACK=1, or telemetry: false.
-    this.telemetry = new TelemetryClient({
-      sdkVersion: VERSION,
-      flag: options.telemetry,
-    });
+    // The telemetry client was constructed above (before the activation-blocker
+    // validation) so `config_incomplete` could be emitted on the failing path.
+    // Here we emit the normal startup events.
     const initDims = {
       carrier: carrierFamily(carrier),
       tunnel:
@@ -586,6 +596,29 @@ export class Patter {
   }
 
   // === Agent definition ===
+
+  /**
+   * Emit the activation-blocker `config_incomplete` signal, at most once.
+   *
+   * Fire-and-forget: records the coarse `missing` category right before a
+   * validation `throw` and then lets that error propagate unchanged. It NEVER
+   * throws and NEVER alters control flow. Deduped per instance so a retry loop or
+   * a second `agent()` call on the same Patter cannot double-emit. Only the
+   * allowlisted enum leaves the process — never the key value, env var name,
+   * carrier credentials, or any PII. `config_incomplete` is in the never-sampled
+   * set, so the telemetry client always delivers it.
+   */
+  private recordConfigIncomplete(
+    missing: 'carrier_credentials' | 'llm_key' | 'engine_config' | 'other',
+  ): void {
+    try {
+      if (this.telemetryConfigIncompleteEmitted) return;
+      this.telemetryConfigIncompleteEmitted = true;
+      this.telemetry.record('config_incomplete', { missing });
+    } catch {
+      // Telemetry must never break construction or agent setup.
+    }
+  }
 
   /** Resolve user-supplied agent options against engine defaults and return the merged config. */
   agent(opts: AgentOptions): AgentOptions {
@@ -708,6 +741,7 @@ export class Patter {
           voice: working.voice ?? engine.voice,
         };
       } else {
+        this.recordConfigIncomplete('engine_config');
         throw new Error(
           "Unknown engine. Expected OpenAIRealtime, OpenAIRealtime2, or ElevenLabsConvAI instance.",
         );
@@ -727,6 +761,7 @@ export class Patter {
     if (working.provider) {
       const valid = ['openai_realtime', 'elevenlabs_convai', 'pipeline'];
       if (!valid.includes(working.provider)) {
+        this.recordConfigIncomplete('engine_config');
         throw new Error(`provider must be one of: ${valid.join(', ')}. Got: '${working.provider}'`);
       }
     }
@@ -746,6 +781,7 @@ export class Patter {
         // call instead of a clear error (parity with Python).
         this.localConfig = { ...this.localConfig, openaiKey: envKey };
       } else {
+        this.recordConfigIncomplete('llm_key');
         throw new Error(
           "OpenAI Realtime mode requires an OpenAI API key. Pass " +
             "engine: new OpenAIRealtime({ apiKey: 'sk-...' }) or set " +

--- a/libraries/typescript/src/telemetry/call-metrics.ts
+++ b/libraries/typescript/src/telemetry/call-metrics.ts
@@ -14,6 +14,7 @@
  */
 
 import type { TelemetryClient } from './client';
+import { installAgeSeconds } from './install-id';
 
 type Metricsish = Record<string, unknown>;
 
@@ -72,6 +73,98 @@ function latencyMs(m: Metricsish): unknown {
   return undefined;
 }
 
+/**
+ * Coerce a millisecond latency to a whole non-negative int, or `undefined`.
+ * `undefined` when the source is absent OR `0` (a stage that did not run — e.g.
+ * realtime/convai have no separate STT/TTS span, so those breakdown fields stay
+ * `0` and are omitted rather than reported as a false zero).
+ */
+function wholeMs(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  const ms = Math.max(0, Math.round(value));
+  return ms > 0 ? ms : undefined;
+}
+
+/**
+ * Read the per-stage latency breakdown off the existing p95 accumulator.
+ * Read-only — no new audio-path instrumentation. Maps the `LatencyBreakdown`
+ * fields onto the wire dims, omitting any stage whose source is absent or `0`
+ * (stage did not run). Same source object as `latency_ms` (`m.latency_p95`).
+ */
+function perStageLatencies(m: Metricsish): Record<string, number> {
+  const p95raw = m.latency_p95;
+  if (!p95raw || typeof p95raw !== 'object') return {};
+  const p95 = p95raw as Record<string, unknown>;
+  const mapping: Record<string, unknown> = {
+    stt_latency_ms: p95.stt_ms,
+    llm_ttft_ms: p95.llm_ttft_ms,
+    tts_first_byte_ms: p95.tts_ms,
+    eou_latency_ms: p95.endpoint_ms,
+  };
+  const out: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(mapping)) {
+    const whole = wholeMs(raw);
+    if (whole !== undefined) out[key] = whole;
+  }
+  return out;
+}
+
+// Coarse, deterministic error_code -> error_layer mapping. NEVER the message;
+// the layer is inferred only from the structured code. `provider_error` is not
+// attributable to a specific stage from the code alone, so it maps to `other`.
+// Keep byte-for-byte identical to `_ERROR_LAYER_BY_CODE` in `call_metrics.py`.
+const ERROR_LAYER_BY_CODE: Record<string, string> = {
+  auth: 'llm',
+  rate_limit: 'llm',
+  timeout: 'llm',
+  provider_error: 'other',
+  connection: 'other',
+  webhook_verification: 'carrier',
+  provision: 'carrier',
+  config: 'config',
+  input_validation: 'config',
+  internal: 'internal',
+};
+
+/**
+ * Map a terminal `errorCode` to its coarse originating layer. `'none'` on a
+ * clean completion (no code); the value allowlist coerces anything off the enum
+ * to `'other'`.
+ */
+function errorLayer(errorCode: string): string {
+  if (!errorCode) return 'none';
+  return ERROR_LAYER_BY_CODE[errorCode] ?? 'other';
+}
+
+/**
+ * Map the terminal outcome (+ errorCode) to a coarse disconnect reason. Derived
+ * only from already-known state. `hangup_local` / `hangup_remote` are NOT set
+ * here because the hanging-up side is not reliably known on this path; clean
+ * ends collapse to `completed` and the value allowlist coerces anything off-list
+ * to `other`. Keep identical to `_disconnect_reason` in `call_metrics.py`.
+ */
+function disconnectReason(outcome: string, errorCode: string): string {
+  if (outcome === 'no_answer') return 'no_answer';
+  if (outcome === 'busy') return 'busy';
+  if (outcome === 'error') return errorCode === 'timeout' ? 'timeout' : 'error';
+  if (outcome === 'failed') return errorCode === 'timeout' ? 'timeout' : 'error';
+  if (outcome === 'completed') return 'completed';
+  return 'other';
+}
+
+/**
+ * Bucket the install age (seconds) into a coarse time-to-first-call band.
+ * `unknown` when the age can't be read. Keep boundaries byte-for-byte identical
+ * to `_time_to_first_call_bucket` in `call_metrics.py`.
+ */
+function timeToFirstCallBucket(ageSeconds: number | undefined): string {
+  if (ageSeconds === undefined) return 'unknown';
+  if (ageSeconds < 3600) return 'lt_1h';
+  if (ageSeconds < 86400) return '1h_1d';
+  if (ageSeconds < 604800) return '1d_7d';
+  return 'gt_7d';
+}
+
 export interface RecordCallStartedOptions {
   readonly providerMode?: string;
   readonly telephonyProvider?: string;
@@ -101,6 +194,8 @@ export function recordCallStarted(
     const d = direction(opts.direction);
     if (d !== undefined) dims.direction = d;
     if (opts.callUid) dims.call_uid = opts.callUid;
+    // F4: how long after install this call fires (coarse bucket).
+    dims.time_to_first_call_bucket = timeToFirstCallBucket(installAgeSeconds());
     telemetry.record('call_started', dims);
   } catch {
     /* swallow — telemetry is never load-bearing */
@@ -153,16 +248,34 @@ export function recordCallCompleted(
       if (Array.isArray(m.turns)) {
         dims.turn_count_bucket = turnCountBucket(m.turns.length);
       }
+      // F2: per-stage latency, read-only off the same p95 breakdown as
+      // latency_ms. Each dim is omitted when its stage didn't run.
+      Object.assign(dims, perStageLatencies(m));
       // A connected call that ended with a terminal error: surface the code and
       // flip the outcome to "error" (the value allowlist coerces unknowns to "other").
-      const errorCode = m.error_code;
-      if (typeof errorCode === 'string' && errorCode) {
+      const rawCode = m.error_code;
+      const errorCode = typeof rawCode === 'string' ? rawCode : '';
+      if (errorCode) {
         dims.error_code = errorCode;
         dims.outcome = 'error';
       }
+      // F3: coarse error layer + disconnect reason, derived deterministically
+      // from the (now-final) outcome and error_code. error_layer is "none" on a
+      // clean completion.
+      dims.error_layer = errorLayer(errorCode);
+      dims.disconnect_reason = disconnectReason(dims.outcome as string, errorCode);
     } else if (opts.carrier !== undefined) {
       dims.carrier = carrierFamily(opts.carrier);
+      // F3: non-connected failures (no_answer/busy/failed) carry no metrics, so
+      // there is no error_code — map the disconnect reason from the outcome
+      // alone; error_layer stays "carrier" only when the carrier itself failed
+      // (outcome "failed"), else "none".
+      dims.error_layer = opts.outcome === 'failed' ? 'carrier' : 'none';
+      dims.disconnect_reason = disconnectReason(opts.outcome, '');
     }
+    // F4: how long after install this call fires (coarse bucket) — on both
+    // call_started and call_completed for the activation-funnel join.
+    dims.time_to_first_call_bucket = timeToFirstCallBucket(installAgeSeconds());
     telemetry.record('call_completed', dims);
   } catch {
     /* swallow — telemetry is never load-bearing */

--- a/libraries/typescript/src/telemetry/client.ts
+++ b/libraries/typescript/src/telemetry/client.ts
@@ -17,10 +17,19 @@
  * new dependency. Mirrors `getpatter/telemetry/client.py`.
  */
 
+import { createHash } from 'node:crypto';
+
 import { getLogger } from '../logger';
 import { isEnabled } from './consent';
-import { buildEvent, type Dimensions, type TelemetryEvent } from './events';
-import { isTruthy } from './env';
+import {
+  EVENT_CALL_COMPLETED,
+  EVENT_CALL_STARTED,
+  buildEvent,
+  type Dimensions,
+  type TelemetryEvent,
+} from './events';
+import { isTruthy, sampleRate } from './env';
+import { runId } from './install-id';
 
 export const DEFAULT_ENDPOINT = 'https://telemetry.getpatter.com/v1/ingest';
 
@@ -29,6 +38,32 @@ const BUFFER_MAX = 256;
 // The relay rejects batches larger than 64 events per request — a full buffer
 // must ship as multiple POSTs or events 65..256 silently vanish server-side.
 const MAX_EVENTS_PER_POST = 64;
+
+// The ONLY events the client-side sampling gate may drop. Everything else
+// (first_run, config_incomplete, sdk_initialized, cli_command, feature_used,
+// agent_configured) is always delivered — those are low-frequency activation /
+// usage signals, never high-volume call traffic. An *error* call_completed is
+// also force-kept (see record()) so error rates stay unbiased.
+const SAMPLEABLE_EVENTS = new Set<string>([EVENT_CALL_STARTED, EVENT_CALL_COMPLETED]);
+
+/**
+ * A stable per-run value in `[0, 1)` derived from this process's run id.
+ *
+ * Hashing the run id (constant for the process) makes the keep/drop decision
+ * DETERMINISTIC PER RUN: the whole run consistently keeps or drops its
+ * sampleable call events rather than flipping a per-event coin — which would
+ * bias short runs. `Math.random` would NOT be deterministic per run. Any
+ * failure degrades to `0` so the caller keeps the event (fail safe). Mirrors
+ * Python's `_run_keep_ratio`.
+ */
+function runKeepRatio(): number {
+  try {
+    const digest = createHash('sha256').update(runId(), 'utf8').digest('hex').slice(0, 8);
+    return parseInt(digest, 16) / 0xffffffff;
+  } catch {
+    return 0;
+  }
+}
 
 let noticeShown = false;
 // WeakRefs so a client whose owning `Patter` was discarded is garbage-collected
@@ -89,6 +124,14 @@ export class TelemetryClient {
   private inflight: Promise<void> | null = null;
   private closed = false;
   private readonly selfRef: WeakRef<TelemetryClient> = new WeakRef(this);
+  // Client-side sampling gate (computed ONCE at construction):
+  //   * sampleRate — the effective rate in [0, 1] from the env.
+  //   * keepSampled — the deterministic per-run keep/drop decision for the
+  //     high-frequency call events. Because the seed is the run id (constant for
+  //     the process) the whole run consistently keeps or drops them — never a
+  //     per-event coin flip. rate >= 1.0 always keeps. See record().
+  private readonly sampleRate: number;
+  private readonly keepSampled: boolean;
 
   constructor(options: TelemetryClientOptions) {
     this.sdkVersion = options.sdkVersion;
@@ -96,6 +139,8 @@ export class TelemetryClient {
     this.endpoint =
       options.endpoint ?? process.env.PATTER_TELEMETRY_ENDPOINT ?? DEFAULT_ENDPOINT;
     this.debug = isTruthy(process.env.PATTER_TELEMETRY_DEBUG);
+    this.sampleRate = sampleRate();
+    this.keepSampled = this.sampleRate >= 1.0 || runKeepRatio() < this.sampleRate;
 
     if (this.enabledFlag && !this.debug) {
       showNoticeOnce();
@@ -108,13 +153,40 @@ export class TelemetryClient {
     return this.enabledFlag;
   }
 
-  /** Enqueue an event. Fire-and-forget; never throws, never blocks. */
+  /**
+   * Enqueue an event. Fire-and-forget; never throws, never blocks.
+   *
+   * Applies the client-side sampling gate (see constructor): only the
+   * high-frequency `call_started` / `call_completed` events may be dropped, and
+   * only when this run's deterministic decision says so. An error
+   * `call_completed` (`outcome === 'error'` or an `error_code` present) is
+   * ALWAYS kept so error rates stay unbiased. A kept sampled event carries
+   * `sample_rate` so analytics can extrapolate (weight `1/sample_rate`). All
+   * other events bypass the gate entirely.
+   */
   record(name: string, dimensions?: Dimensions): void {
     if (!this.enabledFlag || this.closed) return;
 
+    // -- sampling gate (high-frequency call events only) --------------------
+    let dims = dimensions;
+    if (SAMPLEABLE_EVENTS.has(name) && this.sampleRate < 1.0) {
+      // Force-keep error call_completed events regardless of rate — error rates
+      // would be biased if errors were sampled like clean calls.
+      const isError =
+        name === EVENT_CALL_COMPLETED &&
+        ((dims?.outcome === 'error') || (dims != null && 'error_code' in dims));
+      if (!this.keepSampled && !isError) return; // sampled out for this run
+      // Kept (by the run decision or because it's an error): stamp the rate so
+      // analytics can extrapolate (weight = 1/rate). buildEvent keeps it (the
+      // Schema phase added sample_rate to the numeric allowlist). Stamped only
+      // when rate < 1.0 to keep payloads lean. New object — never mutate the
+      // caller's dimensions.
+      dims = { ...dims, sample_rate: this.sampleRate };
+    }
+
     let event: TelemetryEvent;
     try {
-      event = buildEvent(name, { sdkVersion: this.sdkVersion, dimensions });
+      event = buildEvent(name, { sdkVersion: this.sdkVersion, dimensions: dims });
     } catch (err) {
       getLogger().debug('telemetry buildEvent failed', err);
       return;

--- a/libraries/typescript/src/telemetry/env.ts
+++ b/libraries/typescript/src/telemetry/env.ts
@@ -34,6 +34,31 @@ export function isTruthy(value: string | undefined): boolean {
   return v !== '' && v !== '0' && v !== 'false' && v !== 'no' && v !== 'off';
 }
 
+/**
+ * Client-side sampling rate for high-frequency call events, in `[0, 1]`.
+ *
+ * Read from `PATTER_TELEMETRY_SAMPLE` and clamped to `[0, 1]`. Defaults to `1.0`
+ * (no sampling — every event kept) when the var is unset, empty, non-numeric,
+ * `< 0`, or `> 1`. Fail-safe: this never throws — a bad value degrades to `1.0`
+ * so a misconfigured env can never silently drop data.
+ *
+ * Only the high-frequency `call_started` / `call_completed` events are gated by
+ * this rate (see `TelemetryClient`); activation and error events are always
+ * delivered regardless. Mirrors `sample_rate` in `env.py`.
+ */
+export function sampleRate(): number {
+  const raw = process.env.PATTER_TELEMETRY_SAMPLE;
+  if (raw === undefined) return 1.0;
+  const trimmed = raw.trim();
+  if (trimmed === '') return 1.0;
+  const rate = Number(trimmed);
+  // NaN/Infinity or out of range → fail safe to 1.0 (keep everything). A value
+  // of exactly 0 is honored (drop all sampleable events); only invalid input
+  // degrades to the no-sampling default.
+  if (!Number.isFinite(rate) || rate < 0 || rate > 1) return 1.0;
+  return rate;
+}
+
 /** True when running under a recognised CI provider. */
 export function isCi(): boolean {
   return CI_ENV_VARS.some((name) => isTruthy(process.env[name]));

--- a/libraries/typescript/src/telemetry/events.ts
+++ b/libraries/typescript/src/telemetry/events.ts
@@ -23,7 +23,7 @@ import { isCi, isTest } from './env';
 import { installId, runId } from './install-id';
 import { STACK_VENDORS } from './stack';
 
-export const SCHEMA_VERSION = 7;
+export const SCHEMA_VERSION = 8;
 
 export const EVENT_SDK_INITIALIZED = 'sdk_initialized';
 export const EVENT_FIRST_RUN = 'first_run';
@@ -32,6 +32,9 @@ export const EVENT_FEATURE_USED = 'feature_used';
 export const EVENT_AGENT_CONFIGURED = 'agent_configured';
 export const EVENT_CALL_STARTED = 'call_started';
 export const EVENT_CALL_COMPLETED = 'call_completed';
+// Activation-blocker signal: emitted once when required runtime config is missing
+// so the instance cannot proceed. In the NEVER-sampled set (always delivered).
+export const EVENT_CONFIG_INCOMPLETE = 'config_incomplete';
 
 const ALLOWED_EVENTS = new Set<string>([
   EVENT_SDK_INITIALIZED,
@@ -41,6 +44,7 @@ const ALLOWED_EVENTS = new Set<string>([
   EVENT_AGENT_CONFIGURED,
   EVENT_CALL_STARTED,
   EVENT_CALL_COMPLETED,
+  EVENT_CONFIG_INCOMPLETE,
 ]);
 
 /**
@@ -106,15 +110,46 @@ export const DIMENSION_VALUES: Record<string, ReadonlySet<string>> = {
   turn_detection: new Set(['default', 'custom', 'none']),
   // call_completed: how many conversational turns the call had.
   turn_count_bucket: new Set(['0', '1', '2_3', '4_6', '7_12', '13_plus']),
+  // config_incomplete: coarse category of the absent required runtime config
+  // blocking activation. Never the key value, env var name, or any PII.
+  missing: new Set(['carrier_credentials', 'llm_key', 'engine_config', 'other']),
+  // call_completed: which layer the terminal error originated in (derived from
+  // CallMetrics.errorCode/outcome). "none" when the call ended cleanly.
+  error_layer: new Set(['stt', 'llm', 'tts', 'carrier', 'config', 'internal', 'none', 'other']),
+  // call_completed: coarse reason the call ended (derived from terminal
+  // outcome/error/AMD state). hangup_local/hangup_remote only when the side is
+  // reliably known; else fall back to completed (clean end) or other.
+  disconnect_reason: new Set([
+    'hangup_local',
+    'hangup_remote',
+    'error',
+    'timeout',
+    'no_answer',
+    'busy',
+    'completed',
+    'other',
+  ]),
+  // call_started / call_completed: coarse age of the install at call time
+  // (install-id file mtime vs now). "unknown" when the timestamp can't be read.
+  time_to_first_call_bucket: new Set(['lt_1h', '1h_1d', '1d_7d', 'gt_7d', 'unknown']),
 };
 
 // Numeric dimensions pass through without value coercion. latency_ms (whole ms)
-// and duration_seconds (whole seconds) are raw operational metrics.
+// and duration_seconds (whole seconds) are raw operational metrics. The per-stage
+// call_completed latencies (stt_latency_ms, llm_ttft_ms, tts_first_byte_ms,
+// eou_latency_ms) are read off the existing CallMetrics latency breakdown — whole
+// ints, omitted when the stage didn't run. sample_rate is the client-side
+// sampling rate in (0,1] for high-frequency call events (weight = 1/sample_rate).
 const NUMERIC_DIMENSIONS = new Set<string>([
   'builtin_tool_count',
   'latency_ms',
   'duration_seconds',
   'cost_usd',
+  'stt_latency_ms',
+  'llm_ttft_ms',
+  'tts_first_byte_ms',
+  'eou_latency_ms',
+  'sample_rate',
 ]);
 // feature_used (pipeline): sanitized per-layer model token (e.g.
 // "deepgram-nova-3", "anthropic-claude-haiku-4-5"). NOT a closed enum — produced

--- a/libraries/typescript/src/telemetry/install-id.ts
+++ b/libraries/typescript/src/telemetry/install-id.ts
@@ -165,6 +165,23 @@ export function daysSinceInstallBucket(): string {
   return '30_plus';
 }
 
+/**
+ * Seconds since this install was created, from the install-id file mtime.
+ * Reuses the same mtime seam as `daysSinceInstallBucket`. Returns `undefined`
+ * on an unreadable / read-only filesystem (the caller buckets that to
+ * `'unknown'`). Best-effort and never throws. Mirrors `install_age_seconds`
+ * in `install_id.py`.
+ */
+export function installAgeSeconds(): number | undefined {
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(statePath()).mtimeMs;
+  } catch {
+    return undefined;
+  }
+  return Math.max(0, (Date.now() - mtimeMs) / 1000);
+}
+
 function firstRunPath(): string {
   return path.join(path.dirname(statePath()), 'first-run');
 }

--- a/libraries/typescript/tests/telemetry-call-stages.test.ts
+++ b/libraries/typescript/tests/telemetry-call-stages.test.ts
@@ -1,0 +1,317 @@
+/**
+ * [unit] Authentic tests for the per-stage / error / time-to-first-call dims.
+ *
+ * Covers telemetry workstream F2 (per-stage latency), F3 (error_layer +
+ * disconnect_reason), and F4 (time_to_first_call_bucket) on the shared
+ * `call_started` / `call_completed` emit path.
+ *
+ * These exercise the REAL builders in `src/telemetry/call-metrics` against
+ * REAL CallMetrics-shaped objects (snake_case wire keys, matching `metrics.ts`).
+ * Only the outermost boundary — the telemetry client's `record` sink — is a
+ * local capture double (no HTTP), so every assertion checks the dimension
+ * object the builder actually produced. Nothing here mocks the code under test.
+ *
+ * Mirror of `libraries/python/tests/test_telemetry_call_stages.py`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { recordCallCompleted, recordCallStarted } from '../src/telemetry/call-metrics';
+import { installAgeSeconds } from '../src/telemetry/install-id';
+import type { TelemetryClient } from '../src/telemetry/client';
+import type { LatencyBreakdown, CallMetrics } from '../src/metrics';
+
+/**
+ * Capture double for the telemetry sink — the only mocked surface. Mirrors
+ * `TelemetryClient.record(name, dimensions)` and stores each call so a test can
+ * assert the real, fully-built dimension object.
+ */
+class CaptureTelemetry {
+  readonly records: Array<{ name: string; dims: Record<string, unknown> }> = [];
+  record(name: string, dimensions?: Record<string, unknown>): void {
+    this.records.push({ name, dims: { ...(dimensions ?? {}) } });
+  }
+}
+
+function asClient(cap: CaptureTelemetry): TelemetryClient {
+  // The builders only ever call `.record(...)`; the capture double satisfies
+  // that surface. Cast through unknown to avoid pulling the full client type.
+  return cap as unknown as TelemetryClient;
+}
+
+function latency(partial: Partial<LatencyBreakdown>): LatencyBreakdown {
+  return { stt_ms: 0, llm_ms: 0, tts_ms: 0, total_ms: 0, ...partial };
+}
+
+function metricsObj(opts: {
+  providerMode: string;
+  latency: LatencyBreakdown;
+  errorCode?: string;
+  llmProvider?: string;
+}): Partial<CallMetrics> {
+  return {
+    call_id: 'ca-test',
+    duration_seconds: 12,
+    turns: [],
+    cost: { stt: 0, tts: 0, llm: 0, telephony: 0, total: 0.06, llm_cached_savings: 0 },
+    latency_avg: opts.latency,
+    latency_p95: opts.latency,
+    provider_mode: opts.providerMode,
+    telephony_provider: 'twilio',
+    llm_provider: opts.llmProvider ?? '',
+    ...(opts.errorCode !== undefined ? { error_code: opts.errorCode } : {}),
+  };
+}
+
+// --- isolate the persisted-state dir per test (for F4 mtime control) -------
+let stateDir: string;
+let savedStateDir: string | undefined;
+
+beforeEach(() => {
+  savedStateDir = process.env.PATTER_TELEMETRY_STATE_DIR;
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-tel-stages-'));
+  process.env.PATTER_TELEMETRY_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  if (savedStateDir === undefined) delete process.env.PATTER_TELEMETRY_STATE_DIR;
+  else process.env.PATTER_TELEMETRY_STATE_DIR = savedStateDir;
+  try {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+function setInstallMtime(ageSeconds: number): void {
+  const p = path.join(stateDir, 'install-id');
+  fs.writeFileSync(p, '0'.repeat(32), 'utf8');
+  const when = new Date(Date.now() - ageSeconds * 1000);
+  fs.utimesSync(p, when, when);
+}
+
+// --------------------------------------------------------------------------- //
+// F2 — per-stage latency                                                      //
+// --------------------------------------------------------------------------- //
+
+describe('[unit] call_completed per-stage latency (F2)', () => {
+  it('emits the four per-stage dims as whole ints for a pipeline call', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({
+        providerMode: 'pipeline',
+        llmProvider: 'cerebras',
+        latency: latency({
+          stt_ms: 120.4,
+          tts_ms: 88.9,
+          llm_ttft_ms: 305.5,
+          endpoint_ms: 42.2,
+          agent_response_ms: 436,
+        }),
+      }),
+    });
+
+    expect(cap.records).toHaveLength(1);
+    const { name, dims } = cap.records[0];
+    expect(name).toBe('call_completed');
+    expect(dims.stt_latency_ms).toBe(120);
+    expect(dims.tts_first_byte_ms).toBe(89);
+    expect(dims.llm_ttft_ms).toBe(306);
+    expect(dims.eou_latency_ms).toBe(42);
+    for (const k of ['stt_latency_ms', 'tts_first_byte_ms', 'llm_ttft_ms', 'eou_latency_ms']) {
+      expect(Number.isInteger(dims[k])).toBe(true);
+    }
+  });
+
+  it('omits stt/tts stage dims for a realtime engine (no separate STT/TTS span)', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({
+        providerMode: 'openai_realtime',
+        latency: latency({ stt_ms: 0, tts_ms: 0, llm_ttft_ms: 210, endpoint_ms: 30 }),
+      }),
+    });
+
+    const { dims } = cap.records[0];
+    expect(dims.stt_latency_ms).toBeUndefined();
+    expect(dims.tts_first_byte_ms).toBeUndefined();
+    expect(dims.llm_ttft_ms).toBe(210);
+    expect(dims.eou_latency_ms).toBe(30);
+  });
+
+  it('omits an absent optional stage (undefined ttft/endpoint), never sends 0', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({
+        providerMode: 'pipeline',
+        latency: latency({ stt_ms: 100, tts_ms: 50 }),
+      }),
+    });
+
+    const { dims } = cap.records[0];
+    expect(dims.stt_latency_ms).toBe(100);
+    expect(dims.tts_first_byte_ms).toBe(50);
+    expect(dims.llm_ttft_ms).toBeUndefined();
+    expect(dims.eou_latency_ms).toBeUndefined();
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// F3 — error_layer + disconnect_reason                                        //
+// --------------------------------------------------------------------------- //
+
+describe('[unit] call_completed error_layer + disconnect_reason (F3)', () => {
+  it('maps a clean completion to error_layer=none, disconnect_reason=completed', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({ providerMode: 'pipeline', latency: latency({}) }),
+    });
+    const { dims } = cap.records[0];
+    expect(dims.error_layer).toBe('none');
+    expect(dims.disconnect_reason).toBe('completed');
+    expect(dims.outcome).toBe('completed');
+  });
+
+  it('maps an llm auth error to error_layer=llm, disconnect_reason=error', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({ providerMode: 'pipeline', latency: latency({}), errorCode: 'auth' }),
+    });
+    const { dims } = cap.records[0];
+    expect(dims.outcome).toBe('error');
+    expect(dims.error_code).toBe('auth');
+    expect(dims.error_layer).toBe('llm');
+    expect(dims.disconnect_reason).toBe('error');
+  });
+
+  it('maps a timeout error to disconnect_reason=timeout', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({ providerMode: 'pipeline', latency: latency({}), errorCode: 'timeout' }),
+    });
+    const { dims } = cap.records[0];
+    expect(dims.error_layer).toBe('llm');
+    expect(dims.disconnect_reason).toBe('timeout');
+  });
+
+  it('maps webhook_verification to error_layer=carrier', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({
+        providerMode: 'pipeline',
+        latency: latency({}),
+        errorCode: 'webhook_verification',
+      }),
+    });
+    expect(cap.records[0].dims.error_layer).toBe('carrier');
+  });
+
+  it('maps provider_error to error_layer=other (not attributable to a stage)', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), {
+      outcome: 'completed',
+      metrics: metricsObj({
+        providerMode: 'pipeline',
+        latency: latency({}),
+        errorCode: 'provider_error',
+      }),
+    });
+    const { dims } = cap.records[0];
+    expect(dims.error_layer).toBe('other');
+    expect(dims.disconnect_reason).toBe('error');
+  });
+
+  it('maps a no_answer failure to disconnect_reason=no_answer, layer=none', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), { outcome: 'no_answer', carrier: 'twilio' });
+    const { dims } = cap.records[0];
+    expect(dims.outcome).toBe('no_answer');
+    expect(dims.disconnect_reason).toBe('no_answer');
+    expect(dims.error_layer).toBe('none');
+  });
+
+  it('maps a busy failure to disconnect_reason=busy', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), { outcome: 'busy', carrier: 'telnyx' });
+    const { dims } = cap.records[0];
+    expect(dims.disconnect_reason).toBe('busy');
+    expect(dims.error_layer).toBe('none');
+  });
+
+  it('maps a carrier failure (outcome=failed) to disconnect_reason=error, layer=carrier', () => {
+    const cap = new CaptureTelemetry();
+    recordCallCompleted(asClient(cap), { outcome: 'failed', carrier: 'twilio' });
+    const { dims } = cap.records[0];
+    expect(dims.disconnect_reason).toBe('error');
+    expect(dims.error_layer).toBe('carrier');
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// F4 — time_to_first_call_bucket (both events)                                //
+// --------------------------------------------------------------------------- //
+
+describe('[unit] time_to_first_call_bucket (F4)', () => {
+  it('attaches lt_1h on both call_started and call_completed for a 30-min install', () => {
+    setInstallMtime(30 * 60);
+
+    const started = new CaptureTelemetry();
+    recordCallStarted(asClient(started), { providerMode: 'pipeline', telephonyProvider: 'twilio' });
+
+    const completed = new CaptureTelemetry();
+    recordCallCompleted(asClient(completed), {
+      outcome: 'completed',
+      metrics: metricsObj({ providerMode: 'pipeline', latency: latency({}) }),
+    });
+
+    expect(started.records[0].dims.time_to_first_call_bucket).toBe('lt_1h');
+    expect(completed.records[0].dims.time_to_first_call_bucket).toBe('lt_1h');
+  });
+
+  it('buckets at every boundary', () => {
+    const cases: Array<[number, string]> = [
+      [60, 'lt_1h'],
+      [3600 + 1, '1h_1d'],
+      [86400 + 1, '1d_7d'],
+      [604800 + 1, 'gt_7d'],
+    ];
+    for (const [age, expected] of cases) {
+      setInstallMtime(age);
+      const cap = new CaptureTelemetry();
+      recordCallStarted(asClient(cap), { providerMode: 'pipeline' });
+      expect(cap.records[0].dims.time_to_first_call_bucket).toBe(expected);
+    }
+  });
+
+  it('falls back to unknown when the install state is unreadable', () => {
+    // No install-id file written → statSync throws → bucket is unknown.
+    const cap = new CaptureTelemetry();
+    recordCallStarted(asClient(cap), { providerMode: 'pipeline' });
+    expect(cap.records[0].dims.time_to_first_call_bucket).toBe('unknown');
+  });
+
+  it('installAgeSeconds reads the mtime', () => {
+    setInstallMtime(7200);
+    const age = installAgeSeconds();
+    expect(age).not.toBeUndefined();
+    expect(age!).toBeGreaterThanOrEqual(7000);
+    expect(age!).toBeLessThanOrEqual(7400);
+  });
+});
+
+describe('[unit] call builders are fire-and-forget', () => {
+  it('never throw with an undefined telemetry sink', () => {
+    expect(() => recordCallStarted(undefined, { providerMode: 'pipeline' })).not.toThrow();
+    expect(() => recordCallCompleted(undefined, { outcome: 'completed' })).not.toThrow();
+  });
+});

--- a/libraries/typescript/tests/telemetry-config-incomplete.test.ts
+++ b/libraries/typescript/tests/telemetry-config-incomplete.test.ts
@@ -1,0 +1,305 @@
+/**
+ * [integration] Authentic tests for the `config_incomplete` activation-blocker
+ * signal (F1).
+ *
+ * The real `Patter` client runs its real credential / engine validation against a
+ * real `TelemetryClient`. The only substituted surface is the outbound HTTP
+ * boundary: a real local `node:http` collector captures what the SDK actually
+ * POSTs over the global `fetch` (the same authentic pattern as `telemetry.test.ts`).
+ * Everything from `new Patter(...)` / `patter.agent(...)` inward — the
+ * `recordConfigIncomplete` dedupe, the validation, and the `throw` — is real.
+ *
+ * Each test asserts that the blocking validation BOTH emits exactly one
+ * `config_incomplete` event with the correct coarse `missing` enum AND still
+ * throws the original error unchanged.
+ *
+ * Mirror of `libraries/python/tests/test_telemetry_config_incomplete.py`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Keep the persisted install id out of the developer's home during tests.
+process.env.PATTER_TELEMETRY_STATE_DIR =
+  process.env.PATTER_TELEMETRY_STATE_DIR ?? fs.mkdtempSync(path.join(os.tmpdir(), 'patter-cfg-'));
+
+import { Patter, Twilio, DeepgramSTT } from '../src/index';
+
+const CI_KEYS = [
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'TRAVIS',
+  'CIRCLECI',
+  'APPVEYOR',
+  'TF_BUILD',
+  'TEAMCITY_VERSION',
+  'BUILDKITE',
+  'DRONE',
+  'JENKINS_URL',
+  'HUDSON_URL',
+  'BAMBOO_BUILDKEY',
+  'CODEBUILD_BUILD_ID',
+];
+const TEST_KEYS = ['VITEST', 'JEST_WORKER_ID'];
+const DISABLE_KEYS = [
+  'DO_NOT_TRACK',
+  'PATTER_TELEMETRY_DISABLED',
+  'PATTER_TELEMETRY_DEBUG',
+  'PATTER_TELEMETRY_ENDPOINT',
+];
+const ALL_KEYS = [...CI_KEYS, ...TEST_KEYS, ...DISABLE_KEYS, 'NODE_ENV', 'OPENAI_API_KEY'];
+
+let savedEnv: Record<string, string | undefined> = {};
+
+function snapshotEnv(): void {
+  savedEnv = {};
+  for (const k of ALL_KEYS) savedEnv[k] = process.env[k];
+}
+function restoreEnv(): void {
+  for (const k of ALL_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+}
+/** Clear every detection/disable signal so telemetry resolves to enabled. */
+function enableTelemetryEnv(): void {
+  for (const k of [...CI_KEYS, ...TEST_KEYS, ...DISABLE_KEYS]) delete process.env[k];
+  process.env.NODE_ENV = 'development';
+}
+
+class Collector {
+  requests: unknown[] = [];
+  private server!: Server;
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        try {
+          this.requests.push(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch {
+          this.requests.push(null);
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) => this.server.listen(0, '127.0.0.1', () => resolve()));
+  }
+
+  get url(): string {
+    const addr = this.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    return `http://127.0.0.1:${port}/v1/ingest`;
+  }
+
+  get events(): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    for (const batch of this.requests) {
+      if (Array.isArray(batch)) out.push(...(batch as Array<Record<string, unknown>>));
+    }
+    return out;
+  }
+
+  configIncomplete(): Array<Record<string, unknown>> {
+    return this.events.filter((e) => e.event === 'config_incomplete');
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
+/** Wait until at least one `config_incomplete` event has reached the collector. */
+async function waitForConfigIncomplete(collector: Collector, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (collector.configIncomplete().length < 1 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+/** Give the buffered fire-and-forget flush a few ticks to attempt an egress. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 10));
+}
+
+const VALID_CARRIER = { accountSid: 'AC_test', authToken: 'tok_test' };
+
+describe('[integration] config_incomplete activation-blocker signal', () => {
+  let collector: Collector;
+
+  beforeEach(async () => {
+    snapshotEnv();
+    enableTelemetryEnv();
+    collector = new Collector();
+    await collector.start();
+    process.env.PATTER_TELEMETRY_ENDPOINT = collector.url;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(async () => {
+    await collector.stop();
+    restoreEnv();
+  });
+
+  // --- (1) missing carrier credentials (constructor) ------------------------
+
+  it('emits carrier_credentials and still throws when phoneNumber is missing', async () => {
+    expect(
+      () => new Patter({ carrier: new Twilio(VALID_CARRIER) } as never),
+    ).toThrow(/Local mode requires phoneNumber/);
+
+    await waitForConfigIncomplete(collector);
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('carrier_credentials');
+  });
+
+  it('emits carrier_credentials and still throws when carrier is missing', async () => {
+    expect(
+      () => new Patter({ phoneNumber: '+15550000000' } as never),
+    ).toThrow(/Local mode requires a `carrier` instance/);
+
+    await waitForConfigIncomplete(collector);
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('carrier_credentials');
+  });
+
+  // --- (2) missing LLM / engine key (agent) ---------------------------------
+
+  it('emits llm_key and still throws when the OpenAI Realtime key is missing', async () => {
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+
+    // The OpenAI-key check fires for the explicit openai_realtime provider with no
+    // engine marker and no key in env/config (parity with Python's realtime path).
+    expect(() =>
+      phone.agent({ systemPrompt: 'You are a helpful assistant.', provider: 'openai_realtime' }),
+    ).toThrow(/OpenAI Realtime mode requires an OpenAI API key/);
+
+    await waitForConfigIncomplete(collector);
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('llm_key');
+  });
+
+  // --- (3) incomplete engine config (agent) ---------------------------------
+
+  it('emits engine_config and still throws on an invalid provider', async () => {
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+
+    expect(() =>
+      phone.agent({ systemPrompt: 'prompt', provider: 'bogus' as never }),
+    ).toThrow(/provider must be one of/);
+
+    await waitForConfigIncomplete(collector);
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('engine_config');
+  });
+
+  it('emits engine_config and still throws on an unknown engine instance', async () => {
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+
+    // A bare object that is not an OpenAIRealtime/OpenAIRealtime2/ElevenLabsConvAI
+    // instance hits the unknown-engine branch.
+    expect(() =>
+      phone.agent({ systemPrompt: 'prompt', engine: {} as never }),
+    ).toThrow(/Unknown engine/);
+
+    await waitForConfigIncomplete(collector);
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('engine_config');
+  });
+
+  // --- emitted at most once per instance ------------------------------------
+
+  it('emits config_incomplete at most once per Patter instance', async () => {
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+
+    // First failing agent() emits once; subsequent failures on the SAME instance
+    // (a retry, a second agent() call) must NOT double-emit.
+    expect(() =>
+      phone.agent({ systemPrompt: 'one', provider: 'openai_realtime' }),
+    ).toThrow();
+    expect(() =>
+      phone.agent({ systemPrompt: 'two', provider: 'openai_realtime' }),
+    ).toThrow();
+    expect(() => phone.agent({ systemPrompt: 'three', provider: 'bogus' as never })).toThrow();
+
+    await settle();
+    const events = collector.configIncomplete();
+    expect(events.length).toBe(1);
+    expect(events[0].missing).toBe('llm_key');
+  });
+
+  // --- a fully-valid agent never emits the activation-blocker signal ---------
+
+  it('does not emit config_incomplete for a valid Realtime agent', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test-not-a-real-key';
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+    phone.agent({ systemPrompt: 'You are a helpful assistant.' });
+
+    await settle();
+    expect(collector.configIncomplete().length).toBe(0);
+  });
+
+  it('does not emit config_incomplete for a valid pipeline agent with an STT', async () => {
+    const phone = new Patter({ carrier: new Twilio(VALID_CARRIER), phoneNumber: '+15550000000' });
+    phone.agent({
+      systemPrompt: 'You are a helpful assistant.',
+      provider: 'pipeline',
+      stt: new DeepgramSTT({ apiKey: 'dg-test' }),
+    });
+
+    await settle();
+    expect(collector.configIncomplete().length).toBe(0);
+  });
+});
+
+// --- opt-out emits nothing ---------------------------------------------------
+
+describe('[integration] config_incomplete respects opt-out', () => {
+  let collector: Collector;
+
+  beforeEach(async () => {
+    snapshotEnv();
+    enableTelemetryEnv();
+    collector = new Collector();
+    await collector.start();
+    process.env.PATTER_TELEMETRY_ENDPOINT = collector.url;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(async () => {
+    await collector.stop();
+    restoreEnv();
+  });
+
+  it('emits nothing when telemetry: false', async () => {
+    expect(
+      () => new Patter({ carrier: new Twilio(VALID_CARRIER), telemetry: false } as never),
+    ).toThrow(/Local mode requires phoneNumber/);
+
+    await settle();
+    expect(collector.configIncomplete().length).toBe(0);
+  });
+
+  it('emits nothing when PATTER_TELEMETRY_DISABLED=1', async () => {
+    process.env.PATTER_TELEMETRY_DISABLED = '1';
+
+    expect(
+      () => new Patter({ carrier: new Twilio(VALID_CARRIER) } as never),
+    ).toThrow(/Local mode requires phoneNumber/);
+
+    await settle();
+    expect(collector.configIncomplete().length).toBe(0);
+  });
+});

--- a/libraries/typescript/tests/telemetry-sampling.test.ts
+++ b/libraries/typescript/tests/telemetry-sampling.test.ts
@@ -1,0 +1,340 @@
+/**
+ * [unit] Authentic tests for the client-side telemetry sampling gate (F4).
+ *
+ * A real local HTTP collector (node:http) captures what the SDK actually sends
+ * over the real global `fetch`. The sampling decision, the per-run SHA-256 hash
+ * of `runId`, the `sample_rate` stamping, the payload builder, and the network
+ * egress are all REAL — only the CI/test environment detection is neutralised
+ * (so the enabled path runs inside vitest) and the network boundary is local.
+ * `runId` is the only thing mocked to a fixed value, because the keep/drop
+ * decision is deterministic per run and the test must exercise BOTH branches.
+ *
+ * Mirrors `libraries/python/tests/test_telemetry_sampling.py`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Pin the per-run sampling seed. The gate hashes `runId()` (imported by the
+// client from this module); overriding it lets one test KEEP and another DROP
+// within the same process. Everything else in the module stays real.
+let mockRunId = 'run00000000000000000000000000000000';
+vi.mock('../src/telemetry/install-id', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/telemetry/install-id')>();
+  return { ...actual, runId: () => mockRunId };
+});
+
+import { TelemetryClient } from '../src/telemetry/client';
+import { sampleRate } from '../src/telemetry/env';
+
+// Keep the persisted install id out of the developer's home during tests.
+process.env.PATTER_TELEMETRY_STATE_DIR =
+  process.env.PATTER_TELEMETRY_STATE_DIR ?? fs.mkdtempSync(path.join(os.tmpdir(), 'patter-tel-smpl-'));
+
+// Two fixed run ids whose SHA-256-derived ratio straddles 0.5, so at rate=0.5
+// one run KEEPS its sampleable call events and the other DROPS them. The
+// formula is asserted below, not trusted blind.
+const KEEP_RUN_ID = 'run00000000000000000000000000000000'; // ratio ~0.031 -> keep @0.5
+const DROP_RUN_ID = 'run00000000000000000000000000000003'; // ratio ~0.742 -> drop @0.5
+
+function ratioFor(runId: string): number {
+  const d = createHash('sha256').update(runId, 'utf8').digest('hex').slice(0, 8);
+  return parseInt(d, 16) / 0xffffffff;
+}
+
+const CI_KEYS = [
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'TRAVIS',
+  'CIRCLECI',
+  'APPVEYOR',
+  'TF_BUILD',
+  'TEAMCITY_VERSION',
+  'BUILDKITE',
+  'DRONE',
+  'JENKINS_URL',
+  'HUDSON_URL',
+  'BAMBOO_BUILDKEY',
+  'CODEBUILD_BUILD_ID',
+];
+const TEST_KEYS = ['VITEST', 'JEST_WORKER_ID'];
+const DISABLE_KEYS = [
+  'DO_NOT_TRACK',
+  'PATTER_TELEMETRY_DISABLED',
+  'PATTER_TELEMETRY_DEBUG',
+  'PATTER_TELEMETRY_ENDPOINT',
+  'PATTER_TELEMETRY_SAMPLE',
+];
+const ALL_KEYS = [...CI_KEYS, ...TEST_KEYS, ...DISABLE_KEYS, 'NODE_ENV'];
+
+let savedEnv: Record<string, string | undefined> = {};
+
+function snapshotEnv(): void {
+  savedEnv = {};
+  for (const k of ALL_KEYS) savedEnv[k] = process.env[k];
+}
+function restoreEnv(): void {
+  for (const k of ALL_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+}
+/** Clear every detection/disable signal so telemetry resolves to enabled. */
+function enableTelemetryEnv(): void {
+  for (const k of [...CI_KEYS, ...TEST_KEYS, ...DISABLE_KEYS]) delete process.env[k];
+  process.env.NODE_ENV = 'development';
+}
+
+class Collector {
+  requests: unknown[] = [];
+  private server!: Server;
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        try {
+          this.requests.push(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch {
+          this.requests.push(null);
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) => this.server.listen(0, '127.0.0.1', () => resolve()));
+  }
+
+  get url(): string {
+    const addr = this.server.address();
+    const port = typeof addr === 'object' && addr ? addr.port : 0;
+    return `http://127.0.0.1:${port}/v1/ingest`;
+  }
+
+  get events(): Array<Record<string, unknown>> {
+    const out: Array<Record<string, unknown>> = [];
+    for (const batch of this.requests) {
+      if (Array.isArray(batch)) out.push(...(batch as Array<Record<string, unknown>>));
+    }
+    return out;
+  }
+
+  names(): string[] {
+    return this.events.map((e) => e.event as string);
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
+async function waitFor(collector: Collector, n: number, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (collector.events.length < n && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+let collector: Collector;
+
+beforeEach(async () => {
+  snapshotEnv();
+  collector = new Collector();
+  await collector.start();
+  mockRunId = KEEP_RUN_ID;
+});
+
+afterEach(async () => {
+  await collector.stop();
+  restoreEnv();
+});
+
+describe('[unit] sampling seed fixtures', () => {
+  it('the two pinned run ids really straddle 0.5', () => {
+    expect(ratioFor(KEEP_RUN_ID)).toBeLessThan(0.5);
+    expect(ratioFor(DROP_RUN_ID)).toBeGreaterThanOrEqual(0.5);
+  });
+});
+
+describe('[unit] sampleRate() parsing + clamping + fail-safe', () => {
+  it('defaults to 1.0 when unset', () => {
+    delete process.env.PATTER_TELEMETRY_SAMPLE;
+    expect(sampleRate()).toBe(1.0);
+  });
+
+  it('parses valid values', () => {
+    const cases: Array<[string, number]> = [
+      ['0', 0],
+      ['0.0', 0],
+      ['0.5', 0.5],
+      ['1', 1],
+      ['1.0', 1],
+      ['  0.25  ', 0.25],
+    ];
+    for (const [raw, expected] of cases) {
+      process.env.PATTER_TELEMETRY_SAMPLE = raw;
+      expect(sampleRate()).toBe(expected);
+    }
+  });
+
+  it('degrades malformed / out-of-range values to 1.0 (fail safe)', () => {
+    for (const raw of ['', '   ', 'abc', '0.5x', '-0.1', '-1', '2', '1.5', '10', 'NaN', 'Infinity', '-Infinity']) {
+      process.env.PATTER_TELEMETRY_SAMPLE = raw;
+      expect(sampleRate()).toBe(1.0);
+    }
+  });
+
+  it('never throws', () => {
+    for (const raw of ['', 'garbage', 'NaN', '1e9999', '+-+']) {
+      process.env.PATTER_TELEMETRY_SAMPLE = raw;
+      expect(() => sampleRate()).not.toThrow();
+    }
+  });
+});
+
+describe('[unit] sampling gate — rate = 0', () => {
+  it('drops call events but keeps activation and error events', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = '0';
+    mockRunId = KEEP_RUN_ID; // irrelevant at rate 0 (always drops sampleable)
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    client.record('call_started', { engine: 'realtime', carrier: 'twilio' }); // dropped
+    client.record('call_completed', { outcome: 'completed', carrier: 'twilio' }); // dropped
+
+    // NEVER-sampled events: always delivered, even at rate 0.
+    client.record('first_run');
+    client.record('config_incomplete', { missing: 'carrier_credentials' });
+    client.record('sdk_initialized', { engine: 'realtime' });
+
+    // An ERROR call_completed is force-kept regardless of rate.
+    client.record('call_completed', {
+      outcome: 'error',
+      error_code: 'provider_error',
+      carrier: 'twilio',
+    });
+
+    await waitFor(collector, 4);
+    await client.close();
+
+    expect(collector.names().sort()).toEqual([
+      'call_completed', // the error one
+      'config_incomplete',
+      'first_run',
+      'sdk_initialized',
+    ]);
+    const err = collector.events.find((e) => e.event === 'call_completed');
+    expect(err?.outcome).toBe('error');
+    expect(err?.error_code).toBe('provider_error');
+    expect(err?.sample_rate).toBe(0);
+  });
+
+  it('keeps a call_completed flagged only by error_code (no outcome=error)', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = '0';
+    mockRunId = KEEP_RUN_ID;
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+    client.record('call_completed', { outcome: 'completed', error_code: 'timeout' });
+    client.record('call_started', { engine: 'realtime' }); // dropped
+    await waitFor(collector, 1);
+    await client.close();
+
+    expect(collector.names()).toEqual(['call_completed']);
+    expect(collector.events[0].error_code).toBe('timeout');
+  });
+});
+
+describe('[unit] sampling gate — rate = 0.5 determinism + stamping', () => {
+  it('a KEEP run delivers call events stamped with sample_rate', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = '0.5';
+    mockRunId = KEEP_RUN_ID; // ratio < 0.5 -> KEEP
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    client.record('call_started', { engine: 'realtime', carrier: 'twilio' });
+    client.record('call_completed', { outcome: 'completed', carrier: 'twilio' });
+    await waitFor(collector, 2);
+    await client.close();
+
+    expect(collector.names().sort()).toEqual(['call_completed', 'call_started']);
+    for (const e of collector.events) expect(e.sample_rate).toBe(0.5);
+  });
+
+  it('a DROP run drops clean call events but keeps first_run and error calls', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = '0.5';
+    mockRunId = DROP_RUN_ID; // ratio >= 0.5 -> DROP
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    client.record('call_started', { engine: 'realtime' }); // dropped
+    client.record('call_completed', { outcome: 'completed' }); // dropped
+    client.record('first_run'); // kept
+    client.record('call_completed', { outcome: 'error', error_code: 'auth' }); // kept
+    await waitFor(collector, 2);
+    await client.close();
+
+    expect(collector.names().sort()).toEqual(['call_completed', 'first_run']);
+    const err = collector.events.find((e) => e.event === 'call_completed');
+    expect(err?.outcome).toBe('error');
+    expect(err?.sample_rate).toBe(0.5); // force-kept error still carries the rate
+  });
+
+  it('the keep/drop decision is stable across repeated record calls (no per-event coin)', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = '0.5';
+    mockRunId = DROP_RUN_ID; // this run drops sampleable events
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    for (let i = 0; i < 20; i++) client.record('call_started', { engine: 'realtime' });
+    await new Promise((r) => setTimeout(r, 100));
+    await client.close();
+
+    expect(collector.events).toHaveLength(0); // all 20 dropped, consistently
+
+    // A fresh client in the same run (same pinned runId) makes the SAME call.
+    const client2 = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+    client2.record('call_started', { engine: 'realtime' });
+    await new Promise((r) => setTimeout(r, 100));
+    await client2.close();
+    expect(collector.events).toHaveLength(0);
+  });
+});
+
+describe('[unit] sampling gate — no sampling (unset / >= 1 / malformed)', () => {
+  it('unset keeps everything and does not stamp sample_rate', async () => {
+    enableTelemetryEnv();
+    delete process.env.PATTER_TELEMETRY_SAMPLE;
+    mockRunId = DROP_RUN_ID; // would drop IF sampling were active
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    client.record('call_started', { engine: 'realtime' });
+    client.record('call_completed', { outcome: 'completed' });
+    await waitFor(collector, 2);
+    await client.close();
+
+    expect(collector.names().sort()).toEqual(['call_completed', 'call_started']);
+    for (const e of collector.events) expect(e.sample_rate).toBeUndefined();
+  });
+
+  it('a malformed value degrades to keep-all (no drops, no stamping)', async () => {
+    enableTelemetryEnv();
+    process.env.PATTER_TELEMETRY_SAMPLE = 'garbage';
+    mockRunId = DROP_RUN_ID;
+    const client = new TelemetryClient({ sdkVersion: '0.6.8', endpoint: collector.url });
+
+    client.record('call_started', { engine: 'realtime' });
+    client.record('call_completed', { outcome: 'completed' });
+    await waitFor(collector, 2);
+    await client.close();
+
+    expect(collector.names().sort()).toEqual(['call_completed', 'call_started']);
+    for (const e of collector.events) expect(e.sample_rate).toBeUndefined();
+  });
+});

--- a/libraries/typescript/tests/telemetry.test.ts
+++ b/libraries/typescript/tests/telemetry.test.ts
@@ -240,7 +240,7 @@ describe('[integration] telemetry — enabled path', () => {
     expect(event.sdk).toBe('typescript');
     expect(event.sdk_version).toBe('0.6.3');
     expect(event.runtime).toBe('node');
-    expect(event.schema_version).toBe(7);
+    expect(event.schema_version).toBe(8);
     expect(event.engine).toBe('realtime');
     expect(event.carrier).toBe('twilio');
     expect(typeof event.run_id).toBe('string');
@@ -998,10 +998,10 @@ describe('[integration] telemetry — relay-cap chunking (0.6.8)', () => {
   });
 });
 
-describe('[unit] CLI usage + first-run + call funnel + opt-out (schema v7)', () => {
-  it('is on schema v7', () => {
-    expect(SCHEMA_VERSION).toBe(7);
-    expect(buildEvent('first_run', { sdkVersion: '0.6.5' }).schema_version).toBe(7);
+describe('[unit] CLI usage + first-run + call funnel + opt-out (schema v8)', () => {
+  it('is on schema v8', () => {
+    expect(SCHEMA_VERSION).toBe(8);
+    expect(buildEvent('first_run', { sdkVersion: '0.6.5' }).schema_version).toBe(8);
   });
 
   it('buildEvent accepts the new events and coerces off-list values', () => {


### PR DESCRIPTION
## Summary
- Closes the **activation funnel** and makes call failures **diagnosable** in the anonymous usage telemetry — the dataset previously showed *that* a call happened but not *why* an install never reached one, nor where latency/errors came from.
- Adds one event and several dimensions; all **additive**, **opt-out**, **fire-and-forget** (never affects a live call), **no PII**, **Python ↔ TypeScript parity**. Telemetry schema `v7 → v8`.

## Implementation
- **`config_incomplete`** event — emitted once when required runtime config is missing, immediately before the existing startup `raise` (control flow unchanged). Dimension `missing ∈ {carrier_credentials, llm_key, engine_config, other}` — never the key value or any PII. This is the activation-blocker signal (installs that run but can't proceed).
- **Per-stage latency** on `call_completed`: `stt_latency_ms`, `llm_ttft_ms`, `tts_first_byte_ms`, `eou_latency_ms` (whole ms, read off the existing CallMetrics breakdown; a dimension is omitted when its stage didn't run, e.g. Realtime).
- **Error taxonomy** on `call_completed`: `error_layer ∈ {stt,llm,tts,carrier,config,internal,none,other}` + `disconnect_reason ∈ {hangup_local,hangup_remote,error,timeout,no_answer,busy,completed,other}`, derived from the already-available outcome/error_code (no new call-path plumbing).
- **`time_to_first_call_bucket`** on `call_started`/`call_completed` (install-age at call time).
- **Client sampling**: `PATTER_TELEMETRY_SAMPLE` (default `1.0` = no sampling), deterministic per run via the run id hash, **never** samples `first_run`/`config_incomplete`/error events; the chosen `sample_rate` is stamped so analytics can extrapolate (`weight = 1/sample_rate`).
- Files: `libraries/{python/getpatter,typescript/src}/telemetry/{events,client,env,install_id,call_metrics}.*` + `client.*`. New dedicated test files per feature (the shared telemetry test files are only touched for the `SCHEMA_VERSION` bump).
- The telemetry ingestion endpoint has been updated to accept schema v8, so the new event/fields are not dropped server-side.
- **No version bump in this PR** — entries sit under `## Unreleased`; the bump + `Unreleased → X.Y.Z` rename happen at release time per the release workflow.

## Breaking change?
No. Every addition is optional with a safe default (`PATTER_TELEMETRY_SAMPLE` defaults to 1.0), no existing event/dimension changed or removed, and the schema bump is purely additive. Existing callers are unaffected.

## Test plan
- [x] Python: `pytest tests/` — telemetry **116** new/updated pass; full suite **2712** pass / 0 fail
- [x] TypeScript: `npm test` (telemetry **87** pass; full **2142** pass / 0 fail) + `npm run lint` (clean) + `npm run build` (ok)
- [x] Python ↔ TS parity verified (events, dimension value-sets, `SCHEMA_VERSION=8`, defaults all identical)
- [ ] E2E smoke — n/a (telemetry-only; no pipeline/handler behaviour change)

## Docs updates
- `CHANGELOG.md` updated (`## Unreleased` → `### Added` for the new signals, `### Changed` for the schema bump).
- Follow-up (not in this PR): `docs/telemetry.mdx` to document `PATTER_TELEMETRY_SAMPLE`, the `config_incomplete` event, and the new `call_completed` dimensions; feature-inventory rows.
