### PR TITLE
fix(python): export KrispVivaFilter and DeepFilterNetFilter from package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### Added
 
+- **Python: `KrispVivaFilter` and `DeepFilterNetFilter` are now exported from
+  the package root.** Both noise-suppression `AudioFilter` implementations
+  already shipped as modules (`getpatter/providers/krisp_filter.py`,
+  `getpatter/providers/deepfilternet_filter.py`) but were not surfaced on the
+  `getpatter` barrel, so Python users had to reach into the internal provider
+  path while TypeScript already exported the equivalent `KrispVivaFilter` /
+  `DeepFilterNetFilter` classes. They are now resolvable as
+  `getpatter.KrispVivaFilter` / `getpatter.DeepFilterNetFilter` and listed in
+  `__all__`. Resolution is lazy (via `getpatter.__getattr__`, matching
+  `SileroVAD` / `SmartTurnDetector`) so importing `getpatter` still costs
+  nothing when the proprietary `krisp-audio` SDK or the heavy `deepfilternet`
+  (torch) extra is absent. Additive, backward-compatible, and closes a
+  Python↔TypeScript public-surface parity gap. `libraries/python/getpatter/__init__.py`.
+
 - **Telemetry: `config_incomplete` — activation-blocker signal.** A new event
   emitted at most once per `Patter` instance when required runtime config is
   missing so the instance/agent cannot proceed. It carries a single coarse enum

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -159,6 +159,21 @@ def __getattr__(name):
         from getpatter.providers import krisp_instance as _krisp_instance
 
         return getattr(_krisp_instance, name)
+    # Pre-STT noise-suppression audio filters — opt-in (need the ``krisp`` /
+    # ``deepfilternet`` extras). Both modules defer their heavy imports
+    # (krisp-audio, torch) until instantiation, so surfacing the class here
+    # costs nothing when the extra is absent. Parity with the TypeScript
+    # ``KrispVivaFilter`` / ``DeepFilterNetFilter`` exports.
+    if name == "KrispVivaFilter":
+        from getpatter.providers.krisp_filter import KrispVivaFilter as _KrispVivaFilter
+
+        return _KrispVivaFilter
+    if name == "DeepFilterNetFilter":
+        from getpatter.providers.deepfilternet_filter import (
+            DeepFilterNetFilter as _DeepFilterNetFilter,
+        )
+
+        return _DeepFilterNetFilter
     if name in {"OnnxExecutionProvider", "SileroOnnxSampleRate"}:
         from getpatter.providers import silero_onnx as _silero_onnx
 
@@ -497,6 +512,8 @@ __all__ = [
     "TelnyxTTS",
     "SileroVAD",
     "SmartTurnDetector",
+    "KrispVivaFilter",
+    "DeepFilterNetFilter",
     "init_tracing",
     "start_span",
     "SPAN_CALL",

--- a/libraries/python/tests/unit/test_parity_ports.py
+++ b/libraries/python/tests/unit/test_parity_ports.py
@@ -69,6 +69,33 @@ class TestPublicReexports:
         assert hasattr(getpatter, name), f"getpatter.{name} not importable"
 
 
+@pytest.mark.unit
+class TestAudioFilterReexports:
+    """The noise-suppression filters are reachable from the package root.
+
+    Parity with the TypeScript ``KrispVivaFilter`` / ``DeepFilterNetFilter``
+    exports. Resolution is lazy (via ``getpatter.__getattr__``) so the symbols
+    are importable even without the proprietary ``krisp-audio`` SDK or the
+    heavy ``deepfilternet`` (torch) extra installed — exercised here with no
+    mocks, which is the real code path users hit.
+    """
+
+    @pytest.mark.parametrize("name", ["KrispVivaFilter", "DeepFilterNetFilter"])
+    def test_filter_in_all_and_lazy_resolves(self, name: str) -> None:
+        from getpatter.providers.base import AudioFilter
+
+        assert name in getpatter.__all__, f"{name} missing from getpatter.__all__"
+        cls = getattr(getpatter, name)
+        assert isinstance(cls, type) and issubclass(cls, AudioFilter)
+
+    def test_barrel_symbols_are_the_canonical_classes(self) -> None:
+        from getpatter.providers.deepfilternet_filter import DeepFilterNetFilter
+        from getpatter.providers.krisp_filter import KrispVivaFilter
+
+        assert getpatter.KrispVivaFilter is KrispVivaFilter
+        assert getpatter.DeepFilterNetFilter is DeepFilterNetFilter
+
+
 # ---------------------------------------------------------------------------
 # LLMChunk
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Both noise-suppression `AudioFilter` implementations already shipped as Python
modules (`getpatter/providers/krisp_filter.py`,
`getpatter/providers/deepfilternet_filter.py`) but were never surfaced on the
`getpatter` package barrel — while the TypeScript SDK already exported the
equivalent `KrispVivaFilter` / `DeepFilterNetFilter` classes from `index.ts`.
Python users had to reach into the internal `getpatter.providers.*` path for a
filter TS users got at the top level.

This PR closes that Python↔TypeScript public-surface parity gap by exporting
both classes from the Python package root. It is a visibility-only change:
additive, backward-compatible, and it touches no TypeScript (TS is already at
parity, so no TS change is needed).

## Changes

- Add lazy `__getattr__` resolution for `KrispVivaFilter` and
  `DeepFilterNetFilter` in `libraries/python/getpatter/__init__.py`, matching
  the existing `SileroVAD` / `SmartTurnDetector` pattern. Both filter modules
  already defer their heavy imports (`krisp-audio`, `torch`) until
  instantiation, so importing `getpatter` stays free of the optional `krisp` /
  `deepfilternet` extras.
- Add `"KrispVivaFilter"` and `"DeepFilterNetFilter"` to `__all__`.
- Add a mock-free `TestAudioFilterReexports` to
  `libraries/python/tests/unit/test_parity_ports.py` asserting both symbols are
  in `__all__`, resolve lazily without the extras installed (the real user code
  path), subclass `AudioFilter`, and are identical to the canonical provider
  classes.
- `CHANGELOG.md` entry under `## Unreleased` → `### Added`.

## Pre-merge checklist

- [x] **Local validation is green**: `bash scripts/pr-validate.sh` — ran the
      Python jobs directly: full suite **2599 passed, 28 skipped, 2 xfailed**;
      security tests **29 passed**. `pre-commit`/`gitleaks` weren't installed
      locally so those hooks run first in CI; verified the active hygiene hooks
      manually (trailing whitespace, EOF newline, LF endings, no debug
      statements) — `ruff` is disabled in `.pre-commit-config.yaml`.
- [x] **Both SDKs** — TypeScript already exports `KrispVivaFilter` and
      `DeepFilterNetFilter`; this PR brings Python to parity, so the end-state
      is both-SDK coverage with identical class names. No TS change required.
- [x] **`CHANGELOG.md` updated** — entry added under `## Unreleased` →
      `### Added`.
- [x] **Tests** added (mock-free parity test). No paid/external boundary is
      involved in a visibility-only change, so nothing is mocked.
- [x] **No secrets, credentials, or real phone numbers / PII** in the diff.
- [x] **No external license headers or "ported from <repo>" provenance
      comments** — added comments reference Patter's own TS classes only.

## Breaking change?

No — purely additive. New public re-exports with lazy resolution; no existing
default, signature, or import path changes.