### PR TITLE
docs: add Resemble Detect and Signal MCP example

### DIFF
--- a/docs/python-sdk/mcp.mdx
+++ b/docs/python-sdk/mcp.mdx
@@ -123,6 +123,52 @@ const agent = phone.agent({
 
 A bare string is shorthand for `{"url": <string>}`.
 
+## Hosted MCP example - Resemble Detect
+
+Use this pattern when a caller provides a recording or media URL that should be
+checked for synthetic speech before the agent makes a trust decision. Resemble
+hosts an MCP server, so the agent can discover Detect, Watermark, and
+Intelligence tools without a custom wrapper.
+
+```python
+import asyncio
+import os
+
+from getpatter import OpenAIRealtime, Patter, Twilio
+
+phone = Patter(
+    carrier=Twilio(),
+    phone_number="+15550001234",
+    webhook_url="api.example.com",
+)
+
+agent = phone.agent(
+    engine=OpenAIRealtime(),
+    system_prompt=(
+        "You verify suspicious caller-provided recordings with Resemble Detect. "
+        "When a media URL is available, call the Resemble MCP detect tool and "
+        "explain whether the result indicates real or synthetic speech."
+    ),
+    mcp_servers=[
+        {
+            "url": "https://mcp.resemble.ai/mcp",
+            "headers": {
+                "Authorization": f"Bearer {os.environ['RESEMBLE_API_KEY']}",
+            },
+            "name": "resemble-detect",
+        },
+    ],
+)
+
+async def main():
+    await phone.serve(agent, port=8000)
+
+asyncio.run(main())
+```
+
+This is a tool-call integration for caller-provided media URLs. It does not
+inspect live caller audio or replace application-specific escalation policy.
+
 ## Real-world example — Postgres MCP server
 
 Connect a phone agent to a Postgres MCP server so the caller can query an orders table by phone number.

--- a/docs/python-sdk/mcp.mdx
+++ b/docs/python-sdk/mcp.mdx
@@ -123,11 +123,12 @@ const agent = phone.agent({
 
 A bare string is shorthand for `{"url": <string>}`.
 
-## Hosted MCP example - Resemble Detect
+## Hosted MCP example - Resemble Detect and Signal
 
 Use this pattern when a caller provides a recording or media URL that should be
-checked for synthetic speech before the agent makes a trust decision. Resemble
-hosts an MCP server, so the agent can discover Detect, Watermark, and
+checked for synthetic speech, or when caller-provided text should be scored for
+fraud and scam intent before the agent makes a trust decision. Resemble hosts an
+MCP server, so the agent can discover Detect, Signal, Watermark, and
 Intelligence tools without a custom wrapper.
 
 ```python
@@ -145,9 +146,11 @@ phone = Patter(
 agent = phone.agent(
     engine=OpenAIRealtime(),
     system_prompt=(
-        "You verify suspicious caller-provided recordings with Resemble Detect. "
-        "When a media URL is available, call the Resemble MCP detect tool and "
-        "explain whether the result indicates real or synthetic speech."
+        "You verify suspicious caller-provided recordings with Resemble Detect "
+        "and suspicious requests with Resemble Signal. When a media URL is "
+        "available, call the Detect tool. When a caller asks for a reset code, "
+        "wire transfer, credential, or account change, call the Signal tool "
+        "before deciding whether to continue or escalate."
     ),
     mcp_servers=[
         {
@@ -155,7 +158,7 @@ agent = phone.agent(
             "headers": {
                 "Authorization": f"Bearer {os.environ['RESEMBLE_API_KEY']}",
             },
-            "name": "resemble-detect",
+            "name": "resemble-trust",
         },
     ],
 )

--- a/docs/typescript-sdk/mcp.mdx
+++ b/docs/typescript-sdk/mcp.mdx
@@ -119,11 +119,12 @@ agent = phone.agent(
 
 A bare string is shorthand for `{ url: <string> }`.
 
-## Hosted MCP example - Resemble Detect
+## Hosted MCP example - Resemble Detect and Signal
 
 Use this pattern when a caller provides a recording or media URL that should be
-checked for synthetic speech before the agent makes a trust decision. Resemble
-hosts an MCP server, so the agent can discover Detect, Watermark, and
+checked for synthetic speech, or when caller-provided text should be scored for
+fraud and scam intent before the agent makes a trust decision. Resemble hosts an
+MCP server, so the agent can discover Detect, Signal, Watermark, and
 Intelligence tools without a custom wrapper.
 
 ```typescript
@@ -138,16 +139,18 @@ const phone = new Patter({
 const agent = phone.agent({
   engine: new OpenAIRealtime(),
   systemPrompt:
-    "You verify suspicious caller-provided recordings with Resemble Detect. " +
-    "When a media URL is available, call the Resemble MCP detect tool and " +
-    "explain whether the result indicates real or synthetic speech.",
+    "You verify suspicious caller-provided recordings with Resemble Detect " +
+    "and suspicious requests with Resemble Signal. When a media URL is " +
+    "available, call the Detect tool. When a caller asks for a reset code, " +
+    "wire transfer, credential, or account change, call the Signal tool " +
+    "before deciding whether to continue or escalate.",
   mcpServers: [
     {
       url: "https://mcp.resemble.ai/mcp",
       headers: {
         Authorization: `Bearer ${process.env.RESEMBLE_API_KEY}`,
       },
-      name: "resemble-detect",
+      name: "resemble-trust",
     },
   ],
 });
@@ -155,8 +158,9 @@ const agent = phone.agent({
 await phone.serve({ agent, port: 8000 });
 ```
 
-This is a tool-call integration for caller-provided media URLs. It does not
-inspect live caller audio or replace application-specific escalation policy.
+This is a tool-call integration for caller-provided media URLs and text. It
+does not inspect live caller audio or replace application-specific escalation
+policy.
 
 ## Real-world example — Postgres MCP server
 

--- a/docs/typescript-sdk/mcp.mdx
+++ b/docs/typescript-sdk/mcp.mdx
@@ -119,6 +119,45 @@ agent = phone.agent(
 
 A bare string is shorthand for `{ url: <string> }`.
 
+## Hosted MCP example - Resemble Detect
+
+Use this pattern when a caller provides a recording or media URL that should be
+checked for synthetic speech before the agent makes a trust decision. Resemble
+hosts an MCP server, so the agent can discover Detect, Watermark, and
+Intelligence tools without a custom wrapper.
+
+```typescript
+import { OpenAIRealtime, Patter, Twilio } from "getpatter";
+
+const phone = new Patter({
+  carrier: new Twilio(),
+  phoneNumber: "+15550001234",
+  webhookUrl: "api.example.com",
+});
+
+const agent = phone.agent({
+  engine: new OpenAIRealtime(),
+  systemPrompt:
+    "You verify suspicious caller-provided recordings with Resemble Detect. " +
+    "When a media URL is available, call the Resemble MCP detect tool and " +
+    "explain whether the result indicates real or synthetic speech.",
+  mcpServers: [
+    {
+      url: "https://mcp.resemble.ai/mcp",
+      headers: {
+        Authorization: `Bearer ${process.env.RESEMBLE_API_KEY}`,
+      },
+      name: "resemble-detect",
+    },
+  ],
+});
+
+await phone.serve({ agent, port: 8000 });
+```
+
+This is a tool-call integration for caller-provided media URLs. It does not
+inspect live caller audio or replace application-specific escalation policy.
+
 ## Real-world example — Postgres MCP server
 
 Connect a phone agent to a Postgres MCP server so the caller can query an orders table by phone number.


### PR DESCRIPTION
## Summary
- update the MCP docs to show Resemble Detect and Signal together
- describe Detect for media authenticity checks and Signal for fraud/scam-intent scoring
- add an agent prompt that routes risky requests through the hosted MCP tools

## Validation
- `git diff --check`