### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.7.0 (2026-06-30)
+
 ### Added
 
 - **Inworld integration completed: full TTS pricing, a config helper, and an

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -20,7 +20,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.6.9"
+__version__ = "0.7.0"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.6.9"
+version = "0.7.0"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Release 0.7.0

Minor version bump (**0.6.9 → 0.7.0**) — new backward-compatible public API has accumulated since 0.6.9, so semver minor. This PR only bumps the three version files and datestamps the CHANGELOG; all the actual feature/fix work already merged via #196–#200.

### Version files (move together)
- `libraries/python/getpatter/__init__.py` → `0.7.0`
- `libraries/python/pyproject.toml` → `0.7.0`
- `libraries/typescript/package.json` → `0.7.0`

### CHANGELOG
The accumulated `## Unreleased` section is datestamped `## 0.7.0 (2026-06-30)` and a fresh empty `## Unreleased` is opened.

### What's in 0.7.0
- **Audio / Skills / Memory (#196):** rate-aware resampler + opt-in HPF/AGC inbound front-end (fixes the chipmunk/aliasing bug), user-supplied agent skills (progressive disclosure), token-aware pipeline compaction. New public API: `AgcConfig`, `Skill`, `CompactionConfig` + `Agent` fields.
- **Security (#197, #198):** SSRF guard folds non-canonical IP encodings (decimal/octal/hex/short IPv4, IPv4-mapped IPv6) — shared `getpatter/ssrf.py`; plus 6 parity-drift hardening fixes (TS redirect SSRF, DTMF/phone-number log PII, call-id path traversal, response-size cap enforced during read, Unicode-newline sanitizer).
- **Inworld (#199):** corrected/completed TTS pricing (both SDKs), `providers.inworld()` config helper, and `InworldLLM` Realtime Router preset (OpenAI-compatible, 220+ models).
- **Pipeline (#200):** fixed a false barge-in that self-interrupted the user-turn LLM (agent went mute after its opening line).

### Publish flow (per `release-via-pr.md`)
1. CI green on this PR.
2. **You merge** (squash). AI does not auto-merge.
3. **After merge**, the tag `v0.7.0` is pushed to `main`, which triggers `.github/workflows/release.yml` → **PyPI (OIDC) + npm**.
4. A **GitHub Release** for `v0.7.0` is created with notes linking this PR.

(I'll do steps 3–4 once you've merged — just say go, or I can run them as soon as the merge lands.)

### Test plan
- [x] All three version files read `0.7.0`; `import getpatter` → `0.7.0`, `pyproject` → `0.7.0`, `package.json` → `0.7.0`.
- [x] No remaining hardcoded `0.6.9` references in source/tests.
- [ ] Full CI green (this PR) before merge + tag.
