### PR TITLE
feat(realtime): pin transcription language + anti-alias realtime-2 audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ### Added
 
+- **OpenAI Realtime: `transcriptionLanguage` option on both engine markers.**
+  `OpenAIRealtime` / `OpenAIRealtime2` (TS) and `engines.openai_realtime` /
+  `engines.openai_realtime_2` (Python) now accept an optional ISO-639-1
+  `transcriptionLanguage` (`transcription_language` in Python) that pins the
+  Realtime session's `input_audio_transcription.language` instead of letting
+  Whisper auto-detect per utterance. Auto-detect mislabels short / noisy phone
+  utterances (an Italian "sì" comes back tagged Spanish or English), which only
+  corrupted the display-side transcript (dashboard / `onTranscript` / history) —
+  the speech-to-speech model's comprehension was never affected. Optional,
+  omitted by default (auto-detect preserved, no behaviour change for existing
+  callers). `libraries/typescript/src/engines/openai.ts`, `engines/openai-2.ts`,
+  `providers/openai-realtime.ts`, `providers/openai-realtime-2.ts`, `server.ts`.
+
 - **Python: `KrispVivaFilter` and `DeepFilterNetFilter` are now exported from
   the package root.** Both noise-suppression `AudioFilter` implementations
   already shipped as modules (`getpatter/providers/krisp_filter.py`,
@@ -109,6 +122,19 @@
   understood was removed or renamed — all changes are additive.
 
 ### Fixed
+
+- **OpenAI Realtime 2: raspy / crackly agent voice on telephony.** The GA
+  adapter decimated `gpt-realtime-2`'s 24 kHz output down to mulaw 8 kHz through
+  a 24→16 (linear, unfiltered) → 16→8 (gentle 5-tap binomial) chain that
+  under-attenuated energy above 4 kHz. `gpt-realtime-2` emits significant
+  high-frequency content, which aliased into the telephony band and was heard as
+  raspy speech. A 63-tap Hamming-windowed-sinc anti-alias low-pass (cutoff
+  3.7 kHz, ~53 dB stopband, stateful across audio deltas) now runs on the 24 kHz
+  signal before decimation, so the downstream stages have nothing above the
+  cutoff left to fold back. Contained to the Realtime-2 outbound path — the
+  shared `StatefulResampler` / pipeline TTS is untouched.
+  `libraries/typescript/src/audio/transcoding.ts` (new `StatefulFirLowpass`),
+  `providers/openai-realtime-2.ts`.
 
 - **Telemetry: `call_completed` now carries the call `direction`
   (inbound/outbound).** The media-stream bridge's end payload has no direction,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   omitted by default (auto-detect preserved, no behaviour change for existing
   callers). `libraries/typescript/src/engines/openai.ts`, `engines/openai-2.ts`,
   `providers/openai-realtime.ts`, `providers/openai-realtime-2.ts`, `server.ts`.
+  Python mirror: `engines/openai_realtime.py`, `engines/openai_realtime_2.py`,
+  `providers/openai_realtime.py`, `providers/openai_realtime_2.py`, `client.py`,
+  `models.py`, `stream_handler.py`.
 
 - **Python: `KrispVivaFilter` and `DeepFilterNetFilter` are now exported from
   the package root.** Both noise-suppression `AudioFilter` implementations
@@ -134,7 +137,9 @@
   cutoff left to fold back. Contained to the Realtime-2 outbound path — the
   shared `StatefulResampler` / pipeline TTS is untouched.
   `libraries/typescript/src/audio/transcoding.ts` (new `StatefulFirLowpass`),
-  `providers/openai-realtime-2.ts`.
+  `providers/openai-realtime-2.ts`. Python mirror:
+  `libraries/python/getpatter/audio/transcoding.py` (`StatefulFirLowpass`),
+  `providers/openai_realtime_2.py`.
 
 - **Telemetry: `call_completed` now carries the call `direction`
   (inbound/outbound).** The media-stream bridge's end payload has no direction,

--- a/libraries/python/getpatter/audio/transcoding.py
+++ b/libraries/python/getpatter/audio/transcoding.py
@@ -13,7 +13,10 @@ Public API
 
 from __future__ import annotations
 
+import array
 import logging
+import math
+import sys
 import warnings
 from typing import Optional, Tuple
 
