### PR TITLE
feat: add LiteLLM as LLM provider (Python SDK + TypeScript proxy)

### DIFF
--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -125,6 +125,7 @@ from getpatter.llm.anthropic import LLM as AnthropicLLM
 from getpatter.llm.groq import LLM as GroqLLM
 from getpatter.llm.cerebras import LLM as CerebrasLLM
 from getpatter.llm.google import LLM as GoogleLLM
+from getpatter.llm.litellm import LLM as LiteLLMLLM
 from getpatter.llm.openai_compatible import (
     LLM as OpenAICompatibleLLM,
     OpenAICompatibleLLMProvider,
@@ -483,6 +484,7 @@ __all__ = [
     "GroqLLM",
     "CerebrasLLM",
     "GoogleLLM",
+    "LiteLLMLLM",
     "OpenAICompatibleLLM",
     "OpenAICompatibleLLMProvider",
     "CustomLLM",

--- a/libraries/python/getpatter/llm/__init__.py
+++ b/libraries/python/getpatter/llm/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "groq",
     "cerebras",
     "google",
+    "litellm",
     "openai_compatible",
     "custom",
     "hermes",

--- a/libraries/python/getpatter/llm/litellm.py
+++ b/libraries/python/getpatter/llm/litellm.py
@@ -1,0 +1,38 @@
+"""LiteLLM for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+from getpatter.providers.litellm_llm import LiteLLMProvider as _LiteLLM
+
+__all__ = ["LLM"]
+
+
+class LLM(_LiteLLM):
+    """LiteLLM provider (unified gateway to 100+ LLM providers).
+
+    Routes to any LiteLLM-supported model (OpenAI, Anthropic, Google,
+    Azure, Bedrock, Ollama, and more) through a single interface.
+
+    Example::
+
+        from getpatter.llm import litellm
+
+        llm = litellm.LLM(model="gpt-4o")
+        llm = litellm.LLM(model="anthropic/claude-sonnet-4-6", api_key="sk-ant-...")
+        llm = litellm.LLM(model="ollama/llama3")
+    """
+
+    provider_key: ClassVar[str] = "litellm"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        **kwargs,
+    ) -> None:
+        key = api_key or os.environ.get("LITELLM_API_KEY")
+        super().__init__(api_key=key, model=model, **kwargs)

--- a/libraries/python/getpatter/providers/__init__.py
+++ b/libraries/python/getpatter/providers/__init__.py
@@ -99,6 +99,12 @@ def _load_google_llm():
     return GoogleLLMProvider
 
 
+def _load_litellm():
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    return LiteLLMProvider
+
+
 def __getattr__(name: str):
     """Lazy-load optional LLM providers to avoid importing heavy vendor SDKs."""
     loaders = {
@@ -106,6 +112,7 @@ def __getattr__(name: str):
         "GroqLLMProvider": _load_groq_llm,
         "CerebrasLLMProvider": _load_cerebras_llm,
         "GoogleLLMProvider": _load_google_llm,
+        "LiteLLMProvider": _load_litellm,
     }
     if name in loaders:
         return loaders[name]()
@@ -130,4 +137,5 @@ __all__ = [
     "GroqLLMProvider",
     "CerebrasLLMProvider",
     "GoogleLLMProvider",
+    "LiteLLMProvider",
 ]

--- a/libraries/python/getpatter/providers/litellm_llm.py
+++ b/libraries/python/getpatter/providers/litellm_llm.py
@@ -1,0 +1,268 @@
+"""LiteLLM LLM provider for Patter's pipeline mode.
+
+LiteLLM is an AI gateway that provides a unified interface to 100+ LLM
+providers (OpenAI, Anthropic, Google, Azure, AWS Bedrock, Ollama, Cohere,
+Mistral, and more) through a single ``litellm.acompletion()`` call.
+
+LiteLLM's streaming response is OpenAI-compatible, so the chunk parsing
+is identical to :class:`getpatter.services.llm_loop.OpenAILLMProvider`.
+Unlike the Groq / Cerebras providers (which subclass ``OpenAILLMProvider``
+and swap the ``AsyncOpenAI`` client), this provider calls the ``litellm``
+SDK directly so it does NOT depend on ``openai`` at runtime.
+
+``drop_params=True`` is enabled by default: LiteLLM silently drops
+per-provider-unsupported kwargs (``seed``, ``response_format``, etc.)
+instead of 400-ing, which is the safe default for a voice AI SDK where
+you want things to work across providers without per-model config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, AsyncIterator, ClassVar
+
+logger = logging.getLogger("getpatter.providers.litellm_llm")
+
+__all__ = ["LiteLLMProvider"]
+
+
+class LiteLLMProvider:
+    """LLM provider backed by LiteLLM's unified completion API (streaming).
+
+    Implements Patter's :class:`LLMProvider` protocol: ``stream`` yields
+    ``{"type": "text" | "tool_call" | "done", ...}`` chunks.
+
+    Args:
+        api_key: API key for the underlying provider. If omitted,
+            ``LITELLM_API_KEY`` is read from the environment (or the
+            provider-specific env var is used by LiteLLM automatically).
+        model: LiteLLM model identifier (e.g. ``"gpt-4o"``,
+            ``"anthropic/claude-sonnet-4-6"``, ``"ollama/llama3"``).
+        api_base: Optional base URL override (e.g. for a self-hosted
+            LiteLLM proxy or Azure endpoint).
+        drop_params: Silently drop provider-unsupported kwargs instead
+            of erroring. Defaults to ``True`` for maximum cross-provider
+            compatibility.
+        temperature: Optional sampling temperature.
+        max_tokens: Max tokens in the assistant response.
+        response_format: Optional OpenAI-style ``response_format`` dict
+            for JSON mode / structured outputs.
+        parallel_tool_calls: Whether to allow parallel tool calls.
+        tool_choice: ``"auto" | "none" | "required"`` or a specific
+            tool dict.
+        seed: Sampling seed for reproducible outputs.
+        top_p: Nucleus sampling cutoff in [0, 1].
+        frequency_penalty: Penalty in [-2, 2] applied to repeated tokens.
+        presence_penalty: Penalty in [-2, 2] applied to seen tokens.
+        stop: Stop sequence(s).
+    """
+
+    provider_key: ClassVar[str] = "litellm"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "gpt-4o-mini",
+        *,
+        api_base: str | None = None,
+        drop_params: bool = True,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        response_format: dict | None = None,
+        parallel_tool_calls: bool | None = None,
+        tool_choice: str | dict | None = None,
+        seed: int | None = None,
+        top_p: float | None = None,
+        frequency_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        stop: str | list[str] | None = None,
+    ) -> None:
+        try:
+            import litellm  # noqa: F401
+        except ImportError as e:
+            raise RuntimeError(
+                "The 'litellm' package is required for LiteLLMProvider. "
+                "Install it with: pip install 'getpatter[litellm]'"
+            ) from e
+
+        self._api_key = api_key or os.environ.get("LITELLM_API_KEY")
+        self._model = model
+        self._api_base = api_base
+        self._drop_params = drop_params
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._response_format = response_format
+        self._parallel_tool_calls = parallel_tool_calls
+        self._tool_choice = tool_choice
+        self._seed = seed
+        self._top_p = top_p
+        self._frequency_penalty = frequency_penalty
+        self._presence_penalty = presence_penalty
+        self._stop = stop
+
+    async def warmup(self) -> None:
+        """Best-effort pre-call DNS / TLS warmup.
+
+        Issues a lightweight HTTPS GET so the connection pool is warm by
+        the time the first ``acompletion`` call lands. Best-effort: 5 s
+        timeout, all exceptions swallowed at DEBUG.
+        """
+        base = self._api_base
+        if not base:
+            return
+        try:
+            import httpx
+
+            url = base.rstrip("/")
+            if not url.endswith("/models"):
+                url = f"{url}/models"
+            headers: dict[str, str] = {}
+            if self._api_key:
+                headers["Authorization"] = f"Bearer {self._api_key}"
+            async with httpx.AsyncClient(timeout=5.0) as http:
+                await http.get(url, headers=headers)
+        except Exception as exc:  # noqa: BLE001 - best-effort
+            logger.debug("LiteLLM warmup failed (best-effort): %s", exc)
+
+    def _build_completion_kwargs(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None,
+    ) -> dict[str, Any]:
+        """Assemble kwargs for ``litellm.acompletion``."""
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self._api_base is not None:
+            kwargs["api_base"] = self._api_base
+        if self._drop_params:
+            kwargs["drop_params"] = True
+        if tools:
+            kwargs["tools"] = tools
+        if self._response_format is not None:
+            kwargs["response_format"] = self._response_format
+        if self._parallel_tool_calls is not None:
+            kwargs["parallel_tool_calls"] = self._parallel_tool_calls
+        if self._tool_choice is not None:
+            kwargs["tool_choice"] = self._tool_choice
+        if self._seed is not None:
+            kwargs["seed"] = self._seed
+        if self._top_p is not None:
+            kwargs["top_p"] = self._top_p
+        if self._frequency_penalty is not None:
+            kwargs["frequency_penalty"] = self._frequency_penalty
+        if self._presence_penalty is not None:
+            kwargs["presence_penalty"] = self._presence_penalty
+        if self._stop is not None:
+            kwargs["stop"] = self._stop
+        if self._temperature is not None:
+            kwargs["temperature"] = self._temperature
+        if self._max_tokens is not None:
+            kwargs["max_completion_tokens"] = self._max_tokens
+        return kwargs
+
+    async def stream(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        *,
+        cancel_event: asyncio.Event | None = None,
+        call_id: str | None = None,
+    ) -> AsyncIterator[dict]:
+        """Stream chunks from LiteLLM's unified completion API.
+
+        ``call_id`` is accepted for protocol parity with session-aware
+        providers but ignored.
+
+        ``cancel_event`` (set on barge-in by the stream handler) is checked
+        between chunks and short-circuits the stream so the next user
+        transcript is not blocked behind a long-running fetch.
+        """
+        import litellm
+
+        kwargs = self._build_completion_kwargs(messages, tools)
+        response = await litellm.acompletion(**kwargs)
+
+        last_usage = None
+        try:
+            async for chunk in response:
+                if cancel_event is not None and cancel_event.is_set():
+                    return
+
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    last_usage = usage
+
+                delta = chunk.choices[0].delta if chunk.choices else None
+                if delta is None:
+                    continue
+
+                content = getattr(delta, "content", None)
+                if content:
+                    yield {"type": "text", "content": content}
+
+                tool_calls = getattr(delta, "tool_calls", None)
+                if tool_calls:
+                    for tc in tool_calls:
+                        yield {
+                            "type": "tool_call",
+                            "index": tc.index,
+                            "id": tc.id,
+                            "name": tc.function.name if tc.function else None,
+                            "arguments": (
+                                tc.function.arguments if tc.function else None
+                            ),
+                        }
+
+            if last_usage is not None:
+                prompt_tokens = getattr(last_usage, "prompt_tokens", 0) or 0
+                completion_tokens = (
+                    getattr(last_usage, "completion_tokens", 0) or 0
+                )
+                cache_read = 0
+                details = getattr(last_usage, "prompt_tokens_details", None)
+                if details is not None:
+                    cache_read = getattr(details, "cached_tokens", 0) or 0
+                uncached_input = max(0, prompt_tokens - cache_read)
+                self._record_completion_cost(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                )
+                yield {
+                    "type": "usage",
+                    "input_tokens": uncached_input,
+                    "output_tokens": completion_tokens,
+                    "cache_read_tokens": cache_read,
+                }
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if cancel_event is not None and cancel_event.is_set():
+                return
+            raise
+
+        yield {"type": "done"}
+
+    def _record_completion_cost(
+        self, *, prompt_tokens: int, completion_tokens: int
+    ) -> None:
+        """Stamp ``patter.cost.llm_*_tokens`` on the current span."""
+        try:
+            from getpatter.observability.attributes import record_patter_attrs
+
+            record_patter_attrs(
+                {
+                    "patter.cost.llm_input_tokens": prompt_tokens,
+                    "patter.cost.llm_output_tokens": completion_tokens,
+                    "patter.llm.provider": "litellm",
+                }
+            )
+        except Exception:  # pragma: no cover - defense in depth
+            logger.debug("_record_completion_cost failed", exc_info=True)

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -125,6 +125,10 @@ cerebras = [
 google = [
     "google-genai>=1.55",
 ]
+# LiteLLM unified AI gateway (100+ LLM providers via one interface).
+litellm = [
+    "litellm>=1.80.0,<2.0",
+]
 # Background audio player (hold music + ambient cues). Mixes bundled .ogg
 # clips with the outbound PCM stream. Requires numpy for PCM math and
 # soundfile for .ogg decoding.

--- a/libraries/python/tests/test_litellm_llm.py
+++ b/libraries/python/tests/test_litellm_llm.py
@@ -1,0 +1,169 @@
+"""Tests for the LiteLLM LLM provider."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_chunk(content=None, tool_calls=None, usage=None):
+    chunk = MagicMock()
+    delta = MagicMock()
+    delta.content = content
+    delta.tool_calls = tool_calls
+    choice = MagicMock()
+    choice.delta = delta
+    chunk.choices = [choice] if (content is not None or tool_calls is not None) else []
+    chunk.usage = usage
+    return chunk
+
+
+def _make_usage(prompt=10, completion=20):
+    usage = MagicMock()
+    usage.prompt_tokens = prompt
+    usage.completion_tokens = completion
+    usage.prompt_tokens_details = None
+    return usage
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+@pytest.fixture
+def mock_litellm():
+    mock = MagicMock()
+    with patch.dict(sys.modules, {"litellm": mock}):
+        yield mock
+
+
+@pytest.mark.mocked
+@pytest.mark.asyncio
+async def test_litellm_stream_text(mock_litellm):
+    mock_litellm.acompletion = AsyncMock(
+        return_value=_async_iter([
+            _make_chunk(content="Hello "),
+            _make_chunk(content="world!"),
+            _make_chunk(usage=_make_usage()),
+        ])
+    )
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    provider = LiteLLMProvider(api_key="test-key", model="gpt-4o")
+    chunks = []
+    async for chunk in provider.stream([{"role": "user", "content": "Hi"}]):
+        chunks.append(chunk)
+
+    text_chunks = [c for c in chunks if c["type"] == "text"]
+    assert text_chunks == [
+        {"type": "text", "content": "Hello "},
+        {"type": "text", "content": "world!"},
+    ]
+    assert any(c["type"] == "usage" for c in chunks)
+    assert any(c["type"] == "done" for c in chunks)
+
+
+@pytest.mark.mocked
+@pytest.mark.asyncio
+async def test_litellm_stream_tool_call(mock_litellm):
+    tc = MagicMock()
+    tc.index = 0
+    tc.id = "call_123"
+    tc.function.name = "get_weather"
+    tc.function.arguments = '{"city": "Paris"}'
+
+    mock_litellm.acompletion = AsyncMock(
+        return_value=_async_iter([
+            _make_chunk(tool_calls=[tc]),
+        ])
+    )
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    provider = LiteLLMProvider(api_key="test-key", model="gpt-4o")
+    chunks = []
+    async for chunk in provider.stream([{"role": "user", "content": "weather?"}]):
+        chunks.append(chunk)
+
+    tool_chunks = [c for c in chunks if c["type"] == "tool_call"]
+    assert len(tool_chunks) == 1
+    assert tool_chunks[0]["name"] == "get_weather"
+    assert tool_chunks[0]["id"] == "call_123"
+
+
+@pytest.mark.mocked
+@pytest.mark.asyncio
+async def test_litellm_cancel_event(mock_litellm):
+    cancel = asyncio.Event()
+    cancel.set()
+
+    mock_litellm.acompletion = AsyncMock(
+        return_value=_async_iter([
+            _make_chunk(content="should not appear"),
+        ])
+    )
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    provider = LiteLLMProvider(api_key="test-key", model="gpt-4o")
+    chunks = []
+    async for chunk in provider.stream(
+        [{"role": "user", "content": "Hi"}], cancel_event=cancel
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 0
+
+
+@pytest.mark.mocked
+@pytest.mark.asyncio
+async def test_litellm_kwargs_forwarded(mock_litellm):
+    mock_litellm.acompletion = AsyncMock(return_value=_async_iter([]))
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    provider = LiteLLMProvider(
+        api_key="test-key",
+        model="gpt-4o",
+        temperature=0.5,
+        max_tokens=100,
+        api_base="https://my-proxy.com/v1",
+    )
+    chunks = [c async for c in provider.stream([{"role": "user", "content": "Hi"}])]
+
+    call_kwargs = mock_litellm.acompletion.call_args[1]
+    assert call_kwargs["temperature"] == 0.5
+    assert call_kwargs["max_completion_tokens"] == 100
+    assert call_kwargs["api_base"] == "https://my-proxy.com/v1"
+    assert call_kwargs["drop_params"] is True
+
+
+@pytest.mark.mocked
+@pytest.mark.asyncio
+async def test_litellm_error_propagates(mock_litellm):
+    mock_litellm.acompletion = AsyncMock(side_effect=Exception("API Error"))
+    from getpatter.providers.litellm_llm import LiteLLMProvider
+
+    provider = LiteLLMProvider(api_key="test-key", model="gpt-4o")
+    with pytest.raises(Exception, match="API Error"):
+        async for _ in provider.stream([{"role": "user", "content": "Hi"}]):
+            pass
+
+
+@pytest.mark.mocked
+def test_litellm_llm_wrapper_env_fallback(mock_litellm):
+    with patch.dict("os.environ", {"LITELLM_API_KEY": "env-key"}):
+        from getpatter.llm.litellm import LLM
+
+        llm = LLM(model="gpt-4o")
+        assert llm._api_key == "env-key"
+
+
+@pytest.mark.mocked
+def test_litellm_missing_dependency():
+    with patch.dict(sys.modules, {"litellm": None}):
+        with pytest.raises(RuntimeError, match="litellm"):
+            from getpatter.providers.litellm_llm import LiteLLMProvider
+
+            LiteLLMProvider(api_key="test")

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -191,6 +191,8 @@ export { LLM as CerebrasLLM } from "./llm/cerebras";
 export type { CerebrasLLMOptions } from "./llm/cerebras";
 export { LLM as GoogleLLM } from "./llm/google";
 export type { GoogleLLMOptions } from "./llm/google";
+export { LLM as LiteLLMLLM } from "./llm/litellm";
+export type { LiteLLMLLMOptions } from "./llm/litellm";
 // Agent-runtime LLM providers (Patter as the voice shell in front of an
 // OpenAI-compatible agent runtime / local inference gateway).
 export { LLM as OpenAICompatibleLLM, OpenAICompatibleLLMProvider } from "./llm/openai-compatible";
@@ -213,10 +215,12 @@ import { LLM as HermesLLMClass } from "./llm/hermes";
 import { LLM as OpenClawLLMClass } from "./llm/openclaw";
 import { LLM as OpenAICompatibleLLMClass } from "./llm/openai-compatible";
 import { LLM as CustomLLMClass } from "./llm/custom";
+import { LLM as LiteLLMLLMClass } from "./llm/litellm";
 export const hermes = Object.freeze({ LLM: HermesLLMClass });
 export const openclaw = Object.freeze({ LLM: OpenClawLLMClass });
 export const openaiCompatible = Object.freeze({ LLM: OpenAICompatibleLLMClass });
 export const custom = Object.freeze({ LLM: CustomLLMClass });
+export const litellm = Object.freeze({ LLM: LiteLLMLLMClass });
 
 // Voice Activity Detection (server-side) — Silero ONNX.
 export { SileroVAD } from "./providers/silero-vad";

--- a/libraries/typescript/src/llm/litellm.ts
+++ b/libraries/typescript/src/llm/litellm.ts
@@ -1,0 +1,95 @@
+/**
+ * LiteLLM LLM provider for Patter's pipeline mode.
+ *
+ * Thin preset over {@link OpenAICompatibleLLMProvider} that points at a
+ * LiteLLM proxy endpoint. LiteLLM exposes an OpenAI-compatible
+ * ``/chat/completions`` API that routes to 100+ providers (OpenAI,
+ * Anthropic, Google, Azure, Bedrock, Ollama, and more).
+ *
+ * The proxy must be running and reachable at ``baseUrl`` (default:
+ * ``http://localhost:4000/v1`` or ``LITELLM_BASE_URL`` env var).
+ */
+import {
+  OpenAICompatibleLLMProvider,
+  type OpenAICompatibleLLMOptions,
+} from './openai-compatible';
+
+/** Default LiteLLM proxy base URL. */
+const DEFAULT_BASE_URL = 'http://localhost:4000/v1';
+/** Env var for the LiteLLM proxy base URL. */
+const BASE_URL_ENV = 'LITELLM_BASE_URL';
+/** Env var for the LiteLLM proxy API key (master/virtual key). */
+const API_KEY_ENV = 'LITELLM_API_KEY';
+
+/** Constructor options for the LiteLLM ``LLM`` preset. */
+export interface LiteLLMLLMOptions {
+  /** API key for the LiteLLM proxy. Falls back to ``LITELLM_API_KEY`` env var. */
+  apiKey?: string;
+  /** LiteLLM proxy base URL. Falls back to ``LITELLM_BASE_URL`` env, then ``http://localhost:4000/v1``. */
+  baseUrl?: string;
+  /** Model identifier routed by the LiteLLM proxy (e.g. ``"gpt-4o"``, ``"anthropic/claude-sonnet-4-6"``). */
+  model?: string;
+  /** Per-request timeout in seconds. Default ``60``. */
+  timeout?: number;
+  /** Extra headers merged after the SDK ``User-Agent``. */
+  extraHeaders?: Record<string, string>;
+  /** Sampling temperature [0, 2]. */
+  temperature?: number;
+  /** Max tokens in the assistant response (sent as ``max_completion_tokens``). */
+  maxTokens?: number;
+  /** OpenAI-style ``response_format`` for JSON mode / structured outputs. */
+  responseFormat?: Record<string, unknown>;
+  /** Whether to allow parallel tool calls. */
+  parallelToolCalls?: boolean;
+  /** ``"auto" | "none" | "required"`` or a specific tool object. */
+  toolChoice?: string | Record<string, unknown>;
+  /** Sampling seed for reproducible outputs. */
+  seed?: number;
+  /** Nucleus sampling cutoff in [0, 1]. */
+  topP?: number;
+  /** Penalty in [-2, 2] applied to repeated tokens. */
+  frequencyPenalty?: number;
+  /** Penalty in [-2, 2] applied to seen tokens. */
+  presencePenalty?: number;
+  /** Stop sequence(s). */
+  stop?: string | string[];
+}
+
+/**
+ * LiteLLM proxy LLM provider (OpenAI-compatible, streaming).
+ *
+ * @example
+ * ```ts
+ * import * as litellm from "getpatter/llm/litellm";
+ * const llm = new litellm.LLM({ model: "gpt-4o" });
+ * const llm = new litellm.LLM({ model: "anthropic/claude-sonnet-4-6" });
+ * ```
+ */
+export class LLM extends OpenAICompatibleLLMProvider {
+  static readonly providerKey = 'litellm';
+
+  constructor(opts: LiteLLMLLMOptions = {}) {
+    const baseUrl =
+      opts.baseUrl ?? process.env[BASE_URL_ENV] ?? DEFAULT_BASE_URL;
+    const model = opts.model ?? 'gpt-4o-mini';
+    const options: OpenAICompatibleLLMOptions = {
+      apiKey: opts.apiKey,
+      apiKeyEnv: API_KEY_ENV,
+      baseUrl,
+      model,
+      timeout: opts.timeout,
+      extraHeaders: opts.extraHeaders,
+      temperature: opts.temperature,
+      maxTokens: opts.maxTokens,
+      responseFormat: opts.responseFormat,
+      parallelToolCalls: opts.parallelToolCalls,
+      toolChoice: opts.toolChoice,
+      seed: opts.seed,
+      topP: opts.topP,
+      frequencyPenalty: opts.frequencyPenalty,
+      presencePenalty: opts.presencePenalty,
+      stop: opts.stop,
+    };
+    super(options);
+  }
+}

--- a/libraries/typescript/tests/litellm-llm.test.ts
+++ b/libraries/typescript/tests/litellm-llm.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for the LiteLLM LLM provider (proxy mode).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+describe('LiteLLM LLM provider', () => {
+  it('uses gpt-4o-mini as default model', async () => {
+    const { LLM } = await import('../src/llm/litellm');
+    const llm = new LLM({ baseUrl: 'http://localhost:4000/v1' });
+    expect(llm.model).toBe('gpt-4o-mini');
+  });
+
+  it('honours explicit model override', async () => {
+    const { LLM } = await import('../src/llm/litellm');
+    const llm = new LLM({
+      model: 'anthropic/claude-sonnet-4-6',
+      baseUrl: 'http://localhost:4000/v1',
+    });
+    expect(llm.model).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('has litellm as providerKey', async () => {
+    const { LLM } = await import('../src/llm/litellm');
+    expect(LLM.providerKey).toBe('litellm');
+  });
+
+  it('accepts custom baseUrl', async () => {
+    const { LLM } = await import('../src/llm/litellm');
+    const llm = new LLM({
+      baseUrl: 'https://my-proxy.example.com/v1',
+      model: 'gpt-4o',
+    });
+    expect(llm.model).toBe('gpt-4o');
+  });
+});


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://github.com/BerriAI/litellm) as an LLM provider, giving users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, AWS Bedrock, Ollama, Cohere, Mistral, and more) through a single unified interface. Python SDK uses the native `litellm` SDK (`litellm.acompletion`); TypeScript SDK uses LiteLLM as an OpenAI-compatible proxy.

## Changes

- `libraries/python/getpatter/providers/litellm_llm.py` - `LiteLLMProvider` satisfying the `LLMProvider` protocol (streaming, tool calls, cancel_event barge-in, usage tracking, warmup). `drop_params=True` by default for cross-provider compatibility.
- `libraries/python/getpatter/llm/litellm.py` - thin `LLM` wrapper with `LITELLM_API_KEY` env var fallback.
- `libraries/typescript/src/llm/litellm.ts` - `LLM` preset extending `OpenAICompatibleLLMProvider` with LiteLLM proxy defaults (`LITELLM_BASE_URL`, `LITELLM_API_KEY`).
- `libraries/python/pyproject.toml` - `litellm = ["litellm>=1.80.0,<2.0"]` optional extra.
- `libraries/python/tests/test_litellm_llm.py` - 7 unit tests (mocked).
- `libraries/typescript/tests/litellm-llm.test.ts` - 4 unit tests.
- Registration in both SDK barrels (`__init__.py`, `index.ts`) with `LiteLLMLLM` flat alias and `litellm` namespace object.

## Pre-merge checklist

- [x] **Local validation is green**: `bash scripts/pr-validate.sh` (mirrors the
      PR-blocking CI — Python + TypeScript tests, lint, pre-commit).
- [x] **Both SDKs** updated when the change is user-visible — every public
      feature ships in **Python AND TypeScript** in the same PR, same API shape
      and defaults (`snake_case` ↔ `camelCase`). New/Python-only or TS-only is
      not accepted.
- [ ] **`CHANGELOG.md` updated** — added an entry under `## Unreleased`
      (`### Added` / `### Changed` / `### Fixed` / …) for any user-visible
      change. Refactor / test-only / docs-only diffs are exempt — say so below.
- [x] **Tests** added for new behaviour; only the paid/external boundary
      (carrier / provider WebSocket) is mocked.
- [x] **No secrets, credentials, or real phone numbers / PII** in the diff.
- [x] **No external license headers or "ported from <repo>" provenance
      comments** in source files (integrating a provider/carrier and naming it
      is fine; copying a competitor's lineage is not).

## Breaking change?

No — or describe the migration path.
