### PR TITLE
feat(evals): port the evals harness to the TypeScript SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## Unreleased
 
+### Added
+
+- **TypeScript evals harness — parity with the Python `getpatter.evals` core.**
+  The TypeScript SDK now ships the evaluation harness that was previously
+  Python-only (the CLI printed *"Evaluations are not yet available in the
+  TypeScript SDK"*). New `src/evals/` exports `EvalCase` / `EvalTurn` /
+  `EvalSuite` / `JudgeResult` / `TranscriptEntry` / `EvalResult`, the
+  `LLMJudge` (OpenAI-as-judge, strict JSON, verdict computed locally from the
+  clamped score so a hallucinated `passed: true` on a low score still fails),
+  `EvalRunner` (drives a suite against an async `reply()` agent factory, one
+  transient judge failure no longer aborts the whole suite), and async
+  `loadSuite()` for JSON and (optional `yaml` dependency) YAML suite files.
+  The suite file schema and JSON report shape are identical across SDKs, so a
+  suite authored for `patter eval run` works unchanged in either. The CLI stub
+  is replaced by a real `getpatter eval run <suite> [--agent module:export]
+  [--judge-model M] [--pass-threshold T] [--output FILE]` (exit 0 all-pass / 1
+  any-fail / 2 bad usage). Purely additive — no breaking change. The judge
+  uses raw `fetch` (the SDK has no `openai` dependency) mirroring
+  `src/llm-loop.ts`; a `JudgeBackend` seam makes the judge injectable for
+  tests. `libraries/typescript/src/evals/{case,llm-judge,runner,cli,index}.ts`,
+  `libraries/typescript/src/cli.ts`, `libraries/typescript/src/index.ts`,
+  mirrors `libraries/python/getpatter/evals/{case,llm_judge,runner,cli}.py`.
+  (The real-pipeline `EvalSession` layer — `session.py` / `assertions.py` —
+  remains Python-only for now and is tracked as a follow-up.)
+
 ## 0.6.7 (2026-06-10)
 
 ### Fixed

--- a/libraries/python/getpatter/evals/__init__.py
+++ b/libraries/python/getpatter/evals/__init__.py
@@ -25,7 +25,7 @@ The session-layer names are loaded lazily (PEP 562) so importing
 
 from getpatter.evals.case import EvalCase, EvalTurn, JudgeResult, EvalResult
 from getpatter.evals.llm_judge import LLMJudge
-from getpatter.evals.runner import EvalRunner, EvalSuite
+from getpatter.evals.runner import EvalRunner, EvalSuite, load_suite
 
 __all__ = [
     "EvalCase",
@@ -35,6 +35,7 @@ __all__ = [
     "LLMJudge",
     "EvalRunner",
     "EvalSuite",
+    "load_suite",
     # Real-pipeline harness (lazy):
     "EvalSession",
     "TurnResult",

--- a/libraries/python/tests/test_evals.py
+++ b/libraries/python/tests/test_evals.py
@@ -7,7 +7,6 @@ is not set.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 
@@ -15,7 +14,6 @@ import pytest
 
 from getpatter.evals import (
     EvalCase,
-    EvalResult,
     EvalRunner,
     EvalSuite,
     EvalTurn,
@@ -57,7 +55,9 @@ async def test_llm_judge_parses_score_and_reasoning():
 
 @pytest.mark.asyncio
 async def test_llm_judge_tolerates_code_fences():
-    judge = LLMJudge(backend=FakeBackend({"score": 0.5, "passed": False, "reasoning": "meh"}))
+    judge = LLMJudge(
+        backend=FakeBackend({"score": 0.5, "passed": False, "reasoning": "meh"})
+    )
     # Replace backend to return a fenced string instead of the raw dict.
     fenced = '```json\n{"score": 0.5, "passed": false, "reasoning": "meh"}\n```'
 
@@ -87,10 +87,27 @@ async def test_llm_judge_fails_safely_on_invalid_json():
 
 @pytest.mark.asyncio
 async def test_llm_judge_clamps_score_to_unit_range():
-    judge = LLMJudge(backend=FakeBackend({"score": 1.5, "passed": True, "reasoning": ""}))
+    judge = LLMJudge(
+        backend=FakeBackend({"score": 1.5, "passed": True, "reasoning": ""})
+    )
     case = EvalCase(name="t", turns=[], expected_behavior="", rubric="")
     result = await judge.judge_case(case, [])
     assert result.score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_llm_judge_computes_verdict_locally_from_score():
+    # A hallucinated ``passed: true`` paired with a sub-threshold score must
+    # still fail — the verdict is computed locally from the clamped score, not
+    # trusted from the model. Mirrors the TS test of the same invariant.
+    judge = LLMJudge(
+        pass_threshold=0.7,
+        backend=FakeBackend({"score": 0.2, "passed": True, "reasoning": "lies"}),
+    )
+    case = EvalCase(name="t", turns=[], expected_behavior="", rubric="")
+    result = await judge.judge_case(case, [])
+    assert result.score == pytest.approx(0.2)
+    assert result.passed is False
 
 
 @pytest.mark.asyncio
@@ -144,7 +161,9 @@ async def test_runner_handles_agent_exception():
         rubric="",
     )
     suite = EvalSuite(name="s", cases=[case])
-    judge = LLMJudge(backend=FakeBackend({"score": 0, "passed": False, "reasoning": ""}))
+    judge = LLMJudge(
+        backend=FakeBackend({"score": 0, "passed": False, "reasoning": ""})
+    )
     runner = EvalRunner(judge=judge)
 
     async def broken(_: str) -> str:

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -31,7 +31,8 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "cloudflared": "^0.7.1",
         "node-cron": "^4.0.0",
-        "onnxruntime-node": "~1.18.0"
+        "onnxruntime-node": "~1.18.0",
+        "yaml": "^2.0.0"
       },
       "peerDependencies": {
         "@google/genai": "^0.3.0"
@@ -4223,6 +4224,22 @@
       "optional": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -74,7 +74,8 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "cloudflared": "^0.7.1",
     "node-cron": "^4.0.0",
-    "onnxruntime-node": "~1.18.0"
+    "onnxruntime-node": "~1.18.0",
+    "yaml": "^2.0.0"
   },
   "peerDependencies": {
     "@google/genai": "^0.3.0"

--- a/libraries/typescript/src/cli.ts
+++ b/libraries/typescript/src/cli.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   npx getpatter dashboard [--port 8000]
- *   npx getpatter eval                        (stub — evals are Python-only today)
+ *   npx getpatter eval run <suite>            Run an evaluation suite
  *   npx getpatter telemetry [status|disable|enable]
  */
 
@@ -13,6 +13,7 @@ import { createServer } from 'node:http';
 import express from 'express';
 import { MetricsStore } from './dashboard/store';
 import { mountDashboard, mountApi } from './dashboard/routes';
+import { runEval } from './evals/cli';
 import { getLogger } from './logger';
 import { showBanner } from './banner';
 import { VERSION } from './version';
@@ -102,16 +103,6 @@ function parseArgs(argv: string[]): { port: number } {
   return { port };
 }
 
-function printEvalStub(): void {
-  console.log(
-    'Evaluations are not yet available in the TypeScript SDK.\n' +
-      'Use the Python SDK instead:\n\n' +
-      '  pip install getpatter\n' +
-      '  patter eval --help\n\n' +
-      'See https://github.com/PatterAI/Patter for docs.',
-  );
-}
-
 function printHermesStub(): void {
   console.log(
     'The Hermes wizard (doctor / setup / test / trace / diagnose /\n' +
@@ -151,8 +142,7 @@ async function main(): Promise<void> {
 
   if (command === 'eval') {
     await emitCliCommand('eval');
-    printEvalStub();
-    process.exit(0);
+    process.exit(await runEval(process.argv.slice(3)));
   }
   if (command === 'hermes') {
     printHermesStub();
@@ -165,7 +155,7 @@ async function main(): Promise<void> {
   if (command !== 'dashboard') {
     await emitCliCommand(command ? 'other' : 'none');
     console.log('Usage: getpatter dashboard [--port 8000]');
-    console.log('       getpatter eval          (stub — use Python SDK for evals)');
+    console.log('       getpatter eval run <suite>   Run an evaluation suite');
     console.log('       getpatter hermes        (stub — use Python SDK for the wizard)');
     console.log('       getpatter openclaw      (stub — use Python SDK for the wizard)');
     console.log('       getpatter telemetry [status|disable|enable]');

--- a/libraries/typescript/src/evals/case.ts
+++ b/libraries/typescript/src/evals/case.ts
@@ -1,0 +1,77 @@
+/**
+ * Eval case data model.
+ *
+ * An {@link EvalCase} is a scripted scenario: a sequence of user turns, an
+ * expected-behavior description, and a rubric used by the judge LLM.
+ *
+ * Designed to be loaded from a YAML/JSON suite file — see `loadSuite` in
+ * `./runner`. Parity with `getpatter.evals.case` (Python).
+ */
+
+/** A single user utterance in a scripted conversation. */
+export interface EvalTurn {
+  readonly user: string;
+  /**
+   * Optional substrings the agent's reply should contain — used as a cheap,
+   * case-insensitive pre-filter (logged on miss) before invoking the LLM judge.
+   */
+  readonly expectedContains?: readonly string[];
+}
+
+/** A complete evaluation scenario. */
+export interface EvalCase {
+  readonly name: string;
+  readonly turns: readonly EvalTurn[];
+  readonly expectedBehavior: string;
+  readonly rubric: string;
+  /** Optional metadata for reporting/filtering. */
+  readonly tags?: readonly string[];
+  /**
+   * Optional first-message the agent emits before any user turn. On the
+   * legacy `reply()` path it is prepended to the transcript (display-only).
+   */
+  readonly firstMessage?: string;
+}
+
+/** The judge's verdict on one case. */
+export interface JudgeResult {
+  /** Score in the inclusive range 0.0–1.0. */
+  readonly score: number;
+  readonly passed: boolean;
+  readonly reasoning: string;
+}
+
+/** One line of a conversation transcript: who spoke and what they said. */
+export interface TranscriptEntry {
+  /** `"user"` or `"agent"`. */
+  readonly role: string;
+  readonly text: string;
+}
+
+/** The result of running a single {@link EvalCase}. */
+export class EvalResult {
+  constructor(
+    readonly caseName: string,
+    readonly transcript: readonly TranscriptEntry[],
+    readonly judge: JudgeResult,
+    readonly durationS: number,
+    readonly error: string | null = null,
+  ) {}
+
+  /**
+   * Serialise to the JSON-report shape — parity with the Python
+   * `EvalResult.to_dict()` (snake_case keys for the shared report artefact
+   * consumed by CI in either SDK).
+   */
+  toDict(): Record<string, unknown> {
+    return {
+      case: this.caseName,
+      score: this.judge.score,
+      passed: this.judge.passed,
+      reasoning: this.judge.reasoning,
+      transcript: this.transcript.map((t) => ({ role: t.role, text: t.text })),
+      duration_s: Math.round(this.durationS * 1000) / 1000,
+      error: this.error,
+    };
+  }
+}

--- a/libraries/typescript/src/evals/cli.ts
+++ b/libraries/typescript/src/evals/cli.ts
@@ -1,0 +1,152 @@
+/**
+ * Command-line entry point for Patter evals.
+ *
+ * Invoked as `getpatter eval run suite.yaml` via the main CLI dispatcher
+ * (see `src/cli.ts`). Parity with `getpatter.evals.cli` (Python).
+ */
+
+import { promises as fs } from 'node:fs';
+import { LLMJudge } from './llm-judge';
+import { EvalRunner, loadSuite } from './runner';
+import type { AgentFactory, AgentReply } from './runner';
+
+interface EvalRunArgs {
+  suite: string;
+  agent: string;
+  judgeModel: string;
+  passThreshold: number;
+  output: string | null;
+}
+
+/**
+ * Entry for `getpatter eval ...`. `args` is `process.argv` already sliced past
+ * the `eval` command word. Loads the suite, runs it, writes the report, and
+ * returns a process exit code (0 all-pass / 1 any-fail / 2 bad usage).
+ */
+export async function runEval(args: readonly string[]): Promise<number> {
+  const sub = args[0];
+  if (sub === '--help' || sub === '-h') {
+    printEvalHelp();
+    return 0;
+  }
+  if (sub !== 'run') {
+    console.log('Usage: getpatter eval run <suite>');
+    return 2;
+  }
+
+  let parsed: EvalRunArgs;
+  try {
+    parsed = parseRunArgs(args.slice(1));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+  if (!parsed.suite) {
+    printEvalHelp();
+    return 2;
+  }
+
+  const suite = await loadSuite(parsed.suite);
+  const judge = new LLMJudge({
+    model: parsed.judgeModel,
+    passThreshold: parsed.passThreshold,
+  });
+  const runner = new EvalRunner({ judge });
+
+  const factory = await loadAgentFactory(parsed.agent);
+  const results = await runner.run(suite, factory);
+  const report = runner.report(suite, results);
+
+  if (parsed.output) {
+    await fs.writeFile(parsed.output, report, 'utf-8');
+    console.log(`Wrote report to ${parsed.output}`);
+  } else {
+    console.log(report);
+  }
+
+  const total = results.length;
+  const passed = results.filter((r) => r.judge.passed).length;
+  console.error(`\n${passed}/${total} cases passed`);
+  // 0 = all passed (an empty suite is vacuously all-pass, matching Python),
+  // 1 = at least one case failed. Bad usage returns 2 earlier.
+  return passed === total ? 0 : 1;
+}
+
+function printEvalHelp(): void {
+  console.log(
+    'Usage: getpatter eval run <suite> [options]\n\n' +
+      'Run an evaluation suite (YAML or JSON) against a scripted agent.\n\n' +
+      'Arguments:\n' +
+      '  <suite>                 Path to a YAML or JSON suite file\n\n' +
+      'Options:\n' +
+      '  --agent module:export   Dotted import of an async agent factory\n' +
+      '  --judge-model M         Model the LLM judge should use (default gpt-4o-mini)\n' +
+      '  --pass-threshold T      Score threshold for pass (default 0.7)\n' +
+      '  --output FILE           Write the JSON report to FILE instead of stdout',
+  );
+}
+
+function parseRunArgs(args: readonly string[]): EvalRunArgs {
+  const out: EvalRunArgs = {
+    suite: '',
+    agent: '',
+    judgeModel: 'gpt-4o-mini',
+    passThreshold: 0.7,
+    output: null,
+  };
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--agent') {
+      out.agent = requireValue(args, ++i, '--agent');
+    } else if (a === '--judge-model') {
+      out.judgeModel = requireValue(args, ++i, '--judge-model');
+    } else if (a === '--pass-threshold') {
+      const v = Number(requireValue(args, ++i, '--pass-threshold'));
+      if (!Number.isFinite(v)) throw new Error('--pass-threshold must be a number');
+      out.passThreshold = v;
+    } else if (a === '--output') {
+      out.output = requireValue(args, ++i, '--output');
+    } else if (a.startsWith('--')) {
+      throw new Error(`unknown option ${a}`);
+    } else {
+      positionals.push(a);
+    }
+  }
+  if (positionals.length > 0) out.suite = positionals[0];
+  return out;
+}
+
+function requireValue(args: readonly string[], i: number, flag: string): string {
+  const v = args[i];
+  if (v === undefined) throw new Error(`${flag} requires a value`);
+  return v;
+}
+
+/**
+ * Resolve a `module:export` string to an agent factory.
+ *
+ * Falls back to an echo-style mock agent when no factory is provided — lets
+ * developers sanity-check their suite shape before wiring the real agent.
+ */
+async function loadAgentFactory(dotted: string): Promise<AgentFactory> {
+  if (!dotted) {
+    const echo: AgentReply = async (text: string) => `echo: ${text}`;
+    return () => echo;
+  }
+  if (!dotted.includes(':')) {
+    throw new Error("--agent must be of the form 'module:export'");
+  }
+  const idx = dotted.indexOf(':');
+  const modulePath = dotted.slice(0, idx);
+  const attr = dotted.slice(idx + 1);
+  // `modulePath` is developer-supplied CLI config (the operator chooses which
+  // agent factory to load), not untrusted network input — same trust model as
+  // Python's `importlib.import_module(args.agent)`.
+  const mod = (await import(modulePath)) as Record<string, unknown>;
+  const obj = mod[attr];
+  if (typeof obj !== 'function') {
+    throw new Error(`--agent target ${JSON.stringify(dotted)} is not a function`);
+  }
+  return obj as AgentFactory;
+}

--- a/libraries/typescript/src/evals/index.ts
+++ b/libraries/typescript/src/evals/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Patter evaluation framework — TypeScript twin of `getpatter.evals` (Python).
+ *
+ * Primitives:
+ * - {@link EvalCase} — declarative description of a test case
+ * - {@link EvalRunner} — drives one or more cases
+ * - {@link LLMJudge} — scores transcripts against a rubric
+ * - {@link loadSuite} — load a YAML/JSON suite file
+ */
+
+export { EvalResult } from './case';
+export type { EvalTurn, EvalCase, JudgeResult, TranscriptEntry } from './case';
+
+export { LLMJudge, OpenAIJudgeBackend, JUDGE_SYSTEM } from './llm-judge';
+export type { JudgeBackend, LLMJudgeOptions } from './llm-judge';
+
+export { EvalRunner, loadSuite } from './runner';
+export type {
+  EvalSuite,
+  EvalRunnerOptions,
+  AgentReply,
+  AgentFactory,
+} from './runner';
+
+// Note: the CLI entry `runEval` (in `./cli`) is intentionally NOT re-exported
+// here — it mirrors Python's `getpatter.evals`, which exposes the data model /
+// runner / judge but not the CLI dispatcher. `src/cli.ts` imports it directly
+// from `./evals/cli`.

--- a/libraries/typescript/src/evals/llm-judge.ts
+++ b/libraries/typescript/src/evals/llm-judge.ts
@@ -1,0 +1,156 @@
+/**
+ * LLM-as-judge scoring for eval cases. Parity with `getpatter.evals.llm_judge`.
+ */
+
+import { getLogger } from '../logger';
+import type { EvalCase, JudgeResult, TranscriptEntry } from './case';
+
+/**
+ * Backend seam — any object that turns a judge prompt into the model's raw
+ * JSON text. Mirrors Python's injectable `backend` so tests can drive every
+ * inward code path (prompt building, fence stripping, parsing, clamping,
+ * threshold logic) with no network and no module mocks.
+ */
+export interface JudgeBackend {
+  judge(prompt: string): Promise<string>;
+}
+
+export const JUDGE_SYSTEM =
+  'You are a strict but fair evaluator of voice-AI agents. ' +
+  'You will be given: (1) the expected behavior for the agent, (2) a rubric, ' +
+  '(3) a transcript of the conversation. ' +
+  'Return a JSON object with exactly three keys:\n' +
+  '  - "score": float between 0.0 and 1.0\n' +
+  '  - "passed": boolean (true when score >= threshold)\n' +
+  '  - "reasoning": short string explaining the score\n' +
+  'Do not return any text outside the JSON object.';
+
+/**
+ * Default backend — OpenAI Chat Completions via `fetch`, mirroring the exact
+ * request pattern the pipeline LLM loop uses (`src/llm-loop.ts`). The TS SDK
+ * has no `openai` dependency; Python uses the `openai` client — an allowed
+ * language-appropriate divergence with identical behaviour.
+ */
+export class OpenAIJudgeBackend implements JudgeBackend {
+  constructor(
+    private readonly model: string,
+    private readonly apiKey?: string,
+  ) {}
+
+  async judge(prompt: string): Promise<string> {
+    const key = this.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!key) {
+      throw new Error(
+        'LLMJudge requires an OpenAI API key. Pass apiKey or set OPENAI_API_KEY.',
+      );
+    }
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          { role: 'system', content: JUDGE_SYSTEM },
+          { role: 'user', content: prompt },
+        ],
+        response_format: { type: 'json_object' },
+        temperature: 0,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`OpenAI judge request failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    return data.choices?.[0]?.message?.content ?? '{}';
+  }
+}
+
+export interface LLMJudgeOptions {
+  readonly model?: string;
+  readonly apiKey?: string;
+  readonly passThreshold?: number;
+  readonly backend?: JudgeBackend;
+}
+
+/**
+ * Scores conversation transcripts against a rubric via an OpenAI model.
+ *
+ * The judge is intentionally provider-specific (OpenAI chat completions)
+ * because reliability of structured JSON output matters more than provider
+ * flexibility for evals. Callers who need a different backend can implement a
+ * {@link JudgeBackend} and inject it via the `backend` option.
+ */
+export class LLMJudge {
+  readonly model: string;
+  readonly apiKey?: string;
+  readonly passThreshold: number;
+  private readonly backend: JudgeBackend;
+
+  constructor(opts: LLMJudgeOptions = {}) {
+    this.model = opts.model ?? 'gpt-4o-mini';
+    this.apiKey = opts.apiKey;
+    this.passThreshold = opts.passThreshold ?? 0.7;
+    this.backend = opts.backend ?? new OpenAIJudgeBackend(this.model, this.apiKey);
+  }
+
+  /** Return a {@link JudgeResult} for the given transcript. */
+  async judgeCase(
+    evalCase: EvalCase,
+    transcript: readonly TranscriptEntry[],
+  ): Promise<JudgeResult> {
+    const prompt = this.buildPrompt(evalCase, transcript);
+    const raw = await this.backend.judge(prompt);
+    return this.parse(raw);
+  }
+
+  private buildPrompt(
+    evalCase: EvalCase,
+    transcript: readonly TranscriptEntry[],
+  ): string {
+    const lines = [
+      `EXPECTED BEHAVIOR: ${evalCase.expectedBehavior}`,
+      `RUBRIC: ${evalCase.rubric}`,
+      `PASS THRESHOLD: ${this.passThreshold}`,
+      'TRANSCRIPT:',
+    ];
+    for (const turn of transcript) {
+      lines.push(`  ${turn.role ?? '?'}: ${turn.text ?? ''}`);
+    }
+    return lines.join('\n');
+  }
+
+  private parse(raw: string): JudgeResult {
+    let text = raw.trim();
+    // Strip a leading fence if the model added one despite json_object mode.
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+    }
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      getLogger().warn(
+        `LLMJudge: invalid JSON, defaulting to fail: ${JSON.stringify(raw)}`,
+      );
+      return {
+        score: 0,
+        passed: false,
+        reasoning: `Judge returned invalid JSON: ${raw.slice(0, 200)}`,
+      };
+    }
+    let score = Number((data as { score?: unknown }).score ?? 0);
+    if (!Number.isFinite(score)) score = 0;
+    score = Math.max(0, Math.min(1, score));
+    // Verdict is computed LOCALLY from the score: trusting the judge's
+    // self-reported `passed` let a hallucinated `passed: true` with
+    // `score: 0.2` record a pass.
+    const passed = score >= this.passThreshold;
+    const reasoning = String((data as { reasoning?: unknown }).reasoning ?? '');
+    return { score, passed, reasoning };
+  }
+}

--- a/libraries/typescript/src/evals/runner.ts
+++ b/libraries/typescript/src/evals/runner.ts
@@ -1,0 +1,264 @@
+/**
+ * Eval runner — executes an {@link EvalSuite} against a scripted agent and
+ * produces a JSON report. Parity with `getpatter.evals.runner`.
+ *
+ * The caller supplies an `agentFactory` returning an async
+ * `reply(text) => string` callable — no SDK machinery involved. This decouples
+ * the runner from the real Patter Agent wiring and lets callers plug in any
+ * chat-completions client or mock.
+ */
+
+import { promises as fs } from 'node:fs';
+import { basename } from 'node:path';
+import { getLogger } from '../logger';
+import { EvalResult } from './case';
+import type { EvalCase, EvalTurn, JudgeResult, TranscriptEntry } from './case';
+import { LLMJudge } from './llm-judge';
+
+/**
+ * An agent factory takes no arguments and returns an async
+ * `reply(text: string) => string`. `reply` receives one user turn and returns
+ * the agent's final text response. The factory itself may be async.
+ */
+export type AgentReply = (text: string) => Promise<string>;
+export type AgentFactory = () => AgentReply | Promise<AgentReply>;
+
+/** A named collection of {@link EvalCase} to run together. */
+export interface EvalSuite {
+  readonly name: string;
+  readonly cases: readonly EvalCase[];
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface EvalRunnerOptions {
+  readonly judge?: LLMJudge;
+}
+
+/** Drives one or more cases against an agent and produces a JSON report. */
+export class EvalRunner {
+  readonly judge: LLMJudge;
+
+  constructor(opts: EvalRunnerOptions = {}) {
+    this.judge = opts.judge ?? new LLMJudge();
+  }
+
+  /** Run every case in `suite` sequentially. */
+  async run(suite: EvalSuite, agentFactory?: AgentFactory): Promise<EvalResult[]> {
+    const results: EvalResult[] = [];
+    for (const evalCase of suite.cases) {
+      results.push(await this.runCase(evalCase, agentFactory));
+    }
+    return results;
+  }
+
+  /** Run a single case and return its {@link EvalResult}. */
+  async runCase(evalCase: EvalCase, agentFactory?: AgentFactory): Promise<EvalResult> {
+    const start = nowSeconds();
+    const transcript: TranscriptEntry[] = [];
+    let error: string | null = null;
+
+    try {
+      if (agentFactory === undefined) {
+        throw new Error(
+          `case ${JSON.stringify(evalCase.name)} has no agentFactory supplied`,
+        );
+      }
+      await this.runTurnsWithReply(evalCase, agentFactory, transcript);
+    } catch (exc) {
+      error = `${errName(exc)}: ${errMessage(exc)}`;
+      getLogger().error(`case=${JSON.stringify(evalCase.name)} raised: ${error}`);
+    }
+
+    // If we failed to produce any transcript, skip the judge.
+    if (error && transcript.length === 0) {
+      return new EvalResult(
+        evalCase.name,
+        transcript,
+        { score: 0, passed: false, reasoning: error },
+        nowSeconds() - start,
+        error,
+      );
+    }
+
+    let judgeResult: JudgeResult;
+    try {
+      judgeResult = await this.judge.judgeCase(evalCase, transcript);
+    } catch (exc) {
+      // One transient judge failure (429, timeout, missing key) used to abort
+      // the WHOLE suite, discarding every completed case.
+      const message = `judge error: ${errMessage(exc)}`;
+      return new EvalResult(
+        evalCase.name,
+        transcript,
+        { score: 0, passed: false, reasoning: message },
+        nowSeconds() - start,
+        message,
+      );
+    }
+    return new EvalResult(
+      evalCase.name,
+      transcript,
+      judgeResult,
+      nowSeconds() - start,
+      error,
+    );
+  }
+
+  /**
+   * Drives the case against a `reply()` callable. Appends into `transcript`
+   * in place so a mid-case exception still leaves the partial transcript for
+   * the judge (existing semantics).
+   */
+  private async runTurnsWithReply(
+    evalCase: EvalCase,
+    agentFactory: AgentFactory,
+    transcript: TranscriptEntry[],
+  ): Promise<void> {
+    const agent = await agentFactory();
+    if (evalCase.firstMessage) {
+      transcript.push({ role: 'agent', text: evalCase.firstMessage });
+    }
+    for (const turn of evalCase.turns) {
+      transcript.push({ role: 'user', text: turn.user });
+      const reply = (await agent(turn.user)) ?? '';
+      transcript.push({ role: 'agent', text: reply });
+      logMissingExpected(evalCase, turn, reply);
+    }
+  }
+
+  /** Render a JSON report suitable for CI artefacts. */
+  report(suite: EvalSuite, results: readonly EvalResult[]): string {
+    const total = results.length;
+    const passed = results.filter((r) => r.judge.passed).length;
+    const payload = {
+      suite: suite.name,
+      total,
+      passed,
+      failed: total - passed,
+      pass_rate: total ? passed / total : 0,
+      cases: results.map((r) => r.toDict()),
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+}
+
+/**
+ * Load a suite from YAML or JSON. The on-disk schema is identical to the
+ * Python loader (snake_case keys) so a suite file runs unchanged in either
+ * SDK.
+ *
+ * Schema (YAML):
+ *
+ * ```yaml
+ * name: "customer support v1"
+ * cases:
+ *   - name: "greeting is warm"
+ *     expected_behavior: "Agent greets the caller warmly and asks how it can help."
+ *     rubric: "Pass if reply contains a greeting and an open-ended question."
+ *     turns:
+ *       - user: "hi"
+ * ```
+ */
+export async function loadSuite(path: string): Promise<EvalSuite> {
+  const text = await fs.readFile(path, 'utf-8');
+  const lower = path.toLowerCase();
+  let data: unknown;
+  if (lower.endsWith('.yaml') || lower.endsWith('.yml')) {
+    let yamlMod: { parse(source: string): unknown };
+    try {
+      yamlMod = (await import('yaml')) as { parse(source: string): unknown };
+    } catch {
+      throw new Error(
+        "Loading YAML suites requires the 'yaml' package. Install with: npm install yaml",
+      );
+    }
+    data = yamlMod.parse(text);
+  } else {
+    data = JSON.parse(text);
+  }
+
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`Eval suite ${path} must be a mapping`);
+  }
+  const obj = data as Record<string, unknown>;
+
+  const casesRaw = obj.cases ?? [];
+  if (!Array.isArray(casesRaw)) {
+    throw new Error(`Eval suite ${path}: 'cases' must be a list`);
+  }
+
+  const cases: EvalCase[] = casesRaw.map((cRaw, i) => {
+    if (cRaw === null || typeof cRaw !== 'object' || Array.isArray(cRaw)) {
+      throw new Error(`Eval suite ${path}: case ${i} must be a mapping`);
+    }
+    const c = cRaw as Record<string, unknown>;
+    const turnsRaw = Array.isArray(c.turns) ? c.turns : [];
+    const turns: EvalTurn[] = turnsRaw
+      .filter(
+        (t): t is Record<string, unknown> =>
+          t !== null && typeof t === 'object' && !Array.isArray(t),
+      )
+      .map((t) => ({
+        user: String(t.user ?? ''),
+        expectedContains: toStringArray(t.expected_contains),
+      }));
+    return {
+      name: String(c.name ?? `case_${i}`),
+      turns,
+      expectedBehavior: String(c.expected_behavior ?? ''),
+      rubric: String(c.rubric ?? ''),
+      tags: toStringArray(c.tags),
+      firstMessage: String(c.first_message ?? ''),
+    };
+  });
+
+  return {
+    name: String(obj.name ?? stem(path)),
+    cases,
+    metadata: (obj.metadata ?? {}) as Record<string, unknown>,
+  };
+}
+
+function nowSeconds(): number {
+  return performance.now() / 1000;
+}
+
+function errName(exc: unknown): string {
+  // `exc.name` survives minification and reflects custom error subclasses;
+  // fall back to the constructor name, then a generic label. Mirrors Python's
+  // `type(exc).__name__`.
+  if (exc instanceof Error) return exc.name || exc.constructor.name || 'Error';
+  return 'Error';
+}
+
+function errMessage(exc: unknown): string {
+  return exc instanceof Error ? exc.message : String(exc);
+}
+
+/**
+ * Cheap pre-filter — if a required substring is missing we still let the judge
+ * decide, but log for easier debugging.
+ */
+function logMissingExpected(evalCase: EvalCase, turn: EvalTurn, reply: string): void {
+  for (const needle of turn.expectedContains ?? []) {
+    if (!reply.toLowerCase().includes(needle.toLowerCase())) {
+      getLogger().info(
+        `case=${JSON.stringify(evalCase.name)} expectedContains=${JSON.stringify(
+          needle,
+        )} missing in reply`,
+      );
+    }
+  }
+}
+
+function toStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((x) => String(x));
+}
+
+/** File stem, mirroring Python `Path.stem` (basename without final suffix). */
+function stem(path: string): string {
+  const base = basename(path);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -51,6 +51,27 @@ export {
   ProvisionError,
   RateLimitError,
 } from "./errors";
+// Evaluation harness — parity with `getpatter.evals` (Python).
+export {
+  EvalResult,
+  LLMJudge,
+  OpenAIJudgeBackend,
+  JUDGE_SYSTEM,
+  EvalRunner,
+  loadSuite,
+} from "./evals";
+export type {
+  EvalTurn,
+  EvalCase,
+  JudgeResult,
+  TranscriptEntry,
+  JudgeBackend,
+  LLMJudgeOptions,
+  EvalSuite,
+  EvalRunnerOptions,
+  AgentReply,
+  AgentFactory,
+} from "./evals";
 export {
   deepgram,
   whisper,

--- a/libraries/typescript/tests/evals.mocked.test.ts
+++ b/libraries/typescript/tests/evals.mocked.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Mocked-boundary tests for the OpenAI judge backend.
+ *
+ * The ONLY thing mocked here is the OpenAI HTTP endpoint (global `fetch`) — a
+ * paid external API we must not hit in CI. Everything inward (request shaping,
+ * response parsing, LLMJudge clamp/threshold logic) is the real code.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LLMJudge, OpenAIJudgeBackend } from '../src/index';
+import type { EvalCase } from '../src/index';
+
+function mockFetchOnceJson(content: string): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ choices: [{ message: { content } }] }),
+  }));
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+describe('[mocked] OpenAIJudgeBackend — OpenAI HTTP boundary', () => {
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('builds the correct chat-completions request and returns the content', async () => {
+    const fetchMock = mockFetchOnceJson(
+      '{"score": 0.8, "passed": true, "reasoning": "ok"}',
+    );
+    const backend = new OpenAIJudgeBackend('gpt-4o-mini', 'sk-test-key');
+
+    const raw = await backend.judge('EXPECTED BEHAVIOR: x');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer sk-test-key');
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(init.body as string) as {
+      model: string;
+      temperature: number;
+      response_format: { type: string };
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.model).toBe('gpt-4o-mini');
+    expect(body.temperature).toBe(0);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+    expect(body.messages[0].role).toBe('system');
+    expect(body.messages[1]).toEqual({
+      role: 'user',
+      content: 'EXPECTED BEHAVIOR: x',
+    });
+    expect(raw).toBe('{"score": 0.8, "passed": true, "reasoning": "ok"}');
+  });
+
+  it('reads the api key from OPENAI_API_KEY when none is passed', async () => {
+    const fetchMock = mockFetchOnceJson('{"score": 1, "passed": true, "reasoning": ""}');
+    process.env.OPENAI_API_KEY = 'sk-env-key';
+    const backend = new OpenAIJudgeBackend('gpt-4o-mini');
+
+    await backend.judge('prompt');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer sk-env-key');
+  });
+
+  it('throws a clear error when no api key is available', async () => {
+    mockFetchOnceJson('{}');
+    const backend = new OpenAIJudgeBackend('gpt-4o-mini');
+    await expect(backend.judge('prompt')).rejects.toThrow(/OpenAI API key/);
+  });
+
+  it('throws on a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 429, statusText: 'Too Many Requests' })),
+    );
+    const backend = new OpenAIJudgeBackend('gpt-4o-mini', 'sk-test-key');
+    await expect(backend.judge('prompt')).rejects.toThrow(/429/);
+  });
+
+  it('LLMJudge end-to-end through the default backend parses a mocked response', async () => {
+    mockFetchOnceJson('{"score": 0.95, "passed": true, "reasoning": "excellent"}');
+    const judge = new LLMJudge({ apiKey: 'sk-test-key' });
+    const evalCase: EvalCase = {
+      name: 'c',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: 'be nice',
+      rubric: 'pass if nice',
+    };
+    const result = await judge.judgeCase(evalCase, [{ role: 'user', text: 'hi' }]);
+    expect(result.score).toBeCloseTo(0.95);
+    expect(result.passed).toBe(true);
+    expect(result.reasoning).toBe('excellent');
+  });
+});

--- a/libraries/typescript/tests/evals.test.ts
+++ b/libraries/typescript/tests/evals.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the Patter evals framework (TypeScript).
+ *
+ * These tests inject a fake judge backend so every inward code path — prompt
+ * building, code-fence stripping, JSON parsing, score clamping, threshold
+ * logic, runner orchestration — runs for real with no network and no module
+ * mocks. The ONLY external boundary (the OpenAI HTTP endpoint) is covered
+ * separately in `evals.mocked.test.ts`. Mirrors `tests/test_evals.py` (Python).
+ */
+
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  EvalRunner,
+  LLMJudge,
+  loadSuite,
+  type AgentReply,
+  type EvalCase,
+  type EvalSuite,
+  type JudgeBackend,
+  type TranscriptEntry,
+} from '../src/index';
+
+/** Test double for the judge backend — returns a canned JSON string. */
+class FakeBackend implements JudgeBackend {
+  calls = 0;
+  constructor(private readonly payload: unknown) {}
+  async judge(_prompt: string): Promise<string> {
+    this.calls += 1;
+    return JSON.stringify(this.payload);
+  }
+}
+
+const tmpDirs: string[] = [];
+async function makeTmpDir(): Promise<string> {
+  const dir = await fs.mkdtemp(join(tmpdir(), 'patter-evals-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Probe `yaml` once so the YAML test runs for real when installed (CI) and
+// skips cleanly when it is not (JSON-only environments).
+let yamlAvailable = false;
+try {
+  await import('yaml');
+  yamlAvailable = true;
+} catch {
+  yamlAvailable = false;
+}
+
+describe('[unit] LLMJudge', () => {
+  const minimalCase: EvalCase = {
+    name: 't',
+    turns: [],
+    expectedBehavior: '',
+    rubric: '',
+  };
+
+  it('parses score and reasoning from the judge JSON', async () => {
+    const backend = new FakeBackend({ score: 0.9, passed: true, reasoning: 'great' });
+    const judge = new LLMJudge({ backend });
+    const evalCase: EvalCase = {
+      name: 'test',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: 'reply politely',
+      rubric: 'pass if polite',
+    };
+    const result = await judge.judgeCase(evalCase, [{ role: 'user', text: 'hi' }]);
+    expect(result.score).toBeCloseTo(0.9);
+    expect(result.passed).toBe(true);
+    expect(result.reasoning).toBe('great');
+    expect(backend.calls).toBe(1);
+  });
+
+  it('tolerates ```code fences``` around the JSON', async () => {
+    const fenced =
+      '```json\n{"score": 0.5, "passed": false, "reasoning": "meh"}\n```';
+    const judge = new LLMJudge({
+      backend: { judge: async () => fenced },
+    });
+    const result = await judge.judgeCase(minimalCase, []);
+    expect(result.score).toBeCloseTo(0.5);
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails safely (score 0, not passed) on invalid JSON', async () => {
+    const judge = new LLMJudge({
+      backend: { judge: async () => 'not json at all' },
+    });
+    const result = await judge.judgeCase(minimalCase, []);
+    expect(result.score).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('clamps an out-of-range score to the unit interval', async () => {
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 1.5, passed: true, reasoning: '' }),
+    });
+    const result = await judge.judgeCase(minimalCase, []);
+    expect(result.score).toBe(1);
+  });
+
+  it('computes the verdict locally — a hallucinated passed=true with a low score fails', async () => {
+    const judge = new LLMJudge({
+      passThreshold: 0.7,
+      backend: new FakeBackend({ score: 0.2, passed: true, reasoning: 'lies' }),
+    });
+    const result = await judge.judgeCase(minimalCase, []);
+    expect(result.score).toBeCloseTo(0.2);
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('[unit] EvalRunner', () => {
+  it('runs a case end to end and produces a transcript and report', async () => {
+    const evalCase: EvalCase = {
+      name: 'greeting',
+      turns: [{ user: 'hello' }, { user: 'how are you?' }],
+      expectedBehavior: 'greet and respond',
+      rubric: 'pass if reply is non-empty',
+      firstMessage: 'Hi, how can I help?',
+    };
+    const suite: EvalSuite = { name: 'demo', cases: [evalCase] };
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 1.0, passed: true, reasoning: 'looks good' }),
+    });
+    const runner = new EvalRunner({ judge });
+
+    const reply: AgentReply = async (text) => `echo:${text}`;
+    const results = await runner.run(suite, () => reply);
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.caseName).toBe('greeting');
+    expect(result.judge.passed).toBe(true);
+    // first_message (agent) + user + agent + user + agent = 5 entries.
+    expect(result.transcript).toHaveLength(5);
+    expect(result.transcript[0]).toEqual<TranscriptEntry>({
+      role: 'agent',
+      text: 'Hi, how can I help?',
+    });
+    expect(result.transcript[1]).toEqual<TranscriptEntry>({
+      role: 'user',
+      text: 'hello',
+    });
+    expect(result.transcript[2].role).toBe('agent');
+    expect(result.transcript[2].text).toBe('echo:hello');
+
+    const report = JSON.parse(runner.report(suite, results)) as {
+      suite: string;
+      total: number;
+      passed: number;
+      pass_rate: number;
+    };
+    expect(report.suite).toBe('demo');
+    expect(report.total).toBe(1);
+    expect(report.passed).toBe(1);
+    expect(report.pass_rate).toBe(1.0);
+  });
+
+  it('handles an agent exception without aborting the suite', async () => {
+    const evalCase: EvalCase = {
+      name: 'boom',
+      turns: [{ user: 'hi' }],
+      expectedBehavior: '',
+      rubric: '',
+    };
+    const suite: EvalSuite = { name: 's', cases: [evalCase] };
+    const judge = new LLMJudge({
+      backend: new FakeBackend({ score: 0, passed: false, reasoning: '' }),
+    });
+    const runner = new EvalRunner({ judge });
+
+    const broken: AgentReply = async () => {
+      throw new Error('agent died');
+    };
+    const results = await runner.run(suite, () => broken);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].error).not.toBeNull();
+    expect(results[0].error).toContain('agent died');
+    expect(results[0].judge.passed).toBe(false);
+  });
+});
+
+describe('[unit] loadSuite', () => {
+  it('loads a JSON suite', async () => {
+    const dir = await makeTmpDir();
+    const file = join(dir, 'suite.json');
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        name: 'json-suite',
+        cases: [
+          {
+            name: 't1',
+            expected_behavior: 'b',
+            rubric: 'r',
+            turns: [{ user: 'hey' }],
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    const suite = await loadSuite(file);
+    expect(suite.name).toBe('json-suite');
+    expect(suite.cases[0].turns[0].user).toBe('hey');
+  });
+
+  (yamlAvailable ? it : it.skip)('loads a YAML suite', async () => {
+    const dir = await makeTmpDir();
+    const file = join(dir, 'suite.yaml');
+    await fs.writeFile(
+      file,
+      [
+        'name: test-suite',
+        'cases:',
+        '  - name: greeting',
+        '    expected_behavior: greet',
+        '    rubric: pass if greeting',
+        '    turns:',
+        '      - user: hi',
+        '        expected_contains: [hello, hi]',
+        '    tags: [smoke]',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    const suite = await loadSuite(file);
+    expect(suite.name).toBe('test-suite');
+    expect(suite.cases).toHaveLength(1);
+    const evalCase = suite.cases[0];
+    expect(evalCase.name).toBe('greeting');
+    expect(evalCase.turns[0].user).toBe('hi');
+    expect(evalCase.turns[0].expectedContains).toEqual(['hello', 'hi']);
+    expect(evalCase.tags).toEqual(['smoke']);
+  });
+
+  it('rejects a non-mapping suite', async () => {
+    const dir = await makeTmpDir();
+    const file = join(dir, 'bad.json');
+    await fs.writeFile(file, JSON.stringify(['not', 'a', 'mapping']), 'utf-8');
+    await expect(loadSuite(file)).rejects.toThrow(/must be a mapping/);
+  });
+});

--- a/libraries/typescript/tsup.config.ts
+++ b/libraries/typescript/tsup.config.ts
@@ -28,5 +28,8 @@ export default defineConfig({
     // installed package is used rather than a bundled copy.
     "cloudflared",
     "@ngrok/ngrok",
+    // Optional YAML suite loader — `await import("yaml")` in src/evals/runner.ts.
+    // Kept external so JSON-only users don't need the dependency installed.
+    "yaml",
   ],
 });


### PR DESCRIPTION
## Summary
- Port the evals harness **core** to the TypeScript SDK, closing the top Python↔TS parity gap — the TS CLI previously printed *"Evaluations are not yet available in the TypeScript SDK"* and pointed users to Python.
- `import { EvalCase, EvalSuite, LLMJudge, EvalRunner, loadSuite } from 'getpatter'` now works, and `npx getpatter eval run suite.yaml` runs a suite — behavioural parity with `getpatter.evals`.

## Implementation
- New `libraries/typescript/src/evals/`: `case.ts`, `llm-judge.ts`, `runner.ts`, `cli.ts`, `index.ts` — a 1:1 port of `case.py` / `llm_judge.py` / `runner.py` / `cli.py`.
- The judge uses raw `fetch` (the SDK has no `openai` dependency) mirroring the request pattern in `src/llm-loop.ts`; an injectable `JudgeBackend` seam keeps the unit tests authentic. The verdict is computed **locally** from the clamped score, so a hallucinated `passed: true` on a low score still fails.
- `loadSuite` parses JSON always; YAML via an **optional** `yaml` dependency (added to `optionalDependencies` + marked `external` in `tsup`). The suite-file schema and the JSON report shape are identical across SDKs, so a suite authored for `patter eval run` works unchanged in either.
- The CLI stub is replaced by a real `getpatter eval run <suite> [--agent module:export] [--judge-model M] [--pass-threshold T] [--output FILE]` (exit `0` all-pass / `1` any-fail / `2` bad usage). `src/index.ts` re-exports the public surface.
- Parity tidy-ups (both directions): expose `load_suite` in `getpatter.evals.__all__` (matches the TS root export), and add the "verdict computed locally" test to the Python suite.
- Deps: `yaml` added to `optionalDependencies` and the lockfile.

## Breaking change?
**No** — purely additive (it replaces a "not available" stub). No migration.

## Test plan
- [x] TypeScript: `npm test` — **2073 passed, 8 skipped** + `npm run lint` (tsc clean) + `npm run build` (tsup bundles `src/evals`, real `eval` command in `dist/cli.js`)
- [x] Python: `pytest tests/test_evals.py` — **9 passed** (incl. the new local-verdict test); Python source otherwise untouched
- [x] Functional smoke: `node dist/cli.js eval run suite.json` → real OpenAI judge, 1/1 passed, exit 0; `eval --help` exit 0; bad usage exit 2
- [x] sdk-parity review: core **ALIGNED** (defaults byte-for-byte, behaviour symmetric); only the deferred `EvalSession` layer remains
- [ ] E2E smoke — N/A (no pipeline/handler change)

## Docs updates
- Follow-up (not in this PR): a TS evals page under `docs/typescript-sdk/` + the `patter_sdk_features.xlsx` row flip (`evals: python → both`) via the `docs-sync` agent.

## Out of scope — tracked follow-up
- The real-pipeline `EvalSession` layer (`session.py`, `assertions.py`, and the `agent` / `llm_provider` fields on `EvalCase`) stays Python-only for now. It drives the actual `PipelineStreamHandler` with fake STT/TTS/audio and deserves its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