@@ -36,6 +39,7 @@ __all__ = [
     "resample_24k_to_16k",
     "PcmCarry",
     "StatefulResampler",
+    "StatefulFirLowpass",
     "create_resampler_8k_to_16k",
     "create_resampler_16k_to_8k",
     "create_resampler_24k_to_16k",
@@ -263,6 +267,146 @@ class StatefulResampler:
         """Reset internal state for a new stream without recreating the object."""
         self._carry.reset()
         self._state = None
+
+
+# ---------------------------------------------------------------------------
+# StatefulFirLowpass — windowed-sinc anti-alias low-pass
+# ---------------------------------------------------------------------------
+
+
+def _pcm16le_to_int_list(data: bytes) -> array.array:
+    """Decode little-endian PCM16 bytes to a signed-int ``array('h')``."""
+    samples = array.array("h")
+    samples.frombytes(data)
+    if sys.byteorder == "big":
+        # ``array('h')`` parses in native order; the wire format is LE.
+        samples.byteswap()
+    return samples
+
+
+def _int_list_to_pcm16le(samples: array.array) -> bytes:
+    """Encode a signed-int ``array('h')`` to little-endian PCM16 bytes."""
+    if sys.byteorder == "big":
+        swapped = array.array("h", samples)
+        swapped.byteswap()
+        return swapped.tobytes()
+    return samples.tobytes()
+
+
+class StatefulFirLowpass:
+    """Linear-phase FIR low-pass with cross-chunk history — an anti-alias
+    pre-filter to run BEFORE decimation.
+
+    Why this exists: decimating ``gpt-realtime-2``'s 24 kHz output straight
+    down to 8 kHz aliases any energy above 4 kHz into the telephony band,
+    heard as raspy / crackly speech. The 24→16 (linear) + 16→8 resampler
+    chain under-attenuates that band. Running this low-pass on the 24 kHz
+    signal FIRST removes everything above the cutoff, so the downstream
+    decimation has nothing left to alias.
+
+    Coefficients are a Hamming-windowed sinc (~53 dB stopband), DC-normalised
+    to unity gain. State is the previous ``num_taps - 1`` input samples,
+    carried across :meth:`process` calls so the output is continuous (no
+    per-chunk transient). Group delay is a constant ``(num_taps - 1) / 2``
+    samples — inaudible at these tap counts. Odd trailing bytes are buffered
+    across calls via :class:`PcmCarry`, mirroring :class:`StatefulResampler`.
+
+    Parameters
+    ----------
+    num_taps:
+        Number of FIR taps. Must be a positive ODD integer (linear phase).
+    cutoff_hz:
+        -6 dB cutoff frequency in Hz.
+    sample_rate_hz:
+        Sample rate of the stream being filtered, in Hz.
+    """
+
+    __slots__ = ("_coeffs", "_num_taps", "_history", "_carry")
+
+    def __init__(self, num_taps: int, cutoff_hz: float, sample_rate_hz: float) -> None:
+        if num_taps < 1 or num_taps % 2 == 0:
+            raise ValueError(
+                f"StatefulFirLowpass: num_taps must be a positive odd integer, "
+                f"got {num_taps}"
+            )
+        if cutoff_hz <= 0 or cutoff_hz >= sample_rate_hz / 2:
+            raise ValueError(
+                f"StatefulFirLowpass: cutoff_hz must be in (0, "
+                f"{sample_rate_hz / 2}), got {cutoff_hz}"
+            )
+        self._num_taps = num_taps
+        self._coeffs = self._design(num_taps, cutoff_hz, sample_rate_hz)
+        # Last ``num_taps - 1`` input samples: history[k] = x[k - (num_taps-1)].
+        self._history: list[float] = [0.0] * (num_taps - 1)
+        self._carry = PcmCarry(2)
+
+    @staticmethod
+    def _design(num_taps: int, cutoff_hz: float, sample_rate_hz: float) -> list[float]:
+        """Hamming-windowed sinc low-pass, DC-normalised to unity gain."""
+        fc = cutoff_hz / sample_rate_hz  # normalised cutoff (cycles/sample)
+        m = num_taps - 1
+        coeffs = [0.0] * num_taps
+        total = 0.0
+        for n in range(num_taps):
+            k = n - m / 2
+            if k == 0:
+                sinc = 2 * fc
+            else:
+                sinc = math.sin(2 * math.pi * fc * k) / (math.pi * k)
+            window = 0.54 - 0.46 * math.cos((2 * math.pi * n) / m)  # Hamming
+            coeffs[n] = sinc * window
+            total += coeffs[n]
+        return [c / total for c in coeffs]  # unity DC gain
+
+    def process(self, pcm: bytes) -> bytes:
+        """Filter a chunk of PCM16-LE samples, returning the same number of
+        samples. Odd trailing bytes are buffered across calls.
+        """
+        aligned = self._carry.feed(pcm)
+        if not aligned:
+            return b""
+        x = _pcm16le_to_int_list(aligned)
+        n = len(x)
+
+        taps = self._num_taps
+        keep = taps - 1
+        c = self._coeffs
+        hist = self._history
+        out = array.array("h", bytes(n * 2))
+
+        for i in range(n):
+            acc = 0.0
+            # y[i] = sum_{j=0..taps-1} c[j] * x[i - (taps-1) + j]
+            for j in range(taps):
+                idx = i - keep + j
+                s = x[idx] if idx >= 0 else hist[keep + idx]
+                acc += c[j] * s
+            out[i] = _clamp_int16(int(round(acc)))
+
+        # New history = last ``keep`` input samples of the virtual stream.
+        # Build into a temp first so small chunks (n < keep) don't read
+        # overwritten slots.
+        nxt = [0.0] * keep
+        for k in range(keep):
+            idx = n - keep + k
+            nxt[k] = float(x[idx]) if idx >= 0 else hist[keep + idx]
+        self._history = nxt
+
+        return _int_list_to_pcm16le(out)
+
+    def reset(self) -> None:
+        """Clear filter history (e.g. at call boundaries)."""
+        self._history = [0.0] * (self._num_taps - 1)
+        self._carry.reset()
+
+
+def _clamp_int16(value: int) -> int:
+    """Clamp an int to the signed 16-bit range."""
+    if value > 32767:
+        return 32767
+    if value < -32768:
+        return -32768
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -1388,6 +1388,13 @@ class Patter:
                     adapter_kwargs["input_audio_transcription_model"] = (
                         transcription_model
                     )
+                transcription_language = getattr(
+                    agent,
+                    "openai_realtime_transcription_language",
+                    None,
+                )
+                if transcription_language is not None:
+                    adapter_kwargs["transcription_language"] = transcription_language
                 tmp_adapter = OpenAIRealtime2Adapter(**adapter_kwargs)
                 ws = await tmp_adapter.open_parked_connection()
                 if self._prewarmed_connections.get(call_id) is not slot:
@@ -1939,6 +1946,7 @@ class Patter:
         # stream-handler can forward them to ``OpenAIRealtimeAdapter``.
         openai_realtime_reasoning_effort: str | None = None
         openai_realtime_input_audio_transcription_model: str | None = None
+        openai_realtime_transcription_language: str | None = None
         if engine is not None:
             # Engine mode handles the LLM internally — `llm=` is ignored.
             # Emit a one-time warning so the user knows.
@@ -1961,6 +1969,9 @@ class Patter:
                 openai_realtime_reasoning_effort = engine_fields.get("reasoning_effort")
                 openai_realtime_input_audio_transcription_model = engine_fields.get(
                     "input_audio_transcription_model"
+                )
+                openai_realtime_transcription_language = engine_fields.get(
+                    "transcription_language"
                 )
                 # Explicit agent() kwargs win over the engine marker value.
                 if openai_realtime_noise_reduction is None:
@@ -2163,6 +2174,7 @@ class Patter:
             prewarm_first_message=prewarm_first_message,
             openai_realtime_reasoning_effort=openai_realtime_reasoning_effort,
             openai_realtime_input_audio_transcription_model=openai_realtime_input_audio_transcription_model,
+            openai_realtime_transcription_language=openai_realtime_transcription_language,
             openai_realtime_noise_reduction=openai_realtime_noise_reduction,
             realtime_turn_detection=realtime_turn_detection,
             realtime_gate_response_on_transcript=realtime_gate_response_on_transcript,
@@ -2185,6 +2197,7 @@ class Patter:
                 "model": engine.model,
                 "reasoning_effort": engine.reasoning_effort,
                 "input_audio_transcription_model": engine.input_audio_transcription_model,
+                "transcription_language": engine.transcription_language,
                 "noise_reduction": engine.noise_reduction,
                 "turn_detection": engine.turn_detection,
                 "gate_response_on_transcript": engine.gate_response_on_transcript,
@@ -2196,6 +2209,7 @@ class Patter:
                 "model": engine.model,
                 "reasoning_effort": engine.reasoning_effort,
                 "input_audio_transcription_model": engine.input_audio_transcription_model,
+                "transcription_language": engine.transcription_language,
                 "noise_reduction": engine.noise_reduction,
                 "turn_detection": engine.turn_detection,
                 "gate_response_on_transcript": engine.gate_response_on_transcript,

--- a/libraries/python/getpatter/engines/openai.py
+++ b/libraries/python/getpatter/engines/openai.py
@@ -49,6 +49,14 @@ class Realtime:
     # ``"gpt-realtime-whisper"`` for low-latency partials, ``"gpt-4o-transcribe"``
     # for higher accuracy.
     input_audio_transcription_model: str | None = None
+    # ISO-639-1 language hint for the Realtime session's
+    # ``input_audio_transcription.language`` (e.g. ``"it"``, ``"en"``, ``"es"``).
+    # Pins the input transcription model to one language instead of
+    # auto-detecting per utterance — auto-detect mislabels short / noisy phone
+    # utterances. ``None`` (default) keeps auto-detect. Display-only: the
+    # transcript feeds the dashboard / ``on_transcript``, not the model's
+    # comprehension.
+    transcription_language: str | None = None
     # Input noise reduction for speakerphone / conference audio. ``None``
     # (default) omits the field (no reduction). ``"far_field"`` recommended
     # for phone calls. Mirrors ``Patter.agent(openai_realtime_noise_reduction=)``.

--- a/libraries/python/getpatter/engines/openai_realtime_2.py
+++ b/libraries/python/getpatter/engines/openai_realtime_2.py
@@ -55,6 +55,13 @@ class Realtime2:
     # adapter default (``whisper-1``). Use ``"gpt-realtime-whisper"`` for
     # low-latency transcript partials.
     input_audio_transcription_model: str | None = None
+    # ISO-639-1 language hint for ``audio.input.transcription.language``
+    # (e.g. ``"it"``, ``"en"``, ``"es"``). Pins the input transcription model to
+    # one language instead of auto-detecting per utterance — auto-detect
+    # mislabels short / noisy phone utterances. ``None`` (default) keeps
+    # auto-detect. Display-only: the transcript feeds the dashboard /
+    # ``on_transcript``, not the model's comprehension.
+    transcription_language: str | None = None
     # Input noise reduction for speakerphone / conference audio. ``None``
     # (default) omits the field (no reduction). ``"far_field"`` recommended
     # for phone calls. Mirrors ``Patter.agent(openai_realtime_noise_reduction=)``.

--- a/libraries/python/getpatter/models.py
+++ b/libraries/python/getpatter/models.py
@@ -607,6 +607,12 @@ class Agent:
     # ``None`` (default) keeps the adapter default (``whisper-1``). Set to
     # e.g. ``"gpt-realtime-whisper"`` for low-latency transcript partials.
     openai_realtime_input_audio_transcription_model: str | None = None
+    # OpenAI Realtime — ISO-639-1 language hint for
+    # ``input_audio_transcription.language`` (e.g. ``"it"``). ``None`` (default)
+    # keeps Whisper auto-detect; pinning a language stops auto-detect from
+    # mislabelling short / noisy phone utterances. Display-only (transcript
+    # feeds dashboard / ``on_transcript``, not the model's comprehension).
+    openai_realtime_transcription_language: str | None = None
     # OpenAI Realtime — input noise reduction for speakerphone / conference
     # audio. ``None`` (default) omits the field entirely (no reduction —
     # today's behavior). ``"far_field"`` is recommended for phone /

--- a/libraries/python/getpatter/providers/openai_realtime.py
+++ b/libraries/python/getpatter/providers/openai_realtime.py
@@ -189,6 +189,11 @@ class OpenAIRealtimeAdapter:
         tool_choice: str | dict | None = None,
         input_audio_transcription_model: OpenAITranscriptionModel
         | str = OpenAITranscriptionModel.WHISPER_1,
+        # ISO-639-1 language hint for ``input_audio_transcription.language``
+        # (e.g. ``"it"``). Pins the transcription model to one language instead
+        # of auto-detecting per utterance. ``None`` (default) omits the field
+        # (auto-detect — today's behavior).
+        transcription_language: str | None = None,
         vad_type: Literal[
             "server_vad", "semantic_vad"
         ] = OpenAIRealtimeVADType.SERVER_VAD.value,
@@ -236,6 +241,7 @@ class OpenAIRealtimeAdapter:
         self.modalities = modalities
         self.tool_choice = tool_choice
         self.input_audio_transcription_model = input_audio_transcription_model
+        self.transcription_language = transcription_language
         self.vad_type = vad_type
         self.silence_duration_ms = silence_duration_ms
         self.reasoning_effort = reasoning_effort
@@ -435,6 +441,12 @@ class OpenAIRealtimeAdapter:
                 "model": self.input_audio_transcription_model,
             },
         }
