### PR TITLE
fix(security): fold non-canonical IP encodings in SSRF guard (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,27 @@
   `libraries/python/getpatter/audio/transcoding.py` (`StatefulFirLowpass`),
   `providers/openai_realtime_2.py`.
 
+### Security
+
+- **SSRF guard now folds non-canonical IP encodings.** The outbound-URL guards
+  (tool webhooks, `on_message`, `consult`, MCP) recognised only canonical IP
+  literals, so alternate spellings of an internal address that `getaddrinfo` /
+  the WHATWG URL parser accept slipped past the private-range checks and
+  connected to the blocked host — including `169.254.169.254` cloud-metadata
+  (IAM-credential theft). Now every spelling is normalised before the range
+  check: decimal / octal / hex / short IPv4 (`http://2130706433/`,
+  `0x7f.0.0.1`, `0177.0.0.1`, `127.1`) and IPv4-mapped IPv6
+  (`[::ffff:169.254.169.254]`, incl. Node's canonical `::ffff:a9fe:a9fe` hex
+  form). A mapped *public* address (`::ffff:8.8.8.8`) stays allowed. Python adds
+  a shared `getpatter/ssrf.py` (`resolve_literal_ip` via `socket.inet_aton` +
+  `is_internal_ip` unwrapping `ipv4_mapped`) used by both
+  `tools/tool_executor.py::_validate_webhook_url` and the
+  `server.py::validate_webhook_url` mirror, closing the drift between them; TS
+  unwraps IPv4-mapped IPv6 in `src/server.ts::validateWebhookUrl`. Reported via
+  responsible disclosure (#195). The guard remains best-effort against
+  DNS-rebinding by design (hostnames resolve at request time) — webhook URLs are
+  trusted SDK-user config, not caller-supplied.
+
 ## 0.6.9 (2026-06-23)
 
 ### Added

--- a/libraries/python/getpatter/server.py
+++ b/libraries/python/getpatter/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import ipaddress
 import logging
 import os
 import re
@@ -26,6 +25,7 @@ from getpatter.services.call_log import (
     alog_turn,
     resolve_log_root,
 )
+from getpatter.ssrf import is_internal_ip, resolve_literal_ip
 from getpatter.utils.log_sanitize import mask_phone_number, sanitize_log_value
 
 logger = logging.getLogger("getpatter")
@@ -130,22 +130,15 @@ def validate_webhook_url(url: str) -> bool:
     host = raw_host.strip("[]").lower()
     if host in _BLOCKED_WEBHOOK_HOSTNAMES:
         return False
-    try:
-        addr = ipaddress.ip_address(host)
-    except ValueError:
-        # Hostname (not a literal IP) — DNS resolution at fetch time can
-        # still hit private space, but we avoid blocking the event loop
-        # with a sync resolver here.  This matches the TS counterpart.
+    # Fold every numeric spelling a resolver accepts (decimal / octal / hex /
+    # short IPv4, IPv4-mapped IPv6) to the concrete address before range-
+    # checking it. A genuine hostname returns None — DNS resolution at fetch
+    # time can still hit private space, but we avoid blocking the event loop
+    # with a sync resolver here. Matches the TS counterpart.
+    addr = resolve_literal_ip(host)
+    if addr is None:
         return True
-    if (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_reserved
-        or addr.is_unspecified
-    ):
-        return False
-    return True
+    return not is_internal_ip(addr)
 
 
 def _client_ip_for_ws(websocket: WebSocket) -> str:

--- a/libraries/python/getpatter/ssrf.py
+++ b/libraries/python/getpatter/ssrf.py
@@ -1,0 +1,75 @@
+"""Shared SSRF host-normalization for outbound-URL guards.
+
+Centralises the IP-literal handling used by every outbound-URL validator so the
+tool-executor guard and the server mirror cannot drift. They had drifted: both
+recognised only *canonical* IP literals (dotted-quad IPv4, RFC-5952 IPv6), so
+the equivalent spellings that ``getaddrinfo`` honours — decimal / octal / hex /
+short IPv4, and IPv4-mapped IPv6 — slipped past the private-range checks and
+connected to the very internal host the guard meant to block (including the
+``169.254.169.254`` cloud-metadata endpoint).
+
+The two helpers below fold every such spelling to a concrete
+:class:`ipaddress` object and answer "is this address internal?" identically
+for both validators.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def resolve_literal_ip(host: str) -> IPAddress | None:
+    """Return the IP literal *host* denotes, or ``None`` when *host* is a name.
+
+    Folds the numeric encodings ``getaddrinfo`` (Python ``httpx`` /
+    ``websockets``) accepts so the caller can range-check the address the
+    client would actually connect to:
+
+      * canonical dotted-quad IPv4 and RFC-5952 IPv6 (via :mod:`ipaddress`)
+      * decimal / octal / hex / short IPv4 — ``2130706433``, ``0x7f.0.0.1``,
+        ``0177.0.0.1``, ``127.1`` — via :func:`socket.inet_aton`
+
+    A genuine DNS hostname (``example.com``) returns ``None``: it is resolved at
+    request time, not here, to avoid a blocking synchronous lookup on the event
+    loop.
+    """
+    host = host.strip("[]")
+    if not host:
+        return None
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    # Non-canonical numeric IPv4 (decimal / octal / hex / short forms). These
+    # raise above but resolve to a real IPv4 — fold them the same way the C
+    # resolver does. inet_aton rejects genuine hostnames, leaving them as DNS.
+    try:
+        packed = socket.inet_aton(host)
+    except OSError:
+        return None
+    return ipaddress.IPv4Address(packed)
+
+
+def is_internal_ip(addr: IPAddress) -> bool:
+    """True when *addr* — or the IPv4 an IPv4-mapped IPv6 embeds — is private,
+    loopback, link-local, reserved, or unspecified.
+
+    Unwrapping ``ipv4_mapped`` matters on Python < 3.13, where the range flags
+    on the IPv6 wrapper do not reflect the embedded IPv4 (so
+    ``::ffff:169.254.169.254`` would otherwise read as public).
+    """
+    candidates: list[IPAddress] = [addr]
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        candidates.append(mapped)
+    return any(
+        a.is_private
+        or a.is_loopback
+        or a.is_link_local
+        or a.is_reserved
+        or a.is_unspecified
+        for a in candidates
+    )

--- a/libraries/python/getpatter/tools/tool_executor.py
+++ b/libraries/python/getpatter/tools/tool_executor.py
@@ -12,7 +12,6 @@ per call to avoid the connection-setup tax on tool-heavy turns.
 """
 
 import asyncio
-import ipaddress
 import json
 import logging
 import random
@@ -22,6 +21,7 @@ from urllib.parse import urlparse
 import httpx
 
 from getpatter.observability.tracing import SPAN_TOOL, start_span
+from getpatter.ssrf import is_internal_ip, resolve_literal_ip
 from getpatter.tools.circuit_breaker import (
     CircuitBreakerOptions,
     CircuitBreakerRegistry,
@@ -165,25 +165,17 @@ def _validate_webhook_url(url: str, *, allow_loopback: bool = False) -> None:
         # even when they do not resolve to a literal IP in the URL string.
         if hostname.lower() in _BLOCKED_HOSTNAMES:
             raise ValueError(f"Webhook URL points to a blocked hostname: {hostname!r}")
-        # Block literal private/loopback IP addresses in the URL itself.
-        # We intentionally avoid blocking based on DNS resolution here because
-        # synchronous socket.gethostbyname() would block the async event loop.
-        try:
-            addr = ipaddress.ip_address(hostname)
-            if (
-                addr.is_private
-                or addr.is_loopback
-                or addr.is_link_local
-                or addr.is_reserved
-            ):
-                raise ValueError(
-                    f"Webhook URL points to a private/reserved address: {hostname!r}"
-                )
-        except ValueError as exc:
-            # Re-raise only our own ValueError (private IP rejection), not the
-            # ip_address() parsing error which just means it's a hostname.
-            if "private" in str(exc) or "reserved" in str(exc):
-                raise
+        # Block literal private/loopback IP addresses in the URL itself,
+        # across every spelling a resolver accepts (decimal / octal / hex /
+        # short IPv4, IPv4-mapped IPv6) — not just the canonical dotted-quad
+        # form. We intentionally avoid blocking based on DNS resolution here
+        # because a synchronous lookup would stall the async event loop; a
+        # genuine hostname returns None and is checked at request time.
+        addr = resolve_literal_ip(hostname)
+        if addr is not None and is_internal_ip(addr):
+            raise ValueError(
+                f"Webhook URL points to a private/reserved address: {hostname!r}"
+            )
 
 
 class ToolExecutor:

--- a/libraries/python/tests/security/test_security.py
+++ b/libraries/python/tests/security/test_security.py
@@ -14,6 +14,8 @@ from getpatter.telephony.common import _sanitize_variable_value, _validate_e164
 from getpatter.telephony.twilio import _xml_escape, _validate_twilio_sid
 from getpatter.local_config import LocalConfig
 from getpatter.models import Agent
+from getpatter.server import validate_webhook_url
+from getpatter.tools.tool_executor import _validate_webhook_url
 
 
 # ── SEC-1: SSRF on user-supplied webhook URLs ─────────────────────────────
@@ -43,6 +45,61 @@ class TestSSRFProtection:
     def test_rejects_wrong_prefix(self) -> None:
         sid = "XX" + "a" * 32
         assert _validate_twilio_sid(sid, "CA") is False
+
+
+# ── SEC-1b: SSRF via non-canonical IP encodings ───────────────────────────
+# Regression for the SSRF-guard bypass: the dotted-quad-only checks let
+# decimal / octal / hex / short IPv4 spellings, and IPv4-mapped IPv6, slip
+# past the private-range rejection even though getaddrinfo resolves them to
+# the very internal host the guard meant to block (incl. 169.254.169.254).
+
+# Each entry resolves to an internal address the guard must reject, across
+# every spelling a resolver accepts.
+_SSRF_ENCODED_INTERNAL = [
+    ("decimal 127.0.0.1", "http://2130706433/x"),
+    ("hex 127.0.0.1", "http://0x7f.0.0.1/x"),
+    ("octal 127.0.0.1", "http://0177.0.0.1/x"),
+    ("short 127.0.0.1", "http://127.1/x"),
+    ("decimal 169.254.169.254 metadata", "http://2852039166/latest/meta-data/"),
+    ("ipv4-mapped loopback", "http://[::ffff:127.0.0.1]/x"),
+    ("ipv4-mapped metadata", "http://[::ffff:169.254.169.254]/latest/meta-data/"),
+]
+
+
+@pytest.mark.security
+class TestSSRFAlternateEncodings:
+    """SEC-1b — every encoding of an internal IP is rejected like its
+    dotted-quad form; a mapped public address stays allowed."""
+
+    @pytest.mark.parametrize(
+        "label,url", _SSRF_ENCODED_INTERNAL, ids=[c[0] for c in _SSRF_ENCODED_INTERNAL]
+    )
+    def test_tool_executor_rejects_encoded_internal(self, label: str, url: str) -> None:
+        with pytest.raises(ValueError, match="private|reserved"):
+            _validate_webhook_url(url)
+
+    @pytest.mark.parametrize(
+        "label,url", _SSRF_ENCODED_INTERNAL, ids=[c[0] for c in _SSRF_ENCODED_INTERNAL]
+    )
+    def test_server_mirror_rejects_encoded_internal(self, label: str, url: str) -> None:
+        assert validate_webhook_url(url) is False
+
+    def test_mapped_public_address_allowed(self) -> None:
+        """An IPv4-mapped *public* address must remain reachable."""
+        _validate_webhook_url("http://[::ffff:8.8.8.8]/x")  # no raise
+        assert validate_webhook_url("http://[::ffff:8.8.8.8]/x") is True
+
+    def test_public_hostname_and_ip_still_allowed(self) -> None:
+        _validate_webhook_url("https://example.com/webhook")  # no raise
+        assert validate_webhook_url("https://example.com/webhook") is True
+        assert validate_webhook_url("http://8.8.8.8/x") is True
+
+    def test_decimal_loopback_blocked_for_consult_only_when_strict(self) -> None:
+        """allow_loopback bypasses the IP check (consult escape hatch), so an
+        encoded loopback is permitted there — but stays blocked by default."""
+        _validate_webhook_url("http://2130706433/x", allow_loopback=True)  # no raise
+        with pytest.raises(ValueError, match="private|reserved"):
+            _validate_webhook_url("http://2130706433/x")
 
 
 # ── SEC-2: XSS injection in dashboard fields ──────────────────────────────

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -220,6 +220,50 @@ export function telnyxHangupOutcome(cause: string): CallOutcome | null {
 }
 
 /**
+ * True when an IPv4, given as four octets, falls in a private / loopback /
+ * link-local / reserved range that an outbound webhook must never reach.
+ */
+function isPrivateIPv4(oct: readonly number[]): boolean {
+  const [a, b] = oct;
+  return (
+    a === 0 || // 0.0.0.0/8 (any 0.x — unspecified / "this network")
+    a === 10 || // 10.0.0.0/8
+    a === 127 || // 127.0.0.0/8 loopback
+    (a === 169 && b === 254) || // 169.254.0.0/16 link-local (cloud metadata)
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) // 192.168.0.0/16
+  );
+}
+
+/**
+ * Unwrap an IPv4-mapped IPv6 literal to its four embedded IPv4 octets, or
+ * return ``null`` for any other IPv6 literal.
+ *
+ * Node's WHATWG ``URL`` canonicalizes ``::ffff:127.0.0.1`` to the hex form
+ * ``::ffff:7f00:1`` — which matched none of the IPv6 range checks below, so a
+ * mapped internal address (incl. ``::ffff:169.254.169.254`` metadata) slipped
+ * through. Both the dotted and hex spellings are folded here so the embedded
+ * address is range-checked exactly like its bare IPv4 form. ``host`` is already
+ * lowercased and bracket-stripped by the caller.
+ */
+function mappedIPv4Octets(host: string): number[] | null {
+  // Dotted embedded form: ::ffff:127.0.0.1
+  const dotted = /^::ffff:(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (dotted) {
+    const oct = dotted.slice(1, 5).map((s) => parseInt(s, 10));
+    return oct.every((n) => n >= 0 && n <= 255) ? oct : null;
+  }
+  // Hex embedded form (Node's canonical output): ::ffff:7f00:1
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
+  if (hex) {
+    const g1 = parseInt(hex[1], 16);
+    const g2 = parseInt(hex[2], 16);
+    return [(g1 >> 8) & 0xff, g1 & 0xff, (g2 >> 8) & 0xff, g2 & 0xff];
+  }
+  return null;
+}
+
+/**
  * Validate that a webhook URL is safe to fetch (SSRF protection).
  *
  * Blocks:
@@ -287,15 +331,7 @@ export function validateWebhookUrl(url: string, allowLoopback = false): void {
     if (oct.some((n) => n < 0 || n > 255)) {
       throw new Error(`Webhook URL blocked: ${rawHost} is not a valid IPv4 address`);
     }
-    const [a, b] = oct;
-    if (
-      a === 0 ||                              // 0.0.0.0/8 (any 0.x)
-      a === 10 ||                             // 10.0.0.0/8
-      a === 127 ||                            // 127.0.0.0/8 loopback
-      (a === 169 && b === 254) ||             // 169.254.0.0/16 link-local
-      (a === 172 && b >= 16 && b <= 31) ||    // 172.16.0.0/12
-      (a === 192 && b === 168)                // 192.168.0.0/16
-    ) {
+    if (isPrivateIPv4(oct)) {
       throw new Error(`Webhook URL blocked: ${rawHost} is a private/internal address`);
     }
     return;
@@ -304,6 +340,13 @@ export function validateWebhookUrl(url: string, allowLoopback = false): void {
   // --- IPv6 literal checks (after bracket strip) --------------------------
   // Heuristic detection: IPv6 literals contain ':'.
   if (host.includes(':')) {
+    // IPv4-mapped IPv6 (``::ffff:<v4>``) — range-check the embedded IPv4 the
+    // same as its bare form, before the IPv6 range checks. A mapped *public*
+    // address (``::ffff:8.8.8.8``) returns its octets and is allowed through.
+    const mapped = mappedIPv4Octets(host);
+    if (mapped && isPrivateIPv4(mapped)) {
+      throw new Error(`Webhook URL blocked: ${rawHost} is a private/internal address`);
+    }
     // Loopback / unspecified
     if (host === '::1' || host === '::') {
       throw new Error(`Webhook URL blocked: ${rawHost} is a private/internal address`);

--- a/libraries/typescript/tests/security/security.test.ts
+++ b/libraries/typescript/tests/security/security.test.ts
@@ -78,6 +78,31 @@ describe("SEC-1: SSRF protection on webhook URLs", () => {
   });
 });
 
+// ── SEC-1b: SSRF via non-canonical IP encodings ───────────────────────────
+// Regression: WHATWG folds decimal/octal/hex/short IPv4 (so those are caught
+// by the dotted-quad check) but canonicalizes IPv4-mapped IPv6 to its hex
+// form (``::ffff:7f00:1``), which slipped past every IPv6 range check and
+// connected to the internal host — including 169.254.169.254 metadata.
+
+describe("SEC-1b: SSRF via non-canonical IP encodings", () => {
+  it.each([
+    ["decimal 127.0.0.1", "http://2130706433/x"],
+    ["hex 127.0.0.1", "http://0x7f.0.0.1/x"],
+    ["octal 127.0.0.1", "http://0177.0.0.1/x"],
+    ["short 127.0.0.1", "http://127.1/x"],
+    ["ipv4-mapped loopback (dotted)", "http://[::ffff:127.0.0.1]/x"],
+    ["ipv4-mapped loopback (hex)", "http://[::ffff:7f00:1]/x"],
+    ["ipv4-mapped metadata", "http://[::ffff:169.254.169.254]/latest/meta-data/"],
+    ["ipv4-mapped 10.x private", "http://[::ffff:10.0.0.1]/x"],
+  ])("rejects %s", (_label, url) => {
+    expect(() => validateWebhookUrl(url)).toThrow(/blocked|private|internal/i);
+  });
+
+  it("allows an IPv4-mapped public address", () => {
+    expect(() => validateWebhookUrl("http://[::ffff:8.8.8.8]/x")).not.toThrow();
+  });
+});
+
 // ── SEC-2: XSS injection in dashboard fields ──────────────────────────────
 
 describe("SEC-2: XSS sanitisation", () => {


### PR DESCRIPTION
## Summary
- Fixes a real SSRF-guard bypass (#195): non-canonical IP encodings of an internal host slipped past the private-range checks and connected to the blocked address — including the `169.254.169.254` cloud-metadata endpoint (IAM-credential theft).
- Every spelling a resolver accepts is now normalised **before** the range check, in both SDKs, with parity.

## Implementation
- **Root cause.** The guards only recognised *canonical* IP literals (dotted-quad IPv4, RFC-5952 IPv6). The equivalent encodings that `getaddrinfo` (Python `httpx`/`websockets`) and the WHATWG `URL` parser (Node) honour were not folded, so they fell through to the "it's a hostname, allow it" branch.
- **Python** — new shared `getpatter/ssrf.py`:
  - `resolve_literal_ip(host)` folds decimal / octal / hex / short IPv4 (`2130706433`, `0x7f.0.0.1`, `0177.0.0.1`, `127.1`) via `socket.inet_aton`, returns `None` for genuine hostnames.
  - `is_internal_ip(addr)` checks private / loopback / link-local / reserved / unspecified, and unwraps `ipv4_mapped` so `::ffff:169.254.169.254` is caught on Python < 3.13 too.
  - Used by **both** `tools/tool_executor.py::_validate_webhook_url` (raises) and the `server.py::validate_webhook_url` mirror (returns bool) — closing the drift the report flagged. `services/remote_message.py` delegates to the former, so it's covered.
- **TypeScript** — `src/server.ts::validateWebhookUrl`: WHATWG already folds the IPv4 spellings, but canonicalises IPv4-mapped IPv6 to its hex form (`::ffff:7f00:1`), which matched no IPv6 check. New `mappedIPv4Octets()` unwraps both the dotted and hex forms; `isPrivateIPv4()` (extracted) range-checks the embedded octets. A mapped **public** address (`::ffff:8.8.8.8`) stays allowed.
- **Scope note.** The guard remains best-effort against DNS rebinding by design (hostnames resolve at request time) — webhook URLs are trusted SDK-user config, not caller-supplied. Deprecated non-routed forms (`::a.b.c.d` IPv4-compatible, `::ffff:0:0/96` SIIT) are not folded because modern resolvers don't route them to the embedded IPv4; both SDKs behave identically there.
- Files: `libraries/python/getpatter/ssrf.py` (new), `getpatter/server.py`, `getpatter/tools/tool_executor.py`, `libraries/typescript/src/server.ts`, plus tests + `CHANGELOG.md` (`### Security`). No new dependencies.

## Breaking change?
No. URLs that were *silently allowed but should always have been blocked* are now rejected (a security tightening, not an API change). Public hostnames, public IPs, and the `allow_loopback`/`allowLoopback` consult escape hatch are unchanged.

## Test plan
- [x] Python: `pytest tests/` — 2876 passed, 8 skipped, 2 xfailed. New `TestSSRFAlternateEncodings` (parametrised over every encoding × both validators; RED→GREEN confirmed).
- [x] TypeScript: `npm test` (2289 passed) + `npm run lint` (clean) + new `SEC-1b` block in `tests/security/security.test.ts` (8 reject vectors + public-mapped allow).
- [x] /parity-check intent: identical reject/allow behaviour across SDKs; mechanism may differ (Python `inet_aton`, TS WHATWG) per `sdk-parity.md`.
- [ ] E2E smoke — N/A (validator-level, no pipeline/handler change).

## Docs updates
- N/A (internal SSRF plumbing, no new public API surface). `CHANGELOG.md` `### Security` entry added.
