### PR TITLE
feat: getpatter init setup wizard + npm create getpatter launcher (0.6.9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,23 @@ jobs:
         run: |
           cd libraries/typescript
           npm publish
+
+  release-create-getpatter:
+    name: Publish create-getpatter launcher to npm
+    # The launcher's npx fallback fetches `getpatter@<version>`, so publish the
+    # SDK first to guarantee it is resolvable when `npm create getpatter` runs.
+    needs: release-ts-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd create-getpatter
+          npm publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 ## Unreleased
 
+## 0.6.9 (2026-06-23)
+
 ### Added
+
+- **`getpatter init` — greenfield project setup wizard, plus the
+  `npm create getpatter` launcher.** A new interactive scaffolder generates a
+  complete, runnable inbound voice-agent project so a new user goes from nothing
+  to a project they can run in under a minute. It prompts for a voice mode
+  (`realtime` — one engine — or `pipeline` — STT + LLM + TTS), the
+  engine/providers, and the telephony carrier, then writes the entry file
+  (`main.py` / `src/index.ts`), a `.env` (chmod 0600 — secrets are never echoed
+  or logged) and `.env.example`, the dependency manifest, `.gitignore`, and a
+  `README.md`. Every prompt has a matching flag (`--mode`, `--engine`, `--stt`,
+  `--llm`, `--tts`, `--carrier`, `--yes`, …) so it also runs fully
+  non-interactively in CI. Exposed as `getpatter init` on both CLIs
+  (`libraries/python/getpatter/init/`, `libraries/typescript/src/init/cli.ts`)
+  and as `npm create getpatter` via the new zero-dependency `create-getpatter`
+  launcher package, which re-dispatches to the same wizard (single source of
+  truth — no bundled copy). Additive: no existing command or public API
+  changes. Python ↔ TypeScript parity (byte-for-byte mirrored prompts, flags,
+  defaults, and scaffold codegen). Docs: `docs/quickstart-create.mdx`.
 
 - **Python: `KrispVivaFilter` and `DeepFilterNetFilter` are now exported from
   the package root.** Both noise-suppression `AudioFilter` implementations

--- a/create-getpatter/README.md
+++ b/create-getpatter/README.md
@@ -1,0 +1,77 @@
+# create-getpatter
+
+The npm `create` shim that powers:
+
+```sh
+npm create getpatter my-app
+# or, forwarding flags:
+npm create getpatter my-app -- --mode pipeline --carrier telnyx --yes
+```
+
+It scaffolds a runnable Patter voice-agent project — exactly what
+`getpatter init` produces.
+
+## What it is
+
+A ~120-line, **zero-dependency** Node bootstrap (`index.js`). It does not
+contain any wizard logic of its own. All prompts, the provider matrix, and the
+scaffold codegen live in the SDK's setup wizard
+(`libraries/typescript/src/init/cli.ts`, the behavioural mirror of the Python
+`getpatter/init/cli.py`). The shim's only job is to hand its arguments to
+`getpatter init`.
+
+## Design choice — why a re-dispatch, not a bundled copy
+
+Two options were on the table:
+
+1. **Spawn the published `getpatter init`** (what this does).
+2. **Bundle / re-export a minimal copy of the wizard** inside this package.
+
+Option 1 wins on the principle that matters most here — **single source of
+truth**. The wizard is non-trivial (provider matrix, parity-locked codegen,
+secure `.env` writing). Duplicating it into a second package guarantees drift:
+the day someone adds a provider to the SDK, `create-getpatter` would silently
+scaffold the old set. By re-dispatching, the shim is always in lockstep with
+whatever `getpatter` version it targets, and there is exactly one
+implementation to test and maintain.
+
+### How "spawn" avoids a needless network hit
+
+`create-getpatter` resolves the CLI in two steps:
+
+1. **Local first (no network):** if `getpatter` is already resolvable from the
+   directory where `npm create` runs (installed in the project's
+   `node_modules` or globally), it spawns that package's `getpatter init`
+   directly. Nothing is fetched.
+2. **`npx` fallback:** otherwise it runs
+   `npx -y getpatter@<pinned-version> init`, letting npm fetch the package on
+   demand. This is the same network access `npm create` already implies, so it
+   adds no new dependency at create-time — the package itself has an empty
+   dependency tree.
+
+The targeted `getpatter` version is pinned in this package's `version` field
+(kept in lockstep with the SDK — currently `0.6.3`).
+
+## Argument handling
+
+- The first bare positional (`my-app`) is promoted to `--name my-app`, the
+  ergonomic `npm create <tool> <dir>` shape.
+- Every flag is forwarded verbatim to `getpatter init`: `--mode`, `--runtime`,
+  `--engine`, `--stt`, `--llm`, `--tts`, `--carrier`, `--phone`, `--skip-keys`,
+  `--ide`, `--no-skills`, `--no-git`, `--force`, `--yes`/`-y`, `--help`/`-h`.
+
+Run `npm create getpatter -- --help` to see the full wizard usage.
+
+## Verifying locally
+
+```sh
+# Build the SDK so a local getpatter CLI exists, then run the smoke test:
+cd libraries/typescript && npm run build && cd ../..
+node create-getpatter/index.js --help        # forwards to the wizard
+npm --prefix create-getpatter test            # full end-to-end smoke test
+```
+
+`smoke-test.mjs` links the freshly-built SDK as a local `getpatter`, exercises
+the no-network resolution path, and asserts that
+`create-getpatter my-app --yes` scaffolds a project whose `.env` is written at
+mode `0600`.

--- a/create-getpatter/index.js
+++ b/create-getpatter/index.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * `create-getpatter` — the thin bootstrap behind `npm create getpatter`.
+ *
+ * `npm create getpatter my-app -- --mode pipeline` resolves to running this
+ * bin as `create-getpatter my-app --mode pipeline`. All this shim does is hand
+ * those arguments to the TypeScript SDK's setup wizard (`getpatter init`),
+ * which owns every prompt, the provider matrix, and the scaffold codegen — see
+ * `libraries/typescript/src/init/cli.ts` (behavioural mirror of the Python
+ * `getpatter/init/cli.py`). Keeping the wizard logic in the SDK and re-using it
+ * here means there is exactly one implementation to maintain, with full
+ * Python <-> TypeScript parity.
+ *
+ * Argument handling:
+ *   - The first bare positional (e.g. `my-app`) becomes `--name my-app`, the
+ *     ergonomic shape `npm create <tool> <dir>` users expect. If the caller
+ *     passes `--name` explicitly, the positional is still mapped but the
+ *     explicit flag the wizard sees last wins — so prefer one or the other.
+ *   - Every flag is forwarded verbatim (`--mode`, `--yes`, `--help`, ...).
+ *
+ * Resolution strategy (no bundled copy of the wizard — single source of truth):
+ *   1. If `getpatter` is already resolvable on this machine (installed in the
+ *      cwd's node_modules or globally), spawn its `init` directly — no network.
+ *   2. Otherwise fall back to `npx -y getpatter@<pinned-version> init`, which
+ *      npm fetches on demand. This is the same network access `npm create`
+ *      already implies, so it costs nothing extra.
+ *
+ * This file is plain Node with zero dependencies so it runs the instant npm
+ * fetches it, before anything is installed.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Pinned getpatter version this shim targets (kept in lockstep with the SDK). */
+function pinnedVersion() {
+  try {
+    const pkg = JSON.parse(readFileSync(join(HERE, 'package.json'), 'utf8'));
+    return typeof pkg.version === 'string' && pkg.version.length > 0 ? pkg.version : 'latest';
+  } catch {
+    return 'latest';
+  }
+}
+
+/**
+ * Turn the raw argv tail into the argument list `getpatter init` expects.
+ * The first bare positional is promoted to `--name <value>`.
+ */
+function buildInitArgs(argv) {
+  const out = [];
+  let positionalConsumed = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!positionalConsumed && !a.startsWith('-')) {
+      out.push('--name', a);
+      positionalConsumed = true;
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Walk up from a path until a directory containing a `getpatter` package.json
+ * is found, returning that directory. Used to locate the package root from its
+ * resolved main entry (the `exports` map blocks resolving `package.json`
+ * directly).
+ */
+function findPackageRoot(startFile) {
+  let dir = dirname(startFile);
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'package.json');
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, 'utf8'));
+      if (pkg.name === 'getpatter') return { dir, pkg };
+    } catch {
+      /* keep walking */
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Try to locate an already-installed `getpatter` CLI entry point so we can run
+ * it without touching the network. Returns the absolute path to the CLI JS
+ * file, or null if getpatter isn't resolvable from here.
+ */
+function resolveLocalCli() {
+  // Resolve relative to the directory `npm create` is run in, not this shim's
+  // own (npx-cached) location — that's where a project's getpatter would live.
+  const req = createRequire(join(process.cwd(), 'noop.js'));
+  let mainEntry;
+  try {
+    mainEntry = req.resolve('getpatter');
+  } catch {
+    return null; // not installed locally — fall through to npx
+  }
+  const root = findPackageRoot(mainEntry);
+  if (!root) return null;
+  // `bin.getpatter` points at dist/cli.js — the CLI entry that owns `init`.
+  const binField = root.pkg.bin;
+  const binRel = typeof binField === 'string' ? binField : binField && binField.getpatter;
+  if (!binRel) return null;
+  return join(root.dir, binRel);
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const initArgs = buildInitArgs(argv);
+
+  const localCli = resolveLocalCli();
+  if (localCli) {
+    const res = spawnSync(process.execPath, [localCli, 'init', ...initArgs], {
+      stdio: 'inherit',
+    });
+    process.exit(res.status ?? 1);
+  }
+
+  // Fall back to fetching the published package on demand via npx.
+  const ref = `getpatter@${pinnedVersion()}`;
+  const child = spawn('npx', ['-y', ref, 'init', ...initArgs], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  child.on('error', (err) => {
+    if (err && err.code === 'ENOENT') {
+      console.error(
+        'create-getpatter needs `npx` (Node.js) on your PATH to fetch the ' +
+          'Patter CLI. Install Node 18+ from https://nodejs.org, then re-run ' +
+          '`npm create getpatter`.',
+      );
+    } else {
+      console.error(`create-getpatter failed to launch the Patter wizard: ${err.message}`);
+    }
+    process.exit(1);
+  });
+  child.on('exit', (code) => process.exit(code ?? 0));
+}
+
+main();

--- a/create-getpatter/package.json
+++ b/create-getpatter/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "create-getpatter",
+  "version": "0.6.9",
+  "description": "npm create shim for Patter — runs `getpatter init`, the greenfield voice-agent setup wizard",
+  "license": "MIT",
+  "author": {
+    "name": "PatterAI",
+    "email": "hello@getpatter.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PatterAI/Patter.git",
+    "directory": "create-getpatter"
+  },
+  "homepage": "https://www.getpatter.com",
+  "bugs": {
+    "url": "https://github.com/PatterAI/Patter/issues"
+  },
+  "keywords": [
+    "voice",
+    "ai",
+    "phone",
+    "telephony",
+    "scaffold",
+    "create",
+    "getpatter",
+    "patter"
+  ],
+  "type": "module",
+  "bin": {
+    "create-getpatter": "./index.js"
+  },
+  "scripts": {
+    "test": "node smoke-test.mjs"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/create-getpatter/smoke-test.mjs
+++ b/create-getpatter/smoke-test.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Tiny dependency-free smoke test for the `create-getpatter` shim.
+ *
+ * It builds a throwaway project dir with a locally-installed `getpatter`
+ * (linked from the freshly-built TypeScript SDK) so the shim's local-CLI
+ * resolution path is exercised without any network access, then asserts:
+ *
+ *   1. `create-getpatter --help` forwards to the wizard and prints its help.
+ *   2. `create-getpatter my-app --yes ...` promotes the positional to
+ *      `--name my-app` and scaffolds a runnable project (src/index.ts,
+ *      package.json named `my-app`, `.env` at mode 0600).
+ *
+ * Run: `node create-getpatter/smoke-test.mjs` from the repo root after
+ * `cd libraries/typescript && npm run build`.
+ *
+ * Exits 0 on success, non-zero (with a message) on the first failed check.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, cpSync, copyFileSync, symlinkSync, existsSync, statSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = dirname(HERE);
+const TS_SDK = join(REPO_ROOT, 'libraries', 'typescript');
+const SHIM = join(HERE, 'index.js');
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+const distCli = join(TS_SDK, 'dist', 'cli.js');
+if (!existsSync(distCli)) {
+  fail('TypeScript SDK is not built. Run `cd libraries/typescript && npm run build` first.');
+}
+
+const work = mkdtempSync(join(tmpdir(), 'create-getpatter-smoke-'));
+try {
+  // Stage a locally-installed getpatter so the shim resolves it (no network).
+  const gp = join(work, 'node_modules', 'getpatter');
+  mkdirSync(gp, { recursive: true });
+  copyFileSync(join(TS_SDK, 'package.json'), join(gp, 'package.json'));
+  cpSync(join(TS_SDK, 'dist'), join(gp, 'dist'), { recursive: true });
+  // The bundled CLI eagerly requires `express`; link the SDK's deps so the
+  // module loads. A real npm install of getpatter ships these transitively.
+  symlinkSync(join(TS_SDK, 'node_modules'), join(gp, 'node_modules'));
+
+  // 1. --help forwards to the wizard.
+  const help = spawnSync(process.execPath, [SHIM, '--help'], { cwd: work, encoding: 'utf8' });
+  if (help.status !== 0) fail(`--help exited ${help.status}: ${help.stderr}`);
+  if (!help.stdout.includes('Scaffold a new Patter voice-agent project')) {
+    fail(`--help did not reach the wizard. Got:\n${help.stdout}`);
+  }
+  console.log('ok  --help forwards to `getpatter init`');
+
+  // 2. Positional name + scaffold.
+  const scaffold = spawnSync(
+    process.execPath,
+    [SHIM, 'my-app', '--yes', '--no-git', '--no-skills'],
+    { cwd: work, encoding: 'utf8' },
+  );
+  if (scaffold.status !== 0) fail(`scaffold exited ${scaffold.status}: ${scaffold.stderr}`);
+
+  const app = join(work, 'my-app');
+  for (const rel of ['src/index.ts', 'package.json', '.env', '.env.example', '.gitignore', 'README.md']) {
+    if (!existsSync(join(app, rel))) fail(`expected scaffold file missing: ${rel}`);
+  }
+  const pkg = JSON.parse(readFileSync(join(app, 'package.json'), 'utf8'));
+  if (pkg.name !== 'my-app') fail(`positional name not applied: package.json name = ${pkg.name}`);
+
+  const mode = statSync(join(app, '.env')).mode & 0o777;
+  if (mode !== 0o600) fail(`.env mode is ${mode.toString(8)}, expected 600`);
+
+  const index = readFileSync(join(app, 'src', 'index.ts'), 'utf8');
+  if (!index.includes('from "getpatter"')) fail('src/index.ts does not import from getpatter');
+
+  console.log('ok  `create-getpatter my-app` scaffolds a runnable project (.env @ 0600)');
+  console.log('\nPASS: create-getpatter shim works end-to-end.');
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,7 +43,8 @@
           {
             "group": "Welcome",
             "pages": [
-              "home/index"
+              "home/index",
+              "quickstart-create"
             ]
           },
           {

--- a/docs/quickstart-create.mdx
+++ b/docs/quickstart-create.mdx
@@ -1,0 +1,230 @@
+---
+title: "Create a Project"
+description: "Scaffold a runnable Patter voice agent in seconds with the interactive setup wizard — npm create getpatter (TypeScript) or getpatter init (Python)."
+icon: "wand-magic-sparkles"
+---
+
+# Create a Project
+
+The setup wizard scaffolds a complete, runnable inbound voice agent — entry file, environment template, dependency manifest, `.gitignore`, and a README — so you go from nothing to a project you can run in under a minute. It is the fastest way to start a new Patter project, and it works the same on both SDKs.
+
+<CardGroup cols={2}>
+  <Card title="TypeScript" icon="js">
+    ```sh
+    npm create getpatter
+    ```
+  </Card>
+  <Card title="Python" icon="python">
+    ```sh
+    uvx getpatter init
+    # or, if getpatter is installed:
+    getpatter init
+    ```
+  </Card>
+</CardGroup>
+
+The wizard asks a short series of questions, then writes the project to disk. Every question has a flag, so you can also run it fully non-interactively in CI or a script.
+
+## Run it
+
+### TypeScript
+
+`npm create getpatter` fetches the matching SDK release and launches the wizard. No global install required.
+
+```sh
+npm create getpatter
+```
+
+You can pass flags straight through:
+
+```sh
+npm create getpatter -- --name my-agent --mode realtime --carrier twilio --yes
+```
+
+Equivalently, if you already have the package installed, the same wizard is exposed on the SDK CLI:
+
+```sh
+npx getpatter init
+```
+
+### Python
+
+`getpatter init` is a subcommand of the `getpatter` CLI. If you have not installed the SDK, [uv](https://docs.astral.sh/uv/) can run the wizard one-off with `uvx`:
+
+```sh
+uvx getpatter init
+```
+
+If the SDK is already installed (`pip install getpatter`), call it directly:
+
+```sh
+getpatter init
+```
+
+## The two voice modes
+
+The wizard's central choice is the **voice mode**. Patter has exactly two, and they trade latency for control.
+
+<CardGroup cols={2}>
+  <Card title="Realtime" icon="bolt">
+    One end-to-end engine owns the entire turn — it hears the caller and speaks back in a single model. Lowest latency, fewest moving parts.
+  </Card>
+  <Card title="Pipeline" icon="sliders">
+    Compose three providers yourself — speech-to-text, then an LLM, then text-to-speech. Maximum control over each stage.
+  </Card>
+</CardGroup>
+
+The mode you pick determines which providers the wizard offers next.
+
+### Realtime
+
+In realtime mode you choose a single **engine**. ElevenLabs ConvAI is itself a realtime engine — it is not a separate mode.
+
+| Engine | Notes | Required env |
+| --- | --- | --- |
+| `OpenAIRealtime2` (default) | OpenAI Realtime 2, model `gpt-realtime-2` | `OPENAI_API_KEY` |
+| `OpenAIRealtime` | Legacy `gpt-realtime-mini` | `OPENAI_API_KEY` |
+| `ElevenLabsConvAI` | Needs a pre-built ConvAI agent | `ELEVENLABS_API_KEY`, `ELEVENLABS_AGENT_ID` |
+
+### Pipeline
+
+In pipeline mode you pick one provider for each of the three stages. Sensible defaults are pre-selected.
+
+| Stage | Default | Other options |
+| --- | --- | --- |
+| STT (speech-to-text) | Deepgram | AssemblyAI, Cartesia, Soniox, Speechmatics, OpenAI Whisper, OpenAI Transcribe |
+| LLM | Cerebras (`gpt-oss-120b`) | OpenAI, Anthropic Claude, Groq, Google Gemini |
+| TTS (text-to-speech) | ElevenLabs | OpenAI, Cartesia, Rime, LMNT, Inworld |
+
+<Note>
+On the Python SDK, providers outside the base set install via a pip extra (for example `getpatter[anthropic,cartesia]`). The wizard works out which extras you need and pins them in `requirements.txt` automatically. The TypeScript SDK bundles every provider, so no extras are needed.
+</Note>
+
+## What the wizard asks
+
+The prompts are identical across both SDKs (only naming idioms differ — `snake_case` in Python, `camelCase` in TypeScript). Each step has a matching flag for non-interactive runs.
+
+| Step | Prompt | Flag | Default |
+| --- | --- | --- | --- |
+| 1 | Project name (becomes the target directory) | `--name <dir>` | `my-patter-agent` |
+| 2 | SDK runtime | `--runtime python\|typescript` | prefilled to the CLI you ran |
+| 3 | Voice mode | `--mode realtime\|pipeline` | `realtime` |
+| 4a | Realtime engine (realtime mode only) | `--engine <name>` | `OpenAIRealtime2` |
+| 4b | STT / LLM / TTS (pipeline mode only) | `--stt`, `--llm`, `--tts` | Deepgram / Cerebras / ElevenLabs |
+| 5 | Telephony carrier | `--carrier twilio\|telnyx\|plivo` | `twilio` |
+| 6 | API keys (written to `.env`) | `--skip-keys` | prompted, skippable |
+| 7 | IDE skills to install | `--ide <list>`, `--no-skills` | prompted multi-select |
+| 8 | Initialize a git repository | `--no-git` | yes (interactive) |
+| 9 | Allow a non-empty target directory | `--force` | off |
+
+A phone number for your agent can be supplied with `--phone` (E.164, for example `+15550001234`); leave it blank to fill in later. The wizard also reads the carrier's phone-number env var (`TWILIO_PHONE_NUMBER`, `TELNYX_PHONE_NUMBER`, or `PLIVO_PHONE_NUMBER`) at runtime.
+
+## Non-interactive mode
+
+Pass `--yes` (or `-y`) to skip every prompt and accept the defaults. Combine it with the flags above to fully script project creation:
+
+```sh
+# TypeScript, realtime + OpenAI, Twilio carrier, no prompts
+npm create getpatter -- --yes --name support-line --mode realtime --carrier twilio
+
+# Python, pipeline with Anthropic + Cartesia on Telnyx
+getpatter init --yes --name claims-bot --runtime python \
+  --mode pipeline --stt deepgram --llm anthropic --tts cartesia --carrier telnyx
+```
+
+In `--yes` mode the wizard never prompts for API keys; it writes blank placeholders to `.env` for you to fill in. `--skip-keys` does the same in interactive mode.
+
+## What gets scaffolded
+
+The wizard writes a small, focused project. For a TypeScript realtime project on Twilio it produces:
+
+```text
+my-patter-agent/
+├── src/index.ts        # runnable inbound agent, wired to your choices
+├── package.json        # getpatter pinned; "start": "tsx src/index.ts"
+├── .env                # your keys (chmod 0600) or blank placeholders
+├── .env.example        # committable template, no secrets
+├── .gitignore          # ignores .env, node_modules/
+└── README.md           # how to run this project
+```
+
+A Python project mirrors it exactly:
+
+```text
+my-patter-agent/
+├── main.py             # runnable inbound agent, wired to your choices
+├── requirements.txt    # getpatter[<extras>] pinned to the SDK version
+├── .env                # your keys (chmod 0600) or blank placeholders
+├── .env.example        # committable template, no secrets
+├── .gitignore          # ignores .env, __pycache__/, .venv/
+└── README.md           # how to run this project
+```
+
+The generated entry file is a minimal inbound agent. A realtime project looks like this (Python shown; TypeScript mirrors it with `new` and an options object):
+
+```python
+from getpatter import Patter, Twilio, OpenAIRealtime2
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+agent = phone.agent(
+    engine=OpenAIRealtime2(),
+    system_prompt="...",
+    first_message="...",
+)
+
+await phone.serve(agent, tunnel=True)
+```
+
+A pipeline project swaps the single `engine=` for the three composed providers:
+
+```python
+agent = phone.agent(
+    stt=DeepgramSTT(),
+    llm=CerebrasLLM(),
+    tts=ElevenLabsTTS(),
+    system_prompt="...",
+)
+```
+
+Every provider and carrier reads its credentials from the environment when constructed with no arguments, so the generated code stays clean and your secrets live only in `.env`.
+
+<Warning>
+Your API keys are written to `.env` with file mode `0600` (owner read/write only) and `.env` is listed in `.gitignore`. The wizard never prints or logs the values you enter. Keep `.env` out of version control — commit `.env.example` instead.
+</Warning>
+
+## IDE skills
+
+Optionally, the wizard installs Patter's editor "skills" — reference material your AI coding assistant can use while you build. It is a multi-select step supporting `claude-code`, `cursor`, `copilot`, and `codex`:
+
+```sh
+getpatter init --ide claude-code,cursor
+```
+
+This shells out to `npx skills add` under the hood. If Node (`npx`) is not available — common on Python-only machines — the step is skipped gracefully and the rest of the scaffold still completes. Use `--no-skills` to skip it entirely.
+
+## Next steps
+
+Once the project is created:
+
+1. `cd` into the new directory.
+2. Fill in your API keys in `.env`.
+3. Install dependencies — `npm install` (TypeScript) or `pip install -r requirements.txt` (Python).
+4. Run it — `npm start` (TypeScript) or `python main.py` (Python).
+
+The agent answers inbound calls and starts a Cloudflare Quick Tunnel (`tunnel=True`) so your carrier can reach your local server during development.
+
+<CardGroup cols={2}>
+  <Card title="Python Quickstart" icon="rocket" href="/python-sdk/quickstart">
+    The four-line walkthrough, credentials, and your first call.
+  </Card>
+  <Card title="TypeScript Quickstart" icon="rocket" href="/typescript-sdk/quickstart">
+    The same first call, in TypeScript.
+  </Card>
+  <Card title="Core Concepts" icon="lightbulb" href="/concepts">
+    Agents, voice modes, and the audio pipeline.
+  </Card>
+  <Card title="Tunneling" icon="cloud" href="/dev-tools/tunneling">
+    How the dev tunnel exposes your local server to the carrier.
+  </Card>
+</CardGroup>

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -20,7 +20,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/getpatter/cli.py
+++ b/libraries/python/getpatter/cli.py
@@ -32,6 +32,11 @@ def main() -> None:
 
     build_eval_parser(subparsers)
 
+    # patter init — greenfield voice-agent project setup wizard
+    from getpatter.init import build_init_parser, dispatch_init
+
+    build_init_parser(subparsers)
+
     # patter hermes {doctor|setup|test|trace|diagnose|attach-number|numbers}
     from getpatter.cli_hermes import build_hermes_parser, dispatch_hermes
 
@@ -68,6 +73,8 @@ def main() -> None:
         asyncio.run(_run_dashboard(args.port))
     elif args.command == "eval":
         sys.exit(dispatch_eval(args))
+    elif args.command == "init":
+        sys.exit(dispatch_init(args))
     elif args.command == "hermes":
         sys.exit(dispatch_hermes(args))
     elif args.command == "openclaw":

--- a/libraries/python/getpatter/init/__init__.py
+++ b/libraries/python/getpatter/init/__init__.py
@@ -1,0 +1,21 @@
+"""``getpatter init`` — greenfield setup wizard for the Patter SDK.
+
+Mirrors the ``getpatter.evals.cli`` registration pattern: this package exposes
+:func:`build_init_parser` (attaches the ``init`` subcommand to the main CLI's
+subparsers) and :func:`dispatch_init` (runs the wizard, returns an exit code).
+The wizard scaffolds a runnable inbound voice agent project — choosing a voice
+mode (``realtime`` or ``pipeline``), engine/providers, telephony carrier — and
+writes ``main.py`` (Python) or ``src/index.ts`` (TypeScript), ``.env`` (chmod
+0600), ``.env.example``, dependency manifest, ``.gitignore``, and ``README.md``.
+
+The TypeScript SDK ships a byte-for-byte behavioural mirror in
+``libraries/typescript/src/init/`` — keep the prompt strings, flag names,
+default values, and scaffold codegen rules in sync (see ``cli.py`` module
+docstring for the parity contract).
+"""
+
+from __future__ import annotations
+
+from getpatter.init.cli import build_init_parser, dispatch_init
+
+__all__ = ["build_init_parser", "dispatch_init"]

--- a/libraries/python/getpatter/init/cli.py
+++ b/libraries/python/getpatter/init/cli.py
@@ -1,0 +1,1067 @@
+"""``getpatter init`` — greenfield setup wizard (Python reference impl).
+
+Invoked as ``getpatter init [options]`` via the main CLI dispatcher
+(see :mod:`getpatter.cli`). Mirrors the ``eval`` registration shape:
+:func:`build_init_parser` attaches the subcommand, :func:`dispatch_init`
+runs it, and the actual work happens in an ``async`` ``_run`` coroutine.
+
+PARITY CONTRACT (TypeScript port in ``libraries/typescript/src/init/`` must
+match this file byte-for-byte in *behaviour*):
+
+* Prompt strings, the trailing default hint in brackets, and the numbered
+  menu rendering are identical (snake_case → camelCase only where a flag /
+  field name is shown).
+* Flag names map snake_case (Python ``--skip-keys``) ↔ kebab-case is shared
+  (both SDKs use ``--skip-keys``); the parsed attribute differs by language
+  idiom but the CLI surface is identical.
+* Default selections: mode=realtime, realtime engine=OpenAIRealtime2,
+  pipeline stt=Deepgram / llm=Cerebras / tts=ElevenLabs, carrier=twilio,
+  phone placeholder ``+15550001234``.
+* Scaffold codegen rules (import line, ``Patter(...)`` call shape, agent
+  call shape, ``.env`` key set, requirements/package manifest, .gitignore,
+  README) are defined here as pure string builders so the TS port can
+  replicate them exactly.
+
+Security: API keys are optional, written to ``.env`` with mode ``0o600``,
+listed in ``.gitignore``, and NEVER echoed to stdout or logged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess  # noqa: S404 — used with arg arrays only, never shell=True
+import sys
+from pathlib import Path
+
+from getpatter import __version__
+
+logger = logging.getLogger("getpatter.init")
+
+# Placeholder phone number — NANP 555 fiction range (see security.md). Never a
+# real number. Used when the user does not supply one via --phone / prompt.
+DEFAULT_PHONE = "+15550001234"
+
+# Valid IDE targets for the skills shell-out (`npx skills add ... -a <ide>`).
+IDE_CHOICES = ("claude-code", "cursor", "copilot", "codex")
+
+
+# ---------------------------------------------------------------------------
+# Provider matrix — the single source of truth the scaffold builders read.
+# Each entry: key -> (class_name, env_vars tuple, pip_extra or "").
+# class_name is the flat alias importable from ``getpatter`` in BOTH SDKs.
+# ---------------------------------------------------------------------------
+
+# Realtime engines (mode=realtime — pick ONE). Order = menu order.
+REALTIME_ENGINES: dict[str, dict] = {
+    "OpenAIRealtime2": {
+        "class": "OpenAIRealtime2",
+        "label": "OpenAI Realtime 2 (gpt-realtime-2) — default",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+        "ctor": "OpenAIRealtime2()",
+    },
+    "OpenAIRealtime": {
+        "class": "OpenAIRealtime",
+        "label": "OpenAI Realtime (legacy gpt-realtime-mini)",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+        "ctor": "OpenAIRealtime()",
+    },
+    "ElevenLabsConvAI": {
+        "class": "ElevenLabsConvAI",
+        "label": "ElevenLabs ConvAI (needs ELEVENLABS_AGENT_ID)",
+        "env": ("ELEVENLABS_API_KEY", "ELEVENLABS_AGENT_ID"),
+        "extra": "",
+        # agent_id is REQUIRED — read from ELEVENLABS_AGENT_ID env at construct.
+        "ctor": "ElevenLabsConvAI()",
+    },
+}
+DEFAULT_REALTIME_ENGINE = "OpenAIRealtime2"
+
+# Pipeline STT providers.
+PIPELINE_STT: dict[str, dict] = {
+    "deepgram": {
+        "class": "DeepgramSTT",
+        "label": "Deepgram — default",
+        "env": ("DEEPGRAM_API_KEY",),
+        "extra": "",
+    },
+    "assemblyai": {
+        "class": "AssemblyAISTT",
+        "label": "AssemblyAI",
+        "env": ("ASSEMBLYAI_API_KEY",),
+        "extra": "assemblyai",
+    },
+    "cartesia": {
+        "class": "CartesiaSTT",
+        "label": "Cartesia",
+        "env": ("CARTESIA_API_KEY",),
+        "extra": "cartesia",
+    },
+    "soniox": {
+        "class": "SonioxSTT",
+        "label": "Soniox",
+        "env": ("SONIOX_API_KEY",),
+        "extra": "soniox",
+    },
+    "speechmatics": {
+        "class": "SpeechmaticsSTT",
+        "label": "Speechmatics",
+        "env": ("SPEECHMATICS_API_KEY",),
+        "extra": "speechmatics",
+    },
+    "whisper": {
+        "class": "WhisperSTT",
+        "label": "OpenAI Whisper",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+    },
+    "openai": {
+        "class": "OpenAITranscribeSTT",
+        "label": "OpenAI Transcribe",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+    },
+}
+DEFAULT_STT = "deepgram"
+
+# Pipeline LLM providers.
+PIPELINE_LLM: dict[str, dict] = {
+    "cerebras": {
+        "class": "CerebrasLLM",
+        "label": "Cerebras (gpt-oss-120b) — default",
+        "env": ("CEREBRAS_API_KEY",),
+        "extra": "cerebras",
+    },
+    "openai": {
+        "class": "OpenAILLM",
+        "label": "OpenAI",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+    },
+    "anthropic": {
+        "class": "AnthropicLLM",
+        "label": "Anthropic Claude",
+        "env": ("ANTHROPIC_API_KEY",),
+        "extra": "anthropic",
+    },
+    "groq": {
+        "class": "GroqLLM",
+        "label": "Groq",
+        "env": ("GROQ_API_KEY",),
+        "extra": "groq",
+    },
+    "google": {
+        "class": "GoogleLLM",
+        "label": "Google Gemini",
+        "env": ("GOOGLE_API_KEY",),
+        "extra": "google",
+    },
+}
+DEFAULT_LLM = "cerebras"
+
+# Pipeline TTS providers.
+PIPELINE_TTS: dict[str, dict] = {
+    "elevenlabs": {
+        "class": "ElevenLabsTTS",
+        "label": "ElevenLabs — default",
+        "env": ("ELEVENLABS_API_KEY",),
+        "extra": "",
+    },
+    "openai": {
+        "class": "OpenAITTS",
+        "label": "OpenAI",
+        "env": ("OPENAI_API_KEY",),
+        "extra": "",
+    },
+    "cartesia": {
+        "class": "CartesiaTTS",
+        "label": "Cartesia",
+        "env": ("CARTESIA_API_KEY",),
+        "extra": "cartesia",
+    },
+    "rime": {
+        "class": "RimeTTS",
+        "label": "Rime",
+        "env": ("RIME_API_KEY",),
+        "extra": "rime",
+    },
+    "lmnt": {
+        "class": "LMNTTTS",
+        "label": "LMNT",
+        "env": ("LMNT_API_KEY",),
+        "extra": "lmnt",
+    },
+    "inworld": {
+        "class": "InworldTTS",
+        "label": "Inworld",
+        "env": ("INWORLD_API_KEY",),
+        "extra": "inworld",
+    },
+}
+DEFAULT_TTS = "elevenlabs"
+
+# Telephony carriers.
+CARRIERS: dict[str, dict] = {
+    "twilio": {
+        "class": "Twilio",
+        "label": "Twilio — default",
+        "env": ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN"),
+        "phone_env": "TWILIO_PHONE_NUMBER",
+    },
+    "telnyx": {
+        "class": "Telnyx",
+        "label": "Telnyx",
+        "env": ("TELNYX_API_KEY", "TELNYX_CONNECTION_ID"),
+        "phone_env": "TELNYX_PHONE_NUMBER",
+    },
+    "plivo": {
+        "class": "Plivo",
+        "label": "Plivo",
+        "env": ("PLIVO_AUTH_ID", "PLIVO_AUTH_TOKEN"),
+        "phone_env": "PLIVO_PHONE_NUMBER",
+    },
+}
+DEFAULT_CARRIER = "twilio"
+
+
+# ---------------------------------------------------------------------------
+# Argparse
+# ---------------------------------------------------------------------------
+
+
+def build_init_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Attach the ``init`` subcommand to a parent CLI (mirror of ``eval``)."""
+    p = subparsers.add_parser(
+        "init",
+        help="Scaffold a new Patter voice-agent project (setup wizard)",
+    )
+    p.add_argument("--name", default=None, help="Project name → target directory")
+    p.add_argument(
+        "--runtime",
+        choices=("python", "typescript"),
+        default=None,
+        help="SDK runtime (default: python for this CLI)",
+    )
+    p.add_argument(
+        "--mode",
+        choices=("realtime", "pipeline"),
+        default=None,
+        help="Voice mode: realtime (one engine) or pipeline (STT+LLM+TTS)",
+    )
+    p.add_argument(
+        "--engine",
+        choices=tuple(REALTIME_ENGINES),
+        default=None,
+        help="Realtime engine (realtime mode only)",
+    )
+    p.add_argument(
+        "--stt",
+        choices=tuple(PIPELINE_STT),
+        default=None,
+        help="STT provider (pipeline mode only)",
+    )
+    p.add_argument(
+        "--llm",
+        choices=tuple(PIPELINE_LLM),
+        default=None,
+        help="LLM provider (pipeline mode only)",
+    )
+    p.add_argument(
+        "--tts",
+        choices=tuple(PIPELINE_TTS),
+        default=None,
+        help="TTS provider (pipeline mode only)",
+    )
+    p.add_argument(
+        "--carrier", choices=tuple(CARRIERS), default=None, help="Telephony carrier"
+    )
+    p.add_argument(
+        "--phone",
+        default=None,
+        help=f"Phone number in E.164 (placeholder {DEFAULT_PHONE})",
+    )
+    p.add_argument(
+        "--skip-keys",
+        action="store_true",
+        help="Do not prompt for API keys; write placeholders to .env",
+    )
+    p.add_argument(
+        "--ide",
+        default=None,
+        help=(f"Comma-separated IDE skills targets ({', '.join(IDE_CHOICES)})"),
+    )
+    p.add_argument(
+        "--no-skills", action="store_true", help="Skip the IDE skills install step"
+    )
+    p.add_argument(
+        "--no-git", action="store_true", help="Skip 'git init' in the new project"
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow scaffolding into a non-empty directory",
+    )
+    p.add_argument(
+        "--yes", "-y", action="store_true", help="Non-interactive: accept all defaults"
+    )
+    return p
+
+
+def dispatch_init(args: argparse.Namespace) -> int:
+    """Entry for ``getpatter init ...``. Returns a process exit code."""
+    try:
+        return asyncio.run(_run(args))
+    except InitError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+# ---------------------------------------------------------------------------
+# Prompt helpers (stdlib input() only — no third-party prompt libs)
+# ---------------------------------------------------------------------------
+
+
+def _ask_text(prompt: str, default: str) -> str:
+    """Free-text prompt with a default shown in brackets."""
+    raw = input(f"{prompt} [{default}]: ").strip()
+    return raw or default
+
+
+def _ask_choice(prompt: str, options: list[tuple[str, str]], default_key: str) -> str:
+    """Numbered menu. ``options`` is [(key, label)]. Returns the chosen key.
+
+    Empty input picks the default. Accepts either the 1-based number or the
+    literal key. Re-prompts on invalid input.
+    """
+    keys = [k for k, _ in options]
+    default_idx = keys.index(default_key) + 1
+    print(prompt)
+    for i, (key, label) in enumerate(options, start=1):
+        marker = " (default)" if key == default_key else ""
+        print(f"  {i}) {label}{marker}")
+    while True:
+        raw = input(f"Choose [1-{len(options)}, default {default_idx}]: ").strip()
+        if not raw:
+            return default_key
+        if raw in keys:
+            return raw
+        if raw.isdigit() and 1 <= int(raw) <= len(options):
+            return keys[int(raw) - 1]
+        print(
+            f"  Invalid choice {raw!r} — enter a number 1-{len(options)} "
+            f"or a name ({', '.join(keys)})."
+        )
+
+
+def _ask_yes_no(prompt: str, default: bool) -> bool:
+    """Yes/no prompt. Empty input picks the default."""
+    hint = "Y/n" if default else "y/N"
+    raw = input(f"{prompt} [{hint}]: ").strip().lower()
+    if not raw:
+        return default
+    return raw in ("y", "yes")
+
+
+def _ask_multi(prompt: str, options: list[tuple[str, str]]) -> list[str]:
+    """Multi-select numbered menu. Comma-separated numbers/keys. Empty = none."""
+    keys = [k for k, _ in options]
+    print(prompt)
+    for i, (key, label) in enumerate(options, start=1):
+        print(f"  {i}) {label}")
+    raw = input("Select (comma-separated, blank for none): ").strip()
+    if not raw:
+        return []
+    chosen: list[str] = []
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if tok in keys and tok not in chosen:
+            chosen.append(tok)
+        elif tok.isdigit() and 1 <= int(tok) <= len(options):
+            k = keys[int(tok) - 1]
+            if k not in chosen:
+                chosen.append(k)
+    return chosen
+
+
+# ---------------------------------------------------------------------------
+# Selection resolution — flags + prompts → a plan dict
+# ---------------------------------------------------------------------------
+
+
+class InitError(ValueError):
+    """User-facing error raised when wizard input is invalid (bad name, …)."""
+
+
+# A project label (final path segment) may only contain these characters.
+# This is the safe set we interpolate into generated files; it forbids quotes,
+# shell metacharacters, and path separators that could break package.json or
+# escape the target directory.
+_SAFE_LABEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_name(name: str) -> None:
+    """Reject project names that are unsafe to use as a path or in codegen.
+
+    Raises :class:`InitError` with a clear message. Guards against path
+    traversal (``..``), path-separator injection in the *label* segment, and
+    characters outside the safe set that would corrupt generated files
+    (notably double-quotes breaking ``package.json``). The full ``name`` may
+    still be a path (``/tmp/foo/my-agent``); only its final segment becomes the
+    project label, so that is what we validate.
+    """
+    if not name or not name.strip():
+        raise InitError("Project name must not be empty.")
+    # Path traversal anywhere in the supplied name is rejected outright.
+    parts = re.split(r"[\\/]", name)
+    if any(p == ".." for p in parts):
+        raise InitError(f"Project name {name!r} must not contain '..' path segments.")
+    label = Path(name).name
+    if not label:
+        raise InitError(f"Project name {name!r} has no final path segment.")
+    if not _SAFE_LABEL_RE.match(label):
+        raise InitError(
+            f"Project name {label!r} contains invalid characters. "
+            "Use only letters, digits, '.', '_' and '-'."
+        )
+
+
+def _npm_package_name(label: str) -> str:
+    """Coerce a project label into a valid npm package name.
+
+    npm names allow only ``[a-z0-9._-]`` and are capped at 214 chars. The label
+    has already passed :func:`_validate_name`, so this only lower-cases, maps
+    spaces (defensive — validation forbids them) to dashes, drops any residual
+    out-of-set char, and truncates. Never produces quotes or shell metachars.
+    """
+    lowered = label.lower().replace(" ", "-")
+    cleaned = re.sub(r"[^a-z0-9._-]", "", lowered) or "patter-agent"
+    return cleaned[:214]
+
+
+def _resolve_plan(args: argparse.Namespace, interactive: bool) -> dict:
+    """Turn flags (+ prompts when interactive) into a concrete scaffold plan."""
+    # 1. Project name → target dir
+    if args.name is not None:
+        name = args.name
+    elif interactive:
+        name = _ask_text("Project name", "my-patter-agent")
+    else:
+        name = "my-patter-agent"
+
+    # Validate before anything is written or any path is resolved — a bad name
+    # (path traversal, quote injection) must fail fast with a clear message.
+    _validate_name(name)
+
+    # 2. Runtime (this is the Python CLI → prefill python)
+    if args.runtime is not None:
+        runtime = args.runtime
+    elif interactive:
+        runtime = _ask_choice(
+            "SDK runtime?",
+            [
+                ("python", "Python (getpatter)"),
+                ("typescript", "TypeScript (getpatter)"),
+            ],
+            "python",
+        )
+    else:
+        runtime = "python"
+
+    # 3. Voice mode
+    if args.mode is not None:
+        mode = args.mode
+    elif interactive:
+        mode = _ask_choice(
+            "Voice mode?",
+            [
+                ("realtime", "Realtime — one engine owns the turn (lowest latency)"),
+                ("pipeline", "Pipeline — compose STT + LLM + TTS (full control)"),
+            ],
+            "realtime",
+        )
+    else:
+        mode = "realtime"
+
+    # 4. Engine / providers (filtered by mode)
+    engine = None
+    stt = llm = tts = None
+    if mode == "realtime":
+        if args.engine is not None:
+            engine = args.engine
+        elif interactive:
+            engine = _ask_choice(
+                "Realtime engine?",
+                [(k, v["label"]) for k, v in REALTIME_ENGINES.items()],
+                DEFAULT_REALTIME_ENGINE,
+            )
+        else:
+            engine = DEFAULT_REALTIME_ENGINE
+    else:
+        stt = (
+            args.stt
+            if args.stt is not None
+            else (
+                _ask_choice(
+                    "STT provider?",
+                    [(k, v["label"]) for k, v in PIPELINE_STT.items()],
+                    DEFAULT_STT,
+                )
+                if interactive
+                else DEFAULT_STT
+            )
+        )
+        llm = (
+            args.llm
+            if args.llm is not None
+            else (
+                _ask_choice(
+                    "LLM provider?",
+                    [(k, v["label"]) for k, v in PIPELINE_LLM.items()],
+                    DEFAULT_LLM,
+                )
+                if interactive
+                else DEFAULT_LLM
+            )
+        )
+        tts = (
+            args.tts
+            if args.tts is not None
+            else (
+                _ask_choice(
+                    "TTS provider?",
+                    [(k, v["label"]) for k, v in PIPELINE_TTS.items()],
+                    DEFAULT_TTS,
+                )
+                if interactive
+                else DEFAULT_TTS
+            )
+        )
+
+    # 5. Carrier
+    if args.carrier is not None:
+        carrier = args.carrier
+    elif interactive:
+        carrier = _ask_choice(
+            "Telephony carrier?",
+            [(k, v["label"]) for k, v in CARRIERS.items()],
+            DEFAULT_CARRIER,
+        )
+    else:
+        carrier = DEFAULT_CARRIER
+
+    # Phone number
+    if args.phone is not None:
+        phone = args.phone
+    elif interactive:
+        phone = _ask_text("Phone number (E.164)", DEFAULT_PHONE)
+    else:
+        phone = DEFAULT_PHONE
+
+    return {
+        "name": name,
+        "runtime": runtime,
+        "mode": mode,
+        "engine": engine,
+        "stt": stt,
+        "llm": llm,
+        "tts": tts,
+        "carrier": carrier,
+        "phone": phone,
+    }
+
+
+def _collect_env_keys(plan: dict) -> list[str]:
+    """Ordered, de-duplicated list of env var names the chosen stack reads.
+
+    Carrier creds first, then the engine/provider keys, then the phone env.
+    """
+    keys: list[str] = []
+
+    def _add(names) -> None:
+        for n in names:
+            if n not in keys:
+                keys.append(n)
+
+    _add(CARRIERS[plan["carrier"]]["env"])
+    if plan["mode"] == "realtime":
+        _add(REALTIME_ENGINES[plan["engine"]]["env"])
+    else:
+        _add(PIPELINE_STT[plan["stt"]]["env"])
+        _add(PIPELINE_LLM[plan["llm"]]["env"])
+        _add(PIPELINE_TTS[plan["tts"]]["env"])
+    _add((CARRIERS[plan["carrier"]]["phone_env"],))
+    return keys
+
+
+def _collect_extras(plan: dict) -> list[str]:
+    """Sorted, de-duplicated pip extras for the chosen pipeline providers.
+
+    Realtime defaults (OpenAI*) need no extras. Carriers need no extras.
+    """
+    extras: set[str] = set()
+    if plan["mode"] == "pipeline":
+        for table, key in (
+            (PIPELINE_STT, plan["stt"]),
+            (PIPELINE_LLM, plan["llm"]),
+            (PIPELINE_TTS, plan["tts"]),
+        ):
+            extra = table[key]["extra"]
+            if extra:
+                extras.add(extra)
+    else:
+        extra = REALTIME_ENGINES[plan["engine"]]["extra"]
+        if extra:
+            extras.add(extra)
+    return sorted(extras)
+
+
+# ---------------------------------------------------------------------------
+# Scaffold string builders — pure functions, the parity-critical codegen.
+# ---------------------------------------------------------------------------
+
+
+def build_main_py(plan: dict) -> str:
+    """Generate ``main.py`` for the chosen Python stack."""
+    carrier_cls = CARRIERS[plan["carrier"]]["class"]
+    phone = plan["phone"]
+    if plan["mode"] == "realtime":
+        engine_cls = REALTIME_ENGINES[plan["engine"]]["class"]
+        imports = f"from getpatter import Patter, {carrier_cls}, {engine_cls}"
+        agent_block = (
+            f"    agent = phone.agent(\n"
+            f"        engine={engine_cls}(),\n"
+            f"        system_prompt=(\n"
+            f'            "You are the receptionist for Acme Corp. Help callers with "\n'
+            f'            "hours, support questions, and simple account changes. "\n'
+            f'            "Keep replies short."\n'
+            f"        ),\n"
+            f'        first_message="Hi! Thanks for calling Acme Corp. How can I help?",\n'
+            f"    )"
+        )
+    else:
+        stt_cls = PIPELINE_STT[plan["stt"]]["class"]
+        llm_cls = PIPELINE_LLM[plan["llm"]]["class"]
+        tts_cls = PIPELINE_TTS[plan["tts"]]["class"]
+        imports = (
+            f"from getpatter import Patter, {carrier_cls}, "
+            f"{stt_cls}, {llm_cls}, {tts_cls}"
+        )
+        agent_block = (
+            f"    agent = phone.agent(\n"
+            f"        stt={stt_cls}(),\n"
+            f"        llm={llm_cls}(),\n"
+            f"        tts={tts_cls}(),\n"
+            f"        system_prompt=(\n"
+            f'            "You are the receptionist for Acme Corp. Help callers with "\n'
+            f'            "hours, support questions, and simple account changes. "\n'
+            f'            "Keep replies short."\n'
+            f"        ),\n"
+            f'        first_message="Hi! Thanks for calling Acme Corp. How can I help?",\n'
+            f"    )"
+        )
+    return (
+        '"""Patter voice agent — generated by `getpatter init`.\n'
+        "\n"
+        "Answers inbound calls and talks to the caller. Set the API keys in\n"
+        ".env (already scaffolded), then run:  python main.py\n"
+        '"""\n'
+        "\n"
+        "import asyncio\n"
+        "import os\n"
+        "\n"
+        f"{imports}\n"
+        "\n"
+        f'PHONE_NUMBER = os.environ.get("{CARRIERS[plan["carrier"]]["phone_env"]}", "{phone}")\n'
+        "\n"
+        "\n"
+        "async def main() -> None:\n"
+        "    phone = Patter(\n"
+        f"        carrier={carrier_cls}(),   # reads creds from env\n"
+        "        phone_number=PHONE_NUMBER,\n"
+        "    )\n"
+        "\n"
+        f"{agent_block}\n"
+        "\n"
+        '    print(f"Ready on {PHONE_NUMBER}. Waiting for calls... (Ctrl+C to stop)")\n'
+        "    await phone.serve(agent, tunnel=True)\n"
+        "\n"
+        "\n"
+        'if __name__ == "__main__":\n'
+        "    asyncio.run(main())\n"
+    )
+
+
+def build_requirements_txt(plan: dict) -> str:
+    """Generate ``requirements.txt`` pinning getpatter with the right extras."""
+    extras = _collect_extras(plan)
+    spec = "getpatter"
+    if extras:
+        spec += "[" + ",".join(extras) + "]"
+    spec += f"=={__version__}"
+    return spec + "\n"
+
+
+def build_env(plan: dict, *, with_values: dict[str, str] | None = None) -> str:
+    """Generate ``.env`` body. ``with_values`` maps env name → entered secret.
+
+    When a value is absent the line is left as ``NAME=`` (placeholder) so the
+    user fills it in. Secrets are NEVER logged — only written to disk (0600).
+    """
+    with_values = with_values or {}
+    lines = [
+        "# Patter environment — generated by `getpatter init`.",
+        "# Fill in the blanks below. Keep this file out of version control.",
+        "",
+    ]
+    for key in _collect_env_keys(plan):
+        lines.append(f"{key}={with_values.get(key, '')}")
+    return "\n".join(lines) + "\n"
+
+
+def build_env_example(plan: dict) -> str:
+    """Generate ``.env.example`` with empty placeholders (safe to commit)."""
+    return build_env(plan, with_values=None)
+
+
+def build_gitignore(plan: dict) -> str:
+    """Generate ``.gitignore`` — always ignores .env and runtime junk."""
+    common = [".env", ".env.*", "!.env.example"]
+    if plan["runtime"] == "python":
+        rest = ["__pycache__/", "*.pyc", ".venv/", "venv/", ".pytest_cache/"]
+    else:
+        rest = ["node_modules/", "dist/", "*.log"]
+    return "\n".join(common + rest) + "\n"
+
+
+def build_readme(plan: dict) -> str:
+    """Generate ``README.md`` explaining how to run the project."""
+    if plan["runtime"] == "python":
+        run_block = (
+            "```sh\n"
+            "pip install -r requirements.txt\n"
+            "# edit .env with your API keys\n"
+            "python main.py\n"
+            "```"
+        )
+        entry = "main.py"
+    else:
+        run_block = "```sh\nnpm install\n# edit .env with your API keys\nnpm start\n```"
+        entry = "src/index.ts"
+    if plan["mode"] == "realtime":
+        stack = f"Realtime engine: `{REALTIME_ENGINES[plan['engine']]['class']}`"
+    else:
+        stack = (
+            f"Pipeline: STT `{PIPELINE_STT[plan['stt']]['class']}` · "
+            f"LLM `{PIPELINE_LLM[plan['llm']]['class']}` · "
+            f"TTS `{PIPELINE_TTS[plan['tts']]['class']}`"
+        )
+    tunnel_ref = "`tunnel=True`" if plan["runtime"] == "python" else "`tunnel: true`"
+    return (
+        f"# {_project_label(plan)}\n"
+        "\n"
+        "A Patter voice agent, scaffolded by `getpatter init`.\n"
+        "\n"
+        f"- Carrier: `{CARRIERS[plan['carrier']]['class']}`\n"
+        f"- {stack}\n"
+        f"- Entry point: `{entry}`\n"
+        "\n"
+        "## Run\n"
+        "\n"
+        f"{run_block}\n"
+        "\n"
+        "The agent answers inbound calls and starts a Cloudflare Quick Tunnel\n"
+        f"({tunnel_ref}) so the carrier can reach your local server during dev.\n"
+    )
+
+
+def build_index_ts(plan: dict) -> str:
+    """Generate ``src/index.ts`` — kept here so the Python reference documents
+    the exact TS scaffold the TS port must emit (camelCase, ``new``, options).
+    The Python CLI only writes this when ``runtime=typescript`` is forced.
+    """
+    carrier_cls = CARRIERS[plan["carrier"]]["class"]
+    phone = plan["phone"]
+    phone_env = CARRIERS[plan["carrier"]]["phone_env"]
+    if plan["mode"] == "realtime":
+        engine_cls = REALTIME_ENGINES[plan["engine"]]["class"]
+        imports = f'import {{ Patter, {carrier_cls}, {engine_cls} }} from "getpatter";'
+        agent_block = (
+            "  const agent = phone.agent({\n"
+            f"    engine: new {engine_cls}(),\n"
+            "    systemPrompt:\n"
+            '      "You are the receptionist for Acme Corp. Help callers with " +\n'
+            '      "hours, support questions, and simple account changes. " +\n'
+            '      "Keep replies short.",\n'
+            '    firstMessage: "Hi! Thanks for calling Acme Corp. How can I help?",\n'
+            "  });"
+        )
+    else:
+        stt_cls = PIPELINE_STT[plan["stt"]]["class"]
+        llm_cls = PIPELINE_LLM[plan["llm"]]["class"]
+        tts_cls = PIPELINE_TTS[plan["tts"]]["class"]
+        imports = (
+            f"import {{ Patter, {carrier_cls}, {stt_cls}, {llm_cls}, "
+            f'{tts_cls} }} from "getpatter";'
+        )
+        agent_block = (
+            "  const agent = phone.agent({\n"
+            f"    stt: new {stt_cls}(),\n"
+            f"    llm: new {llm_cls}(),\n"
+            f"    tts: new {tts_cls}(),\n"
+            "    systemPrompt:\n"
+            '      "You are the receptionist for Acme Corp. Help callers with " +\n'
+            '      "hours, support questions, and simple account changes. " +\n'
+            '      "Keep replies short.",\n'
+            '    firstMessage: "Hi! Thanks for calling Acme Corp. How can I help?",\n'
+            "  });"
+        )
+    return (
+        "/**\n"
+        " * Patter voice agent — generated by `getpatter init`.\n"
+        " *\n"
+        " * Answers inbound calls and talks to the caller. Set the API keys in\n"
+        " * .env (already scaffolded), then run:  npm start\n"
+        " */\n"
+        f"{imports}\n"
+        "\n"
+        f'const PHONE_NUMBER = process.env.{phone_env} ?? "{phone}";\n'
+        "\n"
+        "async function main(): Promise<void> {\n"
+        "  const phone = new Patter({\n"
+        f"    carrier: new {carrier_cls}(),   // reads creds from env\n"
+        "    phoneNumber: PHONE_NUMBER,\n"
+        "  });\n"
+        "\n"
+        f"{agent_block}\n"
+        "\n"
+        "  console.log(`Ready on ${PHONE_NUMBER}. Waiting for calls... "
+        "(Ctrl+C to stop)`);\n"
+        "  await phone.serve({ agent, tunnel: true });\n"
+        "}\n"
+        "\n"
+        "main().catch((err) => {\n"
+        "  console.error(err);\n"
+        "  process.exit(1);\n"
+        "});\n"
+    )
+
+
+def _project_label(plan: dict) -> str:
+    """Display/basename for the project, derived from ``plan["name"]``.
+
+    ``name`` may be a bare label ("my-agent") or a path ("/tmp/foo/my-agent").
+    The label is always the final path segment so package.json / README never
+    leak the parent directory. Parity rule: TS port uses ``path.basename``.
+    """
+    base = Path(plan["name"]).name or "patter-agent"
+    return base
+
+
+def build_package_json(plan: dict) -> str:
+    """Generate ``package.json`` for the TS scaffold (getpatter pinned)."""
+    # Sanitize to a valid npm name, then JSON-encode so a stray quote / unicode
+    # in the label can never produce malformed JSON that breaks `npm install`.
+    name = json.dumps(_npm_package_name(_project_label(plan)))
+    return (
+        "{\n"
+        f'  "name": {name},\n'
+        '  "version": "0.1.0",\n'
+        '  "private": true,\n'
+        '  "type": "module",\n'
+        '  "scripts": {\n'
+        '    "start": "tsx src/index.ts"\n'
+        "  },\n"
+        '  "dependencies": {\n'
+        f'    "getpatter": "{__version__}"\n'
+        "  },\n"
+        '  "devDependencies": {\n'
+        '    "tsx": "^4.0.0",\n'
+        '    "typescript": "^5.0.0"\n'
+        "  }\n"
+        "}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filesystem + side effects
+# ---------------------------------------------------------------------------
+
+
+def _write_scaffold(target: Path, plan: dict, env_values: dict[str, str]) -> list[Path]:
+    """Write every scaffold file. Returns the list of written paths.
+
+    ``.env`` is created with mode 0600. Secrets in ``env_values`` are written
+    to ``.env`` only — never echoed or logged.
+    """
+    target.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+
+    def _w(rel: str, content: str, *, mode: int | None = None) -> None:
+        path = target / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if mode is not None:
+            # Create the file with the target mode atomically via os.open, so a
+            # secrets-bearing file (.env) is NEVER world-/group-readable for the
+            # window between write and a separate chmod (TOCTOU). O_TRUNC keeps
+            # --force re-scaffolds correct; os.fchmod re-asserts the mode even
+            # when the file already existed (the mode arg to os.open is masked
+            # by umask and only applies on create).
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            fd = os.open(str(path), flags, mode)
+            os.fchmod(fd, mode)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+        written.append(path)
+
+    if plan["runtime"] == "python":
+        _w("main.py", build_main_py(plan))
+        _w("requirements.txt", build_requirements_txt(plan))
+    else:
+        _w("src/index.ts", build_index_ts(plan))
+        _w("package.json", build_package_json(plan))
+
+    # .env first (0600), then the committable example.
+    _w(".env", build_env(plan, with_values=env_values), mode=0o600)
+    _w(".env.example", build_env_example(plan))
+    _w(".gitignore", build_gitignore(plan))
+    _w("README.md", build_readme(plan))
+    return written
+
+
+def _maybe_git_init(target: Path) -> None:
+    """Run ``git init`` in the target dir via subprocess (arg array, no shell)."""
+    git = shutil.which("git")
+    if not git:
+        print("  git not found on PATH — skipping 'git init'.")
+        return
+    try:
+        subprocess.run([git, "init", "--quiet"], cwd=str(target), check=True)  # noqa: S603
+        print("  Initialised a git repository.")
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"  'git init' failed ({exc}) — skipping.")
+
+
+def _maybe_install_skills(target: Path, ides: list[str]) -> None:
+    """Shell out to ``npx skills add ...`` per IDE. Skips if npx is missing."""
+    if not ides:
+        return
+    npx = shutil.which("npx")
+    if not npx:
+        print("  npx (Node) not found — skipping IDE skills install.")
+        return
+    ref = f"patterai/skills#v{__version__}"
+    for ide in ides:
+        print(f"  Installing skills for {ide}...")
+        try:
+            subprocess.run(  # noqa: S603
+                [npx, "skills", "add", ref, "-a", ide],
+                cwd=str(target),
+                check=True,
+            )
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print(f"  skills add for {ide} failed ({exc}) — skipping.")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+async def _run(args: argparse.Namespace) -> int:
+    interactive = not args.yes
+
+    plan = _resolve_plan(args, interactive)
+
+    target = Path(plan["name"]).expanduser().resolve()
+
+    # 9. Non-empty dir guard (--force overrides).
+    if target.exists() and any(target.iterdir()) and not args.force:
+        print(
+            f"Target directory {target} is not empty. "
+            "Re-run with --force to scaffold into it anyway."
+        )
+        return 1
+
+    env_keys = _collect_env_keys(plan)
+
+    # 6. API keys → .env (0600). Skippable; secrets never echoed/logged.
+    env_values: dict[str, str] = {}
+    if not args.skip_keys and interactive:
+        print(
+            "\nAPI keys (input is hidden — press Enter to leave blank, "
+            "fill them in later):"
+        )
+        for key in env_keys:
+            # getpass() does NOT echo characters, so the raw secret never lands
+            # on a shared terminal, a shoulder-surf, or a terminal recording.
+            # The value is written to .env (0600) only — never logged or printed.
+            val = getpass.getpass(f"  {key}: ").strip()
+            if val:
+                env_values[key] = val
+    # In --skip-keys (or non-interactive) mode every value stays a placeholder.
+
+    written = _write_scaffold(target, plan, env_values)
+
+    # 7. IDE skills (multi-select). --no-skills / non-interactive default skips.
+    ides: list[str] = []
+    if not args.no_skills:
+        if args.ide is not None:
+            ides = [s.strip() for s in args.ide.split(",") if s.strip() in IDE_CHOICES]
+        elif interactive:
+            ides = _ask_multi(
+                "Install Patter skills for which IDEs?",
+                [(k, k) for k in IDE_CHOICES],
+            )
+    _maybe_install_skills(target, ides)
+
+    # 8. git init (optional). --no-git / non-interactive default skips.
+    do_git = False
+    if not args.no_git:
+        do_git = (
+            _ask_yes_no("Initialise a git repository?", True) if interactive else False
+        )
+    if do_git:
+        _maybe_git_init(target)
+
+    # Summary — paths only, never secret values.
+    print(f"\nScaffolded {plan['runtime']} project at {target}")
+    for path in written:
+        print(f"  + {path.relative_to(target)}")
+    if plan["runtime"] == "python":
+        print(
+            "\nNext:  cd "
+            f"{target}  &&  pip install -r requirements.txt  &&  python main.py"
+        )
+    else:
+        print(f"\nNext:  cd {target}  &&  npm install  &&  npm start")
+    return 0
+
+
+def main() -> None:
+    """Standalone entry for ``python -m getpatter.init.cli``."""
+    parser = argparse.ArgumentParser(prog="patter-init")
+    subparsers = parser.add_subparsers(dest="command")
+    build_init_parser(subparsers)
+    args = parser.parse_args()
+    if args.command != "init":
+        parser.print_help()
+        sys.exit(2)
+    sys.exit(dispatch_init(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.8"
+version = "0.6.9"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/python/tests/test_init.py
+++ b/libraries/python/tests/test_init.py
@@ -1,0 +1,472 @@
+"""End-to-end tests for the REAL ``getpatter init`` wizard.
+
+Complements ``test_init_wizard.py`` (which pins the pure string builders).
+These run the *whole* wizard — the same ``build_init_parser`` argparse surface
+a user hits on the command line, then ``dispatch_init`` → the async ``_run``
+coroutine — straight into a pytest ``tmp_path``. No fake plan dicts: the
+selections flow through real flag parsing, real selection resolution, the real
+``_write_scaffold`` filesystem path, and the real ``os.chmod`` permission set.
+
+Only TWO boundaries are mocked, and both are mocked at the documented external
+edge (per the authentic-tests rule):
+
+* ``subprocess.run`` — so ``npx skills add ...`` and ``git init`` never shell out
+  to Node / git or touch the network. We still assert the wizard *would* have
+  invoked them with the right arg array.
+* ``shutil.which`` — so the wizard believes ``git`` / ``npx`` exist on PATH
+  without requiring them in CI. Everything from these two hooks inward is real.
+
+Generated ``main.py`` is validated by parsing it with the stdlib ``ast`` module
+(it must be syntactically valid Python) and by extracting the ``from getpatter
+import ...`` symbols and matching them against the chosen mode/engine/providers.
+Coverage spans BOTH voice modes (realtime + pipeline) and several carriers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import stat
+
+import pytest
+
+from getpatter import __version__
+from getpatter.init.cli import build_init_parser, dispatch_init
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    """Build the REAL ``init`` parser and parse argv exactly as the CLI does."""
+    parser = argparse.ArgumentParser(prog="patter")
+    subparsers = parser.add_subparsers(dest="command")
+    build_init_parser(subparsers)
+    args = parser.parse_args(["init", *argv])
+    assert args.command == "init"
+    return args
+
+
+def _imported_getpatter_symbols(main_py_src: str) -> set[str]:
+    """Parse ``main.py`` with ast and return the names imported from getpatter.
+
+    Walks the real AST — proves the file is syntactically valid Python AND that
+    the import line wired the chosen stack. Returns the set of imported names
+    (e.g. {"Patter", "Twilio", "OpenAIRealtime2"}).
+    """
+    tree = ast.parse(main_py_src)
+    symbols: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "getpatter":
+            for alias in node.names:
+                symbols.add(alias.name)
+    return symbols
+
+
+def _run_wizard(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> list:
+    """Run the real wizard with subprocess + which mocked, return recorded calls.
+
+    The returned list holds every ``subprocess.run`` arg array the wizard would
+    have executed (git init / npx skills add). The wizard runs fully otherwise.
+    """
+    recorded: list[list[str]] = []
+
+    def _fake_run(cmd, *args, **kwargs):  # noqa: ANN001 — test double
+        recorded.append(list(cmd))
+
+        class _Completed:
+            returncode = 0
+
+        return _Completed()
+
+    # Make git / npx "exist" so the wizard takes the install/init branch, but
+    # the actual execution is the mocked subprocess.run above. Everything else
+    # (selection resolution, scaffolding, chmod, env-key collection) is real.
+    def _fake_which(name: str):  # noqa: ANN001
+        return f"/usr/bin/{name}"
+
+    monkeypatch.setattr("getpatter.init.cli.subprocess.run", _fake_run)
+    monkeypatch.setattr("getpatter.init.cli.shutil.which", _fake_which)
+
+    args = _parse(argv)
+    rc = dispatch_init(args)
+    assert rc == 0, f"wizard exited non-zero ({rc}) for argv={argv}"
+    return recorded
+
+
+# ---------------------------------------------------------------------------
+# Realtime mode — full end-to-end scaffold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_realtime_default_scaffold_is_complete_and_valid(tmp_path, monkeypatch):
+    target = tmp_path / "rt-agent"
+    _run_wizard(
+        ["--name", str(target), "--yes", "--mode", "realtime", "--carrier", "twilio"],
+        monkeypatch,
+    )
+
+    # Scaffold files exist.
+    for rel in (
+        "main.py",
+        "requirements.txt",
+        ".env",
+        ".env.example",
+        ".gitignore",
+        "README.md",
+    ):
+        assert (target / rel).is_file(), f"missing scaffold file {rel}"
+    # Python scaffold must NOT emit the TS entry point.
+    assert not (target / "src" / "index.ts").exists()
+
+    # .env is 0600.
+    mode = stat.S_IMODE(os.stat(target / ".env").st_mode)
+    assert mode == 0o600, f".env mode {oct(mode)} != 0o600"
+
+    # main.py parses via ast and imports the realtime symbols.
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    symbols = _imported_getpatter_symbols(main_src)
+    assert symbols == {"Patter", "Twilio", "OpenAIRealtime2"}
+    # Realtime stack must not leak pipeline kwargs into the call shape.
+    assert "stt=" not in main_src and "llm=" not in main_src and "tts=" not in main_src
+    assert "engine=OpenAIRealtime2()" in main_src
+
+    # requirements.txt pins the version; realtime default needs no extras.
+    reqs = (target / "requirements.txt").read_text(encoding="utf-8").strip()
+    assert reqs == f"getpatter=={__version__}"
+
+    # .gitignore protects .env.
+    gitignore = (target / ".gitignore").read_text(encoding="utf-8")
+    assert ".env" in gitignore.splitlines()
+
+
+@pytest.mark.unit
+def test_realtime_convai_engine_scaffold(tmp_path, monkeypatch):
+    target = tmp_path / "convai-agent"
+    _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "realtime",
+            "--engine",
+            "ElevenLabsConvAI",
+            "--carrier",
+            "telnyx",
+        ],
+        monkeypatch,
+    )
+
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    ast.parse(main_src)  # must be valid Python
+    symbols = _imported_getpatter_symbols(main_src)
+    assert symbols == {"Patter", "Telnyx", "ElevenLabsConvAI"}
+    assert "engine=ElevenLabsConvAI()" in main_src
+
+    # ConvAI requires ELEVENLABS_AGENT_ID; Telnyx requires its creds + conn id.
+    env_example = (target / ".env.example").read_text(encoding="utf-8")
+    for key in (
+        "TELNYX_API_KEY",
+        "TELNYX_CONNECTION_ID",
+        "ELEVENLABS_API_KEY",
+        "ELEVENLABS_AGENT_ID",
+        "TELNYX_PHONE_NUMBER",
+    ):
+        assert f"{key}=" in env_example, f"{key} missing from .env.example"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline mode — full end-to-end scaffold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pipeline_default_scaffold_is_complete_and_valid(tmp_path, monkeypatch):
+    target = tmp_path / "pl-agent"
+    _run_wizard(
+        ["--name", str(target), "--yes", "--mode", "pipeline", "--carrier", "plivo"],
+        monkeypatch,
+    )
+
+    # Scaffold files exist.
+    for rel in (
+        "main.py",
+        "requirements.txt",
+        ".env",
+        ".env.example",
+        ".gitignore",
+        "README.md",
+    ):
+        assert (target / rel).is_file(), f"missing scaffold file {rel}"
+
+    # .env is 0600.
+    mode = stat.S_IMODE(os.stat(target / ".env").st_mode)
+    assert mode == 0o600
+
+    # main.py parses and imports the default pipeline stack (Deepgram/Cerebras/ElevenLabs).
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    symbols = _imported_getpatter_symbols(main_src)
+    assert symbols == {"Patter", "Plivo", "DeepgramSTT", "CerebrasLLM", "ElevenLabsTTS"}
+    assert "stt=DeepgramSTT()" in main_src
+    assert "llm=CerebrasLLM()" in main_src
+    assert "tts=ElevenLabsTTS()" in main_src
+    # Pipeline must not emit a realtime `engine=` kwarg.
+    assert "engine=" not in main_src
+
+    # requirements.txt pins version AND the cerebras extra (default LLM).
+    reqs = (target / "requirements.txt").read_text(encoding="utf-8").strip()
+    assert reqs == f"getpatter[cerebras]=={__version__}"
+
+
+@pytest.mark.unit
+def test_pipeline_custom_providers_collect_sorted_extras(tmp_path, monkeypatch):
+    target = tmp_path / "pl-custom"
+    _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "pipeline",
+            "--stt",
+            "assemblyai",
+            "--llm",
+            "anthropic",
+            "--tts",
+            "rime",
+            "--carrier",
+            "twilio",
+        ],
+        monkeypatch,
+    )
+
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    symbols = _imported_getpatter_symbols(main_src)
+    assert symbols == {"Patter", "Twilio", "AssemblyAISTT", "AnthropicLLM", "RimeTTS"}
+
+    # Three distinct extras, sorted, all pinned to the version.
+    reqs = (target / "requirements.txt").read_text(encoding="utf-8").strip()
+    assert reqs == f"getpatter[anthropic,assemblyai,rime]=={__version__}"
+
+    # Each provider's required env var lands in .env / .env.example.
+    env_example = (target / ".env.example").read_text(encoding="utf-8")
+    for key in (
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_AUTH_TOKEN",
+        "ASSEMBLYAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "RIME_API_KEY",
+    ):
+        assert f"{key}=" in env_example
+
+
+@pytest.mark.unit
+def test_pipeline_base_only_providers_have_no_extras(tmp_path, monkeypatch):
+    """Deepgram + OpenAI LLM + OpenAI TTS are all base — no pip extras."""
+    target = tmp_path / "pl-base"
+    _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "pipeline",
+            "--stt",
+            "deepgram",
+            "--llm",
+            "openai",
+            "--tts",
+            "openai",
+            "--carrier",
+            "twilio",
+        ],
+        monkeypatch,
+    )
+    reqs = (target / "requirements.txt").read_text(encoding="utf-8").strip()
+    assert reqs == f"getpatter=={__version__}", (
+        "base-only stack should pin with no extras"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Carrier coverage — env-key set per carrier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("carrier", "carrier_cls", "required_env"),
+    [
+        (
+            "twilio",
+            "Twilio",
+            ("TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_PHONE_NUMBER"),
+        ),
+        (
+            "telnyx",
+            "Telnyx",
+            ("TELNYX_API_KEY", "TELNYX_CONNECTION_ID", "TELNYX_PHONE_NUMBER"),
+        ),
+        ("plivo", "Plivo", ("PLIVO_AUTH_ID", "PLIVO_AUTH_TOKEN", "PLIVO_PHONE_NUMBER")),
+    ],
+)
+def test_each_carrier_wires_class_and_env(
+    tmp_path, monkeypatch, carrier, carrier_cls, required_env
+):
+    target = tmp_path / f"carrier-{carrier}"
+    _run_wizard(
+        ["--name", str(target), "--yes", "--mode", "realtime", "--carrier", carrier],
+        monkeypatch,
+    )
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    ast.parse(main_src)
+    assert carrier_cls in _imported_getpatter_symbols(main_src)
+    assert f"carrier={carrier_cls}()" in main_src
+
+    env_example = (target / ".env.example").read_text(encoding="utf-8")
+    for key in required_env:
+        assert f"{key}=" in env_example, f"{carrier}: {key} missing from .env.example"
+
+
+# ---------------------------------------------------------------------------
+# Security: API keys → .env (0600), never echoed; skip-keys leaves placeholders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skip_keys_writes_placeholder_env_at_0600(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "skip-keys"
+    _run_wizard(
+        ["--name", str(target), "--yes", "--skip-keys", "--mode", "realtime"],
+        monkeypatch,
+    )
+    env_body = (target / ".env").read_text(encoding="utf-8")
+    # Every key present but blank (placeholder) when keys are skipped.
+    assert "OPENAI_API_KEY=" in env_body
+    for line in env_body.splitlines():
+        if "=" in line and not line.startswith("#"):
+            assert line.endswith("="), f"placeholder line should be blank: {line!r}"
+    mode = stat.S_IMODE(os.stat(target / ".env").st_mode)
+    assert mode == 0o600
+
+
+@pytest.mark.unit
+def test_provided_phone_lands_in_main_without_echo(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "phone-agent"
+    custom_phone = "+15550009999"
+    _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "realtime",
+            "--carrier",
+            "twilio",
+            "--phone",
+            custom_phone,
+        ],
+        monkeypatch,
+    )
+    main_src = (target / "main.py").read_text(encoding="utf-8")
+    ast.parse(main_src)
+    assert custom_phone in main_src
+    # The wizard prints paths only — it should not have crashed and the summary
+    # line names the scaffolded directory.
+    out = capsys.readouterr().out
+    assert "Scaffolded python project" in out
+
+
+# ---------------------------------------------------------------------------
+# Side-effect boundary: git init + npx skills are invoked with the right argv
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skills_and_git_invoked_with_correct_argv(tmp_path, monkeypatch):
+    target = tmp_path / "with-skills"
+    recorded = _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "realtime",
+            "--ide",
+            "claude-code,cursor",
+        ],
+        monkeypatch,
+    )
+    # --yes is non-interactive: git is NOT initialised by default (no-git path),
+    # but --ide explicitly requests skills installs even non-interactively.
+    skills_calls = [c for c in recorded if "skills" in c]
+    assert len(skills_calls) == 2, f"expected 2 skills installs, got {recorded}"
+    ref = f"patterai/skills#v{__version__}"
+    ides_called = []
+    for call in skills_calls:
+        # arg array: [npx, "skills", "add", ref, "-a", <ide>]
+        assert call[1:5] == ["skills", "add", ref, "-a"]
+        ides_called.append(call[5])
+    assert ides_called == ["claude-code", "cursor"]
+    # Non-interactive + no --no-git override still skips git (interactive-only prompt).
+    assert not any("init" in c for c in recorded)
+
+
+@pytest.mark.unit
+def test_no_skills_flag_suppresses_npx(tmp_path, monkeypatch):
+    target = tmp_path / "no-skills"
+    recorded = _run_wizard(
+        [
+            "--name",
+            str(target),
+            "--yes",
+            "--mode",
+            "realtime",
+            "--ide",
+            "claude-code",
+            "--no-skills",
+        ],
+        monkeypatch,
+    )
+    assert recorded == [], "--no-skills must suppress every subprocess call"
+
+
+# ---------------------------------------------------------------------------
+# Non-empty dir guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_empty_dir_blocks_without_force(tmp_path, monkeypatch):
+    target = tmp_path / "occupied"
+    target.mkdir()
+    (target / "existing.txt").write_text("keep me", encoding="utf-8")
+
+    # which/subprocess still mocked so the test never touches git/npx even if
+    # the guard logic regressed and let us through.
+    monkeypatch.setattr("getpatter.init.cli.subprocess.run", lambda *a, **k: None)
+    monkeypatch.setattr("getpatter.init.cli.shutil.which", lambda name: None)
+
+    args = _parse(["--name", str(target), "--yes"])
+    rc = dispatch_init(args)
+    assert rc == 1, "non-empty dir without --force should exit 1"
+    # The pre-existing file is untouched; no scaffold written.
+    assert (target / "existing.txt").read_text(encoding="utf-8") == "keep me"
+    assert not (target / "main.py").exists()
+
+
+@pytest.mark.unit
+def test_force_allows_scaffold_into_non_empty_dir(tmp_path, monkeypatch):
+    target = tmp_path / "occupied2"
+    target.mkdir()
+    (target / "existing.txt").write_text("keep me", encoding="utf-8")
+
+    _run_wizard(["--name", str(target), "--yes", "--force"], monkeypatch)
+
+    assert (target / "main.py").is_file()
+    assert (target / "existing.txt").read_text(encoding="utf-8") == "keep me"

--- a/libraries/python/tests/test_init_codegen.py
+++ b/libraries/python/tests/test_init_codegen.py
@@ -1,0 +1,366 @@
+"""Unit tests for the ``getpatter init`` setup wizard.
+
+These exercise the REAL scaffold builders and the real write-to-disk flow —
+no mocking. The wizard's codegen is parity-critical (the TypeScript port must
+emit byte-identical files), so the assertions pin the exact import lines,
+agent-call shapes, env-key ordering, pip-extra resolution, and the security
+invariants (``.env`` mode 0600, secrets never appear in printed output).
+"""
+
+from __future__ import annotations
+
+import argparse
+import stat
+
+import pytest
+
+from getpatter import __version__
+from getpatter.init.cli import (
+    InitError,
+    build_env,
+    build_index_ts,
+    build_main_py,
+    build_package_json,
+    build_readme,
+    build_requirements_txt,
+    _collect_env_keys,
+    _collect_extras,
+    _npm_package_name,
+    _validate_name,
+    dispatch_init,
+)
+
+
+def _plan(**overrides) -> dict:
+    base = {
+        "name": "my-patter-agent",
+        "runtime": "python",
+        "mode": "realtime",
+        "engine": "OpenAIRealtime2",
+        "stt": None,
+        "llm": None,
+        "tts": None,
+        "carrier": "twilio",
+        "phone": "+15550001234",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+def test_realtime_main_py_imports_default_engine_and_carrier():
+    code = build_main_py(_plan())
+    assert "from getpatter import Patter, Twilio, OpenAIRealtime2" in code
+    assert "engine=OpenAIRealtime2()," in code
+    assert "carrier=Twilio()," in code
+    assert "await phone.serve(agent, tunnel=True)" in code
+    # Realtime mode must NOT emit pipeline kwargs.
+    assert "stt=" not in code
+    assert "llm=" not in code
+
+
+@pytest.mark.unit
+def test_pipeline_main_py_imports_three_providers_in_order():
+    plan = _plan(
+        mode="pipeline",
+        engine=None,
+        stt="deepgram",
+        llm="cerebras",
+        tts="elevenlabs",
+    )
+    code = build_main_py(plan)
+    assert (
+        "from getpatter import Patter, Twilio, DeepgramSTT, CerebrasLLM, ElevenLabsTTS"
+        in code
+    )
+    assert "stt=DeepgramSTT()," in code
+    assert "llm=CerebrasLLM()," in code
+    assert "tts=ElevenLabsTTS()," in code
+    assert "engine=" not in code
+
+
+@pytest.mark.unit
+def test_index_ts_uses_camelcase_and_new_keyword():
+    plan = _plan(runtime="typescript")
+    code = build_index_ts(plan)
+    assert 'import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";' in code
+    assert "carrier: new Twilio()," in code
+    assert "engine: new OpenAIRealtime2()," in code
+    assert "phoneNumber: PHONE_NUMBER," in code
+    assert "await phone.serve({ agent, tunnel: true });" in code
+
+
+@pytest.mark.unit
+def test_env_keys_carrier_first_then_providers_then_phone_env():
+    plan = _plan(
+        mode="pipeline",
+        engine=None,
+        stt="assemblyai",
+        llm="anthropic",
+        tts="cartesia",
+        carrier="telnyx",
+    )
+    keys = _collect_env_keys(plan)
+    assert keys == [
+        "TELNYX_API_KEY",
+        "TELNYX_CONNECTION_ID",
+        "ASSEMBLYAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CARTESIA_API_KEY",
+        "TELNYX_PHONE_NUMBER",
+    ]
+
+
+@pytest.mark.unit
+def test_requirements_collects_sorted_pip_extras():
+    plan = _plan(
+        mode="pipeline",
+        engine=None,
+        stt="assemblyai",
+        llm="anthropic",
+        tts="cartesia",
+    )
+    assert _collect_extras(plan) == ["anthropic", "assemblyai", "cartesia"]
+    req = build_requirements_txt(plan)
+    assert req == f"getpatter[anthropic,assemblyai,cartesia]=={__version__}\n"
+
+
+@pytest.mark.unit
+def test_realtime_default_requirements_have_no_extras():
+    assert build_requirements_txt(_plan()) == f"getpatter=={__version__}\n"
+
+
+@pytest.mark.unit
+def test_inworld_tts_pins_the_inworld_pip_extra():
+    """InworldTTS imports aiohttp at runtime, declared in pyproject as the
+    ``inworld`` extra. Selecting it must pin ``getpatter[inworld]`` so the
+    install actually pulls aiohttp — otherwise the agent ImportErrors at
+    call construction."""
+    plan = _plan(
+        mode="pipeline",
+        engine=None,
+        stt="deepgram",
+        llm="openai",
+        tts="inworld",
+    )
+    assert _collect_extras(plan) == ["inworld"]
+    req = build_requirements_txt(plan)
+    assert req == f"getpatter[inworld]=={__version__}\n"
+
+
+@pytest.mark.unit
+def test_env_body_keeps_provided_values_and_blanks_the_rest():
+    plan = _plan()
+    body = build_env(plan, with_values={"OPENAI_API_KEY": "sekret"})
+    assert "OPENAI_API_KEY=sekret" in body
+    assert "TWILIO_ACCOUNT_SID=" in body  # left blank
+    assert "TWILIO_PHONE_NUMBER=" in body
+
+
+@pytest.mark.unit
+def test_readme_python_runtime_uses_python_tunnel_syntax():
+    readme = build_readme(_plan(runtime="python"))
+    assert "(`tunnel=True`)" in readme
+    assert "tunnel: true" not in readme
+
+
+@pytest.mark.unit
+def test_readme_typescript_runtime_uses_ts_tunnel_syntax():
+    """A TS scaffold's index.ts uses ``tunnel: true`` — the README prose must
+    match that runtime, not leak Python keyword-argument syntax."""
+    readme = build_readme(_plan(runtime="typescript"))
+    assert "(`tunnel: true`)" in readme
+    assert "tunnel=True" not in readme
+
+
+@pytest.mark.unit
+def test_non_interactive_scaffold_writes_files_with_0600_env(tmp_path, capsys):
+    target = tmp_path / "agent"
+    args = argparse.Namespace(
+        name=str(target),
+        runtime="python",
+        mode="realtime",
+        engine=None,
+        stt=None,
+        llm=None,
+        tts=None,
+        carrier=None,
+        phone=None,
+        skip_keys=True,
+        ide=None,
+        no_skills=True,
+        no_git=True,
+        force=False,
+        yes=True,
+    )
+    rc = dispatch_init(args)
+    assert rc == 0
+
+    assert (target / "main.py").is_file()
+    assert (target / "requirements.txt").is_file()
+    assert (target / ".env").is_file()
+    assert (target / ".env.example").is_file()
+    assert (target / ".gitignore").is_file()
+    assert (target / "README.md").is_file()
+
+    # SECURITY: .env must be owner-only (0600).
+    mode = stat.S_IMODE((target / ".env").stat().st_mode)
+    assert mode == 0o600
+
+    # .gitignore must keep .env out of version control.
+    gi = (target / ".gitignore").read_text()
+    assert ".env" in gi
+    assert "!.env.example" in gi
+
+
+@pytest.mark.unit
+def test_non_empty_dir_guard_blocks_without_force(tmp_path):
+    target = tmp_path / "occupied"
+    target.mkdir()
+    (target / "existing.txt").write_text("keep me")
+    args = argparse.Namespace(
+        name=str(target),
+        runtime="python",
+        mode="realtime",
+        engine=None,
+        stt=None,
+        llm=None,
+        tts=None,
+        carrier=None,
+        phone=None,
+        skip_keys=True,
+        ide=None,
+        no_skills=True,
+        no_git=True,
+        force=False,
+        yes=True,
+    )
+    assert dispatch_init(args) == 1
+    # Original file untouched, no scaffold written.
+    assert (target / "existing.txt").read_text() == "keep me"
+    assert not (target / "main.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# Security regression tests — project-name sanitization (issue 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_name_rejects_double_quote_injection():
+    """A name with a double-quote would corrupt the generated package.json.
+    Validation must reject it before any path resolution or codegen."""
+    with pytest.raises(InitError):
+        _validate_name('evil"proj')
+
+
+@pytest.mark.unit
+def test_validate_name_rejects_path_traversal():
+    with pytest.raises(InitError):
+        _validate_name("../../etc/passwd")
+
+
+@pytest.mark.unit
+def test_validate_name_rejects_shell_metacharacters():
+    for bad in ("foo;rm -rf", "foo$(whoami)", "foo`id`", "foo bar"):
+        with pytest.raises(InitError):
+            _validate_name(bad)
+
+
+@pytest.mark.unit
+def test_validate_name_accepts_safe_label_and_path_prefix():
+    # A path with a safe final segment is fine — only the label is validated.
+    _validate_name("my-agent")
+    _validate_name("/tmp/some/dir/my_agent.v2")
+
+
+@pytest.mark.unit
+def test_npm_package_name_strips_unsafe_chars_and_lowercases():
+    assert _npm_package_name("My Cool Agent") == "my-cool-agent"
+    # Defensive: even if an unsafe char slips through, the npm name is clean.
+    assert '"' not in _npm_package_name('evil"proj')
+    assert _npm_package_name("a" * 300) == "a" * 214
+
+
+@pytest.mark.unit
+def test_package_json_is_valid_json_for_a_safe_label():
+    """package.json must always parse — the name is JSON-encoded, never raw."""
+    import json
+
+    plan = _plan(runtime="typescript")
+    plan["name"] = "my-cool-agent"
+    parsed = json.loads(build_package_json(plan))
+    assert parsed["name"] == "my-cool-agent"
+    assert parsed["dependencies"]["getpatter"] == __version__
+
+
+@pytest.mark.unit
+def test_dispatch_init_returns_2_on_invalid_name(tmp_path, capsys):
+    """An invalid --name must fail fast with exit code 2 and a clear message,
+    not a traceback, and must NOT write any scaffold."""
+    args = argparse.Namespace(
+        name=str(tmp_path / 'bad"name'),
+        runtime="python",
+        mode="realtime",
+        engine=None,
+        stt=None,
+        llm=None,
+        tts=None,
+        carrier=None,
+        phone=None,
+        skip_keys=True,
+        ide=None,
+        no_skills=True,
+        no_git=True,
+        force=False,
+        yes=True,
+    )
+    assert dispatch_init(args) == 2
+    err = capsys.readouterr().err
+    assert "error:" in err
+
+
+# ---------------------------------------------------------------------------
+# Security regression test — atomic 0600 .env (issue 2, no chmod race)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_env_created_with_0600_never_world_readable(tmp_path, monkeypatch):
+    """The .env is created via os.open with the mode set from the start, so it
+    is never group-/world-readable — even momentarily. We assert the chmod path
+    is gone by checking os.chmod is never called on the .env path."""
+    import getpatter.init.cli as init_cli
+
+    real_chmod = init_cli.os.chmod
+    chmodded_paths: list[str] = []
+
+    def _spy_chmod(path, mode, *a, **k):  # pragma: no cover - simple spy
+        chmodded_paths.append(str(path))
+        return real_chmod(path, mode, *a, **k)
+
+    monkeypatch.setattr(init_cli.os, "chmod", _spy_chmod)
+
+    target = tmp_path / "agent"
+    args = argparse.Namespace(
+        name=str(target),
+        runtime="python",
+        mode="realtime",
+        engine=None,
+        stt=None,
+        llm=None,
+        tts=None,
+        carrier=None,
+        phone=None,
+        skip_keys=True,
+        ide=None,
+        no_skills=True,
+        no_git=True,
+        force=False,
+        yes=True,
+    )
+    assert dispatch_init(args) == 0
+    mode = stat.S_IMODE((target / ".env").stat().st_mode)
+    assert mode == 0o600
+    # No path-based chmod on .env — the mode is set at creation (fchmod on fd).
+    assert not any(p.endswith(".env") for p in chmodded_paths)

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {

--- a/libraries/typescript/src/cli.ts
+++ b/libraries/typescript/src/cli.ts
@@ -4,6 +4,7 @@
  * Patter CLI — standalone dashboard and utilities.
  *
  * Usage:
+ *   npx getpatter init [options]   (also runnable as `npm create getpatter`)
  *   npx getpatter dashboard [--port 8000]
  *   npx getpatter eval run <suite> [--agent module:export] [--output report.json]
  *   npx getpatter telemetry [status|disable|enable]
@@ -19,6 +20,7 @@ import { VERSION } from './version';
 import { TelemetryClient, DEFAULT_ENDPOINT } from './telemetry/client';
 import { isEnabled } from './telemetry/consent';
 import { isOptedOut, setOptOut } from './telemetry/install-id';
+import { runInit } from './init/cli';
 
 /**
  * Record which CLI command was invoked (the name only — never args/flags), then
@@ -245,6 +247,15 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   }
+  if (command === 'init') {
+    await emitCliCommand('init');
+    try {
+      process.exit(await runInit(process.argv.slice(3)));
+    } catch (err) {
+      console.error(`init failed: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  }
   if (command === 'hermes') {
     await emitCliCommand('hermes');
     printHermesStub();
@@ -258,6 +269,7 @@ async function main(): Promise<void> {
   if (command !== 'dashboard') {
     await emitCliCommand(command ? 'other' : 'none');
     console.log('Usage: getpatter dashboard [--port 8000]');
+    console.log('       getpatter init          Scaffold a new voice-agent project (setup wizard)');
     console.log('       getpatter eval run <suite> [--agent module:export] [--output report.json]');
     console.log('       getpatter hermes        (stub — use Python SDK for the wizard)');
     console.log('       getpatter openclaw      (stub — use Python SDK for the wizard)');

--- a/libraries/typescript/src/init/cli.ts
+++ b/libraries/typescript/src/init/cli.ts
@@ -1,0 +1,1147 @@
+/**
+ * `getpatter init` — greenfield setup wizard (TypeScript port).
+ *
+ * Behavioural mirror of the Python reference implementation at
+ * `libraries/python/getpatter/init/cli.py`. Keep the prompt strings, flag
+ * names, default values, provider matrix, and scaffold codegen rules in sync
+ * with that file — the only permitted divergence is language idiom
+ * (snake_case → camelCase, `Patter(...)` kwargs → single options object,
+ * `node:readline/promises` instead of stdlib `input()`).
+ *
+ * Invoked two ways, both routing here:
+ *   * `getpatter init [options]`  — argv switch in `src/cli.ts`
+ *   * `npm create getpatter`      — the `create-getpatter` bin re-dispatches
+ *
+ * Security: API keys are optional, written to `.env` with mode 0600, listed
+ * in `.gitignore`, and NEVER echoed to stdout or logged.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as readline from 'node:readline/promises';
+import { VERSION } from '../version';
+
+// Placeholder phone number — NANP 555 fiction range (see security rules).
+// Never a real number. Used when the user supplies none via --phone / prompt.
+const DEFAULT_PHONE = '+15550001234';
+
+// Valid IDE targets for the skills shell-out (`npx skills add ... -a <ide>`).
+const IDE_CHOICES = ['claude-code', 'cursor', 'copilot', 'codex'] as const;
+type IdeChoice = (typeof IDE_CHOICES)[number];
+
+// ---------------------------------------------------------------------------
+// Provider matrix — the single source of truth the scaffold builders read.
+// Each entry mirrors the Python dict: class (importable alias from getpatter),
+// label (menu text), env (env var names), extra (pip extra — TS bundles all,
+// kept only for parity / requirements.txt generation when runtime=python).
+// ---------------------------------------------------------------------------
+
+interface ProviderEntry {
+  readonly cls: string;
+  readonly label: string;
+  readonly env: readonly string[];
+  readonly extra: string;
+}
+
+interface CarrierEntry {
+  readonly cls: string;
+  readonly label: string;
+  readonly env: readonly string[];
+  readonly phoneEnv: string;
+}
+
+// Realtime engines (mode=realtime — pick ONE). Order = menu order.
+const REALTIME_ENGINES: Record<string, ProviderEntry> = {
+  OpenAIRealtime2: {
+    cls: 'OpenAIRealtime2',
+    label: 'OpenAI Realtime 2 (gpt-realtime-2) — default',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+  OpenAIRealtime: {
+    cls: 'OpenAIRealtime',
+    label: 'OpenAI Realtime (legacy gpt-realtime-mini)',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+  ElevenLabsConvAI: {
+    cls: 'ElevenLabsConvAI',
+    label: 'ElevenLabs ConvAI (needs ELEVENLABS_AGENT_ID)',
+    env: ['ELEVENLABS_API_KEY', 'ELEVENLABS_AGENT_ID'],
+    extra: '',
+  },
+};
+const DEFAULT_REALTIME_ENGINE = 'OpenAIRealtime2';
+
+// Pipeline STT providers.
+const PIPELINE_STT: Record<string, ProviderEntry> = {
+  deepgram: {
+    cls: 'DeepgramSTT',
+    label: 'Deepgram — default',
+    env: ['DEEPGRAM_API_KEY'],
+    extra: '',
+  },
+  assemblyai: {
+    cls: 'AssemblyAISTT',
+    label: 'AssemblyAI',
+    env: ['ASSEMBLYAI_API_KEY'],
+    extra: 'assemblyai',
+  },
+  cartesia: {
+    cls: 'CartesiaSTT',
+    label: 'Cartesia',
+    env: ['CARTESIA_API_KEY'],
+    extra: 'cartesia',
+  },
+  soniox: {
+    cls: 'SonioxSTT',
+    label: 'Soniox',
+    env: ['SONIOX_API_KEY'],
+    extra: 'soniox',
+  },
+  speechmatics: {
+    cls: 'SpeechmaticsSTT',
+    label: 'Speechmatics',
+    env: ['SPEECHMATICS_API_KEY'],
+    extra: 'speechmatics',
+  },
+  whisper: {
+    cls: 'WhisperSTT',
+    label: 'OpenAI Whisper',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+  openai: {
+    cls: 'OpenAITranscribeSTT',
+    label: 'OpenAI Transcribe',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+};
+const DEFAULT_STT = 'deepgram';
+
+// Pipeline LLM providers.
+const PIPELINE_LLM: Record<string, ProviderEntry> = {
+  cerebras: {
+    cls: 'CerebrasLLM',
+    label: 'Cerebras (gpt-oss-120b) — default',
+    env: ['CEREBRAS_API_KEY'],
+    extra: 'cerebras',
+  },
+  openai: {
+    cls: 'OpenAILLM',
+    label: 'OpenAI',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+  anthropic: {
+    cls: 'AnthropicLLM',
+    label: 'Anthropic Claude',
+    env: ['ANTHROPIC_API_KEY'],
+    extra: 'anthropic',
+  },
+  groq: {
+    cls: 'GroqLLM',
+    label: 'Groq',
+    env: ['GROQ_API_KEY'],
+    extra: 'groq',
+  },
+  google: {
+    cls: 'GoogleLLM',
+    label: 'Google Gemini',
+    env: ['GOOGLE_API_KEY'],
+    extra: 'google',
+  },
+};
+const DEFAULT_LLM = 'cerebras';
+
+// Pipeline TTS providers.
+const PIPELINE_TTS: Record<string, ProviderEntry> = {
+  elevenlabs: {
+    cls: 'ElevenLabsTTS',
+    label: 'ElevenLabs — default',
+    env: ['ELEVENLABS_API_KEY'],
+    extra: '',
+  },
+  openai: {
+    cls: 'OpenAITTS',
+    label: 'OpenAI',
+    env: ['OPENAI_API_KEY'],
+    extra: '',
+  },
+  cartesia: {
+    cls: 'CartesiaTTS',
+    label: 'Cartesia',
+    env: ['CARTESIA_API_KEY'],
+    extra: 'cartesia',
+  },
+  rime: {
+    cls: 'RimeTTS',
+    label: 'Rime',
+    env: ['RIME_API_KEY'],
+    extra: 'rime',
+  },
+  lmnt: {
+    cls: 'LMNTTTS',
+    label: 'LMNT',
+    env: ['LMNT_API_KEY'],
+    extra: 'lmnt',
+  },
+  inworld: {
+    cls: 'InworldTTS',
+    label: 'Inworld',
+    env: ['INWORLD_API_KEY'],
+    extra: 'inworld',
+  },
+};
+const DEFAULT_TTS = 'elevenlabs';
+
+// Telephony carriers.
+const CARRIERS: Record<string, CarrierEntry> = {
+  twilio: {
+    cls: 'Twilio',
+    label: 'Twilio — default',
+    env: ['TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN'],
+    phoneEnv: 'TWILIO_PHONE_NUMBER',
+  },
+  telnyx: {
+    cls: 'Telnyx',
+    label: 'Telnyx',
+    env: ['TELNYX_API_KEY', 'TELNYX_CONNECTION_ID'],
+    phoneEnv: 'TELNYX_PHONE_NUMBER',
+  },
+  plivo: {
+    cls: 'Plivo',
+    label: 'Plivo',
+    env: ['PLIVO_AUTH_ID', 'PLIVO_AUTH_TOKEN'],
+    phoneEnv: 'PLIVO_PHONE_NUMBER',
+  },
+};
+const DEFAULT_CARRIER = 'twilio';
+
+// ---------------------------------------------------------------------------
+// Flag parsing — mirrors the Python argparse surface (same flag names).
+// ---------------------------------------------------------------------------
+
+export interface InitArgs {
+  name: string | null;
+  runtime: 'python' | 'typescript' | null;
+  mode: 'realtime' | 'pipeline' | null;
+  engine: string | null;
+  stt: string | null;
+  llm: string | null;
+  tts: string | null;
+  carrier: string | null;
+  phone: string | null;
+  skipKeys: boolean;
+  ide: string | null;
+  noSkills: boolean;
+  noGit: boolean;
+  force: boolean;
+  yes: boolean;
+  help: boolean;
+}
+
+const INIT_USAGE = `Usage: getpatter init [options]
+
+Scaffold a new Patter voice-agent project (setup wizard).
+
+Options:
+  --name <dir>           Project name → target directory
+  --runtime <r>          SDK runtime: python | typescript (default: typescript)
+  --mode <m>             Voice mode: realtime | pipeline (default: realtime)
+  --engine <e>           Realtime engine (realtime mode only)
+  --stt <p>              STT provider (pipeline mode only)
+  --llm <p>              LLM provider (pipeline mode only)
+  --tts <p>              TTS provider (pipeline mode only)
+  --carrier <c>          Telephony carrier: twilio | telnyx | plivo
+  --phone <e164>         Phone number in E.164 (placeholder ${DEFAULT_PHONE})
+  --skip-keys            Do not prompt for API keys; write placeholders to .env
+  --ide <list>           Comma-separated IDE skills targets (${IDE_CHOICES.join(', ')})
+  --no-skills            Skip the IDE skills install step
+  --no-git               Skip 'git init' in the new project
+  --force                Allow scaffolding into a non-empty directory
+  --yes, -y              Non-interactive: accept all defaults`;
+
+/**
+ * Parse the `init` flags out of an argv slice (everything after `init`).
+ * Unknown flags are tolerated (ignored) to stay forgiving like argparse's
+ * usage here; value flags consume the following token.
+ */
+export function parseInitArgs(rest: readonly string[]): InitArgs {
+  const args: InitArgs = {
+    name: null,
+    runtime: null,
+    mode: null,
+    engine: null,
+    stt: null,
+    llm: null,
+    tts: null,
+    carrier: null,
+    phone: null,
+    skipKeys: false,
+    ide: null,
+    noSkills: false,
+    noGit: false,
+    force: false,
+    yes: false,
+    help: false,
+  };
+
+  const takeValue = (i: number): string | null =>
+    i + 1 < rest.length ? rest[i + 1] : null;
+
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    switch (a) {
+      case '--name':
+        args.name = takeValue(i);
+        i++;
+        break;
+      case '--runtime': {
+        const v = takeValue(i);
+        if (v === 'python' || v === 'typescript') args.runtime = v;
+        i++;
+        break;
+      }
+      case '--mode': {
+        const v = takeValue(i);
+        if (v === 'realtime' || v === 'pipeline') args.mode = v;
+        i++;
+        break;
+      }
+      case '--engine':
+        args.engine = takeValue(i);
+        i++;
+        break;
+      case '--stt':
+        args.stt = takeValue(i);
+        i++;
+        break;
+      case '--llm':
+        args.llm = takeValue(i);
+        i++;
+        break;
+      case '--tts':
+        args.tts = takeValue(i);
+        i++;
+        break;
+      case '--carrier':
+        args.carrier = takeValue(i);
+        i++;
+        break;
+      case '--phone':
+        args.phone = takeValue(i);
+        i++;
+        break;
+      case '--ide':
+        args.ide = takeValue(i);
+        i++;
+        break;
+      case '--skip-keys':
+        args.skipKeys = true;
+        break;
+      case '--no-skills':
+        args.noSkills = true;
+        break;
+      case '--no-git':
+        args.noGit = true;
+        break;
+      case '--force':
+        args.force = true;
+        break;
+      case '--yes':
+      case '-y':
+        args.yes = true;
+        break;
+      case '--help':
+      case '-h':
+        args.help = true;
+        break;
+      default:
+        // Ignore unknown tokens (forgiving, like the Python surface).
+        break;
+    }
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Selection plan — what the wizard resolved to.
+// ---------------------------------------------------------------------------
+
+export interface ScaffoldPlan {
+  name: string;
+  runtime: 'python' | 'typescript';
+  mode: 'realtime' | 'pipeline';
+  engine: string | null;
+  stt: string | null;
+  llm: string | null;
+  tts: string | null;
+  carrier: string;
+  phone: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validation — guard the project name before any path resolution or codegen
+// ---------------------------------------------------------------------------
+
+/** User-facing error for invalid wizard input (bad project name, …). */
+export class InitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InitError';
+  }
+}
+
+// A project label (final path segment) may only contain these characters.
+// Forbids quotes, shell metacharacters, and path separators that could break
+// package.json or escape the target directory.
+const SAFE_LABEL_RE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Reject project names unsafe to use as a path or in generated files.
+ *
+ * Mirrors Python `_validate_name`: guards against path traversal (`..`),
+ * path-separator injection in the label, and characters outside the safe set
+ * (notably double-quotes that would corrupt package.json). The full name may
+ * still be a path; only the final segment becomes the project label.
+ */
+export function validateName(name: string): void {
+  if (!name || !name.trim()) {
+    throw new InitError('Project name must not be empty.');
+  }
+  const parts = name.split(/[\\/]/);
+  if (parts.some((p) => p === '..')) {
+    throw new InitError(`Project name '${name}' must not contain '..' path segments.`);
+  }
+  const label = path.basename(name);
+  if (!label) {
+    throw new InitError(`Project name '${name}' has no final path segment.`);
+  }
+  if (!SAFE_LABEL_RE.test(label)) {
+    throw new InitError(
+      `Project name '${label}' contains invalid characters. ` +
+        "Use only letters, digits, '.', '_' and '-'.",
+    );
+  }
+}
+
+/**
+ * Coerce a project label into a valid npm package name: only `[a-z0-9._-]`,
+ * capped at 214 chars. The label has already passed `validateName`.
+ */
+export function npmPackageName(label: string): string {
+  const lowered = label.toLowerCase().replace(/ /g, '-');
+  const cleaned = lowered.replace(/[^a-z0-9._-]/g, '') || 'patter-agent';
+  return cleaned.slice(0, 214);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt helpers (node:readline/promises only — no third-party prompt libs)
+// ---------------------------------------------------------------------------
+
+async function askText(
+  rl: readline.Interface,
+  prompt: string,
+  def: string,
+): Promise<string> {
+  const raw = (await rl.question(`${prompt} [${def}]: `)).trim();
+  return raw || def;
+}
+
+/**
+ * Prompt for a secret WITHOUT echoing the typed characters to the terminal.
+ *
+ * The default readline interface echoes every keystroke, so an API key typed
+ * at the prompt is visible to a shoulder-surf or a terminal recording. We mute
+ * the echo by temporarily overriding the interface's internal `_writeToOutput`
+ * so only the prompt string is shown — the typed value never reaches stdout.
+ * Restores the original writer afterwards so later prompts echo normally.
+ */
+async function askSecret(rl: readline.Interface, prompt: string): Promise<string> {
+  // `_writeToOutput` is the internal hook readline uses to render the prompt
+  // and echo input. Casting to access it is the stdlib-only equivalent of
+  // Python's getpass — no third-party dependency.
+  const iface = rl as unknown as {
+    _writeToOutput?: (s: string) => void;
+    output?: NodeJS.WritableStream;
+  };
+  const original = iface._writeToOutput?.bind(rl);
+  let promptShown = false;
+  iface._writeToOutput = (s: string): void => {
+    // Show the prompt itself exactly once; swallow every echoed keystroke.
+    if (!promptShown && s.includes(prompt)) {
+      promptShown = true;
+      iface.output?.write(prompt);
+    }
+    // Anything else (the echoed secret characters) is intentionally dropped.
+  };
+  try {
+    const raw = (await rl.question(prompt)).trim();
+    return raw;
+  } finally {
+    // Terminate the muted prompt line and restore normal echo.
+    iface.output?.write('\n');
+    if (original) iface._writeToOutput = original;
+    else delete iface._writeToOutput;
+  }
+}
+
+async function askChoice(
+  rl: readline.Interface,
+  prompt: string,
+  options: ReadonlyArray<readonly [string, string]>,
+  defaultKey: string,
+): Promise<string> {
+  const keys = options.map(([k]) => k);
+  const defaultIdx = keys.indexOf(defaultKey) + 1;
+  console.log(prompt);
+  options.forEach(([key, label], i) => {
+    const marker = key === defaultKey ? ' (default)' : '';
+    console.log(`  ${i + 1}) ${label}${marker}`);
+  });
+  for (;;) {
+    const raw = (
+      await rl.question(`Choose [1-${options.length}, default ${defaultIdx}]: `)
+    ).trim();
+    if (!raw) return defaultKey;
+    if (keys.includes(raw)) return raw;
+    const n = Number.parseInt(raw, 10);
+    if (/^\d+$/.test(raw) && n >= 1 && n <= options.length) return keys[n - 1];
+    console.log(
+      `  Invalid choice '${raw}' — enter a number 1-${options.length} ` +
+        `or a name (${keys.join(', ')}).`,
+    );
+  }
+}
+
+async function askYesNo(
+  rl: readline.Interface,
+  prompt: string,
+  def: boolean,
+): Promise<boolean> {
+  const hint = def ? 'Y/n' : 'y/N';
+  const raw = (await rl.question(`${prompt} [${hint}]: `)).trim().toLowerCase();
+  if (!raw) return def;
+  return raw === 'y' || raw === 'yes';
+}
+
+async function askMulti(
+  rl: readline.Interface,
+  prompt: string,
+  options: ReadonlyArray<readonly [string, string]>,
+): Promise<string[]> {
+  const keys = options.map(([k]) => k);
+  console.log(prompt);
+  options.forEach(([, label], i) => console.log(`  ${i + 1}) ${label}`));
+  const raw = (await rl.question('Select (comma-separated, blank for none): ')).trim();
+  if (!raw) return [];
+  const chosen: string[] = [];
+  for (const tokRaw of raw.split(',')) {
+    const tok = tokRaw.trim();
+    if (!tok) continue;
+    if (keys.includes(tok) && !chosen.includes(tok)) {
+      chosen.push(tok);
+    } else if (/^\d+$/.test(tok)) {
+      const n = Number.parseInt(tok, 10);
+      if (n >= 1 && n <= options.length) {
+        const k = keys[n - 1];
+        if (!chosen.includes(k)) chosen.push(k);
+      }
+    }
+  }
+  return chosen;
+}
+
+// ---------------------------------------------------------------------------
+// Selection resolution — flags + prompts → a concrete scaffold plan.
+// ---------------------------------------------------------------------------
+
+async function resolvePlan(
+  rl: readline.Interface | null,
+  args: InitArgs,
+): Promise<ScaffoldPlan> {
+  const interactive = rl !== null;
+
+  // 1. Project name → target dir
+  let name: string;
+  if (args.name !== null) name = args.name;
+  else if (interactive) name = await askText(rl!, 'Project name', 'my-patter-agent');
+  else name = 'my-patter-agent';
+
+  // Validate before anything is written or any path is resolved — a bad name
+  // (path traversal, quote injection) must fail fast with a clear message.
+  validateName(name);
+
+  // 2. Runtime (this is the TypeScript CLI → prefill typescript)
+  let runtime: 'python' | 'typescript';
+  if (args.runtime !== null) {
+    runtime = args.runtime;
+  } else if (interactive) {
+    runtime = (await askChoice(
+      rl!,
+      'SDK runtime?',
+      [
+        ['typescript', 'TypeScript (getpatter)'],
+        ['python', 'Python (getpatter)'],
+      ],
+      'typescript',
+    )) as 'python' | 'typescript';
+  } else {
+    runtime = 'typescript';
+  }
+
+  // 3. Voice mode
+  let mode: 'realtime' | 'pipeline';
+  if (args.mode !== null) {
+    mode = args.mode;
+  } else if (interactive) {
+    mode = (await askChoice(
+      rl!,
+      'Voice mode?',
+      [
+        ['realtime', 'Realtime — one engine owns the turn (lowest latency)'],
+        ['pipeline', 'Pipeline — compose STT + LLM + TTS (full control)'],
+      ],
+      'realtime',
+    )) as 'realtime' | 'pipeline';
+  } else {
+    mode = 'realtime';
+  }
+
+  // 4. Engine / providers (filtered by mode)
+  let engine: string | null = null;
+  let stt: string | null = null;
+  let llm: string | null = null;
+  let tts: string | null = null;
+  if (mode === 'realtime') {
+    if (args.engine !== null && args.engine in REALTIME_ENGINES) engine = args.engine;
+    else if (interactive) {
+      engine = await askChoice(
+        rl!,
+        'Realtime engine?',
+        Object.entries(REALTIME_ENGINES).map(([k, v]) => [k, v.label] as const),
+        DEFAULT_REALTIME_ENGINE,
+      );
+    } else engine = DEFAULT_REALTIME_ENGINE;
+  } else {
+    if (args.stt !== null && args.stt in PIPELINE_STT) stt = args.stt;
+    else if (interactive)
+      stt = await askChoice(
+        rl!,
+        'STT provider?',
+        Object.entries(PIPELINE_STT).map(([k, v]) => [k, v.label] as const),
+        DEFAULT_STT,
+      );
+    else stt = DEFAULT_STT;
+
+    if (args.llm !== null && args.llm in PIPELINE_LLM) llm = args.llm;
+    else if (interactive)
+      llm = await askChoice(
+        rl!,
+        'LLM provider?',
+        Object.entries(PIPELINE_LLM).map(([k, v]) => [k, v.label] as const),
+        DEFAULT_LLM,
+      );
+    else llm = DEFAULT_LLM;
+
+    if (args.tts !== null && args.tts in PIPELINE_TTS) tts = args.tts;
+    else if (interactive)
+      tts = await askChoice(
+        rl!,
+        'TTS provider?',
+        Object.entries(PIPELINE_TTS).map(([k, v]) => [k, v.label] as const),
+        DEFAULT_TTS,
+      );
+    else tts = DEFAULT_TTS;
+  }
+
+  // 5. Carrier
+  let carrier: string;
+  if (args.carrier !== null && args.carrier in CARRIERS) carrier = args.carrier;
+  else if (interactive) {
+    carrier = await askChoice(
+      rl!,
+      'Telephony carrier?',
+      Object.entries(CARRIERS).map(([k, v]) => [k, v.label] as const),
+      DEFAULT_CARRIER,
+    );
+  } else carrier = DEFAULT_CARRIER;
+
+  // Phone number
+  let phone: string;
+  if (args.phone !== null) phone = args.phone;
+  else if (interactive) phone = await askText(rl!, 'Phone number (E.164)', DEFAULT_PHONE);
+  else phone = DEFAULT_PHONE;
+
+  return { name, runtime, mode, engine, stt, llm, tts, carrier, phone };
+}
+
+function collectEnvKeys(plan: ScaffoldPlan): string[] {
+  const keys: string[] = [];
+  const add = (names: readonly string[]): void => {
+    for (const n of names) if (!keys.includes(n)) keys.push(n);
+  };
+  add(CARRIERS[plan.carrier].env);
+  if (plan.mode === 'realtime') {
+    add(REALTIME_ENGINES[plan.engine!].env);
+  } else {
+    add(PIPELINE_STT[plan.stt!].env);
+    add(PIPELINE_LLM[plan.llm!].env);
+    add(PIPELINE_TTS[plan.tts!].env);
+  }
+  add([CARRIERS[plan.carrier].phoneEnv]);
+  return keys;
+}
+
+function collectExtras(plan: ScaffoldPlan): string[] {
+  const extras = new Set<string>();
+  if (plan.mode === 'pipeline') {
+    const tables: ReadonlyArray<[Record<string, ProviderEntry>, string]> = [
+      [PIPELINE_STT, plan.stt!],
+      [PIPELINE_LLM, plan.llm!],
+      [PIPELINE_TTS, plan.tts!],
+    ];
+    for (const [table, key] of tables) {
+      const extra = table[key].extra;
+      if (extra) extras.add(extra);
+    }
+  } else {
+    const extra = REALTIME_ENGINES[plan.engine!].extra;
+    if (extra) extras.add(extra);
+  }
+  return [...extras].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Scaffold string builders — pure functions, parity-critical codegen.
+// ---------------------------------------------------------------------------
+
+const PROMPT_LINES_PY =
+  '            "You are the receptionist for Acme Corp. Help callers with "\n' +
+  '            "hours, support questions, and simple account changes. "\n' +
+  '            "Keep replies short."\n';
+
+const PROMPT_LINES_TS =
+  '      "You are the receptionist for Acme Corp. Help callers with " +\n' +
+  '      "hours, support questions, and simple account changes. " +\n' +
+  '      "Keep replies short.",\n';
+
+export function buildMainPy(plan: ScaffoldPlan): string {
+  const carrierCls = CARRIERS[plan.carrier].cls;
+  const phoneEnv = CARRIERS[plan.carrier].phoneEnv;
+  let imports: string;
+  let agentBlock: string;
+  if (plan.mode === 'realtime') {
+    const engineCls = REALTIME_ENGINES[plan.engine!].cls;
+    imports = `from getpatter import Patter, ${carrierCls}, ${engineCls}`;
+    agentBlock =
+      '    agent = phone.agent(\n' +
+      `        engine=${engineCls}(),\n` +
+      '        system_prompt=(\n' +
+      PROMPT_LINES_PY +
+      '        ),\n' +
+      '        first_message="Hi! Thanks for calling Acme Corp. How can I help?",\n' +
+      '    )';
+  } else {
+    const sttCls = PIPELINE_STT[plan.stt!].cls;
+    const llmCls = PIPELINE_LLM[plan.llm!].cls;
+    const ttsCls = PIPELINE_TTS[plan.tts!].cls;
+    imports = `from getpatter import Patter, ${carrierCls}, ${sttCls}, ${llmCls}, ${ttsCls}`;
+    agentBlock =
+      '    agent = phone.agent(\n' +
+      `        stt=${sttCls}(),\n` +
+      `        llm=${llmCls}(),\n` +
+      `        tts=${ttsCls}(),\n` +
+      '        system_prompt=(\n' +
+      PROMPT_LINES_PY +
+      '        ),\n' +
+      '        first_message="Hi! Thanks for calling Acme Corp. How can I help?",\n' +
+      '    )';
+  }
+  return (
+    '"""Patter voice agent — generated by `getpatter init`.\n' +
+    '\n' +
+    'Answers inbound calls and talks to the caller. Set the API keys in\n' +
+    '.env (already scaffolded), then run:  python main.py\n' +
+    '"""\n' +
+    '\n' +
+    'import asyncio\n' +
+    'import os\n' +
+    '\n' +
+    `${imports}\n` +
+    '\n' +
+    `PHONE_NUMBER = os.environ.get("${phoneEnv}", "${plan.phone}")\n` +
+    '\n' +
+    '\n' +
+    'async def main() -> None:\n' +
+    '    phone = Patter(\n' +
+    `        carrier=${carrierCls}(),   # reads creds from env\n` +
+    '        phone_number=PHONE_NUMBER,\n' +
+    '    )\n' +
+    '\n' +
+    `${agentBlock}\n` +
+    '\n' +
+    '    print(f"Ready on {PHONE_NUMBER}. Waiting for calls... (Ctrl+C to stop)")\n' +
+    '    await phone.serve(agent, tunnel=True)\n' +
+    '\n' +
+    '\n' +
+    'if __name__ == "__main__":\n' +
+    '    asyncio.run(main())\n'
+  );
+}
+
+export function buildIndexTs(plan: ScaffoldPlan): string {
+  const carrierCls = CARRIERS[plan.carrier].cls;
+  const phoneEnv = CARRIERS[plan.carrier].phoneEnv;
+  let imports: string;
+  let agentBlock: string;
+  if (plan.mode === 'realtime') {
+    const engineCls = REALTIME_ENGINES[plan.engine!].cls;
+    imports = `import { Patter, ${carrierCls}, ${engineCls} } from "getpatter";`;
+    agentBlock =
+      '  const agent = phone.agent({\n' +
+      `    engine: new ${engineCls}(),\n` +
+      '    systemPrompt:\n' +
+      PROMPT_LINES_TS +
+      '    firstMessage: "Hi! Thanks for calling Acme Corp. How can I help?",\n' +
+      '  });';
+  } else {
+    const sttCls = PIPELINE_STT[plan.stt!].cls;
+    const llmCls = PIPELINE_LLM[plan.llm!].cls;
+    const ttsCls = PIPELINE_TTS[plan.tts!].cls;
+    imports = `import { Patter, ${carrierCls}, ${sttCls}, ${llmCls}, ${ttsCls} } from "getpatter";`;
+    agentBlock =
+      '  const agent = phone.agent({\n' +
+      `    stt: new ${sttCls}(),\n` +
+      `    llm: new ${llmCls}(),\n` +
+      `    tts: new ${ttsCls}(),\n` +
+      '    systemPrompt:\n' +
+      PROMPT_LINES_TS +
+      '    firstMessage: "Hi! Thanks for calling Acme Corp. How can I help?",\n' +
+      '  });';
+  }
+  return (
+    '/**\n' +
+    ' * Patter voice agent — generated by `getpatter init`.\n' +
+    ' *\n' +
+    ' * Answers inbound calls and talks to the caller. Set the API keys in\n' +
+    ' * .env (already scaffolded), then run:  npm start\n' +
+    ' */\n' +
+    `${imports}\n` +
+    '\n' +
+    `const PHONE_NUMBER = process.env.${phoneEnv} ?? "${plan.phone}";\n` +
+    '\n' +
+    'async function main(): Promise<void> {\n' +
+    '  const phone = new Patter({\n' +
+    `    carrier: new ${carrierCls}(),   // reads creds from env\n` +
+    '    phoneNumber: PHONE_NUMBER,\n' +
+    '  });\n' +
+    '\n' +
+    `${agentBlock}\n` +
+    '\n' +
+    '  console.log(`Ready on ${PHONE_NUMBER}. Waiting for calls... (Ctrl+C to stop)`);\n' +
+    '  await phone.serve({ agent, tunnel: true });\n' +
+    '}\n' +
+    '\n' +
+    'main().catch((err) => {\n' +
+    '  console.error(err);\n' +
+    '  process.exit(1);\n' +
+    '});\n'
+  );
+}
+
+export function buildRequirementsTxt(plan: ScaffoldPlan): string {
+  const extras = collectExtras(plan);
+  let spec = 'getpatter';
+  if (extras.length) spec += `[${extras.join(',')}]`;
+  spec += `==${VERSION}`;
+  return `${spec}\n`;
+}
+
+export function buildEnv(
+  plan: ScaffoldPlan,
+  withValues: Record<string, string> = {},
+): string {
+  const lines = [
+    '# Patter environment — generated by `getpatter init`.',
+    '# Fill in the blanks below. Keep this file out of version control.',
+    '',
+  ];
+  for (const key of collectEnvKeys(plan)) {
+    lines.push(`${key}=${withValues[key] ?? ''}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function buildEnvExample(plan: ScaffoldPlan): string {
+  return buildEnv(plan, {});
+}
+
+export function buildGitignore(plan: ScaffoldPlan): string {
+  const common = ['.env', '.env.*', '!.env.example'];
+  const rest =
+    plan.runtime === 'python'
+      ? ['__pycache__/', '*.pyc', '.venv/', 'venv/', '.pytest_cache/']
+      : ['node_modules/', 'dist/', '*.log'];
+  return `${[...common, ...rest].join('\n')}\n`;
+}
+
+function projectLabel(plan: ScaffoldPlan): string {
+  return path.basename(plan.name) || 'patter-agent';
+}
+
+export function buildPackageJson(plan: ScaffoldPlan): string {
+  // Sanitize to a valid npm name, then JSON-encode so a stray quote / unicode
+  // in the label can never produce malformed JSON that breaks `npm install`.
+  const name = JSON.stringify(npmPackageName(projectLabel(plan)));
+  return (
+    '{\n' +
+    `  "name": ${name},\n` +
+    '  "version": "0.1.0",\n' +
+    '  "private": true,\n' +
+    '  "type": "module",\n' +
+    '  "scripts": {\n' +
+    '    "start": "tsx src/index.ts"\n' +
+    '  },\n' +
+    '  "dependencies": {\n' +
+    `    "getpatter": "${VERSION}"\n` +
+    '  },\n' +
+    '  "devDependencies": {\n' +
+    '    "tsx": "^4.0.0",\n' +
+    '    "typescript": "^5.0.0"\n' +
+    '  }\n' +
+    '}\n'
+  );
+}
+
+export function buildReadme(plan: ScaffoldPlan): string {
+  let runBlock: string;
+  let entry: string;
+  if (plan.runtime === 'python') {
+    runBlock =
+      '```sh\n' +
+      'pip install -r requirements.txt\n' +
+      '# edit .env with your API keys\n' +
+      'python main.py\n' +
+      '```';
+    entry = 'main.py';
+  } else {
+    runBlock = '```sh\nnpm install\n# edit .env with your API keys\nnpm start\n```';
+    entry = 'src/index.ts';
+  }
+  let stack: string;
+  if (plan.mode === 'realtime') {
+    stack = `Realtime engine: \`${REALTIME_ENGINES[plan.engine!].cls}\``;
+  } else {
+    stack =
+      `Pipeline: STT \`${PIPELINE_STT[plan.stt!].cls}\` · ` +
+      `LLM \`${PIPELINE_LLM[plan.llm!].cls}\` · ` +
+      `TTS \`${PIPELINE_TTS[plan.tts!].cls}\``;
+  }
+  const tunnelRef = plan.runtime === 'python' ? '`tunnel=True`' : '`tunnel: true`';
+  return (
+    `# ${projectLabel(plan)}\n` +
+    '\n' +
+    'A Patter voice agent, scaffolded by `getpatter init`.\n' +
+    '\n' +
+    `- Carrier: \`${CARRIERS[plan.carrier].cls}\`\n` +
+    `- ${stack}\n` +
+    `- Entry point: \`${entry}\`\n` +
+    '\n' +
+    '## Run\n' +
+    '\n' +
+    `${runBlock}\n` +
+    '\n' +
+    'The agent answers inbound calls and starts a Cloudflare Quick Tunnel\n' +
+    `(${tunnelRef}) so the carrier can reach your local server during dev.\n`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem + side effects
+// ---------------------------------------------------------------------------
+
+function writeScaffold(
+  target: string,
+  plan: ScaffoldPlan,
+  envValues: Record<string, string>,
+): string[] {
+  fs.mkdirSync(target, { recursive: true });
+  const written: string[] = [];
+
+  const w = (rel: string, content: string, mode?: number): void => {
+    const p = path.join(target, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    if (mode !== undefined) {
+      // Create the file with the target mode atomically, so a secrets-bearing
+      // file (.env) is NEVER world-/group-readable for the window between
+      // write and a separate chmod (TOCTOU). The mode passed to openSync is
+      // masked by umask on create, so fchmodSync re-asserts it; using the fd
+      // (not the path) closes the race even on a re-scaffold (--force).
+      const fd = fs.openSync(p, 'w', mode);
+      try {
+        fs.fchmodSync(fd, mode);
+        fs.writeSync(fd, content, null, 'utf8');
+      } finally {
+        fs.closeSync(fd);
+      }
+    } else {
+      fs.writeFileSync(p, content, { encoding: 'utf8' });
+    }
+    written.push(p);
+  };
+
+  if (plan.runtime === 'python') {
+    w('main.py', buildMainPy(plan));
+    w('requirements.txt', buildRequirementsTxt(plan));
+  } else {
+    w('src/index.ts', buildIndexTs(plan));
+    w('package.json', buildPackageJson(plan));
+  }
+
+  // .env first (0600), then the committable example.
+  w('.env', buildEnv(plan, envValues), 0o600);
+  w('.env.example', buildEnvExample(plan));
+  w('.gitignore', buildGitignore(plan));
+  w('README.md', buildReadme(plan));
+  return written;
+}
+
+function maybeGitInit(target: string): void {
+  const res = spawnSync('git', ['init', '--quiet'], {
+    cwd: target,
+    stdio: 'ignore',
+  });
+  if (res.error || res.status !== 0) {
+    console.log("  'git init' failed or git not found — skipping.");
+    return;
+  }
+  console.log('  Initialised a git repository.');
+}
+
+function maybeInstallSkills(target: string, ides: readonly string[]): void {
+  if (!ides.length) return;
+  const ref = `patterai/skills#v${VERSION}`;
+  for (const ide of ides) {
+    console.log(`  Installing skills for ${ide}...`);
+    const res = spawnSync('npx', ['skills', 'add', ref, '-a', ide], {
+      cwd: target,
+      stdio: 'inherit',
+    });
+    if (res.error || res.status !== 0) {
+      console.log(`  skills add for ${ide} failed (or npx missing) — skipping.`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the wizard. Returns a process exit code.
+ *
+ * @param rest argv slice after the `init` token.
+ */
+export async function runInit(rest: readonly string[]): Promise<number> {
+  const args = parseInitArgs(rest);
+  if (args.help) {
+    console.log(INIT_USAGE);
+    return 0;
+  }
+
+  const interactive = !args.yes;
+  const rl = interactive
+    ? readline.createInterface({ input: process.stdin, output: process.stdout })
+    : null;
+
+  try {
+    const plan = await resolvePlan(rl, args);
+
+    const target = path.resolve(expandHome(plan.name));
+
+    // 9. Non-empty dir guard (--force overrides).
+    if (fs.existsSync(target) && fs.readdirSync(target).length > 0 && !args.force) {
+      console.log(
+        `Target directory ${target} is not empty. ` +
+          'Re-run with --force to scaffold into it anyway.',
+      );
+      return 1;
+    }
+
+    const envKeys = collectEnvKeys(plan);
+
+    // 6. API keys → .env (0600). Skippable; secrets never echoed/logged.
+    const envValues: Record<string, string> = {};
+    if (!args.skipKeys && interactive && rl) {
+      console.log(
+        '\nAPI keys (input is hidden — press Enter to leave blank, fill them in later):',
+      );
+      for (const key of envKeys) {
+        // askSecret suppresses echo so the raw key never lands on a shared
+        // terminal or a recording. Written to .env (0600) only — never logged.
+        const val = await askSecret(rl, `  ${key}: `);
+        if (val) envValues[key] = val;
+      }
+    }
+    // In --skip-keys (or non-interactive) mode every value stays a placeholder.
+
+    const written = writeScaffold(target, plan, envValues);
+
+    // 7. IDE skills (multi-select). --no-skills / non-interactive default skips.
+    let ides: string[] = [];
+    if (!args.noSkills) {
+      if (args.ide !== null) {
+        ides = args.ide
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s): s is IdeChoice => (IDE_CHOICES as readonly string[]).includes(s));
+      } else if (interactive && rl) {
+        ides = await askMulti(
+          rl,
+          'Install Patter skills for which IDEs?',
+          IDE_CHOICES.map((k) => [k, k] as const),
+        );
+      }
+    }
+    maybeInstallSkills(target, ides);
+
+    // 8. git init (optional). --no-git / non-interactive default skips.
+    let doGit = false;
+    if (!args.noGit) {
+      doGit = interactive && rl ? await askYesNo(rl, 'Initialise a git repository?', true) : false;
+    }
+    if (doGit) maybeGitInit(target);
+
+    // Summary — paths only, never secret values.
+    console.log(`\nScaffolded ${plan.runtime} project at ${target}`);
+    for (const p of written) console.log(`  + ${path.relative(target, p)}`);
+    if (plan.runtime === 'python') {
+      console.log(
+        `\nNext:  cd ${target}  &&  pip install -r requirements.txt  &&  python main.py`,
+      );
+    } else {
+      console.log(`\nNext:  cd ${target}  &&  npm install  &&  npm start`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof InitError) {
+      console.error(`error: ${err.message}`);
+      return 2;
+    }
+    throw err;
+  } finally {
+    if (rl) rl.close();
+  }
+}
+
+function expandHome(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    return path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}

--- a/libraries/typescript/tests/init-codegen.test.ts
+++ b/libraries/typescript/tests/init-codegen.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for the `getpatter init` setup wizard (TypeScript port).
+ *
+ * These exercise the REAL scaffold builders and the real flag parser — no
+ * mocking. The codegen is parity-critical: each generated file must match the
+ * Python reference (`libraries/python/getpatter/init/cli.py`) byte-for-byte
+ * (camelCase / `new` / options-object being the only permitted divergence).
+ * The assertions pin the exact import lines, agent-call shapes, env-key
+ * ordering, pip-extra resolution, and the security invariants.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { VERSION } from '../src/version';
+import {
+  buildEnv,
+  buildGitignore,
+  buildIndexTs,
+  buildMainPy,
+  buildPackageJson,
+  buildReadme,
+  buildRequirementsTxt,
+  InitError,
+  npmPackageName,
+  parseInitArgs,
+  runInit,
+  validateName,
+  type ScaffoldPlan,
+} from '../src/init/cli';
+
+function plan(overrides: Partial<ScaffoldPlan> = {}): ScaffoldPlan {
+  return {
+    name: 'my-patter-agent',
+    runtime: 'typescript',
+    mode: 'realtime',
+    engine: 'OpenAIRealtime2',
+    stt: null,
+    llm: null,
+    tts: null,
+    carrier: 'twilio',
+    phone: '+15550001234',
+    ...overrides,
+  };
+}
+
+describe('[unit] init wizard — flag parsing', () => {
+  it('parses value flags and toggles, ignoring unknown tokens', () => {
+    const args = parseInitArgs([
+      '--name',
+      'foo',
+      '--mode',
+      'pipeline',
+      '--stt',
+      'cartesia',
+      '--carrier',
+      'telnyx',
+      '--skip-keys',
+      '--no-git',
+      '--bogus',
+      '-y',
+    ]);
+    expect(args.name).toBe('foo');
+    expect(args.mode).toBe('pipeline');
+    expect(args.stt).toBe('cartesia');
+    expect(args.carrier).toBe('telnyx');
+    expect(args.skipKeys).toBe(true);
+    expect(args.noGit).toBe(true);
+    expect(args.yes).toBe(true);
+  });
+
+  it('rejects invalid enum values (leaves them null)', () => {
+    const args = parseInitArgs(['--mode', 'nonsense', '--runtime', 'rust']);
+    expect(args.mode).toBeNull();
+    expect(args.runtime).toBeNull();
+  });
+});
+
+describe('[unit] init wizard — realtime codegen', () => {
+  it('TS scaffold imports the default engine with camelCase + new', () => {
+    const code = buildIndexTs(plan());
+    expect(code).toContain('import { Patter, Twilio, OpenAIRealtime2 } from "getpatter";');
+    expect(code).toContain('carrier: new Twilio(),');
+    expect(code).toContain('engine: new OpenAIRealtime2(),');
+    expect(code).toContain('await phone.serve({ agent, tunnel: true });');
+    expect(code).not.toContain('stt:');
+    expect(code).not.toContain('llm:');
+  });
+
+  it('python scaffold uses snake_case kwargs', () => {
+    const code = buildMainPy(plan({ runtime: 'python' }));
+    expect(code).toContain('from getpatter import Patter, Twilio, OpenAIRealtime2');
+    expect(code).toContain('engine=OpenAIRealtime2(),');
+    expect(code).toContain('await phone.serve(agent, tunnel=True)');
+  });
+});
+
+describe('[unit] init wizard — pipeline codegen', () => {
+  const pipe = plan({
+    mode: 'pipeline',
+    engine: null,
+    stt: 'deepgram',
+    llm: 'cerebras',
+    tts: 'elevenlabs',
+  });
+
+  it('TS scaffold composes STT + LLM + TTS in order', () => {
+    const code = buildIndexTs(pipe);
+    expect(code).toContain(
+      'import { Patter, Twilio, DeepgramSTT, CerebrasLLM, ElevenLabsTTS } from "getpatter";',
+    );
+    expect(code).toContain('stt: new DeepgramSTT(),');
+    expect(code).toContain('llm: new CerebrasLLM(),');
+    expect(code).toContain('tts: new ElevenLabsTTS(),');
+    expect(code).not.toContain('engine:');
+  });
+});
+
+describe('[unit] init wizard — env + manifest', () => {
+  it('orders env keys carrier-first, then providers, then phone env', () => {
+    const env = buildEnv(
+      plan({
+        mode: 'pipeline',
+        engine: null,
+        stt: 'assemblyai',
+        llm: 'anthropic',
+        tts: 'cartesia',
+        carrier: 'telnyx',
+      }),
+    );
+    const keys = env
+      .split('\n')
+      .filter((l) => l.includes('=') && !l.startsWith('#'))
+      .map((l) => l.split('=')[0]);
+    expect(keys).toEqual([
+      'TELNYX_API_KEY',
+      'TELNYX_CONNECTION_ID',
+      'ASSEMBLYAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'CARTESIA_API_KEY',
+      'TELNYX_PHONE_NUMBER',
+    ]);
+  });
+
+  it('keeps provided values and blanks the rest', () => {
+    const env = buildEnv(plan(), { OPENAI_API_KEY: 'sekret' });
+    expect(env).toContain('OPENAI_API_KEY=sekret');
+    expect(env).toContain('TWILIO_ACCOUNT_SID=');
+  });
+
+  it('requirements.txt pins getpatter with sorted pip extras', () => {
+    const req = buildRequirementsTxt(
+      plan({
+        mode: 'pipeline',
+        engine: null,
+        stt: 'assemblyai',
+        llm: 'anthropic',
+        tts: 'cartesia',
+      }),
+    );
+    expect(req).toBe(`getpatter[anthropic,assemblyai,cartesia]==${VERSION}\n`);
+  });
+
+  it('requirements.txt pins the inworld extra when InworldTTS is chosen', () => {
+    // InworldTTS imports aiohttp at runtime (pyproject `inworld` extra). A
+    // python-runtime scaffold that selects it must pin getpatter[inworld] or
+    // the agent ImportErrors at call construction.
+    const req = buildRequirementsTxt(
+      plan({
+        runtime: 'python',
+        mode: 'pipeline',
+        engine: null,
+        stt: 'deepgram',
+        llm: 'openai',
+        tts: 'inworld',
+      }),
+    );
+    expect(req).toBe(`getpatter[inworld]==${VERSION}\n`);
+  });
+
+  it('package.json pins getpatter and wires the start script', () => {
+    const pkgRaw = buildPackageJson(plan({ name: 'My Cool Agent' }));
+    const pkg = JSON.parse(pkgRaw) as {
+      name: string;
+      scripts: Record<string, string>;
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.name).toBe('my-cool-agent');
+    expect(pkg.scripts.start).toBe('tsx src/index.ts');
+    expect(pkg.dependencies.getpatter).toBe(VERSION);
+    expect(pkg.devDependencies.tsx).toBeDefined();
+    expect(pkg.devDependencies.typescript).toBeDefined();
+  });
+
+  it('.gitignore always keeps .env out of version control', () => {
+    const gi = buildGitignore(plan());
+    expect(gi).toContain('.env');
+    expect(gi).toContain('!.env.example');
+    expect(gi).toContain('node_modules/');
+  });
+});
+
+describe('[unit] init wizard — README tunnel prose is runtime-aware', () => {
+  it('uses Python keyword-argument syntax for runtime=python', () => {
+    const readme = buildReadme(plan({ runtime: 'python' }));
+    expect(readme).toContain('(`tunnel=True`)');
+    expect(readme).not.toContain('tunnel: true');
+  });
+
+  it('uses TS options-object syntax for runtime=typescript', () => {
+    // The generated index.ts uses `tunnel: true`; the README prose must match
+    // the TS runtime instead of leaking Python `tunnel=True` syntax.
+    const readme = buildReadme(plan({ runtime: 'typescript' }));
+    expect(readme).toContain('(`tunnel: true`)');
+    expect(readme).not.toContain('tunnel=True');
+  });
+});
+
+describe('[unit] init wizard — full scaffold to disk via runInit', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('writes every file and chmods .env to 0600 (non-interactive)', async () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-init-'));
+    dirs.push(target);
+    // Drives the REAL orchestrator non-interactively (--yes path: no readline,
+    // no skills, no git). Same code an end user runs.
+    const code = await runInit([
+      '--yes',
+      '--name',
+      target,
+      '--force',
+      '--skip-keys',
+      '--no-skills',
+      '--no-git',
+    ]);
+    expect(code).toBe(0);
+
+    for (const f of ['src/index.ts', 'package.json', '.env', '.env.example', '.gitignore', 'README.md']) {
+      expect(fs.existsSync(path.join(target, f))).toBe(true);
+    }
+
+    // SECURITY: .env must be owner-only (0600).
+    const mode = fs.statSync(path.join(target, '.env')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('blocks scaffolding into a non-empty dir without --force', async () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-init-'));
+    dirs.push(target);
+    fs.writeFileSync(path.join(target, 'keep.txt'), 'keep me');
+    const code = await runInit(['--yes', '--name', target, '--skip-keys']);
+    expect(code).toBe(1);
+    expect(fs.readFileSync(path.join(target, 'keep.txt'), 'utf8')).toBe('keep me');
+    expect(fs.existsSync(path.join(target, 'src/index.ts'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security regression tests — project-name sanitization (issue 3)
+// ---------------------------------------------------------------------------
+
+describe('[unit] init wizard — project-name validation & sanitization', () => {
+  it('rejects a double-quote that would corrupt package.json', () => {
+    expect(() => validateName('evil"proj')).toThrow(InitError);
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => validateName('../../etc/passwd')).toThrow(InitError);
+  });
+
+  it('rejects shell metacharacters and spaces', () => {
+    for (const bad of ['foo;rm -rf', 'foo$(whoami)', 'foo`id`', 'foo bar']) {
+      expect(() => validateName(bad)).toThrow(InitError);
+    }
+  });
+
+  it('accepts a safe label and a path prefix with a safe final segment', () => {
+    expect(() => validateName('my-agent')).not.toThrow();
+    expect(() => validateName('/tmp/some/dir/my_agent.v2')).not.toThrow();
+  });
+
+  it('npmPackageName lowercases, dashes spaces, strips unsafe chars, truncates', () => {
+    expect(npmPackageName('My Cool Agent')).toBe('my-cool-agent');
+    expect(npmPackageName('evil"proj')).not.toContain('"');
+    expect(npmPackageName('a'.repeat(300))).toBe('a'.repeat(214));
+  });
+
+  it('package.json is always valid JSON (name is JSON-encoded, never raw)', () => {
+    const parsed = JSON.parse(buildPackageJson(plan({ name: 'my-cool-agent' }))) as {
+      name: string;
+      dependencies: Record<string, string>;
+    };
+    expect(parsed.name).toBe('my-cool-agent');
+    expect(parsed.dependencies.getpatter).toBe(VERSION);
+  });
+});
+
+describe('[unit] init wizard — invalid --name fails fast', () => {
+  it('returns exit code 2 and writes nothing for an unsafe name', async () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-init-'));
+    try {
+      const target = path.join(base, 'bad"name');
+      const code = await runInit(['--yes', '--name', target, '--skip-keys', '--no-git']);
+      expect(code).toBe(2);
+      expect(fs.existsSync(path.join(target, 'src/index.ts'))).toBe(false);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security regression test — atomic 0600 .env (issue 2, no chmod race)
+// ---------------------------------------------------------------------------
+
+describe('[unit] init wizard — .env created 0600 atomically (no race)', () => {
+  it('creates .env owner-only even under a permissive process umask', async () => {
+    // The secure path uses openSync(p, "w", 0o600) + fchmodSync(fd, 0o600),
+    // so the mode is set at creation — there is no window where .env is
+    // world-/group-readable. We force a maximally permissive umask (0): if the
+    // old write-then-chmod path were used, the file would still settle at 0600,
+    // but the openSync-mode path guarantees it is never *created* world-wide.
+    const prevUmask = process.umask(0o000);
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-init-'));
+    try {
+      const code = await runInit([
+        '--yes',
+        '--name',
+        target,
+        '--force',
+        '--skip-keys',
+        '--no-skills',
+        '--no-git',
+      ]);
+      expect(code).toBe(0);
+      const mode = fs.statSync(path.join(target, '.env')).mode & 0o777;
+      expect(mode).toBe(0o600);
+    } finally {
+      process.umask(prevUmask);
+      fs.rmSync(target, { recursive: true, force: true });
+    }
+  });
+});

--- a/libraries/typescript/tests/init.test.ts
+++ b/libraries/typescript/tests/init.test.ts
@@ -1,0 +1,264 @@
+/**
+ * End-to-end tests for the `getpatter init` setup wizard — exercises the REAL
+ * `runInit` orchestrator writing a real scaffold into an `os.tmpdir()` dir.
+ *
+ * Parity target: `libraries/python/tests/test_init_wizard.py`. The assertions
+ * mirror the Python suite — files exist, the generated `index.ts` wires the
+ * chosen mode/engine/providers/carrier, `package.json` pins the SDK version,
+ * `.env` is owner-only (0600), and `.gitignore` keeps `.env` out of git — but
+ * cover EVERY voice mode (realtime + pipeline) and EVERY carrier
+ * (twilio + telnyx + plivo).
+ *
+ * The ONLY thing mocked is the outer process boundary: `node:child_process`
+ * (the `npx skills add ...` IDE-skills shell-out and `git init`). Everything
+ * inward — flag parsing, plan resolution, codegen string builders, the
+ * write-to-disk flow, env-key ordering, pip/npm manifest generation, and the
+ * chmod 0600 on `.env` — runs as real code. This is the same path an end user
+ * runs; nothing about the scaffold output is faked.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock ONLY the external subprocess boundary (skills `npx` + `git init`).
+// Returning status 0 lets the wizard's "skills installed" path run without
+// spawning a real `npx`/`git`. Everything else in init/cli.ts stays real.
+const spawnSyncMock = vi.fn(() => ({ status: 0, error: undefined } as never));
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+import { VERSION } from '../src/version';
+import { runInit } from '../src/init/cli';
+
+// Carriers under test: class name + the env vars each one reads.
+const CARRIER_CASES = [
+  {
+    carrier: 'twilio',
+    cls: 'Twilio',
+    env: ['TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN'],
+    phoneEnv: 'TWILIO_PHONE_NUMBER',
+  },
+  {
+    carrier: 'telnyx',
+    cls: 'Telnyx',
+    env: ['TELNYX_API_KEY', 'TELNYX_CONNECTION_ID'],
+    phoneEnv: 'TELNYX_PHONE_NUMBER',
+  },
+  {
+    carrier: 'plivo',
+    cls: 'Plivo',
+    env: ['PLIVO_AUTH_ID', 'PLIVO_AUTH_TOKEN'],
+    phoneEnv: 'PLIVO_PHONE_NUMBER',
+  },
+] as const;
+
+const dirs: string[] = [];
+
+function tmpTarget(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'patter-init-e2e-'));
+  dirs.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockClear();
+});
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * Drive the REAL wizard non-interactively into `target`. `--yes` skips
+ * readline; `--ide` exercises the (mocked) skills shell-out. We deliberately
+ * do NOT pass --no-skills so the mocked subprocess boundary is hit.
+ */
+async function scaffold(
+  target: string,
+  extra: readonly string[],
+): Promise<number> {
+  return runInit([
+    '--yes',
+    '--name',
+    target,
+    '--force',
+    '--skip-keys',
+    '--ide',
+    'claude-code,cursor',
+    ...extra,
+  ]);
+}
+
+// Files every TS scaffold must produce (mirrors the Python file-existence set,
+// with src/index.ts + package.json in place of main.py + requirements.txt).
+const EXPECTED_FILES = [
+  'src/index.ts',
+  'package.json',
+  '.env',
+  '.env.example',
+  '.gitignore',
+  'README.md',
+] as const;
+
+function assertCommonScaffold(target: string): void {
+  for (const f of EXPECTED_FILES) {
+    expect(fs.existsSync(path.join(target, f)), `${f} should exist`).toBe(true);
+  }
+
+  // SECURITY: .env owner-only (0600).
+  const mode = fs.statSync(path.join(target, '.env')).mode & 0o777;
+  expect(mode).toBe(0o600);
+
+  // .gitignore keeps .env (and its variants) out of version control, while
+  // explicitly un-ignoring the committable example.
+  const gi = fs.readFileSync(path.join(target, '.gitignore'), 'utf8');
+  expect(gi).toContain('.env');
+  expect(gi).toContain('!.env.example');
+  expect(gi).toContain('node_modules/');
+
+  // package.json pins getpatter to the current SDK version and wires start.
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(target, 'package.json'), 'utf8'),
+  ) as {
+    dependencies: Record<string, string>;
+    scripts: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+  expect(pkg.dependencies.getpatter).toBe(VERSION);
+  expect(pkg.scripts.start).toBe('tsx src/index.ts');
+  expect(pkg.devDependencies.tsx).toBeDefined();
+  expect(pkg.devDependencies.typescript).toBeDefined();
+}
+
+describe('[unit] init wizard e2e — realtime mode across all carriers', () => {
+  for (const c of CARRIER_CASES) {
+    it(`scaffolds a realtime ${c.carrier} project (default engine) to disk`, async () => {
+      const target = tmpTarget();
+      const code = await scaffold(target, ['--mode', 'realtime', '--carrier', c.carrier]);
+      expect(code).toBe(0);
+
+      assertCommonScaffold(target);
+
+      const index = fs.readFileSync(path.join(target, 'src/index.ts'), 'utf8');
+      // Default realtime engine is OpenAIRealtime2; carrier wired via `new`.
+      expect(index).toContain(
+        `import { Patter, ${c.cls}, OpenAIRealtime2 } from "getpatter";`,
+      );
+      expect(index).toContain(`carrier: new ${c.cls}(),`);
+      expect(index).toContain('engine: new OpenAIRealtime2(),');
+      expect(index).toContain('phoneNumber: PHONE_NUMBER,');
+      expect(index).toContain('await phone.serve({ agent, tunnel: true });');
+      expect(index).toContain(`process.env.${c.phoneEnv}`);
+      // Realtime must NOT emit pipeline wiring.
+      expect(index).not.toContain('stt:');
+      expect(index).not.toContain('llm:');
+      expect(index).not.toContain('tts:');
+
+      // .env lists the carrier creds first, then engine key, then phone env.
+      const env = fs.readFileSync(path.join(target, '.env'), 'utf8');
+      const keys = env
+        .split('\n')
+        .filter((l) => l.includes('=') && !l.startsWith('#'))
+        .map((l) => l.split('=')[0]);
+      expect(keys).toEqual([...c.env, 'OPENAI_API_KEY', c.phoneEnv]);
+    });
+  }
+});
+
+describe('[unit] init wizard e2e — pipeline mode across all carriers', () => {
+  for (const c of CARRIER_CASES) {
+    it(`scaffolds a pipeline ${c.carrier} project (default STT/LLM/TTS) to disk`, async () => {
+      const target = tmpTarget();
+      const code = await scaffold(target, ['--mode', 'pipeline', '--carrier', c.carrier]);
+      expect(code).toBe(0);
+
+      assertCommonScaffold(target);
+
+      const index = fs.readFileSync(path.join(target, 'src/index.ts'), 'utf8');
+      // Pipeline defaults: Deepgram STT, Cerebras LLM, ElevenLabs TTS.
+      expect(index).toContain(
+        `import { Patter, ${c.cls}, DeepgramSTT, CerebrasLLM, ElevenLabsTTS } from "getpatter";`,
+      );
+      expect(index).toContain(`carrier: new ${c.cls}(),`);
+      expect(index).toContain('stt: new DeepgramSTT(),');
+      expect(index).toContain('llm: new CerebrasLLM(),');
+      expect(index).toContain('tts: new ElevenLabsTTS(),');
+      expect(index).toContain('await phone.serve({ agent, tunnel: true });');
+      // Pipeline must NOT emit a realtime engine.
+      expect(index).not.toContain('engine:');
+
+      // .env: carrier creds, then STT/LLM/TTS keys in order, then phone env.
+      // (Deepgram + ElevenLabs + Cerebras; OpenAI absent for the defaults.)
+      const env = fs.readFileSync(path.join(target, '.env'), 'utf8');
+      const keys = env
+        .split('\n')
+        .filter((l) => l.includes('=') && !l.startsWith('#'))
+        .map((l) => l.split('=')[0]);
+      expect(keys).toEqual([
+        ...c.env,
+        'DEEPGRAM_API_KEY',
+        'CEREBRAS_API_KEY',
+        'ELEVENLABS_API_KEY',
+        c.phoneEnv,
+      ]);
+    });
+  }
+});
+
+describe('[unit] init wizard e2e — external boundary (skills) is mocked', () => {
+  it('shells out to the mocked skills subprocess once per requested IDE', async () => {
+    const target = tmpTarget();
+    const code = await scaffold(target, ['--mode', 'realtime', '--carrier', 'twilio']);
+    expect(code).toBe(0);
+
+    // Two IDEs requested (claude-code, cursor) → two `npx skills add` calls,
+    // each routed through the mock (no real npx/network).
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    const [firstCmd, firstArgs] = spawnSyncMock.mock.calls[0] as [string, string[]];
+    expect(firstCmd).toBe('npx');
+    expect(firstArgs).toContain('skills');
+    expect(firstArgs).toContain('add');
+    expect(firstArgs).toContain('-a');
+    // Pinned to the current SDK version: patterai/skills#v<version>.
+    expect(firstArgs.some((a) => a === `patterai/skills#v${VERSION}`)).toBe(true);
+    const ides = (spawnSyncMock.mock.calls as Array<[string, string[]]>).map(
+      ([, a]) => a[a.length - 1],
+    );
+    expect(ides).toEqual(['claude-code', 'cursor']);
+  });
+
+  it('does not shell out when --no-skills is passed', async () => {
+    const target = tmpTarget();
+    const code = await runInit([
+      '--yes',
+      '--name',
+      target,
+      '--force',
+      '--skip-keys',
+      '--no-skills',
+      '--mode',
+      'realtime',
+      '--carrier',
+      'twilio',
+    ]);
+    expect(code).toBe(0);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('[unit] init wizard e2e — non-empty dir guard', () => {
+  it('blocks scaffolding into a non-empty dir without --force', async () => {
+    const target = tmpTarget();
+    fs.writeFileSync(path.join(target, 'keep.txt'), 'keep me');
+    const code = await runInit(['--yes', '--name', target, '--skip-keys', '--no-skills']);
+    expect(code).toBe(1);
+    // Original file untouched, no scaffold written.
+    expect(fs.readFileSync(path.join(target, 'keep.txt'), 'utf8')).toBe('keep me');
+    expect(fs.existsSync(path.join(target, 'src/index.ts'))).toBe(false);
+    // Guard fires before any subprocess work.
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Ships the **`getpatter init` setup wizard** in both SDKs and the **`npm create getpatter`** launcher — the fastest path from nothing to a runnable inbound voice agent.
- Releases **0.6.9** (also tags out the already-merged-but-unreleased work in the CHANGELOG — see *Release note* below).

## Implementation
- **Python** — new `getpatter/init/` package (`build_init_parser` / `dispatch_init`), wired **additively** into `cli.py` alongside the existing `dashboard`/`eval`/`hermes`/`openclaw`/`telemetry` subcommands.
- **TypeScript** — new `src/init/cli.ts` (`runInit`), wired **additively** into `cli.ts`. The wizard imports only `VERSION` from `src/version.ts`.
- **`create-getpatter/`** — a zero-dependency npm launcher. It resolves a locally-installed `getpatter` and runs its `init`, otherwise falls back to `npx -y getpatter@<pinned-version> init` (pin kept in lockstep at 0.6.9). Single source of truth — no bundled copy of the wizard.
- The wizard scaffolds a complete project — entry file (`main.py` / `src/index.ts`), `.env` (chmod **0600**, secrets never echoed or logged), `.env.example`, dependency manifest, `.gitignore`, `README.md` — choosing voice mode (`realtime`/`pipeline`), engine/providers, and carrier. Every prompt has a matching flag for non-interactive/CI use.
- **`release.yml`** — new `release-create-getpatter` job (`needs: release-ts-sdk`) publishes the launcher to npm after the SDK, so the npx fallback always resolves a published `getpatter`.
- **Version bump** 0.6.8 → 0.6.9 across all four files: `libraries/python/getpatter/__init__.py`, `libraries/python/pyproject.toml`, `libraries/typescript/package.json`, `create-getpatter/package.json`.

### Release note (intentional)
This PR bumps the version, so tagging `v0.6.9` after merge will publish everything currently on `main` that is still unreleased (the telemetry v8 signals, LiteLLM provider, Krisp/DeepFilterNet root exports, etc. — #181–#189), folded into the `## 0.6.9` CHANGELOG section. The prior `## Unreleased` block was renamed to `## 0.6.9 (2026-06-23)` with a fresh empty `## Unreleased` on top; **full history is preserved** (not truncated).

## Breaking change?
**No.** The `init` command is inserted between `eval` and `hermes` in both CLIs; every existing command, default, and public API symbol is untouched. New launcher package only.

## Test plan
- [x] Python: `pytest tests/test_init.py tests/test_init_codegen.py` → 34 passed; full suite `pytest tests/ -m "not soak"` → 2636 passed, 26 skipped, 2 xfailed (Python 3.13).
- [x] TypeScript: `npm test` → 2187 passed / 9 skipped (137 files, incl. `init.test.ts`, `init-codegen.test.ts`) · `npm run lint` (tsc --noEmit) clean · `npm run build` ESM/CJS/DTS success.
- [x] `node create-getpatter/smoke-test.mjs` → PASS (shim forwards `--help` to the wizard; positional `my-app` scaffolds a runnable project with `.env` @ 0600).
- [x] `/parity-check` (sdk-parity agent) — wizard at Python↔TS parity, no blocking gaps.
- [x] Scaffold symbol audit — all 25 SDK classes the wizard can emit are exported from both package barrels.
- [x] Code review — APPROVE, 0 CRITICAL / 0 HIGH.

## Docs updates
- `docs/quickstart-create.mdx` (new "Create a Project" page) + `docs/docs.json` Welcome-group nav entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMgYbmCJGF3fmQjXGSmTEU