+        # Pin the transcription language when configured — Whisper auto-detect
+        # mislabels short / noisy phone utterances. Omitted when unset.
+        if self.transcription_language is not None:
+            session_config["input_audio_transcription"]["language"] = (
+                self.transcription_language
+            )
         # v1 puts noise reduction at the TOP LEVEL of session (not nested under
         # audio.input as the GA shape does). Omitted entirely when unset.
         if self.noise_reduction is not None:

--- a/libraries/python/getpatter/providers/openai_realtime_2.py
+++ b/libraries/python/getpatter/providers/openai_realtime_2.py
@@ -49,6 +49,7 @@ from typing import Any, AsyncGenerator
 import websockets
 
 from getpatter.audio.transcoding import (
+    StatefulFirLowpass,
     StatefulResampler,
     mulaw_to_pcm16,
     pcm16_to_mulaw,
@@ -119,6 +120,15 @@ class OpenAIRealtime2Adapter(OpenAIRealtimeAdapter):
         # Created lazily on the first audio delta so each session has its own state.
         self._outbound_resampler_24to16: StatefulResampler | None = None
         self._outbound_resampler_16to8: StatefulResampler | None = None
+        # Anti-alias low-pass applied to the 24 kHz model output BEFORE the
+        # 24→16→8 decimation chain. ``gpt-realtime-2`` emits voice with
+        # significant energy above 4 kHz; without a real anti-alias filter that
+        # energy folds back into the telephony band on decimation and is heard
+        # as raspy / crackly speech. A 63-tap Hamming-windowed sinc at 3.7 kHz
+        # (~53 dB stopband) removes it so the downstream linear/binomial stages
+        # have nothing left to alias. Created lazily so each session owns its
+        # state.
+        self._outbound_lowpass_24k: StatefulFirLowpass | None = None
         # Last 8 kHz input sample carried across chunk boundaries for the
         # direct 3x linear upsample. The carry guarantees the first output of
         # each chunk interpolates from the real preceding sample, not from a
@@ -202,6 +212,14 @@ class OpenAIRealtime2Adapter(OpenAIRealtimeAdapter):
             include_response_gating=True,
             gate_response_on_transcript=self.gate_response_on_transcript,
         )
+        # Pin the transcription language when configured — Whisper auto-detect
+        # mislabels short / noisy phone utterances. Inherited from the v1
+        # constructor; omitted when unset. GA path is
+        # ``audio.input.transcription.language``.
+        if self.transcription_language is not None:
+            config["audio"]["input"]["transcription"]["language"] = (
+                self.transcription_language
+            )
         # GA nests noise reduction under audio.input AND renames the key: the
         # v1-beta ``input_audio_noise_reduction`` becomes ``noise_reduction``
         # (same ``input_audio_`` → nested drop as format/transcription). Sending
@@ -304,8 +322,13 @@ class OpenAIRealtime2Adapter(OpenAIRealtimeAdapter):
             self._outbound_resampler_16to8 = StatefulResampler(
                 src_rate=16000, dst_rate=8000
             )
+            self._outbound_lowpass_24k = StatefulFirLowpass(
+                num_taps=63, cutoff_hz=3700, sample_rate_hz=24000
+            )
         pcm24 = base64.b64decode(delta_b64)
-        pcm16 = self._outbound_resampler_24to16.process(pcm24)
+        # Anti-alias FIRST (at 24 kHz), THEN decimate — see field docstring.
+        filtered24 = self._outbound_lowpass_24k.process(pcm24)  # type: ignore[union-attr]
+        pcm16 = self._outbound_resampler_24to16.process(filtered24)
         pcm8 = self._outbound_resampler_16to8.process(pcm16)  # type: ignore[union-attr]
         if not pcm8:
             return b""

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -1769,6 +1769,11 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
         )
         if transcription_model is not None:
             adapter_kwargs["input_audio_transcription_model"] = transcription_model
+        transcription_language = getattr(
+            self.agent, "openai_realtime_transcription_language", None
+        )
+        if transcription_language is not None:
+            adapter_kwargs["transcription_language"] = transcription_language
         # Forward the speakerphone noise-reduction + turn-detection tuning
         # knobs only when set, so the adapter's own defaults stay authoritative
         # for users who don't pass them. (POINT 1a / 1b.)

--- a/libraries/python/tests/test_fir_lowpass.py
+++ b/libraries/python/tests/test_fir_lowpass.py
@@ -1,18 +1,25 @@
 """Unit tests for ``StatefulFirLowpass`` — the windowed-sinc anti-alias
-low-pass that runs on the 24 kHz Realtime-2 output before the 24→16→8
+low-pass that runs on the 24 kHz Realtime-2 output before the 24->16->8
 decimation to mulaw.
 
 These exercise the REAL filter (no mocks): they feed real sinusoids through
 ``process()`` and assert on the real output bytes. A low-frequency tone passes
 near unity; a tone above the cutoff is strongly attenuated; and feeding a
 signal in two chunks yields byte-for-byte the same result as one chunk
-(stateful cross-chunk continuity). numpy is used only to synthesise the test
-signals and measure RMS — the filter itself is pure stdlib.
+(stateful cross-chunk continuity).
+
+Signal synthesis + RMS use only the stdlib (``struct`` / ``math``) — numpy is
+NOT a base dependency, so importing it here would break the base
+``Python SDK Tests`` CI job at collection time. The filter itself is pure
+stdlib too (``array``), so this keeps the whole path dependency-clean.
 """
 
 from __future__ import annotations
 
