### PR TITLE
fix(pipeline): stop false barge-in from self-interrupting the user-turn LLM (agent goes mute)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@
 
 ### Fixed
 
+- **(TypeScript) Pipeline self-interrupted the user-turn LLM (false barge-in →
+  agent went mute after its opening line).** Two structural defects combined:
+  (1) `beginSpeaking()` armed barge-in at LLM *dispatch* time
+  (`firstAudioSentAt` stamped before any audio existed), so a slow-first-token
+  turn became "interruptible" ~500 ms later while the caller had heard nothing;
+  (2) `handleBargeIn` ran before the STT duplicate/hallucination filter, so a
+  lagging Deepgram `speech_final` twin of an already-committed `is_final`
+  aborted the still-producing turn. Now `firstAudioSentAt` is set only by the
+  real outbound-audio path (`markFirstAudioSent`, after `bridge.sendAudio`), so
+  `canBargeIn()` stays false until the agent truly emits audio; and a read-only
+  duplicate check (mirroring `commitTranscript`'s filters without consuming
+  dedup state) gates both barge-in paths. Genuine barge-in (agent audibly
+  speaking + new caller speech) still aborts + re-dispatches; the AEC 1000 ms
+  window and `bargeInThresholdMs`/autoVad branches are unchanged.
+  `libraries/typescript/src/stream-handler.ts`.
+
 - **Chipmunk / aliasing on pipeline TTS at non-16 kHz rates.** The outbound
   sender assumed every TTS source was PCM16 @ 16 kHz and ran a hardcoded
   16 kHz → 8 kHz decimator before μ-law encoding. A provider configured for any

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -1061,21 +1061,22 @@ export class StreamHandler {
     this.tailGraceActive = false;
     this.speakingStartedAt = Date.now();
     this.suppressedSpeechPending = false;
-    // Stamp ``firstAudioSentAt`` synchronously for EVERY turn so the
-    // ``canBargeIn()`` gate (250ms anti-flicker for PSTN no-AEC) runs in
-    // PARALLEL with LLM TTFT + TTS TTFB rather than starting only after
-    // the first audio chunk reaches the wire. Without this, a turn with
-    // a slow LLM (gpt-4o cold cache ~2 s) is effectively un-interruptible
-    // for the entire LLM window: ``firstAudioSentAt`` stays null, so
-    // ``canBargeIn`` returns false and every VAD ``speech_start`` is
-    // suppressed silently. Previously this fix was firstMessage-only;
-    // promoted to default on 2026-05-11 after the user reported
-    // "barge-in non funziona più" with gpt-4o.
+    // Do NOT stamp ``firstAudioSentAt`` here. The barge-in gate must arm only
+    // once REAL audio has reached the carrier (``markFirstAudioSent`` after a
+    // successful ``bridge.sendAudio``), never at LLM-dispatch time. A turn
+    // whose first token is slower than the no-AEC gate (~500 ms — gpt-4o cold
+    // cache, a pre-first-token Hermes/OpenClaw turn, any slow provider) has
+    // emitted NO audio yet, so there is nothing for the caller to interrupt:
+    // ``firstAudioSentAt`` stays null and ``canBargeIn()`` returns false until
+    // audio flows. Stamping it at dispatch (the 2026-05-11 regression) armed
+    // barge-in over silence — a lagging STT final or a phantom VAD event then
+    // aborted the still-producing LLM turn (``llmAbort.abort()``) before its
+    // first token, and the agent went mute. The protected window now begins at
+    // first real audio, exactly as ``firstAudioSentAt`` documents.
     //
-    // Note: the ``isFirstMessage`` parameter is kept for backward
-    // compatibility with the call site, but no longer changes behaviour.
+    // ``isFirstMessage`` is retained for call-site compatibility but no longer
+    // changes behaviour (the gate is anchored on real audio for every turn).
     void isFirstMessage;
-    this.firstAudioSentAt = Date.now();
     // Fresh turn — drop any stale pre-barge-in buffer from a previous turn
     // so we never replay yesterday's audio to STT.
     this.inboundAudioRing = [];
@@ -3973,6 +3974,16 @@ export class StreamHandler {
       this.endTailGraceForNewTurn();
       return false;
     }
+    // Duplicate/hallucination guard BEFORE the cancel decision: a final that
+    // commitTranscript would drop (the lagging Deepgram speech_final twin of an
+    // already-committed is_final) is not new speech and must not abort the
+    // still-producing turn. Parity with the synchronous handleBargeIn.
+    if (this.bargeInFinalIsDuplicate(transcript)) {
+      getLogger().debug(
+        `Barge-in suppressed: duplicate/hallucinated final (len=${(transcript.text ?? '').length})`,
+      );
+      return false;
+    }
     // Echo guard: when audio is forwarded to STT during TTS (no effective AEC),
     // the agent's own voice can be transcribed and would barge in on itself.
     // Drop transcripts that look like a fragment of what the agent is saying.
@@ -4074,6 +4085,16 @@ export class StreamHandler {
       // Tail-grace transcript = next turn, not a barge-in. End the grace and
       // let the transcript dispatch normally (parity with the async path).
       this.endTailGraceForNewTurn();
+      return false;
+    }
+    // Duplicate/hallucination guard BEFORE the cancel decision: a final that
+    // commitTranscript would drop (the lagging Deepgram speech_final twin of an
+    // already-committed is_final) is not new speech and must not abort the
+    // still-producing turn. Parity with handleBargeInAsync.
+    if (this.bargeInFinalIsDuplicate(transcript)) {
+      getLogger().debug(
+        `Barge-in suppressed: duplicate/hallucinated final (len=${(transcript.text ?? '').length})`,
+      );
       return false;
     }
     // Pause-and-resume final-only gate (parity with handleBargeInAsync).
@@ -4597,6 +4618,40 @@ export class StreamHandler {
     this.lastCommitText = normalised;
     this.lastCommitAt = now;
     return true;
+  }
+
+  /**
+   * Read-only mirror of the ``commitTranscript`` duplicate / hallucination
+   * filters for a FINAL transcript, evaluated WITHOUT consuming the dedup
+   * state. Barge-in is decided before ``commitTranscript`` runs, so a final
+   * that commit would DROP — an STT hallucination, a duplicate of the
+   * just-committed utterance, or the back-to-back near-duplicate Deepgram
+   * re-emits as ``is_final`` then ``speech_final`` for the SAME word — is not
+   * genuinely new speech and must NOT abort the in-flight turn. Returns
+   * ``true`` when the transcript is such a droppable final.
+   *
+   * Interims are never droppable here: they cannot reach ``commitTranscript``
+   * (so they have no dedup twin) and a genuine interim over agent audio is a
+   * real barge-in. Echo is handled by the dedicated ``looksLikeEcho`` guard
+   * already at the top of the barge-in paths, so it is intentionally omitted.
+   */
+  private bargeInFinalIsDuplicate(transcript: {
+    text?: string;
+    isFinal?: boolean;
+    speechFinal?: boolean;
+  }): boolean {
+    if (transcript.isFinal !== true && transcript.speechFinal !== true) {
+      return false;
+    }
+    const normalised = (transcript.text ?? '').trim().toLowerCase();
+    const stripped = normalised.replace(/[.,!?;: ]+$/, '').trim();
+    if (HALLUCINATIONS.has(stripped) || stripped === '') return true;
+    const sinceLastMs = Date.now() - this.lastCommitAt;
+    if (sinceLastMs < 2000 && normalised === this.lastCommitText) return true;
+    if (sinceLastMs < 500 && isNearDuplicate(normalised, this.lastCommitText)) {
+      return true;
+    }
+    return false;
   }
 
   // ---------------------------------------------------------------------------

--- a/libraries/typescript/tests/pipeline-bargein-silent-turn.mocked.test.ts
+++ b/libraries/typescript/tests/pipeline-bargein-silent-turn.mocked.test.ts
@@ -1,0 +1,337 @@
+/**
+ * [mocked] Pipeline false-barge-in regressions: a still-silent (no-audio-yet)
+ * LLM turn must NOT be self-interrupted, and a duplicate STT final must not
+ * abort the turn that is still producing it.
+ *
+ * Reproduces the field bug "agent plays its opening line then goes mute": the
+ * barge-in gate armed at LLM *dispatch* time (before any audio reached the
+ * carrier) and ran ahead of the STT duplicate/hallucination filter, so the
+ * lagging Deepgram speech_final twin of an already-committed is_final aborted
+ * the in-flight LLM turn (llmAbort.abort()) before its first token — no output.
+ *
+ * AUTHENTIC: the real StreamHandler + LLMLoop + pipeline turn path. Mocked only
+ * at the external boundary: the LLM provider stream (a deliberately slow /
+ * parked provider, like a cold-cache model or a pre-first-token Hermes turn)
+ * and the TTS byte stream.
+ *
+ *   Test A — silent-turn guard: a parked turn (no audio yet) leaves
+ *            ``firstAudioSentAt`` null, ``canBargeIn()`` false, and a transcript
+ *            delivered past the 500 ms window does NOT abort the turn.
+ *   Test B — duplicate-final guard: with the warmup gate forced open, a second
+ *            identical final (is_final then speech_final) commits exactly one
+ *            user turn and fires NO barge-in/abort.
+ *   Test C — regression: a turn that really emitted audio, past the protected
+ *            window, IS interrupted by a genuinely new transcript and the turn
+ *            is cancelled + re-dispatched.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamHandler } from '../src/stream-handler';
+import type { TelephonyBridge, StreamHandlerDeps } from '../src/stream-handler';
+import { MetricsStore } from '../src/dashboard/store';
+import { RemoteMessageHandler } from '../src/remote-message';
+import type { AgentOptions } from '../src/types';
+import type { LLMProvider, LLMChunk, LLMStreamOptions } from '../src/llm-loop';
+import type { WebSocket as WSWebSocket } from 'ws';
+
+vi.mock('../src/dashboard/persistence', () => ({ notifyDashboard: vi.fn() }));
+
+/**
+ * Plain in-process TTS adapter. ``createTTS`` simply returns ``agent.tts``, so
+ * a bare object with ``synthesizeStream`` is the whole contract. Built as a
+ * plain object (NOT a vi.fn) so ``vi.restoreAllMocks`` between cases cannot
+ * reset it to undefined and silently disable audio for a later test. Each chunk
+ * is an even-length PCM16 frame the outbound encoder accepts, so real audio
+ * actually reaches the carrier and ``markFirstAudioSent`` fires.
+ */
+function makeMockTts(): AgentOptions['tts'] {
+  return {
+    synthesizeStream: async function* (_text: string): AsyncGenerator<Buffer> {
+      yield Buffer.alloc(640, 1); // ~20 ms PCM16 @ 16 kHz
+    },
+  } as unknown as AgentOptions['tts'];
+}
+
+interface SttFinal {
+  isFinal?: boolean;
+  speechFinal?: boolean;
+  text?: string;
+}
+
+function makeMockWs(): WSWebSocket {
+  return {
+    send: vi.fn(), close: vi.fn(), on: vi.fn(), once: vi.fn(), readyState: 1,
+    removeListener: vi.fn(), addEventListener: vi.fn(), removeEventListener: vi.fn(),
+  } as unknown as WSWebSocket;
+}
+
+function makeMockStt() {
+  let cb: ((t: SttFinal) => Promise<void> | undefined) | undefined;
+  return {
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn(),
+    sendAudio: vi.fn(),
+    onTranscript: vi.fn((fn: (t: SttFinal) => Promise<void> | undefined) => {
+      cb = fn;
+    }),
+    get requestId() { return 'stt-silent-req'; },
+    /** Deliver an arbitrary transcript frame (interim or final). */
+    emit(t: SttFinal): Promise<void> | undefined {
+      return cb?.(t);
+    },
+    /** Deliver a committed final (Deepgram is_final by default). */
+    emitFinal(text: string, speechFinal = false): Promise<void> | undefined {
+      return cb?.({ isFinal: true, speechFinal, text });
+    },
+  };
+}
+
+function makeTwilioBridge(mockStt: ReturnType<typeof makeMockStt>): TelephonyBridge {
+  return {
+    label: 'Twilio', telephonyProvider: 'twilio',
+    sendAudio: vi.fn(), sendMark: vi.fn(), sendClear: vi.fn(),
+    transferCall: vi.fn().mockResolvedValue(undefined),
+    endCall: vi.fn().mockResolvedValue(undefined),
+    createStt: vi.fn().mockReturnValue(mockStt),
+    queryTelephonyCost: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelephonyBridge;
+}
+
+interface Gate {
+  promise: Promise<void>;
+  release: () => void;
+}
+function makeGate(): Gate {
+  let release!: () => void;
+  const promise = new Promise<void>((r) => {
+    release = r;
+  });
+  return { promise, release };
+}
+
+/** Provider whose FIRST turn parks (no token, hence no audio) until ``gate``
+ * resolves — models a cold-cache LLM / pre-first-token Hermes turn. Later turns
+ * answer immediately so a re-dispatch after a real barge-in can complete. */
+function makeGatedProvider(gate: Gate, counter: { count: number }): LLMProvider {
+  return {
+    model: 'agent-runtime-1',
+    async *stream(
+      _messages: Array<Record<string, unknown>>,
+      _tools?: Array<Record<string, unknown>> | null,
+      opts?: LLMStreamOptions,
+    ): AsyncGenerator<LLMChunk, void, unknown> {
+      counter.count += 1;
+      if (counter.count === 1) {
+        await gate.promise;
+        if (opts?.signal?.aborted) return;
+        yield { type: 'text', content: 'va bene. ' };
+        return;
+      }
+      yield { type: 'text', content: 'ok ricevuto. ' };
+    },
+  } as unknown as LLMProvider;
+}
+
+/** Provider whose FIRST turn speaks ONE sentence (so real audio reaches the
+ * carrier and ``markFirstAudioSent`` fires) and then parks until aborted, so
+ * the turn stays in flight (``isSpeaking`` true) and a genuine barge-in has
+ * something to interrupt. Later turns answer immediately. */
+function makeSpeakThenParkProvider(counter: { count: number }): LLMProvider {
+  return {
+    model: 'agent-runtime-1',
+    async *stream(
+      _messages: Array<Record<string, unknown>>,
+      _tools?: Array<Record<string, unknown>> | null,
+      opts?: LLMStreamOptions,
+    ): AsyncGenerator<LLMChunk, void, unknown> {
+      counter.count += 1;
+      if (counter.count === 1) {
+        // Two sentences: the first flushes through the chunker (and reaches the
+        // carrier as real audio) when the second arrives; then park so the turn
+        // stays in flight with audio already out.
+        yield { type: 'text', content: 'Ciao, ti racconto una lunga storia. ' };
+        yield { type: 'text', content: 'Comincia proprio adesso. ' };
+        await new Promise<void>((resolve) => {
+          if (opts?.signal?.aborted) return resolve();
+          opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return;
+      }
+      yield { type: 'text', content: 'va bene, mi fermo. ' };
+    },
+  } as unknown as LLMProvider;
+}
+
+function makeDeps(
+  bridge: TelephonyBridge,
+  agentOverrides: Partial<AgentOptions>,
+): StreamHandlerDeps {
+  const agent: AgentOptions = {
+    systemPrompt: 'You are a test pipeline agent.',
+    provider: 'pipeline',
+    tts: makeMockTts(),
+    ...agentOverrides,
+  } as AgentOptions;
+  return {
+    config: {}, agent, bridge,
+    metricsStore: new MetricsStore(),
+    pricing: null,
+    remoteHandler: new RemoteMessageHandler(),
+    recording: false,
+    buildAIAdapter: vi.fn(),
+    sanitizeVariables: vi.fn((raw: Record<string, unknown>) => raw),
+    resolveVariables: vi.fn((tpl: string) => tpl),
+  } as unknown as StreamHandlerDeps;
+}
+
+interface Probe {
+  isSpeaking: boolean;
+  firstAudioSentAt: number | null;
+  llmAbort: AbortController | null;
+  dispatchTask: Promise<void> | null;
+  canBargeIn(): boolean;
+}
+
+describe('[mocked] pipeline silent-turn + duplicate-final barge-in guard', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true, status: 200, json: async () => ({}), text: async () => '',
+    } as unknown as Response);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('A: a silent (no-audio-yet) turn is not armed for barge-in and a transcript past 500 ms does not abort it', async () => {
+    const stt = makeMockStt();
+    const bridge = makeTwilioBridge(stt);
+    const gate = makeGate();
+    const counter = { count: 0 };
+    const handler = new StreamHandler(
+      makeDeps(bridge, {
+        llm: makeGatedProvider(gate, counter) as unknown as AgentOptions['llm'],
+      }),
+      makeMockWs(), '+15551111111', '+15552222222',
+    );
+    const probe = handler as unknown as Probe;
+    await handler.handleCallStart('CA-silent-A');
+
+    // Turn 1 dispatches and parks on its (slow) LLM stream — no token, no audio.
+    await stt.emitFinal('dimmi qualcosa');
+    await vi.waitFor(() => expect(probe.isSpeaking).toBe(true), { timeout: 3000 });
+
+    // DEFECT 1: barge-in must NOT be armed before real audio went out. With the
+    // dispatch-time stamp this is a number and the gate is already counting down.
+    expect(probe.firstAudioSentAt).toBeNull();
+
+    // Let the (buggy) 500 ms warmup gate elapse, then prove the gate stays shut.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(probe.canBargeIn()).toBe(false);
+
+    const abortCtl = probe.llmAbort;
+    expect(abortCtl).not.toBeNull();
+
+    // A transcript lands while the turn is still producing. It must NOT abort
+    // the still-silent turn. Fire-and-forget: a *new* committed final blocks on
+    // the parked dispatch downstream, but handleBargeIn runs synchronously first.
+    void stt.emitFinal('ci sei');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(abortCtl!.signal.aborted).toBe(false);
+    expect(bridge.sendClear as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(probe.isSpeaking).toBe(true);
+
+    // Release the parked turn so it completes cleanly: real audio now flows and
+    // the warmup gate arms from that instant.
+    gate.release();
+    await vi.waitFor(
+      () => expect(bridge.sendAudio as ReturnType<typeof vi.fn>).toHaveBeenCalled(),
+      { timeout: 3000 },
+    );
+    await probe.dispatchTask?.catch(() => {});
+  }, 10000);
+
+  it('B: a duplicate Deepgram final (is_final then speech_final, same text) commits one turn and fires no barge-in', async () => {
+    const stt = makeMockStt();
+    const bridge = makeTwilioBridge(stt);
+    const gate = makeGate();
+    const counter = { count: 0 };
+    const handler = new StreamHandler(
+      makeDeps(bridge, {
+        llm: makeGatedProvider(gate, counter) as unknown as AgentOptions['llm'],
+      }),
+      makeMockWs(), '+15551111111', '+15552222222',
+    );
+    const probe = handler as unknown as Probe;
+    await handler.handleCallStart('CA-silent-B');
+
+    // First final commits and dispatches turn 1 (parks on its slow stream).
+    await stt.emitFinal('voglio prenotare un tavolo', false);
+    await vi.waitFor(() => expect(probe.isSpeaking).toBe(true), { timeout: 3000 });
+
+    // Isolate DEFECT 2 from the warmup gate: force the gate fully open, so the
+    // ONLY thing that may stop the duplicate from cancelling the turn is the
+    // commit-time duplicate filter running ahead of barge-in.
+    (handler as unknown as { canBargeIn: () => boolean }).canBargeIn = () => true;
+
+    const abortCtl = probe.llmAbort;
+    expect(abortCtl).not.toBeNull();
+    const callsAfterTurn1 = counter.count;
+
+    // The lagging speech_final twin of the SAME utterance arrives ~0.5 s later.
+    // It is a duplicate commitTranscript would drop — so it must be a no-op for
+    // barge-in, not abort the turn that is still producing it.
+    await stt.emitFinal('voglio prenotare un tavolo', true);
+
+    expect(abortCtl!.signal.aborted).toBe(false);
+    expect(bridge.sendClear as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(probe.isSpeaking).toBe(true);
+    // Exactly one user turn committed → exactly one LLM dispatch.
+    expect(counter.count).toBe(callsAfterTurn1);
+
+    gate.release();
+    await probe.dispatchTask?.catch(() => {});
+  }, 10000);
+
+  it('C: a genuinely new transcript still interrupts a turn that really emitted audio (re-dispatch)', async () => {
+    const stt = makeMockStt();
+    const bridge = makeTwilioBridge(stt);
+    const counter = { count: 0 };
+    const handler = new StreamHandler(
+      makeDeps(bridge, {
+        llm: makeSpeakThenParkProvider(counter) as unknown as AgentOptions['llm'],
+      }),
+      makeMockWs(), '+15551111111', '+15552222222',
+    );
+    const probe = handler as unknown as Probe;
+    await handler.handleCallStart('CA-silent-C');
+
+    // Turn 1 speaks one sentence (real audio → markFirstAudioSent) then parks.
+    await stt.emitFinal('genera una storia lunga');
+    await vi.waitFor(
+      () => expect(probe.firstAudioSentAt).not.toBeNull(),
+      { timeout: 3000 },
+    );
+    expect(bridge.sendAudio as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+
+    // Move past the 500 ms no-AEC protected window (real audio already out).
+    probe.firstAudioSentAt = Date.now() - 1000;
+    expect(probe.canBargeIn()).toBe(true);
+
+    const abortCtl = probe.llmAbort;
+    expect(abortCtl).not.toBeNull();
+
+    // A genuinely NEW (different) caller utterance over live audio → real
+    // barge-in: cancel the turn and re-dispatch the new utterance.
+    await stt.emitFinal('aspetta fermati un momento');
+
+    await vi.waitFor(
+      () => expect(bridge.sendClear as ReturnType<typeof vi.fn>).toHaveBeenCalled(),
+      { timeout: 3000 },
+    );
+    expect(abortCtl!.signal.aborted).toBe(true);
+    await vi.waitFor(() => expect(counter.count).toBe(2), { timeout: 3000 });
+
+    await probe.dispatchTask?.catch(() => {});
+  }, 10000);
+});


### PR DESCRIPTION
## Summary
Fixes a real, field-found bug: in **pipeline mode** (STT→LLM→TTS) the agent plays its opening line, then goes **mute** — every caller turn aborts its own LLM before the first token (`llm_ms=0`, one `llm_usage_fallback`, `error=null`), while the same provider returns a full response in isolation. The pipeline was killing the turn via a **false barge-in**. No version bump.

## Root cause — two defects (either alone leaves a hole)
1. **Barge-in armed before any real audio.** `beginSpeaking()` stamped `firstAudioSentAt = Date.now()` at LLM **dispatch** time, so `canBargeIn()` flipped `true` ~500 ms later (1000 ms with AEC) while the caller had heard nothing — a slow-first-token turn (cold-start provider, pre-first-token Hermes/OpenClaw) was already "interruptible".
2. **Barge-in evaluated before the STT dedup filter.** `handleBargeIn` ran ahead of `commitTranscript`'s duplicate/hallucination throttle. Deepgram emits a final per `is_final || speech_final`, so one spoken word yields an `is_final` **and** a lagging `speech_final` twin (~0.5–1 s later) with identical text — the twin aborted the still-producing turn.

## Fix (`src/stream-handler.ts`, +72/−13)
1. Removed the dispatch-time stamp. `firstAudioSentAt` is now set **only** by the real outbound-audio path (`markFirstAudioSent`, immediately after a successful `bridge.sendAudio`). `canBargeIn()` returns `false` while it's `null`, so a silent/slow turn cannot self-abort; the 500/1000 ms protected window starts at first **real** audio.
2. Added a read-only `bargeInFinalIsDuplicate(transcript)` that mirrors `commitTranscript`'s hallucination + duplicate-within-2 s + near-duplicate-within-500 ms filters **without consuming dedup state**, and gates **both** `handleBargeIn` and `handleBargeInAsync` before the cancel decision. A duplicate Deepgram final is now a no-op for barge-in.

Genuine barge-in (agent audibly speaking + new caller speech) still aborts + re-dispatches, unchanged. AEC 1000 ms window and `bargeInThresholdMs`/autoVad branches preserved. Public API unchanged (the inert `isFirstMessage` param is retained for call-site compatibility).

## Tests (`tests/pipeline-bargein-silent-turn.mocked.test.ts`)
Authentic — real `StreamHandler` + `LLMLoop` + pipeline turn path; mocked only at the external boundaries (a gated/slow LLM provider stream, in-process STT/TTS, telephony bridge).
- **A** silent-turn guard: dispatched turn with no audio yet + a transcript past 500 ms → `llmAbort` not aborted, turn completes.
- **B** duplicate-final guard: `is_final` then `speech_final` (same text) → exactly one turn commits, no barge-in/abort.
- **C** regression: agent really emitting audio + a genuinely new transcript → barge-in fires + re-dispatches.

Verified **RED on the unpatched source, GREEN on the fix** (the verifier re-ran with the source change stashed: A/B/C all fail unpatched, pass patched).

## Test plan
- [x] `npm run lint` (`tsc --noEmit`) clean.
- [x] `npm test` — **2292 passed**, 9 skipped, 0 failed (incl. the 3 new tests).
- [x] No PII in the new debug lines (log `len=` only, not transcript text); no version bump.

## Notes
- Fresh branch off `origin/main`; only this fix (no Inworld/other work entangled).
- Pre-existing stale `canBargeIn` doc comment (says "250 ms" vs the 500 ms constant) left untouched to keep the diff surgical.
