### PR TITLE
fix(telemetry): carry call direction on call_completed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,21 @@
 
 ### Fixed
 
+- **Telemetry: `call_completed` now carries the call `direction`
+  (inbound/outbound).** The media-stream bridge's end payload has no direction,
+  and the call-end handler — unlike the call-start handler — never resolved it
+  from the active dashboard-store record, so every `call_completed` event was
+  emitted with `direction` omitted while `call_started` carried it. This made the
+  inbound/outbound funnel impossible to close in the usage analytics (the field
+  was empty on 100% of completions). Both SDKs now resolve `direction` from the
+  active store record (seeded with the true inbound/outbound at dial/connect
+  time) before recording the completion, mirroring the start path.
+  `libraries/python/getpatter/server.py` (`_on_call_end`),
+  `libraries/typescript/src/server.ts` (`wrappedEnd`). Resolution depends on the
+  dashboard store, which is present by default; behaviour is unchanged when the
+  store is disabled (the start side has the same dependency). Parity across both
+  SDKs.
+
 - **Plivo `extra_headers` are now exposed to the agent prompt and
   `on_call_start` (parity with Twilio's `<Parameter>` customParameters).**
   Developer-supplied headers delivered on the Plivo `start` frame were parsed

--- a/libraries/python/getpatter/server.py
+++ b/libraries/python/getpatter/server.py
@@ -878,6 +878,19 @@ class EmbeddedServer:
             return None
 
         async def _on_call_end(data):
+            # The media-stream bridge's end payload carries no call direction, so
+            # resolve it from the active store record — seeded with the true
+            # inbound/outbound by ``record_call_initiated`` (outbound) and
+            # ``_on_call_start`` (inbound) — BEFORE ``record_call_end`` finalises
+            # the record. Without this, ``call_completed`` telemetry omits the
+            # direction (the ``call_started`` side already carries it) and the
+            # inbound/outbound funnel cannot be closed. Mirrors ``_on_call_start``.
+            if store is not None and not data.get("direction"):
+                _cid = data.get("call_id", "") or ""
+                if _cid:
+                    _rec = store.get_active(_cid)
+                    if _rec and _rec.get("direction"):
+                        data["direction"] = _rec["direction"]
             if store is not None:
                 store.record_call_end(data, metrics=data.get("metrics"))
             # Anonymous telemetry: per-call completion (engine/provider/carrier +

--- a/libraries/python/tests/unit/test_call_wait.py
+++ b/libraries/python/tests/unit/test_call_wait.py
@@ -181,6 +181,46 @@ async def test_call_wait_true_voicemail_when_amd_machine() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Telemetry — call_completed resolves the call direction from the store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_call_completed_resolves_direction_from_store() -> None:
+    """The media-stream end payload carries no direction, so the real wrapped
+    ``_on_call_end`` must resolve it from the active store record — seeded with
+    the true inbound/outbound at dial/connect time — so ``call_completed`` carries
+    the same direction ``call_started`` does. Regression for the empty-direction
+    gap (call_completed used to omit it, breaking the inbound/outbound funnel)."""
+    from getpatter.dashboard.store import MetricsStore
+
+    phone = _local_phone()
+    agent = Agent(system_prompt="x", prewarm=False)
+    server = _attach_real_server(phone, agent)
+
+    # Seed the store the way an outbound dial does (record_call_initiated).
+    server._metrics_store = MetricsStore()
+    server._metrics_store.record_call_start(
+        {"call_id": "CA_dir", "direction": "outbound"}
+    )
+
+    recorded: list[tuple[str, dict]] = []
+
+    class _Sink:
+        def record(self, name, **dims):
+            recorded.append((name, dims))
+
+    server._telemetry = _Sink()
+    _, on_call_end, _, _, _ = server._wrap_callbacks()
+
+    # End payload from the bridge — note it carries NO ``direction``.
+    await on_call_end({"call_id": "CA_dir", "metrics": _metrics("CA_dir")})
+
+    completed = next(dims for name, dims in recorded if name == "call_completed")
+    assert completed["direction"] == "outbound"
+
+
+# ---------------------------------------------------------------------------
 # wait=True — no-media outcomes resolve via the status-callback path
 # ---------------------------------------------------------------------------
 

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -2782,6 +2782,17 @@ export class EmbeddedServer {
     };
 
     const wrappedEnd = async (data: Record<string, unknown>): Promise<void> => {
+      // The media-stream bridge's end payload carries no call direction, so
+      // resolve it from the active store record (seeded with the true
+      // inbound/outbound at dial/connect time) before recording telemetry.
+      // Without this, ``call_completed`` omits the direction (``call_started``
+      // already carries it) and the inbound/outbound funnel cannot be closed.
+      // Mirrors ``wrappedStart``.
+      if (!data.direction) {
+        const cid = typeof data.call_id === 'string' ? data.call_id : '';
+        const active = cid ? store.getActive(cid) : undefined;
+        if (active?.direction) data.direction = active.direction;
+      }
       // Anonymous telemetry: per-call completion (engine/provider/carrier + raw
       // duration/latency + matching correlation id; no cost, no PII). Fail-safe
       // and O(1). pop=true so the uid is removed once the call reaches its

--- a/libraries/typescript/tests/call-wait.test.ts
+++ b/libraries/typescript/tests/call-wait.test.ts
@@ -205,6 +205,39 @@ describe('[unit] call({ wait: true }) — connected call', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Telemetry — call_completed resolves the call direction from the store
+// ---------------------------------------------------------------------------
+
+describe('[unit] call_completed direction resolution', () => {
+  it('resolves direction from the active store record when the end payload omits it', async () => {
+    // The media-stream end payload carries no direction, so the real wrapped
+    // onCallEnd must resolve it from the active store record (seeded with the
+    // true inbound/outbound at dial/connect time) so call_completed carries the
+    // same direction call_started does. Regression for the empty-direction gap
+    // (call_completed used to omit it, breaking the inbound/outbound funnel).
+    const phone = localPhone();
+    const server = attachRealServer(phone, makeAgent());
+
+    // Seed the store the way an outbound dial does (recordCallInitiated).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (server as any).metricsStore.recordCallStart({ call_id: 'CA_dir', direction: 'outbound' });
+
+    const recorded: Array<Record<string, unknown>> = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (server as any).telemetry = {
+      record: (_name: string, dims?: Record<string, unknown>) => recorded.push(dims ?? {}),
+    };
+
+    const onCallEnd = wrappedOnCallEnd(server);
+    // End payload from the bridge — note it carries NO direction.
+    await onCallEnd({ call_id: 'CA_dir', metrics: metrics('CA_dir') });
+
+    const completed = recorded.find((d) => 'outcome' in d);
+    expect(completed?.direction).toBe('outbound');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // wait: true — no-media outcomes resolve via the status-callback path
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **`call_completed` telemetry now carries the call `direction` (inbound/outbound).** It was empty on 100% of completions while `call_started` carried it, so the inbound/outbound funnel could not be closed in usage analytics.
- Discovered while analysing the `getpatter_usage` Axiom dataset: `direction` was present on `call_started` but absent on every `call_completed`.

## Implementation
- The media-stream bridge's end payload has no `direction`, and the call-end handler — unlike the call-start handler — never resolved it from the active dashboard-store record.
- Both SDKs now resolve `direction` from the active store record (seeded with the true inbound/outbound at dial/connect time) **before** recording the completion, mirroring the call-start path.
  - Python: `libraries/python/getpatter/server.py` → `_on_call_end` (resolves before `record_call_end` finalises the record).
  - TypeScript: `libraries/typescript/src/server.ts` → `wrappedEnd`.
- Resolution depends on the dashboard store, which is present by default; behaviour is unchanged when the store is disabled (the call-start side has the same dependency).
- Regression test added in each SDK exercising the **real** wrapped call-end handler with a seeded store and a capturing telemetry sink (only the carrier boundary is mocked, per the authentic-tests rule).

### Note on scope
The same Axiom analysis flagged `engine="other"` on a chunk of OpenAI calls, but that was an artefact of the **0.6.7 (pre-v8) telemetry** in the historical data. In current `main`, `provider_mode` is constrained to the four mapped values (`models.py:35` + the runtime resolution in `client.py`), so `engine="other"` no longer reproduces for legitimate calls — no speculative fix shipped for it. The broader "other"-bucket taxonomy gaps (e.g. `openai-other`, Deepgram Aura / Gemini TTS) and the coarse `error_code`/`disconnect_reason` are tracked separately as follow-ups.

## Breaking change?
No. Additive telemetry-dimension fix; no public API change.

## Test plan
- [x] Python: `pytest tests/` (2725 passed, 8 skipped, 2 xfailed)
- [x] TypeScript: `npm test` (2155 passed, 9 skipped) + `npm run lint` (tsc --noEmit clean) + `npm run build` (success)
- [x] New regression test green in both SDKs (`test_call_completed_resolves_direction_from_store` / `[unit] call_completed direction resolution`)
- [ ] /parity-check
- [ ] E2E smoke (N/A — no pipeline/handler audio-path change)

## Docs updates
- N/A (anonymous telemetry internals; `CHANGELOG.md` updated under `### Fixed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)