-import numpy as np
+import math
+import struct
+
+import pytest
 
 from getpatter.audio.transcoding import StatefulFirLowpass
 
@@ -23,15 +30,23 @@ _AMP = 10000
 def _sine_pcm16le(
     freq_hz: float, n: int = 4800, sr: int = _SR, amp: int = _AMP
 ) -> bytes:
-    """A pure sine wave as little-endian PCM16 bytes."""
-    t = np.arange(n) / sr
-    samples = (amp * np.sin(2 * np.pi * freq_hz * t)).astype("<i2")
-    return samples.tobytes()
+    """A pure sine wave as little-endian PCM16 bytes (``struct`` is always LE)."""
+    out = bytearray()
+    for i in range(n):
+        v = int(round(amp * math.sin(2 * math.pi * freq_hz * i / sr)))
+        out += struct.pack("<h", max(-32768, min(32767, v)))
+    return bytes(out)
 
 
 def _rms(pcm: bytes) -> float:
-    arr = np.frombuffer(pcm, dtype="<i2").astype(np.float64)
-    return float(np.sqrt(np.mean(arr * arr))) if arr.size else 0.0
+    n = len(pcm) // 2
+    if n == 0:
+        return 0.0
+    total = 0.0
+    for i in range(n):
+        (s,) = struct.unpack_from("<h", pcm, i * 2)
+        total += s * s
+    return math.sqrt(total / n)
 
 
 def _lowpass() -> StatefulFirLowpass:
@@ -75,23 +90,21 @@ def test_stateful_continuity_across_two_chunks() -> None:
     second = chunked_filter.process(inp[half:])
     chunked = first + second
 
-    assert len(chunked) == len(single)
-    a = np.frombuffer(single, dtype="<i2").astype(np.int64)
-    b = np.frombuffer(chunked, dtype="<i2").astype(np.int64)
-    # Exact byte-for-byte (the chunk split changes nothing in the math).
-    assert int(np.max(np.abs(a - b))) == 0
+    # Exact byte-for-byte — the chunk split changes nothing in the math.
+    assert chunked == single
 
 
 def test_unity_dc_gain() -> None:
     # A constant (DC) input must pass through unchanged once the filter's
     # history has filled — the coefficients are DC-normalised to unity gain.
-    const = np.full(4800, 5000, dtype="<i2").tobytes()
+    const = struct.pack("<h", 5000) * 4800
     out = _lowpass().process(const)
-    out_arr = np.frombuffer(out, dtype="<i2")
-    # Skip the full filter-length start-up transient: the FIR only sees a full
-    # window of constant input once num_taps-1 (=62) samples have flowed in.
-    settled = out_arr[63:]
-    assert np.allclose(settled, 5000, atol=1)
+    n = len(out) // 2
+    # Skip the start-up transient: the FIR only sees a full window of constant
+    # input once num_taps-1 (=62) samples have flowed in.
+    for i in range(63, n):
+        (s,) = struct.unpack_from("<h", out, i * 2)
+        assert abs(s - 5000) <= 1, f"sample {i} settled to {s}, expected ~5000"
 
 
 def test_odd_trailing_byte_carried_across_calls() -> None:
@@ -116,14 +129,10 @@ def test_reset_clears_history() -> None:
 
 
 def test_rejects_even_num_taps() -> None:
-    import pytest
-
     with pytest.raises(ValueError):
         StatefulFirLowpass(num_taps=64, cutoff_hz=3700, sample_rate_hz=_SR)
 
 
 def test_rejects_cutoff_above_nyquist() -> None:
-    import pytest
-
     with pytest.raises(ValueError):
         StatefulFirLowpass(num_taps=63, cutoff_hz=13000, sample_rate_hz=_SR)

