### PR TITLE
fix(telemetry): set llm_provider on realtime feature_used events

### DIFF
--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1824,12 +1824,20 @@ class Patter:
             # Realtime has no composed stack, so the model variant is the whole
             # story — resolve it the same way the engine unpacking below does
             # (an explicit model= kwarg wins; otherwise the engine's model).
+            # Pin llm_provider="openai" alongside the model: the realtime family
+            # is always the OpenAI realtime engine, so the per-layer LLM vendor is
+            # openai. Set it explicitly (overriding any stray ``llm=`` provider)
+            # so the feature_used row's provider and model stay consistent.
             _rt_model = (
                 model
                 if model is not None
                 else (getattr(engine, "model", None) or "gpt-realtime-mini")
             )
-            _stack = {**_stack, "llm_model": model_token("openai", _rt_model)}
+            _stack = {
+                **_stack,
+                "llm_provider": "openai",
+                "llm_model": model_token("openai", _rt_model),
+            }
         _feature_key = (
             _family + "|" + ",".join(f"{k}={v}" for k, v in sorted(_stack.items()))
         )

--- a/libraries/python/tests/test_telemetry.py
+++ b/libraries/python/tests/test_telemetry.py
@@ -189,6 +189,9 @@ async def test_agent_records_realtime_model_in_feature_used(
         "openai-gpt-realtime-mini",
     ]
     assert all(e["engine"] == "realtime" for e in feature_events)
+    # The realtime family is always the OpenAI realtime engine, so the per-layer
+    # LLM vendor is pinned to "openai" — provider and model stay consistent.
+    assert all(e.get("llm_provider") == "openai" for e in feature_events)
 
 
 # --- pending-buffer survival (fire-and-forget clients) ----------------------

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -631,9 +631,14 @@ export class Patter {
       // Realtime has no composed stack, so the model variant is the whole
       // story — resolve it the same way the engine merge below does (an
       // explicit model wins; otherwise the engine's model; else the default).
+      // Pin llm_provider="openai" alongside the model: the realtime family is
+      // always the OpenAI realtime engine, so the per-layer LLM vendor is openai.
+      // Set it explicitly (overriding any stray `llm` provider) so the
+      // feature_used row's provider and model stay consistent.
       const engineModel = (opts.engine as { model?: string } | undefined)?.model;
       stack = {
         ...stack,
+        llm_provider: "openai",
         llm_model: modelToken(
           "openai",
           (opts.model as string | undefined) ?? engineModel ?? "gpt-realtime-mini",

--- a/libraries/typescript/tests/telemetry.test.ts
+++ b/libraries/typescript/tests/telemetry.test.ts
@@ -281,6 +281,9 @@ describe('[integration] telemetry — enabled path', () => {
       'openai-gpt-realtime-mini',
     ]);
     for (const e of featureEvents) expect(e.engine).toBe('realtime');
+    // The realtime family is always the OpenAI realtime engine, so the per-layer
+    // LLM vendor is pinned to "openai" — provider and model stay consistent.
+    for (const e of featureEvents) expect(e.llm_provider).toBe('openai');
   });
 
   it('close() delivers an event whose flush was already started by record()', async () => {


### PR DESCRIPTION
## What

Realtime agents recorded `llm_model` in the `feature_used` telemetry event but left `llm_provider` empty, and a stray `llm=` argument could leak an inconsistent provider (observed in production data: `provider=anthropic` paired with `model=openai-gpt-realtime-mini`).

The realtime engine family is always the OpenAI realtime engine, so this pins `llm_provider="openai"` alongside the model for `family == "realtime"` in both SDKs, keeping the per-layer provider and model consistent.

## Why

`feature_used` is where the per-layer provider/model mix is captured. Realtime is the most-used engine, so an empty `llm_provider` left a hole in the provider-mix analytics and produced self-inconsistent rows when an `llm` was also supplied. This makes the realtime provider visible and consistent with its model token.

## Changes

- `libraries/python/getpatter/client.py` — pin `llm_provider="openai"` in the realtime stack override (overriding any stray `llm=` provider).
- `libraries/typescript/src/client.ts` — same change, for parity.
- Tests in both SDKs extended to assert `llm_provider == "openai"` on realtime `feature_used` events.

No schema change (`llm_provider` is already on the allowlist); no relay change required.

## Test plan

- [x] Python telemetry suite — 116 passed
- [x] TypeScript telemetry suite — 87 passed
- [x] TypeScript typecheck (`tsc --noEmit`) clean
- [x] No new lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