--- a/libraries/python/tests/test_fir_lowpass.py
+++ b/libraries/python/tests/test_fir_lowpass.py
@@ -1,0 +1,129 @@
+"""Unit tests for ``StatefulFirLowpass`` — the windowed-sinc anti-alias
+low-pass that runs on the 24 kHz Realtime-2 output before the 24→16→8
+decimation to mulaw.
+
+These exercise the REAL filter (no mocks): they feed real sinusoids through
+``process()`` and assert on the real output bytes. A low-frequency tone passes
+near unity; a tone above the cutoff is strongly attenuated; and feeding a
+signal in two chunks yields byte-for-byte the same result as one chunk
+(stateful cross-chunk continuity). numpy is used only to synthesise the test
+signals and measure RMS — the filter itself is pure stdlib.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from getpatter.audio.transcoding import StatefulFirLowpass
+
+_SR = 24000
+_AMP = 10000
+
+
+def _sine_pcm16le(
+    freq_hz: float, n: int = 4800, sr: int = _SR, amp: int = _AMP
+) -> bytes:
+    """A pure sine wave as little-endian PCM16 bytes."""
+    t = np.arange(n) / sr
+    samples = (amp * np.sin(2 * np.pi * freq_hz * t)).astype("<i2")
+    return samples.tobytes()
+
+
+def _rms(pcm: bytes) -> float:
+    arr = np.frombuffer(pcm, dtype="<i2").astype(np.float64)
+    return float(np.sqrt(np.mean(arr * arr))) if arr.size else 0.0
+
+
+def _lowpass() -> StatefulFirLowpass:
+    return StatefulFirLowpass(num_taps=63, cutoff_hz=3700, sample_rate_hz=_SR)
+
+
+def test_low_frequency_tone_passes_near_unity() -> None:
+    # 500 Hz is well below the 3.7 kHz cutoff — it should survive intact.
+    inp = _sine_pcm16le(500)
+    out = _lowpass().process(inp)
+    ratio = _rms(out) / _rms(inp)
+    assert 0.9 < ratio < 1.1, f"expected near-unity passband, got {ratio:.3f}"
+
+
+def test_high_frequency_tone_strongly_attenuated() -> None:
+    # 7 kHz is almost a full octave above the cutoff — it is exactly the energy
+    # that would alias into the telephony band on decimation, so it must be
+    # heavily suppressed.
+    inp = _sine_pcm16le(7000)
+    out = _lowpass().process(inp)
+    ratio = _rms(out) / _rms(inp)
+    assert ratio < 0.25, f"expected strong stopband attenuation, got {ratio:.3f}"
+
+
+def test_output_length_matches_input_length() -> None:
+    inp = _sine_pcm16le(1000)
+    out = _lowpass().process(inp)
+    assert len(out) == len(inp)
+
+
+def test_stateful_continuity_across_two_chunks() -> None:
+    # Feeding the same signal in two consecutive chunks must reconstruct the
+    # single-chunk output exactly (no per-chunk transient at the boundary) —
+    # this is what makes the filter safe to run on streamed audio deltas.
+    inp = _sine_pcm16le(800)
+    single = _lowpass().process(inp)
+
+    chunked_filter = _lowpass()
+    half = (len(inp) // 4) * 2  # split on an even-byte (whole-sample) boundary
+    first = chunked_filter.process(inp[:half])
+    second = chunked_filter.process(inp[half:])
+    chunked = first + second
+
+    assert len(chunked) == len(single)
+    a = np.frombuffer(single, dtype="<i2").astype(np.int64)
+    b = np.frombuffer(chunked, dtype="<i2").astype(np.int64)
+    # Exact byte-for-byte (the chunk split changes nothing in the math).
+    assert int(np.max(np.abs(a - b))) == 0
+
+
+def test_unity_dc_gain() -> None:
+    # A constant (DC) input must pass through unchanged once the filter's
+    # history has filled — the coefficients are DC-normalised to unity gain.
+    const = np.full(4800, 5000, dtype="<i2").tobytes()
+    out = _lowpass().process(const)
+    out_arr = np.frombuffer(out, dtype="<i2")
+    # Skip the full filter-length start-up transient: the FIR only sees a full
+    # window of constant input once num_taps-1 (=62) samples have flowed in.
+    settled = out_arr[63:]
+    assert np.allclose(settled, 5000, atol=1)
+
+
+def test_odd_trailing_byte_carried_across_calls() -> None:
+    # An odd-length buffer leaves a single byte buffered; combined with the
+    # next call it completes the sample. Mirrors StatefulResampler semantics.
+    lp = _lowpass()
+    out1 = lp.process(b"\x01\x02\x03")  # 1 whole sample + 1 carried byte
+    assert len(out1) == 2
+    out2 = lp.process(b"\x04")  # completes the carried sample
+    assert len(out2) == 2
+
+
+def test_reset_clears_history() -> None:
+    lp = _lowpass()
+    lp.process(_sine_pcm16le(7000))
+    lp.reset()
+    # After reset, filtering a fresh low tone behaves like a cold-start filter.
+    inp = _sine_pcm16le(500)
+    out_after_reset = lp.process(inp)
+    cold = _lowpass().process(inp)
+    assert out_after_reset == cold
+
+
+def test_rejects_even_num_taps() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        StatefulFirLowpass(num_taps=64, cutoff_hz=3700, sample_rate_hz=_SR)
+
+
+def test_rejects_cutoff_above_nyquist() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        StatefulFirLowpass(num_taps=63, cutoff_hz=13000, sample_rate_hz=_SR)

--- a/libraries/python/tests/test_realtime_transcription_language.py
+++ b/libraries/python/tests/test_realtime_transcription_language.py
@@ -1,0 +1,107 @@
+"""Unit tests for the ``transcription_language`` knob on the OpenAI Realtime
+adapters and its threading from the engine markers down to the session config.
+
+``transcription_language`` (ISO-639-1) pins the Realtime session's input
+transcription to one language instead of auto-detecting per utterance —
+auto-detect mislabels short / noisy phone speech (an Italian "sì" comes back
+tagged Spanish or English). It is optional and display-only: omitting it keeps
+today's auto-detect behaviour, so the language key must be ABSENT from the
+session config when unset.
+
+No WebSocket is opened — these assert the dicts produced by the real
+session-config builders directly, so no external boundary is mocked and no
+``mocked`` marker is needed.
+"""
+
+from __future__ import annotations
+
+import os
+
+from getpatter.providers.openai_realtime import OpenAIRealtimeAdapter
+from getpatter.providers.openai_realtime_2 import OpenAIRealtime2Adapter
+
+
+def _v1(**kwargs) -> OpenAIRealtimeAdapter:
+    return OpenAIRealtimeAdapter(api_key="sk-test", **kwargs)
+
+
+def _ga(**kwargs) -> OpenAIRealtime2Adapter:
+    return OpenAIRealtime2Adapter(api_key="sk-test", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Adapter session-config builders
+# ---------------------------------------------------------------------------
+
+
+def test_v1_transcription_language_pins_input_transcription() -> None:
+    config = _v1(transcription_language="it")._build_session_config()
+    assert config["input_audio_transcription"]["language"] == "it"
+
+
+def test_v1_transcription_language_omitted_when_unset() -> None:
+    config = _v1()._build_session_config()
+    # Auto-detect (today's behaviour): no language key emitted.
+    assert "language" not in config["input_audio_transcription"]
+
+
+def test_ga_transcription_language_nested_under_audio_input() -> None:
+    config = _ga(transcription_language="it")._build_ga_session_config()
+    assert config["audio"]["input"]["transcription"]["language"] == "it"
+
+
+def test_ga_transcription_language_omitted_when_unset() -> None:
+    config = _ga()._build_ga_session_config()
+    assert "language" not in config["audio"]["input"]["transcription"]
+
+
+def test_v1_transcription_language_independent_of_model() -> None:
+    # The language key sits alongside the model key; setting one must not drop
+    # the other.
+    config = _v1(
+        transcription_language="es",
+        input_audio_transcription_model="gpt-realtime-whisper",
+    )._build_session_config()
+    transcription = config["input_audio_transcription"]
+    assert transcription["language"] == "es"
+    assert transcription["model"] == "gpt-realtime-whisper"
+
+
+# ---------------------------------------------------------------------------
+# Engine-marker → Agent → adapter threading
+# ---------------------------------------------------------------------------
+
+
+def _phone():
+    from getpatter import Patter, Twilio
+
+    os.environ.setdefault("OPENAI_API_KEY", "sk-test")
+    return Patter(
+        carrier=Twilio(account_sid="ACtest", auth_token="x"),
+        phone_number="+15555550100",
+    )
+
+
+def test_engine_marker_threads_language_to_agent_realtime_2() -> None:
+    from getpatter import OpenAIRealtime2
+
+    eng = OpenAIRealtime2(transcription_language="it")
+    assert eng.transcription_language == "it"
+    agent = _phone().agent(engine=eng, system_prompt="hi")
+    assert agent.openai_realtime_transcription_language == "it"
+
+
+def test_engine_marker_threads_language_to_agent_realtime_v1() -> None:
+    from getpatter import OpenAIRealtime
+
+    eng = OpenAIRealtime(transcription_language="en")
+    assert eng.transcription_language == "en"
+    agent = _phone().agent(engine=eng, system_prompt="hi")
+    assert agent.openai_realtime_transcription_language == "en"
+
+
+def test_agent_language_defaults_to_none_without_engine_field() -> None:
+    from getpatter import OpenAIRealtime2
+
+    agent = _phone().agent(engine=OpenAIRealtime2(), system_prompt="hi")
+    assert agent.openai_realtime_transcription_language is None

--- a/libraries/python/tests/test_realtime_transcription_language.py
+++ b/libraries/python/tests/test_realtime_transcription_language.py
@@ -85,7 +85,7 @@ def _phone():
 def test_engine_marker_threads_language_to_agent_realtime_2() -> None:
     from getpatter import OpenAIRealtime2
 
-    eng = OpenAIRealtime2(transcription_language="it")
+    eng = OpenAIRealtime2(api_key="sk-test", transcription_language="it")
     assert eng.transcription_language == "it"
     agent = _phone().agent(engine=eng, system_prompt="hi")
     assert agent.openai_realtime_transcription_language == "it"
@@ -94,7 +94,7 @@ def test_engine_marker_threads_language_to_agent_realtime_2() -> None:
 def test_engine_marker_threads_language_to_agent_realtime_v1() -> None:
     from getpatter import OpenAIRealtime
 
-    eng = OpenAIRealtime(transcription_language="en")
+    eng = OpenAIRealtime(api_key="sk-test", transcription_language="en")
     assert eng.transcription_language == "en"
     agent = _phone().agent(engine=eng, system_prompt="hi")
     assert agent.openai_realtime_transcription_language == "en"
@@ -103,5 +103,7 @@ def test_engine_marker_threads_language_to_agent_realtime_v1() -> None:
 def test_agent_language_defaults_to_none_without_engine_field() -> None:
     from getpatter import OpenAIRealtime2
 
-    agent = _phone().agent(engine=OpenAIRealtime2(), system_prompt="hi")
+    agent = _phone().agent(
+        engine=OpenAIRealtime2(api_key="sk-test"), system_prompt="hi"
+    )
     assert agent.openai_realtime_transcription_language is None

--- a/libraries/typescript/src/audio/transcoding.ts
+++ b/libraries/typescript/src/audio/transcoding.ts
@@ -489,6 +489,120 @@ export class StatefulResampler {
   }
 }
 
+// ---------- StatefulFirLowpass: windowed-sinc anti-alias low-pass ----------
+
+/** Options for {@link StatefulFirLowpass}. */
+export interface StatefulFirLowpassOptions {
+  /** Number of FIR taps. Must be a positive ODD integer (linear phase). */
+  numTaps: number;
+  /** -6 dB cutoff frequency in Hz. */
+  cutoffHz: number;
+  /** Sample rate of the stream being filtered, in Hz. */
+  sampleRateHz: number;
+}
+
+/**
+ * Linear-phase FIR low-pass with cross-chunk history — an anti-alias
+ * pre-filter to run BEFORE decimation.
+ *
+ * Why this exists: decimating `gpt-realtime-2`'s 24 kHz output straight down
+ * to 8 kHz aliases any energy above 4 kHz into the telephony band, heard as
+ * raspy / crackly speech. The 24→16 (linear, unfiltered) + 16→8 (gentle 5-tap
+ * binomial) resampler chain under-attenuates that band. Running this low-pass
+ * on the 24 kHz signal FIRST removes everything above the cutoff, so the
+ * downstream decimation has nothing left to alias.
+ *
+ * Coefficients are a Hamming-windowed sinc (~53 dB stopband). State is the
+ * previous `numTaps-1` input samples, carried across `process()` calls so the
+ * output is continuous (no per-chunk transient). Group delay is a constant
+ * `(numTaps-1)/2` samples — inaudible at these tap counts.
+ */
+export class StatefulFirLowpass {
+  private readonly coeffs: Float64Array;
+  private readonly numTaps: number;
+  /** Last `numTaps-1` input samples: history[k] = x[k - (numTaps-1)]. */
+  private readonly history: Float64Array;
+  private readonly carry = new PcmCarry();
+
+  constructor(opts: StatefulFirLowpassOptions) {
+    const { numTaps, cutoffHz, sampleRateHz } = opts;
+    if (!Number.isInteger(numTaps) || numTaps < 1 || numTaps % 2 === 0) {
+      throw new Error(
+        `StatefulFirLowpass: numTaps must be a positive odd integer, got ${numTaps}`,
+      );
+    }
+    if (cutoffHz <= 0 || cutoffHz >= sampleRateHz / 2) {
+      throw new Error(
+        `StatefulFirLowpass: cutoffHz must be in (0, ${sampleRateHz / 2}), got ${cutoffHz}`,
+      );
+    }
+    this.numTaps = numTaps;
+    this.coeffs = StatefulFirLowpass.design(numTaps, cutoffHz, sampleRateHz);
+    this.history = new Float64Array(numTaps - 1); // zero-initialised
+  }
+
+  /** Hamming-windowed sinc low-pass, DC-normalised to unity gain. */
+  private static design(numTaps: number, cutoffHz: number, sampleRateHz: number): Float64Array {
+    const fc = cutoffHz / sampleRateHz; // normalised cutoff (cycles/sample)
+    const m = numTaps - 1;
+    const c = new Float64Array(numTaps);
+    let sum = 0;
+    for (let n = 0; n < numTaps; n++) {
+      const k = n - m / 2;
+      const sinc = k === 0 ? 2 * fc : Math.sin(2 * Math.PI * fc * k) / (Math.PI * k);
+      const window = 0.54 - 0.46 * Math.cos((2 * Math.PI * n) / m); // Hamming
+      c[n] = sinc * window;
+      sum += c[n];
+    }
+    for (let n = 0; n < numTaps; n++) c[n] /= sum; // unity DC gain
+    return c;
+  }
+
+  /**
+   * Filter a chunk of PCM16-LE samples, returning the same number of samples.
+   * Odd trailing bytes are buffered across calls.
+   */
+  process(pcm: Buffer): Buffer {
+    const aligned = this.carry.push(pcm);
+    const n = aligned.length >> 1;
+    if (n === 0) return Buffer.alloc(0);
+
+    const taps = this.numTaps;
+    const keep = taps - 1;
+    const c = this.coeffs;
+    const hist = this.history;
+    const out = Buffer.alloc(n * 2);
+
+    for (let i = 0; i < n; i++) {
+      let acc = 0;
+      // y[i] = sum_{j=0..taps-1} c[j] * x[i - (taps-1) + j]
+      for (let j = 0; j < taps; j++) {
+        const idx = i - keep + j;
+        const s = idx >= 0 ? aligned.readInt16LE(idx * 2) : hist[keep + idx];
+        acc += c[j] * s;
+      }
+      out.writeInt16LE(Math.max(-32768, Math.min(32767, Math.round(acc))), i * 2);
+    }
+
+    // New history = last `keep` input samples of the virtual stream. Build into
+    // a temp first so small chunks (n < keep) don't read overwritten slots.
+    const next = new Float64Array(keep);
+    for (let k = 0; k < keep; k++) {
+      const idx = n - keep + k;
+      next[k] = idx >= 0 ? aligned.readInt16LE(idx * 2) : hist[keep + idx];
+    }
+    hist.set(next);
+
+    return out;
+  }
+
+  /** Clear filter history (e.g. at call boundaries). */
+  reset(): void {
+    this.history.fill(0);
+    this.carry.reset();
+  }
+}
+
 /** Create a stateful 16 kHz → 8 kHz downsampling resampler. */
 export function createResampler16kTo8k(): StatefulResampler {
   return new StatefulResampler({ srcRate: 16000, dstRate: 8000 });

--- a/libraries/typescript/src/engines/openai-2.ts
+++ b/libraries/typescript/src/engines/openai-2.ts
@@ -31,6 +31,16 @@ export interface Realtime2Options {
    */
   inputAudioTranscriptionModel?: string;
   /**
+   * ISO-639-1 language hint for `audio.input.transcription.language`
+   * (e.g. `"it"`, `"en"`, `"es"`). Pins the input transcription model to one
+   * language instead of auto-detecting per utterance — auto-detect mislabels
+   * short / noisy phone utterances (an Italian "sì" comes back tagged Spanish
+   * or English). Omit to keep auto-detect (default). Display-only: the
+   * transcript feeds the dashboard / `onTranscript`, not the model's
+   * comprehension. Mirrors `transcription_language` on the Python marker.
+   */
+  transcriptionLanguage?: string;
+  /**
    * Input noise reduction for speakerphone / conference audio. `undefined`
    * (default) omits the field (no reduction). `"far_field"` recommended for
    * phone / speakerphone calls; `"near_field"` for a handset close to the
@@ -93,6 +103,7 @@ export class Realtime2 {
   readonly voice: string;
   readonly reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   readonly inputAudioTranscriptionModel?: string;
+  readonly transcriptionLanguage?: string;
   readonly noiseReduction?: 'near_field' | 'far_field';
   readonly turnDetection?: RealtimeTurnDetection;
   readonly gateResponseOnTranscript?: boolean;
@@ -116,6 +127,7 @@ export class Realtime2 {
     this.voice = opts.voice ?? "alloy";
     this.reasoningEffort = opts.reasoningEffort;
     this.inputAudioTranscriptionModel = opts.inputAudioTranscriptionModel;
+    this.transcriptionLanguage = opts.transcriptionLanguage;
     this.noiseReduction = opts.noiseReduction;
     this.turnDetection = opts.turnDetection;
     this.gateResponseOnTranscript = opts.gateResponseOnTranscript;

--- a/libraries/typescript/src/engines/openai.ts
+++ b/libraries/typescript/src/engines/openai.ts
@@ -31,6 +31,15 @@ export interface RealtimeOptions {
    */
   inputAudioTranscriptionModel?: string;
   /**
+   * ISO-639-1 language hint for the Realtime session's
+   * `input_audio_transcription.language` (e.g. `"it"`, `"en"`, `"es"`). Pins
+   * the input transcription model to one language instead of auto-detecting
+   * per utterance — auto-detect mislabels short / noisy phone utterances.
+   * Omit to keep auto-detect (default). Display-only: the transcript feeds the
+   * dashboard / `onTranscript`, not the model's comprehension.
+   */
+  transcriptionLanguage?: string;
+  /**
    * Input noise reduction for speakerphone / conference audio. `undefined`
    * (default) omits the field (no reduction). `"far_field"` recommended for
    * phone / speakerphone calls; `"near_field"` for a handset close to the
@@ -90,6 +99,7 @@ export class Realtime {
   readonly voice: string;
   readonly reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   readonly inputAudioTranscriptionModel?: string;
+  readonly transcriptionLanguage?: string;
   readonly noiseReduction?: 'near_field' | 'far_field';
   readonly turnDetection?: RealtimeTurnDetection;
   readonly gateResponseOnTranscript?: boolean;
@@ -113,6 +123,7 @@ export class Realtime {
     this.voice = opts.voice ?? "alloy";
     this.reasoningEffort = opts.reasoningEffort;
     this.inputAudioTranscriptionModel = opts.inputAudioTranscriptionModel;
+    this.transcriptionLanguage = opts.transcriptionLanguage;
     this.noiseReduction = opts.noiseReduction;
     this.turnDetection = opts.turnDetection;
     this.gateResponseOnTranscript = opts.gateResponseOnTranscript;

--- a/libraries/typescript/src/providers/openai-realtime-2.ts
+++ b/libraries/typescript/src/providers/openai-realtime-2.ts
@@ -31,6 +31,7 @@ import {
 import {
   mulawToPcm16,
   pcm16ToMulaw,
+  StatefulFirLowpass,
   StatefulResampler,
 } from '../audio/transcoding';
 
@@ -88,6 +89,15 @@ export class OpenAIRealtime2Adapter extends OpenAIRealtimeAdapter {
   private outboundResampler24To16: StatefulResampler | null = null;
   private outboundResampler16To8: StatefulResampler | null = null;
 
+  /** Anti-alias low-pass applied to the 24 kHz model output BEFORE the
+   *  24→16→8 decimation chain. `gpt-realtime-2` emits voice with significant
+   *  energy above 4 kHz; without a real anti-alias filter that energy folds
+   *  back into the telephony band on decimation and is heard as raspy /
+   *  crackly speech. A 63-tap Hamming-windowed sinc at 3.7 kHz (~53 dB
+   *  stopband) removes it so the downstream linear/binomial stages have
+   *  nothing left to alias. Created lazily so each session owns its state. */
+  private outboundLowpass24k: StatefulFirLowpass | null = null;
+
   /** Last 8 kHz input sample carried across chunk boundaries for the
    *  direct 3× linear upsample (see `transcodeInboundMulaw8ToPcm24`).
    *  The carry guarantees the very first output of each chunk
@@ -110,6 +120,11 @@ export class OpenAIRealtime2Adapter extends OpenAIRealtimeAdapter {
       format: fmt,
       transcription: {
         model: opts.inputAudioTranscriptionModel ?? OpenAITranscriptionModel.WHISPER_1,
+        // Pin the transcription language when configured — Whisper auto-detect
+        // mislabels short / noisy phone utterances. Omitted when unset.
+        ...(opts.transcriptionLanguage
+          ? { language: opts.transcriptionLanguage }
+          : {}),
       },
       // Response creation + barge-in cancellation (issue #154 — hand
       // turn-taking to the server by default):
@@ -675,9 +690,16 @@ export class OpenAIRealtime2Adapter extends OpenAIRealtimeAdapter {
     if (!this.outboundResampler24To16) {
       this.outboundResampler24To16 = new StatefulResampler({ srcRate: 24000, dstRate: 16000 });
       this.outboundResampler16To8 = new StatefulResampler({ srcRate: 16000, dstRate: 8000 });
+      this.outboundLowpass24k = new StatefulFirLowpass({
+        numTaps: 63,
+        cutoffHz: 3700,
+        sampleRateHz: 24000,
+      });
     }
     const pcm24 = Buffer.from(deltaB64, 'base64');
-    const pcm16 = this.outboundResampler24To16.process(pcm24);
+    // Anti-alias FIRST (at 24 kHz), THEN decimate — see field docstring.
+    const filtered24 = this.outboundLowpass24k!.process(pcm24);
+    const pcm16 = this.outboundResampler24To16.process(filtered24);
     const pcm8 = this.outboundResampler16To8!.process(pcm16);
     if (pcm8.length === 0) return Buffer.alloc(0);
     return pcm16ToMulaw(pcm8);

--- a/libraries/typescript/src/providers/openai-realtime.ts
+++ b/libraries/typescript/src/providers/openai-realtime.ts
@@ -114,6 +114,12 @@ export interface OpenAIRealtimeOptions {
   modalities?: string[];
   toolChoice?: string | Record<string, unknown>;
   inputAudioTranscriptionModel?: string;
+  /**
+   * ISO-639-1 language hint for `input_audio_transcription.language`
+   * (e.g. `"it"`). Pins the transcription model to one language instead of
+   * auto-detecting per utterance. Omit to keep auto-detect (default).
+   */
+  transcriptionLanguage?: string;
   vadType?: 'server_vad' | 'semantic_vad';
   /**
    * Trailing silence (ms) the server VAD waits for before treating the user's
@@ -356,6 +362,11 @@ export class OpenAIRealtimeAdapter {
       }),
       input_audio_transcription: {
         model: this.options.inputAudioTranscriptionModel ?? OpenAITranscriptionModel.WHISPER_1,
+        // Pin the transcription language when configured — Whisper auto-detect
+        // mislabels short / noisy phone utterances. Omitted when unset.
+        ...(this.options.transcriptionLanguage
+          ? { language: this.options.transcriptionLanguage }
+          : {}),
       },
     };
     // v1 puts noise reduction at the TOP LEVEL of session (not nested under

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -601,6 +601,9 @@ export function buildAIAdapter(config: LocalConfig, agent: AgentOptions, resolve
     if (engine.inputAudioTranscriptionModel !== undefined) {
       adapterOptions.inputAudioTranscriptionModel = engine.inputAudioTranscriptionModel;
     }
+    if (engine.transcriptionLanguage !== undefined) {
+      adapterOptions.transcriptionLanguage = engine.transcriptionLanguage;
+    }
     if (engine.noiseReduction !== undefined) {
       adapterOptions.noiseReduction = engine.noiseReduction;
     }

--- a/libraries/typescript/tests/openai-realtime-2-session.test.ts
+++ b/libraries/typescript/tests/openai-realtime-2-session.test.ts
@@ -27,6 +27,24 @@ function audioInput(config: Record<string, unknown>): Record<string, unknown> {
   return (config.audio as { input: Record<string, unknown> }).input;
 }
 
+describe('[unit] OpenAIRealtime2Adapter GA transcription language', () => {
+  function transcription(config: Record<string, unknown>): Record<string, unknown> {
+    return audioInput(config).transcription as Record<string, unknown>;
+  }
+
+  it('pins audio.input.transcription.language when transcriptionLanguage is set', () => {
+    const t = transcription(buildGA({ transcriptionLanguage: 'it' }));
+    expect(t.language).toBe('it');
+    // The model is still emitted (default whisper-1) — language is additive.
+    expect(typeof t.model).toBe('string');
+  });
+
+  it('OMITS the language key entirely when unset (Whisper auto-detect, today behavior)', () => {
+    const t = transcription(buildGA({}));
+    expect('language' in t).toBe(false);
+  });
+});
+
 describe('[unit] OpenAIRealtime2Adapter GA noise reduction', () => {
   it("nests noise_reduction under session.audio.input when set to 'far_field'", () => {
     const config = buildGA({ noiseReduction: 'far_field' });

--- a/libraries/typescript/tests/openai-realtime-v1-session.test.ts
+++ b/libraries/typescript/tests/openai-realtime-v1-session.test.ts
@@ -21,6 +21,19 @@ function buildV1(opts: OpenAIRealtimeOptions): Record<string, unknown> {
     .buildSessionConfig();
 }
 
+describe('[unit] OpenAIRealtimeAdapter v1 transcription language', () => {
+  it('pins input_audio_transcription.language when transcriptionLanguage is set', () => {
+    const t = buildV1({ transcriptionLanguage: 'it' }).input_audio_transcription as Record<string, unknown>;
+    expect(t.language).toBe('it');
+    expect(typeof t.model).toBe('string');
+  });
+
+  it('OMITS the language key entirely when unset (Whisper auto-detect)', () => {
+    const t = buildV1({}).input_audio_transcription as Record<string, unknown>;
+    expect('language' in t).toBe(false);
+  });
+});
+
 describe('[unit] OpenAIRealtimeAdapter v1 noise reduction', () => {
   it('injects input_audio_noise_reduction at the TOP LEVEL of session (not nested)', () => {
     const config = buildV1({ noiseReduction: 'far_field' });

--- a/libraries/typescript/tests/transcoding.test.ts
+++ b/libraries/typescript/tests/transcoding.test.ts
@@ -5,7 +5,64 @@ import {
   resample8kTo16k,
   resample16kTo8k,
   resample24kTo16k,
+  StatefulFirLowpass,
 } from "../src/audio/transcoding";
+
+/** Generate `numSamples` of a real sine tone as a PCM16-LE buffer. */
+function sinePcm(freqHz: number, numSamples: number, amp = 10000, rate = 24000): Buffer {
+  const buf = Buffer.alloc(numSamples * 2);
+  for (let i = 0; i < numSamples; i++) {
+    buf.writeInt16LE(Math.round(amp * Math.sin((2 * Math.PI * freqHz * i) / rate)), i * 2);
+  }
+  return buf;
+}
+
+/** RMS amplitude of a PCM16-LE buffer. */
+function rms(buf: Buffer): number {
+  const n = buf.length >> 1;
+  if (n === 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const s = buf.readInt16LE(i * 2);
+    sum += s * s;
+  }
+  return Math.sqrt(sum / n);
+}
+
+describe("[unit] StatefulFirLowpass anti-alias pre-filter", () => {
+  const make = () => new StatefulFirLowpass({ numTaps: 63, cutoffHz: 3700, sampleRateHz: 24000 });
+
+  it("passes a 500 Hz tone (below cutoff) at near-unity amplitude", () => {
+    const input = sinePcm(500, 4800);
+    const out = make().process(input);
+    const skip = 200 * 2; // drop the FIR startup transient before measuring
+    const ratio = rms(out.subarray(skip)) / rms(input.subarray(skip));
+    expect(ratio).toBeGreaterThan(0.9);
+    expect(ratio).toBeLessThan(1.1);
+  });
+
+  it("strongly attenuates a 7 kHz tone (above cutoff) — the aliasing source", () => {
+    const input = sinePcm(7000, 4800);
+    const out = make().process(input);
+    const skip = 200 * 2;
+    const ratio = rms(out.subarray(skip)) / rms(input.subarray(skip));
+    expect(ratio).toBeLessThan(0.1);
+  });
+
+  it("is continuous across chunk boundaries (chunked output === single-shot)", () => {
+    const input = sinePcm(1500, 2400);
+    const whole = make().process(input);
+    const lp = make();
+    const a = lp.process(input.subarray(0, 1000));
+    const b = lp.process(input.subarray(1000));
+    expect(Buffer.concat([a, b]).equals(whole)).toBe(true);
+  });
+
+  it("rejects an even tap count and an out-of-range cutoff", () => {
+    expect(() => new StatefulFirLowpass({ numTaps: 64, cutoffHz: 3700, sampleRateHz: 24000 })).toThrow();
+    expect(() => new StatefulFirLowpass({ numTaps: 63, cutoffHz: 20000, sampleRateHz: 24000 })).toThrow();
+  });
+});
 
 describe("mulawToPcm16", () => {
   it("decodes silence (mulaw 0xFF) to near-zero PCM", () => {


### PR DESCRIPTION
## Summary
- Add an opt-in `transcriptionLanguage` (ISO-639-1) to the OpenAI Realtime engine markers so the Whisper input-transcription is pinned to one language instead of auto-detecting per utterance — auto-detect mislabels short / noisy phone speech (an Italian "sì" comes back tagged Spanish/English). Display-only: the speech-to-speech model's comprehension was never affected, only the dashboard / `onTranscript` / history transcript.
- Fix raspy / crackly agent voice on the Realtime-2 (`gpt-realtime-2`) telephony path by anti-aliasing the 24 kHz model output before it is decimated to mulaw 8 kHz.

## Implementation
- **`transcriptionLanguage` / `transcription_language`** on `OpenAIRealtime` + `OpenAIRealtime2` (and the Python `engines.openai_realtime` / `engines.openai_realtime_2` markers). Threaded to the session config at `input_audio_transcription.language` (v1) / `audio.input.transcription.language` (GA). Optional, omitted by default (auto-detect preserved — no behaviour change for existing callers). Python path: marker → `client` → `Agent` → `stream_handler` → adapter → session config.
- **Anti-alias filter.** New `StatefulFirLowpass` (63-tap Hamming windowed-sinc, cutoff 3.7 kHz, ~53 dB stopband, stateful across audio deltas) runs on the 24 kHz signal before the existing 24→16→8 decimation chain. `gpt-realtime-2` emits significant >4 kHz energy that was folding back into the telephony band as raspiness; the pre-filter removes it. Contained to the realtime-2 adapter — the shared `StatefulResampler` / pipeline TTS path is untouched. TS uses `Buffer`; Python uses stdlib `array` (no numpy) to match the existing dependency-clean transcoding module.
- Files: TS `engines/openai{,-2}.ts`, `providers/openai-realtime{,-2}.ts`, `server.ts`, `audio/transcoding.ts`; Python `engines/openai_realtime{,_2}.py`, `providers/openai_realtime{,_2}.py`, `client.py`, `models.py`, `stream_handler.py`, `audio/transcoding.py`.

## Breaking change?
No. Both additions are optional with safe defaults (auto-detect / no extra filtering disabled until opted in for language; the anti-alias filter is internal and always-on but only improves output fidelity).

## Test plan
- [x] Python: `pytest tests/` → 2745 passed, 8 skipped, 2 xfailed
- [x] TypeScript: `npm test` (2163 passed) + `npm run lint` + `npm run build`
- [x] New unit tests both SDKs: language pinned/omitted on v1 + GA session config; FIR passband (500 Hz near-unity), stopband (7 kHz attenuated <10%), byte-exact chunk-boundary continuity
- [ ] /parity-check (manually verified: every `input_audio_transcription_model` threading site mirrored for `transcription_language`; FIR params identical 63 / 3700 / 24000; defaults aligned)
- [ ] E2E smoke (no pipeline/handler change)

## Docs updates
- N/A in this PR — `transcriptionLanguage` should be added to the Realtime engine reference under `docs/typescript-sdk/engines.mdx` + the Python equivalent as a docs-sync follow-up.