### PR TITLE
feat(engines): GeminiLive/GeminiCascade/InworldRealtime markers + Gemini Live fixes (release 0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,30 @@
   launcher pins the `getpatter` version it bootstraps to its own version, so it
   now tracks the SDK again (`npm create getpatter` provisions the current SDK).
 
+### Security
+
+- **Media-stream WebSockets are now authenticated (both SDKs, all carriers) —
+  fixes #204.** The carrier webhook HTTP routes were signature-validated, but
+  the media-stream WS endpoints (`/ws/stream/…` Twilio, `/ws/telnyx/stream/…`,
+  `/ws/plivo/stream/…`) accepted any peer with an attacker-chosen `call_id`
+  (the only control was a DoS per-IP cap). Anyone who could reach the public
+  host could open the socket, send a `start` frame, and drive a full
+  STT→LLM→TTS session on the operator's provider keys (toll fraud) or converse
+  to extract the agent's system prompt + tool list. Now the signature-validated
+  webhook (which builds the stream URL/TwiML) mints a high-entropy per-call
+  token, delivers it on each carrier's existing custom channel (Twilio
+  `<Parameter>` → `customParameters`, Telnyx URL query, Plivo `extra_headers`),
+  and the WS handler constant-time-validates it **before** opening any provider
+  session — an unauthenticated peer is closed (WS 1008) with no provider connect
+  and no TTS. Fail-closed by default via the new `require_stream_auth` /
+  `requireStreamAuth` option (opt-out for operators serving custom TwiML, which
+  then logs a warning). The token is never logged. The webhook mints only for a
+  legitimate (signed) carrier, so the token is a shared secret an unsigned
+  attacker cannot obtain. Backward compatible for the standard `serve()`
+  inbound + outbound path (the SDK mints/embeds/validates transparently). Also
+  hardened the forgeable-`X-Forwarded-For` per-IP cap with a global concurrent-
+  WS backstop, documented as DoS-cap-only now that auth is enforced separately.
+
 ## 0.7.0 (2026-06-30)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 ### Added
 
+- **Soniox v5 real-time STT adopted (both SDKs).** `SonioxModel` gains
+  `STT_RT_V5 = "stt-rt-v5"` and the default model flips `stt-rt-v4` →
+  `stt-rt-v5` (the GA v5 model, released 2026-06-16); `v4`/`v3`/`v2` stay
+  reachable for back-compat. v5 is fully API-compatible (same WS endpoint,
+  in-band `api_key`, request/token-stream shape), so this is a model-id swap
+  plus two new opt-in v5 endpoint controls (`endpoint_sensitivity` /
+  `endpointSensitivity` in `[-1.0, 1.0]`; `endpoint_latency_adjustment_level` /
+  `endpointLatencyAdjustmentLevel` in `0|1|2|3`), omitted from the wire when
+  unset so existing behavior is byte-identical. Real-time rate unchanged at
+  $0.12/hr ≈ $0.002/min (https://soniox.com/pricing).
+- **Soniox TTS provider (both SDKs).** `SonioxTTS` over the REST one-shot
+  `https://tts-rt.soniox.com/tts` bytes endpoint (`tts-rt-v1`, default voice
+  `Adrian`, shares the `SONIOX_API_KEY` credential with Soniox STT).
+  `forTwilio` / `forTelnyx` emit `pcm_mulaw` @ 8 kHz natively for carrier-wire
+  passthrough (no resampling). Wired end-to-end: package-root export
+  (`SonioxTTS`), `providers.soniox_tts()` / `sonioxTts()` config helper,
+  `_create_tts_from_config` `"soniox_tts"` branch, and a pricing entry modeled
+  per-1k-chars from the $0.70/hr headline (~$0.013/1k chars; native billing is
+  token-based — https://soniox.com/pricing). Reuses the existing `[soniox]`
+  extra (aiohttp).
+- **Sarvam AI TTS provider for Indian languages (both SDKs).** `SarvamTTS` over
+  the REST `https://api.sarvam.ai/text-to-speech` endpoint — Bulbul v3 (default)
+  / v2 across 11 Indian languages (Hindi, Bengali, Tamil, Telugu, Kannada,
+  Malayalam, Marathi, Gujarati, Punjabi, Odia, Indian English) plus code-mixed
+  text. `forTwilio` / `forTelnyx` emit `mulaw` @ 8 kHz natively (carrier-wire
+  passthrough). Wired end-to-end: package-root export (`SarvamTTS`),
+  `providers.sarvam()` config helper, `_create_tts_from_config` `"sarvam"`
+  branch, a new `[sarvam]` pyproject extra (aiohttp), and a per-1k-chars pricing
+  entry — Bulbul v3 ≈ $0.036/1k (Rs 30/10k), v2 ≈ $0.018/1k (Rs 15/10k); INR is
+  authoritative, USD indicative (https://www.sarvam.ai/api-pricing).
 - **Engine markers shipped: `GeminiLive`, `GeminiCascade`, and a native
   `InworldRealtime`.** 0.7.0 exported the Gemini pipeline factory + adapter but
   not the `GeminiLive` engine marker, so `new GeminiLive({...})` / the engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 ## Unreleased
 
+## 0.7.1 (2026-06-30)
+
+### Added
+
+- **Engine markers shipped: `GeminiLive`, `GeminiCascade`, and a native
+  `InworldRealtime`.** 0.7.0 exported the Gemini pipeline factory + adapter but
+  not the `GeminiLive` engine marker, so `new GeminiLive({...})` / the engine
+  import failed at runtime; and there was no native Inworld realtime engine.
+  Now `import { GeminiLive, GeminiCascade, InworldRealtime } from "getpatter"`
+  resolves at runtime. The richer `GeminiLiveAdapter` (mulaw8↔PCM telephony
+  transcode, apiVersion auto-detect, `GEMINI_LIVE_3_1_FLASH_PREVIEW`) plus
+  `GeminiSTT`/`GeminiTTS` are integrated; `InworldRealtimeAdapter` subclasses the
+  OpenAI Realtime adapter and overrides only the transport
+  (`wss://api.inworld.ai/v1/realtime`, Bearer/JWT) via Inworld's OpenAI-Realtime
+  migration path. Backward compatible — OpenAIRealtime / OpenAIRealtime2 /
+  Ultravox / ConvAI unchanged.
+
+### Fixed
+
+- **Gemini Live spoke the model's "thinking" before the reply** (native-audio,
+  every turn). The Live setup now always sends `thinkingConfig` with a voice
+  default of `thinkingBudget: 0` (OFF), opt-in via `thinking`/`thinkingBudget`
+  on `GeminiLiveOptions`; and the adapter defensively drops any `thought===true`
+  part from BOTH the audio stream and the text transcript (never logged).
+- **`gemini-3.1-flash-live-preview` dropped the call with a silent "session
+  ready timeout".** It is a native-audio model served only on `v1alpha`, but its
+  id lacks the `native-audio` token so the heuristic chose `v1beta`. New
+  `geminiRequiresV1Alpha()` selects `v1alpha` for native-audio AND
+  `flash-live-preview` (explicit `apiVersion` overrides); connect failures now
+  throw a clear, actionable error (model id + resolved apiVersion + root causes)
+  instead of dead air.
+
+### Changed
+
+- **`@google/genai` peerDependency bumped `^0.3.0` → `>=2.0.0`** (kept optional)
+  for the 2.x unified SDK, so `npm install getpatter` alongside
+  `@google/genai@^2.x` no longer needs `--legacy-peer-deps`.
+- **`create-getpatter` launcher realigned to the SDK version (lockstep).** The
+  launcher pins the `getpatter` version it bootstraps to its own version, so it
+  now tracks the SDK again (`npm create getpatter` provisions the current SDK).
+
 ## 0.7.0 (2026-06-30)
 
 ### Added

--- a/create-getpatter/package.json
+++ b/create-getpatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-getpatter",
-  "version": "0.6.9",
+  "version": "0.7.1",
   "description": "npm create shim for Patter — runs `getpatter init`, the greenfield voice-agent setup wizard",
   "license": "MIT",
   "author": {

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -20,7 +20,7 @@ Installation extras:
 See ``pyproject.toml`` and the top-level README for the full matrix.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from getpatter._speech_events import (
     AgentState,

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -121,6 +121,8 @@ from getpatter.tts.cartesia import TTS as CartesiaTTS
 from getpatter.tts.rime import TTS as RimeTTS
 from getpatter.tts.lmnt import TTS as LMNTTTS
 from getpatter.tts.inworld import TTS as InworldTTS
+from getpatter.tts.soniox import TTS as SonioxTTS
+from getpatter.tts.sarvam import TTS as SarvamTTS
 
 # LLM flat aliases — parity with libraries/typescript/src/index.ts and mirror of STT/TTS layout.
 from getpatter.llm.openai import LLM as OpenAILLM
@@ -501,6 +503,8 @@ __all__ = [
     "RimeTTS",
     "LMNTTTS",
     "InworldTTS",
+    "SonioxTTS",
+    "SarvamTTS",
     "OpenAILLM",
     "AnthropicLLM",
     "GroqLLM",

--- a/libraries/python/getpatter/client.py
+++ b/libraries/python/getpatter/client.py
@@ -18,6 +18,7 @@ return in a future release.
 from __future__ import annotations
 
 import asyncio
+import secrets
 import logging
 import os
 import re
@@ -348,6 +349,7 @@ class Patter:
         pricing: dict | None = None,
         persist: bool | str | None = None,
         telemetry: bool | None = None,
+        require_stream_auth: bool = True,
         **kwargs: Any,
     ) -> None:
         # --- Reject cloud-mode kwargs explicitly ---
@@ -439,6 +441,10 @@ class Patter:
             phone_number=phone_number,
             webhook_url=webhook_url,
             persist_root=_resolve_persist_root(persist),
+            # SECURITY (#204): fail-closed media-stream auth. Default True; set
+            # False only for custom TwiML/XML that cannot carry the per-call
+            # token (allows the connection but logs a loud one-time warning).
+            require_stream_auth=require_stream_auth,
         )
 
         # The telemetry client + dedup state were constructed above (before the
@@ -908,7 +914,24 @@ class Patter:
                 account_sid=config.twilio_sid,
                 auth_token=config.twilio_token,
             )
-            stream_url = f"wss://{config.webhook_url}/ws/stream/outbound"
+            # SECURITY (#204): outbound Twilio embeds the media stream in the
+            # <Connect><Stream> TwiML at create time (the CallSid is not yet
+            # known), so the WS path can't be the real CallSid. Use a fresh
+            # per-call key (NOT the static "outbound") so two concurrent outbound
+            # dials don't overwrite each other's minted token — the earlier
+            # call's WS would otherwise fail auth. The token is minted under this
+            # same key and delivered as a <Parameter> (Twilio strips query
+            # params); the server validates it before opening the provider
+            # session. Key is unguessable, so it doubles as the auth binding.
+            outbound_stream_key = f"outbound-{secrets.token_hex(8)}"
+            stream_url = f"wss://{config.webhook_url}/ws/stream/{outbound_stream_key}"
+            from getpatter.telephony.common import STREAM_TOKEN_PARAM
+
+            twilio_stream_params: dict[str, str] = {}
+            if self._server is not None:
+                twilio_stream_params[STREAM_TOKEN_PARAM] = (
+                    self._server._mint_stream_token(outbound_stream_key)
+                )
             extra_params: dict = {}
             if wants_amd:
                 # DetectMessageEnd waits for the greeting to finish before
@@ -958,6 +981,7 @@ class Patter:
                 to,
                 stream_url,
                 extra_params=extra_params,
+                parameters=twilio_stream_params or None,
             )
             logger.info("Outbound call initiated: %s", call_id)
             # Pre-register the call so the dashboard surfaces attempts

--- a/libraries/python/getpatter/local_config.py
+++ b/libraries/python/getpatter/local_config.py
@@ -29,6 +29,22 @@ class LocalConfig:
     # accepting the request.
     # Set to False only for local development against mock providers.
     require_signature: bool = True
+    # SECURITY (#204): require a per-call stream-authentication token on the
+    # media-stream WebSocket endpoints (/ws/stream, /ws/telnyx/stream,
+    # /ws/plivo/stream). The token is minted by the SIGNATURE-VALIDATED carrier
+    # webhook (or an operator-initiated outbound call) and delivered back on the
+    # carrier's own custom-param channel (Twilio <Parameter>, Telnyx query
+    # string, Plivo extra_headers). When True (the default), a media WS that
+    # presents no / an invalid / an expired token is closed with WS 1008 BEFORE
+    # any provider (STT/LLM/TTS/Realtime) session is opened — this closes the
+    # toll-fraud + prompt-extraction hole where an unauthenticated peer could
+    # drive a full session on the operator's provider keys. The standard
+    # ``serve()`` path mints + embeds + validates the token itself, so normal
+    # inbound AND outbound calls keep working with zero operator action. Set to
+    # False ONLY for operators serving custom TwiML/XML that cannot carry the
+    # token — the connection is then allowed but a loud one-time WARNING is
+    # logged.
+    require_stream_auth: bool = True
     # When True, only the very first TTFB event per turn is emitted to the
     # EventBus. Default is False to preserve current per-segment emission
     # behaviour.

--- a/libraries/python/getpatter/pricing.py
+++ b/libraries/python/getpatter/pricing.py
@@ -231,6 +231,26 @@ DEFAULT_PRICING: dict[str, dict] = {
             "inworld-tts-1.5-mini": {"price": 0.015},
         },
     },
+    # Soniox real-time TTS. Soniox publishes a $0.70/hr headline for generated
+    # speech (native billing is token-based: input text $4/1M + output audio
+    # $21.50/1M). Patter's TTS cost model is per-character, so we express the
+    # rate per 1k chars: at a typical ~900 chars/min spoken (~150 wpm) ≈ 54,000
+    # chars/hr, $0.70/hr ÷ 54 ≈ $0.013 / 1k chars. Source:
+    # https://soniox.com/pricing (also https://soniox.com/text-to-speech).
+    "soniox_tts": {"unit": PricingUnit.THOUSAND_CHARS, "price": 0.013},
+    # Sarvam AI Bulbul TTS — per 1,000 characters. INR is authoritative; USD is
+    # an indicative FX conversion (~Rs 83-84/USD). Bulbul v3 (default): Rs 30 /
+    # 10k chars ≈ $0.036/1k; Bulbul v2: Rs 15 / 10k ≈ $0.018/1k. Billed per
+    # character, rounded up per request. Source: https://www.sarvam.ai/api-pricing
+    "sarvam": {
+        "unit": PricingUnit.THOUSAND_CHARS,
+        # Default = bulbul:v3.
+        "price": 0.036,
+        "models": {
+            "bulbul:v3": {"price": 0.036},
+            "bulbul:v2": {"price": 0.018},
+        },
+    },
     # OpenAI Realtime — per token (actual tokens from response.done usage).
     # Provider defaults match ``gpt-4o-mini-realtime-preview`` /
     # ``gpt-realtime-mini`` (the Patter default). Per-model overrides under

--- a/libraries/python/getpatter/providers/__init__.py
+++ b/libraries/python/getpatter/providers/__init__.py
@@ -90,6 +90,51 @@ def inworld(
     )
 
 
+def soniox_tts(
+    api_key: str,
+    voice: str = "Adrian",
+    *,
+    model: str = "tts-rt-v1",
+    language: str = "en",
+) -> TTSConfig:
+    """Config helper for Soniox TTS (requires the ``soniox`` optional extra).
+
+    Shares the ``SONIOX_API_KEY`` credential family with Soniox STT. ``voice``
+    defaults to ``Adrian`` (a single voice keeps its timbre across 60+
+    languages). For telephony the carrier-native path is ``SonioxTTS.for_twilio``
+    / ``for_telnyx`` (mu-law @ 8 kHz, no resampling).
+    """
+    return TTSConfig(
+        provider="soniox_tts",
+        api_key=api_key,
+        voice=voice,
+        options={"model": model, "language": language},
+    )
+
+
+def sarvam(
+    api_key: str,
+    voice: str = "shubh",
+    *,
+    model: str = "bulbul:v3",
+    language: str = "en-IN",
+) -> TTSConfig:
+    """Config helper for Sarvam AI TTS (requires the ``sarvam`` optional extra).
+
+    Synthesizes 11 Indian languages (Hindi, Bengali, Tamil, Telugu, Kannada,
+    Malayalam, Marathi, Gujarati, Punjabi, Odia, Indian English) plus code-mixed
+    text. ``voice`` is the Sarvam speaker id (default ``shubh``); ``language`` is
+    a BCP-47 code such as ``"hi-IN"``. ``model`` defaults to ``bulbul:v3`` (pass
+    ``bulbul:v2`` for the legacy generation).
+    """
+    return TTSConfig(
+        provider="sarvam",
+        api_key=api_key,
+        voice=voice,
+        options={"model": model, "language": language},
+    )
+
+
 def _load_anthropic_llm():
     from getpatter.providers.anthropic_llm import AnthropicLLMProvider
 
@@ -148,9 +193,31 @@ __all__ = [
     "cartesia",
     "rime",
     "lmnt",
+    "inworld",
+    "soniox_tts",
+    "sarvam",
     "AnthropicLLMProvider",
     "GroqLLMProvider",
     "CerebrasLLMProvider",
     "GoogleLLMProvider",
     "LiteLLMProvider",
 ]
+
+# ``soniox_tts`` (the helper above) shares its name with the ``soniox_tts``
+# submodule. Importing that submodule — which ``_create_tts_from_config`` does
+# lazily — binds the MODULE object onto this package, shadowing the helper and
+# making ``providers.soniox_tts(...)`` uncallable. Force the submodule import
+# now (so the binding happens once) and then restore the helper. Subsequent
+# ``from getpatter.providers.soniox_tts import ...`` calls find the module
+# already cached in ``sys.modules`` and do NOT re-bind the attribute, so the
+# helper stays callable. ``sarvam`` needs no such guard (its submodule is
+# ``sarvam_tts``, a different name).
+import importlib as _importlib  # noqa: E402
+
+_soniox_tts_helper = soniox_tts
+try:  # pragma: no cover - import side-effect guard
+    _importlib.import_module(__name__ + ".soniox_tts")
+except Exception:  # pragma: no cover - defensive (optional dep may be absent)
+    pass
+soniox_tts = _soniox_tts_helper
+del _importlib, _soniox_tts_helper

--- a/libraries/python/getpatter/providers/sarvam_tts.py
+++ b/libraries/python/getpatter/providers/sarvam_tts.py
@@ -1,0 +1,400 @@
+"""Sarvam AI TTS provider — HTTP REST one-shot endpoint, pure aiohttp.
+
+Sarvam's Bulbul models synthesize 11 Indian languages (Hindi, Bengali, Tamil,
+Telugu, Kannada, Malayalam, Marathi, Gujarati, Punjabi, Odia, Indian English)
+plus code-mixed text. This adapter targets the REST one-shot endpoint
+``POST https://api.sarvam.ai/text-to-speech`` which returns JSON of the form
+``{"request_id": "...", "audios": ["<base64-audio>", ...]}`` — we base64-decode
+each entry and yield the raw bytes, mapping cleanly onto Patter's
+``TTSProvider.synthesize(text) -> AsyncIterator[bytes]`` contract with no vendor
+SDK.
+
+Sarvam also exposes a WebSocket streaming transport
+(``wss://api.sarvam.ai/text-to-speech/ws?model=<model_id>``) with sub-250 ms
+first-byte; like the Cartesia adapter we use the REST path because it already
+meets Patter's TTFB target while keeping the dependency surface minimal (just
+``aiohttp``, no websocket client).
+
+Auth is an API subscription key sent as the ``api-subscription-key`` HTTP
+header (no Bearer scheme). The key is read from the ``api_key`` argument or the
+``SARVAM_API_KEY`` environment variable.
+
+Default config requests ``codec="linear16"`` (raw PCM_S16LE) at 16 kHz so the
+output drops straight into the Patter pipeline without transcoding — the stream
+handler does the final 16 kHz -> 8 kHz mu-law step for the carrier. For real
+phone calls the :meth:`for_twilio` / :meth:`for_telnyx` factories request
+``mulaw`` @ 8 kHz directly (Sarvam supports both natively), so the pipeline
+takes the carrier-native passthrough path with zero resampling.
+
+Bulbul v3 is the default model (latest; 35+ voices; ``temperature`` control).
+Pass ``model="bulbul:v2"`` for the legacy generation, which instead exposes
+``pitch`` / ``loudness`` / ``enable_preprocessing``. Those controls are gated
+per-model so we never send fields the selected model rejects.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from enum import IntEnum, StrEnum
+from typing import ClassVar, Any, AsyncIterator, Optional, Union
+from urllib.parse import urlsplit
+
+from getpatter.providers.base import TTSProvider
+
+logger = logging.getLogger("getpatter.providers.sarvam_tts")
+
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+SARVAM_BASE_URL = "https://api.sarvam.ai/text-to-speech"
+
+
+class SarvamModel(StrEnum):
+    """Sarvam Bulbul TTS model families."""
+
+    BULBUL_V3 = "bulbul:v3"
+    BULBUL_V2 = "bulbul:v2"
+
+
+class SarvamAudioCodec(StrEnum):
+    """``output_audio_codec`` values accepted by the REST API.
+
+    ``LINEAR16`` is headerless 16-bit PCM (the pipeline-friendly default);
+    ``MULAW`` / ``ALAW`` are G.711 telephony codecs.
+    """
+
+    WAV = "wav"
+    MP3 = "mp3"
+    LINEAR16 = "linear16"
+    MULAW = "mulaw"
+    ALAW = "alaw"
+    OPUS = "opus"
+    FLAC = "flac"
+    AAC = "aac"
+
+
+class SarvamLanguage(StrEnum):
+    """BCP-47 ``target_language_code`` values for the 11 supported languages.
+
+    Note Sarvam uses ``od-IN`` for Odia (not the more common ``or-IN``).
+    """
+
+    HINDI = "hi-IN"
+    BENGALI = "bn-IN"
+    TAMIL = "ta-IN"
+    TELUGU = "te-IN"
+    KANNADA = "kn-IN"
+    MALAYALAM = "ml-IN"
+    MARATHI = "mr-IN"
+    GUJARATI = "gu-IN"
+    PUNJABI = "pa-IN"
+    ODIA = "od-IN"
+    ENGLISH = "en-IN"
+
+
+class SarvamSampleRate(IntEnum):
+    """Output sample rates (Hz) accepted by the REST ``speech_sample_rate``."""
+
+    HZ_8000 = 8000
+    HZ_16000 = 16000
+    HZ_22050 = 22050
+    HZ_24000 = 24000
+    HZ_32000 = 32000
+    HZ_44100 = 44100
+    HZ_48000 = 48000
+
+
+class SarvamTTS(TTSProvider):
+    """Sarvam AI TTS over the REST ``/text-to-speech`` one-shot endpoint.
+
+    Output is base64 audio decoded to raw bytes. With the default
+    ``codec="linear16"`` at 16 kHz these are PCM_S16LE samples that line up
+    with Patter's pipeline without a resample step.
+
+    Telephony optimization
+    ----------------------
+    The constructor default ``sample_rate=16000`` is correct for web playback
+    and 16 kHz pipelines. For real phone calls use the carrier-specific
+    factories instead:
+
+    * :meth:`for_twilio` / :meth:`for_telnyx` — emit ``mulaw`` @ 8 kHz, the
+      carrier wire codec, so the pipeline skips resampling AND PCM -> mu-law
+      encoding (bit-clean passthrough). Sarvam supports ``mulaw`` + 8 kHz
+      natively, so no transcoding is needed on either side.
+    """
+
+    #: Stable pricing/dashboard key — read by stream-handler/metrics.
+    provider_key: ClassVar[str] = "sarvam"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: Union[SarvamModel, str] = SarvamModel.BULBUL_V3,
+        speaker: str = "shubh",
+        language: Union[SarvamLanguage, str] = SarvamLanguage.ENGLISH,
+        codec: Union[SarvamAudioCodec, str] = SarvamAudioCodec.LINEAR16,
+        sample_rate: Union[SarvamSampleRate, int] = SarvamSampleRate.HZ_16000,
+        pace: Optional[float] = None,
+        pitch: Optional[float] = None,
+        loudness: Optional[float] = None,
+        temperature: Optional[float] = None,
+        enable_preprocessing: Optional[bool] = None,
+        dict_id: Optional[str] = None,
+        base_url: str = SARVAM_BASE_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for SarvamTTS. "
+                "Install with: pip install getpatter[sarvam]"
+            )
+
+        resolved_key = api_key or os.environ.get("SARVAM_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Sarvam API key is required, either as argument or set "
+                "SARVAM_API_KEY environment variable"
+            )
+
+        self.api_key = resolved_key
+        self.model = model
+        self.speaker = speaker
+        self.language = language
+        self.codec = codec
+        self.sample_rate = sample_rate
+        self.pace = pace
+        self.pitch = pitch
+        self.loudness = loudness
+        self.temperature = temperature
+        self.enable_preprocessing = enable_preprocessing
+        self.dict_id = dict_id
+        self.base_url = base_url
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        # Never leak the API key in repr / logs.
+        return (
+            f"SarvamTTS(model={self.model!r}, speaker={self.speaker!r}, "
+            f"language={self.language!r}, codec={self.codec!r}, "
+            f"sample_rate={self.sample_rate})"
+        )
+
+    # ------------------------------------------------------------------
+    # Telephony factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def for_twilio(
+        cls,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SarvamTTS":
+        """Build an instance pre-configured for Twilio Media Streams.
+
+        Emits ``mulaw`` @ 8 kHz — exactly Twilio's wire codec — so the
+        pipeline takes the passthrough path: zero resampling, zero PCM ->
+        mu-law encoding. Sarvam supports mu-law / 8 kHz natively, so this is a
+        true carrier-native path (no resample on Sarvam's side either).
+        """
+        kwargs.pop("sample_rate", None)
+        kwargs.pop("codec", None)
+        return cls(
+            api_key=api_key,
+            codec=SarvamAudioCodec.MULAW,
+            sample_rate=SarvamSampleRate.HZ_8000,
+            **kwargs,
+        )
+
+    @classmethod
+    def for_telnyx(
+        cls,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SarvamTTS":
+        """Build an instance pre-configured for Telnyx bidirectional media.
+
+        Telnyx pins the wire to PCMU/mu-law @ 8 kHz, so emitting ``mulaw`` @
+        8 kHz flows end-to-end with zero resampling — the same passthrough win
+        as :meth:`for_twilio`.
+        """
+        kwargs.pop("sample_rate", None)
+        kwargs.pop("codec", None)
+        return cls(
+            api_key=api_key,
+            codec=SarvamAudioCodec.MULAW,
+            sample_rate=SarvamSampleRate.HZ_8000,
+            **kwargs,
+        )
+
+    def source_audio_format(self) -> "AudioFormat":
+        """Declare the audio format this adapter emits so the pipeline sender
+        derives the correct resample ratio (or skips it for mu-law / a-law
+        passthrough) instead of assuming a fixed 16 kHz source. See
+        ``getpatter.audio.format``.
+        """
+        from getpatter.audio.format import AudioFormat
+
+        codec = str(self.codec)
+        if codec == SarvamAudioCodec.MULAW.value:
+            return AudioFormat(encoding="mulaw", sample_rate=int(self.sample_rate))
+        if codec == SarvamAudioCodec.ALAW.value:
+            return AudioFormat(encoding="alaw", sample_rate=int(self.sample_rate))
+        return AudioFormat(encoding="pcm_s16le", sample_rate=int(self.sample_rate))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _is_v2(self) -> bool:
+        """True when the configured model is the legacy ``bulbul:v2``."""
+        return str(self.model) == SarvamModel.BULBUL_V2.value
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "text": text,
+            "target_language_code": str(self.language),
+            "model": str(self.model),
+            "speaker": self.speaker,
+            "output_audio_codec": str(self.codec),
+            "speech_sample_rate": int(self.sample_rate),
+        }
+
+        if self.pace is not None:
+            payload["pace"] = self.pace
+
+        # Per-model controls: pitch / loudness / enable_preprocessing are
+        # bulbul:v2-only; temperature / dict_id are bulbul:v3-only. Gate them so
+        # we never POST a field the selected model rejects.
+        if self._is_v2():
+            if self.pitch is not None:
+                payload["pitch"] = self.pitch
+            if self.loudness is not None:
+                payload["loudness"] = self.loudness
+            if self.enable_preprocessing is not None:
+                payload["enable_preprocessing"] = self.enable_preprocessing
+        else:
+            if self.temperature is not None:
+                payload["temperature"] = self.temperature
+            if self.dict_id is not None:
+                payload["dict_id"] = self.dict_id
+
+        return payload
+
+    def _record_synthesis_cost(self, text: str) -> None:
+        """Emit ``patter.cost.tts_chars`` for the synthesised text.
+
+        NO PII: only the character COUNT is recorded, never the text itself.
+        """
+        try:
+            from getpatter.observability.attributes import record_patter_attrs
+
+            record_patter_attrs(
+                {
+                    "patter.cost.tts_chars": len(text),
+                    "patter.tts.provider": "sarvam",
+                }
+            )
+        except Exception:  # pragma: no cover — defense in depth
+            logger.debug("_record_synthesis_cost failed", exc_info=True)
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Synthesize ``text`` and yield decoded audio bytes.
+
+        With the default ``codec="linear16"`` these are raw PCM_S16LE samples
+        at ``sample_rate``. The REST endpoint returns the whole clip in one
+        JSON response (``audios`` is a list of base64 strings); we decode and
+        yield each entry in order.
+        """
+        self._record_synthesis_cost(text)
+        session = self._ensure_session()
+
+        headers = {
+            "Content-Type": "application/json",
+            "api-subscription-key": self.api_key,
+        }
+
+        async with session.post(
+            self.base_url,
+            headers=headers,
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"Sarvam TTS error {resp.status}: {body[:500]}")
+            data = await resp.json()
+            for audio_b64 in _iter_audio_b64(data):
+                try:
+                    decoded = base64.b64decode(audio_b64)
+                except (ValueError, TypeError):
+                    continue
+                if decoded:
+                    yield decoded
+
+    async def warmup(self) -> None:
+        """Pre-call HTTP warmup for the Sarvam TTS API.
+
+        Issues a lightweight ``GET`` against the API origin so DNS + TLS +
+        HTTP/2 are already up by the time the first :meth:`synthesize` POST
+        lands. Best-effort: 5 s timeout, all exceptions swallowed at DEBUG.
+
+        Billing safety: Sarvam does not document a free voice/metadata GET, so
+        this only primes the connection against the API origin root — it never
+        hits the synthesis endpoint, so no characters are billed. The actual
+        synthesis is billed only when ``POST /text-to-speech`` runs with
+        non-empty ``text``.
+
+        Note: like the Cartesia / Inworld adapters this uses the HTTP path
+        (Sarvam also exposes a WebSocket transport we don't use here), so the
+        latency win is the HTTP connection prime (~50-150 ms) rather than a WS
+        pre-handshake.
+        """
+        try:
+            session = self._ensure_session()
+            parts = urlsplit(self.base_url)
+            origin = f"{parts.scheme}://{parts.netloc}/"
+            headers = {"api-subscription-key": self.api_key}
+            async with session.get(
+                origin,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                # Drain so the underlying connection returns cleanly to the pool.
+                await resp.read()
+        except Exception as exc:  # noqa: BLE001 - best-effort
+            logger.debug("Sarvam TTS warmup failed (best-effort): %s", exc)
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None
+
+
+def _iter_audio_b64(data: Any) -> list[str]:
+    """Extract the base64 audio strings from a Sarvam REST response.
+
+    Accepts the documented ``{"audios": [...]}`` shape and is defensive about a
+    single-string ``audios`` value. Returns ``[]`` for anything unexpected so
+    the caller yields nothing rather than raising on a malformed body.
+    """
+    if not isinstance(data, dict):
+        return []
+    audios = data.get("audios")
+    if isinstance(audios, str):
+        return [audios] if audios else []
+    if isinstance(audios, list):
+        return [a for a in audios if isinstance(a, str) and a]
+    return []

--- a/libraries/python/getpatter/providers/soniox_stt.py
+++ b/libraries/python/getpatter/providers/soniox_stt.py
@@ -33,8 +33,16 @@ SONIOX_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
 
 
 class SonioxModel(StrEnum):
-    """Known Soniox real-time STT models."""
+    """Known Soniox real-time STT models.
 
+    ``STT_RT_V5`` is the current default (GA 2026-06-16). It is fully
+    API-compatible with v4 — same WebSocket URL, in-band ``api_key``, request
+    params and token-stream shape — so adopting it is a pure model-id swap.
+    The older ids are kept reachable for back-compat (Soniox auto-routes
+    retired v4/v3 ids to v5 server-side).
+    """
+
+    STT_RT_V5 = "stt-rt-v5"
     STT_RT_V4 = "stt-rt-v4"
     STT_RT_V3 = "stt-rt-v3"
     STT_RT_V2 = "stt-rt-v2"
@@ -139,7 +147,7 @@ class SonioxSTT(STTProvider):
 
     Args:
         api_key: Soniox API key.
-        model: Soniox STT model (default ``"stt-rt-v4"``).
+        model: Soniox STT model (default ``"stt-rt-v5"``).
         language_hints: Optional BCP-47 language hints (e.g. ``["en", "it"]``).
         language_hints_strict: When True, restrict to the hints supplied.
         sample_rate: PCM sample rate (Hz). Defaults to 16 kHz, matching
@@ -149,6 +157,13 @@ class SonioxSTT(STTProvider):
         enable_language_identification: Attach language codes to tokens.
         max_endpoint_delay_ms: Silence, in ms, before Soniox reports an
             endpoint. Must be in ``[500, 3000]`` (validated by the server).
+        endpoint_sensitivity: Optional v5 endpoint control in ``[-1.0, 1.0]``
+            (Soniox default ``0.0``). Higher = more/sooner endpoints, lower =
+            wait longer (good for dictation/slow speakers). Omitted from the
+            config when ``None`` so default behaviour is unchanged.
+        endpoint_latency_adjustment_level: Optional v5 latency-reduction
+            aggressiveness, one of ``0|1|2|3`` (Soniox default ``0``). Omitted
+            from the config when ``None``.
         client_reference_id: Optional correlation ID for Soniox dashboards.
         base_url: Override the Soniox WebSocket URL (used by tests).
     """
@@ -160,7 +175,7 @@ class SonioxSTT(STTProvider):
         self,
         api_key: str,
         *,
-        model: Union[SonioxModel, str] = SonioxModel.STT_RT_V4,
+        model: Union[SonioxModel, str] = SonioxModel.STT_RT_V5,
         language_hints: list[str] | None = None,
         language_hints_strict: bool = False,
         sample_rate: Union[SonioxSampleRate, int] = SonioxSampleRate.HZ_16000,
@@ -168,6 +183,8 @@ class SonioxSTT(STTProvider):
         enable_speaker_diarization: bool = False,
         enable_language_identification: bool = True,
         max_endpoint_delay_ms: int = 500,
+        endpoint_sensitivity: float | None = None,
+        endpoint_latency_adjustment_level: int | None = None,
         client_reference_id: str | None = None,
         base_url: str = SONIOX_WS_URL,
     ) -> None:
@@ -175,6 +192,17 @@ class SonioxSTT(STTProvider):
             raise ValueError("Soniox api_key is required")
         if not (500 <= max_endpoint_delay_ms <= 3000):
             raise ValueError("max_endpoint_delay_ms must be between 500 and 3000")
+        if endpoint_sensitivity is not None and not (
+            -1.0 <= endpoint_sensitivity <= 1.0
+        ):
+            raise ValueError("endpoint_sensitivity must be between -1.0 and 1.0")
+        if (
+            endpoint_latency_adjustment_level is not None
+            and endpoint_latency_adjustment_level not in (0, 1, 2, 3)
+        ):
+            raise ValueError(
+                "endpoint_latency_adjustment_level must be 0, 1, 2, or 3"
+            )
 
         self.api_key = api_key
         self.model = model
@@ -185,6 +213,8 @@ class SonioxSTT(STTProvider):
         self.enable_speaker_diarization = enable_speaker_diarization
         self.enable_language_identification = enable_language_identification
         self.max_endpoint_delay_ms = max_endpoint_delay_ms
+        self.endpoint_sensitivity = endpoint_sensitivity
+        self.endpoint_latency_adjustment_level = endpoint_latency_adjustment_level
         self.client_reference_id = client_reference_id
         self.base_url = base_url
 
@@ -227,7 +257,7 @@ class SonioxSTT(STTProvider):
         cls,
         api_key: str,
         language_hints: list[str] | None = None,
-        model: Union[SonioxModel, str] = SonioxModel.STT_RT_V4,
+        model: Union[SonioxModel, str] = SonioxModel.STT_RT_V5,
     ) -> "SonioxSTT":
         """Create a Soniox adapter configured for Twilio-style 8 kHz linear PCM.
 
@@ -259,6 +289,14 @@ class SonioxSTT(STTProvider):
             "enable_language_identification": self.enable_language_identification,
             "max_endpoint_delay_ms": self.max_endpoint_delay_ms,
         }
+        # v5 endpoint controls — opt-in; omitted when unset so the wire config
+        # stays byte-identical to the pre-v5 default.
+        if self.endpoint_sensitivity is not None:
+            config["endpoint_sensitivity"] = self.endpoint_sensitivity
+        if self.endpoint_latency_adjustment_level is not None:
+            config["endpoint_latency_adjustment_level"] = (
+                self.endpoint_latency_adjustment_level
+            )
         if self.language_hints:
             config["language_hints"] = self.language_hints
             config["language_hints_strict"] = self.language_hints_strict

--- a/libraries/python/getpatter/providers/soniox_tts.py
+++ b/libraries/python/getpatter/providers/soniox_tts.py
@@ -1,0 +1,291 @@
+"""Soniox TTS provider — HTTP one-shot bytes endpoint, pure aiohttp.
+
+Targets the REST ``POST https://tts-rt.soniox.com/tts`` endpoint which returns
+raw audio bytes (Content-Type matches the requested ``audio_format``). This
+maps cleanly onto Patter's ``TTSProvider.synthesize(text) -> AsyncIterator[bytes]``
+contract and requires no vendor SDK — only ``aiohttp``.
+
+Soniox also exposes a richer WebSocket streaming mode
+(``wss://tts-rt.soniox.com/tts-websocket``) that starts emitting audio from
+the first few words for lower TTFB; that mode is not used here because the REST
+endpoint already maps onto Patter's streaming contract while keeping the
+dependency / state surface minimal (mirrors how :class:`CartesiaTTS` opts for
+the HTTP bytes path over Cartesia's WebSocket variant).
+
+Credential: Soniox TTS shares the ``SONIOX_API_KEY`` env var / key family with
+the existing Soniox STT integration (host ``*.soniox.com``). REST auth is an
+``Authorization: Bearer <key>`` header.
+
+Telephony: Soniox natively supports G.711 mu-law @ 8 kHz — request
+``audio_format="pcm_mulaw"`` + ``sample_rate=8000`` (the :meth:`for_twilio` /
+:meth:`for_telnyx` factories do this) to emit carrier-native audio with NO
+resampling, exactly matching Patter's mu-law/8 kHz wire format.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import IntEnum, StrEnum
+from typing import ClassVar, Any, AsyncIterator, Optional, Union
+
+from getpatter.providers.base import TTSProvider
+
+logger = logging.getLogger("getpatter.providers.soniox_tts")
+
+# Lazy import: aiohttp is declared as an optional dep for this provider
+# (shared ``[soniox]`` extra with the Soniox STT adapter).
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+# REST one-shot text-to-speech endpoint. Returns raw audio bytes.
+SONIOX_TTS_REST_URL = "https://tts-rt.soniox.com/tts"
+# WebSocket streaming endpoint (documented for reference; not used by this
+# HTTP-bytes adapter).
+SONIOX_TTS_WS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+
+# Soniox's default voice. A single voice keeps its timbre across 60+
+# languages and supports seamless mid-sentence language switching.
+SONIOX_DEFAULT_VOICE = "Adrian"
+
+
+class SonioxTTSModel(StrEnum):
+    """Soniox real-time TTS model identifiers."""
+
+    TTS_RT_V1 = "tts-rt-v1"
+    # Deprecated alias retained for back-compat — now points at tts-rt-v1.
+    TTS_RT_V1_PREVIEW = "tts-rt-v1-preview"
+
+
+class SonioxTTSAudioFormat(StrEnum):
+    """Output encodings accepted by Soniox TTS ``audio_format``.
+
+    ``PCM_MULAW`` / ``PCM_ALAW`` @ 8 kHz are the carrier-native G.711 codecs
+    (telephony passthrough); the remaining formats target web/dashboard use.
+    """
+
+    PCM_S16LE = "pcm_s16le"
+    PCM_F32LE = "pcm_f32le"
+    PCM_MULAW = "pcm_mulaw"
+    PCM_ALAW = "pcm_alaw"
+    WAV = "wav"
+    MP3 = "mp3"
+    AAC = "aac"
+    OPUS = "opus"
+    FLAC = "flac"
+
+
+class SonioxTTSSampleRate(IntEnum):
+    """Sample rates (Hz) accepted by Soniox TTS ``sample_rate``."""
+
+    HZ_8000 = 8000
+    HZ_16000 = 16000
+    HZ_24000 = 24000
+    HZ_44100 = 44100
+    HZ_48000 = 48000
+
+
+class SonioxTTS(TTSProvider):
+    """Soniox TTS over the HTTP one-shot ``/tts`` bytes endpoint.
+
+    Default output is PCM_S16LE at 16 kHz so it drops into Patter's pipeline
+    without transcoding. Default model is ``tts-rt-v1`` and default voice is
+    ``Adrian``.
+
+    Telephony optimization
+    ----------------------
+    The constructor default ``sample_rate=16000`` / ``audio_format="pcm_s16le"``
+    is correct for web playback, dashboard previews, and 16 kHz pipelines. For
+    real phone calls use the carrier factories instead:
+
+    * :meth:`for_twilio` — emits ``pcm_mulaw`` @ 8 kHz, Twilio's exact wire
+      codec, so the pipeline skips resampling AND PCM -> mu-law encoding
+      (bit-clean passthrough). The sender reads the declared output format via
+      :meth:`source_audio_format`.
+    * :meth:`for_telnyx` — emits ``pcm_mulaw`` @ 8 kHz. The SDK pins the Telnyx
+      wire to PCMU/mu-law @ 8 kHz, so this flows end-to-end with zero
+      resampling — same passthrough win as the Twilio factory.
+    """
+
+    #: Stable pricing/dashboard key — read by stream-handler/metrics.
+    provider_key: ClassVar[str] = "soniox_tts"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: Union[SonioxTTSModel, str] = SonioxTTSModel.TTS_RT_V1,
+        voice: str = SONIOX_DEFAULT_VOICE,
+        language: str = "en",
+        audio_format: Union[SonioxTTSAudioFormat, str] = SonioxTTSAudioFormat.PCM_S16LE,
+        sample_rate: Union[SonioxTTSSampleRate, int] = SonioxTTSSampleRate.HZ_16000,
+        bitrate: Optional[int] = None,
+        speed: Optional[float] = None,
+        base_url: str = SONIOX_TTS_REST_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for SonioxTTS. "
+                "Install with: pip install getpatter[soniox]"
+            )
+
+        resolved_key = api_key or os.environ.get("SONIOX_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Soniox API key is required, either as argument or set "
+                "SONIOX_API_KEY environment variable"
+            )
+
+        self.api_key = resolved_key
+        self.model = model
+        self.voice = voice
+        self.language = language
+        self.audio_format = audio_format
+        self.sample_rate = sample_rate
+        self.bitrate = bitrate
+        self.speed = speed
+        self.base_url = base_url
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        # Never leak the API key in repr / logs.
+        return (
+            f"SonioxTTS(model={self.model!r}, voice={self.voice!r}, "
+            f"language={self.language!r}, audio_format={self.audio_format!r}, "
+            f"sample_rate={self.sample_rate})"
+        )
+
+    # ------------------------------------------------------------------
+    # Telephony factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def for_twilio(
+        cls,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SonioxTTS":
+        """Build an instance pre-configured for Twilio Media Streams.
+
+        Emits ``pcm_mulaw`` @ 8 kHz — exactly Twilio's wire codec — so the
+        pipeline takes the passthrough path: zero resampling, zero PCM ->
+        mu-law encoding, bit-clean audio. Soniox supports mu-law @ 8 kHz
+        natively, so this is a true carrier-native synthesis (no downsampling
+        from a PCM-only model).
+        """
+        kwargs.pop("sample_rate", None)
+        kwargs.pop("audio_format", None)
+        return cls(
+            api_key=api_key,
+            audio_format=SonioxTTSAudioFormat.PCM_MULAW,
+            sample_rate=SonioxTTSSampleRate.HZ_8000,
+            **kwargs,
+        )
+
+    @classmethod
+    def for_telnyx(
+        cls,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SonioxTTS":
+        """Build an instance pre-configured for Telnyx bidirectional media.
+
+        The SDK pins the Telnyx wire to PCMU/mu-law @ 8 kHz, so emitting
+        ``pcm_mulaw`` @ 8 kHz flows end-to-end with zero resampling or
+        transcoding — the same passthrough win as :meth:`for_twilio`.
+        """
+        kwargs.pop("sample_rate", None)
+        kwargs.pop("audio_format", None)
+        return cls(
+            api_key=api_key,
+            audio_format=SonioxTTSAudioFormat.PCM_MULAW,
+            sample_rate=SonioxTTSSampleRate.HZ_8000,
+            **kwargs,
+        )
+
+    def source_audio_format(self) -> "AudioFormat":
+        """Declare the audio format this adapter emits, so the pipeline sender
+        derives the correct resample ratio (or skips it for mu-law passthrough)
+        instead of assuming a fixed 16 kHz source. See ``getpatter.audio.format``.
+        """
+        from getpatter.audio.format import AudioFormat
+
+        fmt = str(self.audio_format)
+        if fmt == SonioxTTSAudioFormat.PCM_MULAW.value:
+            return AudioFormat(encoding="mulaw", sample_rate=int(self.sample_rate))
+        if fmt == SonioxTTSAudioFormat.PCM_ALAW.value:
+            return AudioFormat(encoding="alaw", sample_rate=int(self.sample_rate))
+        return AudioFormat(encoding="pcm_s16le", sample_rate=int(self.sample_rate))
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": str(self.model),
+            "text": text,
+            "voice": self.voice,
+            "language": self.language,
+            "audio_format": str(self.audio_format),
+            "sample_rate": int(self.sample_rate),
+        }
+        if self.bitrate is not None:
+            payload["bitrate"] = self.bitrate
+        if self.speed is not None:
+            payload["speed"] = self.speed
+        return payload
+
+    def _record_synthesis_cost(self, text: str) -> None:
+        """Emit ``patter.cost.tts_chars`` for the synthesised text."""
+        try:
+            from getpatter.observability.attributes import record_patter_attrs
+
+            record_patter_attrs(
+                {
+                    "patter.cost.tts_chars": len(text),
+                    "patter.tts.provider": "soniox_tts",
+                }
+            )
+        except Exception:  # pragma: no cover — defense in depth
+            logger.debug("_record_synthesis_cost failed", exc_info=True)
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream raw audio bytes for ``text`` over HTTP.
+
+        With the default ``audio_format="pcm_s16le"`` these are raw PCM_S16LE
+        chunks at the configured ``sample_rate``; with ``pcm_mulaw`` (see
+        :meth:`for_twilio`) they are carrier-native G.711 mu-law bytes.
+        """
+        self._record_synthesis_cost(text)
+        session = self._ensure_session()
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with session.post(
+            self.base_url,
+            headers=headers,
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"Soniox TTS error {resp.status}: {body[:500]}")
+            async for chunk in resp.content.iter_chunked(4096):
+                if chunk:
+                    yield chunk
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None

--- a/libraries/python/getpatter/providers/twilio_adapter.py
+++ b/libraries/python/getpatter/providers/twilio_adapter.py
@@ -77,11 +77,23 @@ class TwilioAdapter(TelephonyProvider):
         to_number: str,
         stream_url: str,
         extra_params: dict | None = None,
+        parameters: dict | None = None,
     ) -> str:
-        """Place an outbound Twilio call that streams media to *stream_url*."""
+        """Place an outbound Twilio call that streams media to *stream_url*.
+
+        ``parameters`` is forwarded as ``<Parameter name="..." value="..."/>``
+        children of ``<Stream>`` (Twilio strips query params from the stream
+        URL). Used to carry the per-call media-stream auth token (#204) to the
+        WS ``start.customParameters`` for outbound calls.
+        """
         twiml = VoiceResponse()
         connect = Connect()
-        connect.stream(url=stream_url)
+        stream = connect.stream(url=stream_url)
+        if parameters:
+            for name, value in parameters.items():
+                if value is None:
+                    continue
+                stream.parameter(name=name, value=str(value))
         twiml.append(connect)
         call_kwargs: dict = {"to": to_number, "from_": from_number, "twiml": str(twiml)}
         if extra_params:

--- a/libraries/python/getpatter/server.py
+++ b/libraries/python/getpatter/server.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hmac
 import logging
 import os
 import re
+import secrets
 import signal
 import time
 import uuid
@@ -26,6 +28,7 @@ from getpatter.services.call_log import (
     resolve_log_root,
 )
 from getpatter.ssrf import is_internal_ip, resolve_literal_ip
+from getpatter.telephony.common import STREAM_TOKEN_PARAM
 from getpatter.utils.log_sanitize import (
     mask_phone_number,
     safe_path_segment,
@@ -50,6 +53,24 @@ _BLOCKED_WEBHOOK_HOSTNAMES = frozenset(
 # Maximum concurrent WebSocket connections allowed from a single client IP.
 # Mirrors libraries/typescript/src/server.ts:1041 (MAX_WS_PER_IP = 10).
 MAX_WS_PER_IP = 10
+
+# Global concurrent media-stream backstop (#204). The per-IP cap above trusts
+# tunnel headers for its rate-limit key (a tunneled deployment legitimately
+# arrives from loopback and must not share one bucket), so a peer forging
+# ``x-forwarded-for`` behind a non-Cloudflare proxy could otherwise mint a fresh
+# per-IP bucket per connection and open unbounded sockets. Per-call token auth
+# already rejects those peers before any provider work, so this is only a
+# connection-flood DoS; this ceiling caps the total simultaneously-open media
+# WebSockets regardless of source IP so a header-forging flood cannot exhaust
+# memory / fds. Generous vs. any single-box call volume. Kept in parity with the
+# TS ``MAX_WS_TOTAL`` (libraries/typescript/src/server.ts).
+MAX_TOTAL_WS = 500
+
+# SECURITY (#204): per-call stream-auth token lifetime and entropy. The mint ->
+# WS handshake is seconds; a short TTL bounds the replay window while still
+# tolerating a legitimate carrier reconnect. 32 bytes -> ~43 url-safe chars.
+_STREAM_TOKEN_TTL_S = 120.0
+_STREAM_TOKEN_NBYTES = 32
 
 # Hosts that are loopback-only (not reachable from another machine). Used by
 # the dashboard auto-token gate to decide whether the server is "exposed".
@@ -519,6 +540,20 @@ class EmbeddedServer:
         # Per-client-IP active WebSocket counter for DoS protection.
         # Mirrors TS server.ts:1042 (wsConnectionsByIp).
         self._ws_conn_counts: defaultdict[str, int] = defaultdict(int)
+        # SECURITY (#204): fail-closed media-stream auth. When True (default),
+        # a media WS must present a token minted by the signed webhook / the
+        # outbound call. Read via ``getattr`` so LocalConfigs constructed before
+        # this field existed (older tests) default to secure.
+        self._require_stream_auth: bool = getattr(config, "require_stream_auth", True)
+        # Per-server short-TTL token map: ``call_key -> (token, expires_at)``
+        # where ``expires_at`` is a ``time.monotonic()`` deadline. Populated by
+        # ``_mint_stream_token`` at the signed-webhook / outbound stream-URL
+        # build; consumed (kept valid within the TTL) by ``_validate_stream_token``
+        # at WS accept / start-frame. NEVER logged.
+        self._stream_tokens: dict[str, tuple[str, float]] = {}
+        # One-shot latch so the "stream auth disabled" opt-out warning is loud
+        # but not spammed on every connection.
+        self._stream_auth_disabled_warned: bool = False
 
     @property
     def effective_dashboard_token(self) -> str:
@@ -532,6 +567,81 @@ class EmbeddedServer:
         ``EmbeddedServer.resolvedDashboardToken`` getter — see sdk-parity.
         """
         return self._effective_dashboard_token
+
+    # === Per-call media-stream authentication (#204) ===
+
+    def _prune_expired_stream_tokens(self) -> None:
+        """Drop expired entries from the token map (opportunistic GC)."""
+        now = time.monotonic()
+        expired = [k for k, (_, exp) in self._stream_tokens.items() if exp <= now]
+        for key in expired:
+            self._stream_tokens.pop(key, None)
+
+    def _mint_stream_token(self, call_key: str) -> str:
+        """Mint + store a high-entropy stream-auth token bound to ``call_key``.
+
+        Called only from SIGNATURE-VALIDATED webhook / outbound stream-URL build
+        sites, so only a legitimate carrier ever receives the returned token.
+        The entry lives ``_STREAM_TOKEN_TTL_S`` seconds (webhook -> WS handshake
+        is seconds). Returns the token to embed in the carrier's custom-param
+        channel. NEVER logged.
+        """
+        self._prune_expired_stream_tokens()
+        token = secrets.token_urlsafe(_STREAM_TOKEN_NBYTES)
+        self._stream_tokens[call_key] = (
+            token,
+            time.monotonic() + _STREAM_TOKEN_TTL_S,
+        )
+        return token
+
+    def _validate_stream_token(self, call_key: str, presented: str) -> bool:
+        """Constant-time check that ``presented`` matches the live token for
+        ``call_key`` and has not expired. Kept valid within the TTL so a
+        legitimate carrier reconnect within the window is NOT single-use
+        rejected. Never raises; never logs the token value.
+        """
+        self._prune_expired_stream_tokens()
+        entry = self._stream_tokens.get(call_key)
+        if entry is None:
+            return False
+        token, expires_at = entry
+        if expires_at <= time.monotonic():
+            self._stream_tokens.pop(call_key, None)
+            return False
+        if not presented:
+            return False
+        # Compare as bytes so an attacker-supplied non-ASCII string can't raise
+        # (``hmac.compare_digest`` rejects non-ASCII str). Still constant-time.
+        return hmac.compare_digest(
+            token.encode("utf-8"), str(presented).encode("utf-8")
+        )
+
+    def _warn_stream_auth_disabled_once(self) -> None:
+        """Emit a single loud WARNING when the auth opt-out is in effect."""
+        if self._stream_auth_disabled_warned:
+            return
+        self._stream_auth_disabled_warned = True
+        logger.warning(
+            "SECURITY: media-stream authentication is DISABLED "
+            "(require_stream_auth=False). Media WebSockets are accepted without "
+            "a per-call token — an unauthenticated peer that reaches this host "
+            "can drive a full STT/LLM/TTS session on your provider keys. Only "
+            "use this for custom TwiML/XML that cannot carry the token."
+        )
+
+    def _check_stream_auth(self, call_key: str, presented: str) -> bool:
+        """Gate a media stream for ``call_key``.
+
+        Fail-closed by default: when ``require_stream_auth`` is True, the
+        presented token must match the minted token and be unexpired. When the
+        operator explicitly opts out (``require_stream_auth=False``), always
+        allow but log a loud one-time warning. Returning False means the caller
+        MUST close the socket (WS 1008) before opening any provider session.
+        """
+        if not self._require_stream_auth:
+            self._warn_stream_auth_disabled_once()
+            return True
+        return self._validate_stream_token(call_key, presented)
 
     # === Carrier-neutral local recording ===
 
@@ -1280,8 +1390,18 @@ class EmbeddedServer:
             # masked. Same for `To` / `Called`.
             caller = form_data.get("From", "") or form_data.get("Caller", "")
             callee = form_data.get("To", "") or form_data.get("Called", "")
+            # SECURITY (#204): this webhook is signature-validated above, so
+            # only a legitimate carrier reaches here. Mint a per-call token
+            # bound to the CallSid (== the WS path ``call_id``) and embed it as
+            # a <Parameter> so the media WS can prove it originated from this
+            # signed webhook before any provider session is opened.
+            stream_token = self._mint_stream_token(call_sid)
             twiml = twilio_webhook_handler(
-                call_sid, caller, callee, self.config.webhook_url
+                call_sid,
+                caller,
+                callee,
+                self.config.webhook_url,
+                stream_token=stream_token,
             )
             return Response(content=twiml, media_type="text/xml")
 
@@ -1441,8 +1561,22 @@ class EmbeddedServer:
 
         @app.websocket("/ws/stream/{call_id}")
         async def twilio_stream_handler(websocket: WebSocket, call_id: str):
-            # Per-IP DoS cap (mirrors TS server.ts:1041-1064).
+            # DoS cap only (mirrors TS server.ts:1041-1064). NOTE: the per-IP
+            # key trusts the tunnel headers (cf-connecting-ip / x-forwarded-for)
+            # via ``_client_ip_for_ws`` — a header-forging peer can therefore
+            # get a fresh bucket. That is acceptable because it is a DoS cap,
+            # not an auth control: media-stream AUTHENTICATION is enforced
+            # separately by the per-call token below (rejected before any
+            # provider work). ``MAX_TOTAL_WS`` is the global backstop so a
+            # header-forging flood cannot open unbounded sockets.
             client_ip = _client_ip_for_ws(websocket)
+            if len(self._active_connections) >= MAX_TOTAL_WS:
+                logger.warning(
+                    "WebSocket upgrade rejected: server at capacity (%d open)",
+                    MAX_TOTAL_WS,
+                )
+                await websocket.close(code=1008, reason="Server at capacity")
+                return
             if self._ws_conn_counts[client_ip] >= MAX_WS_PER_IP:
                 logger.warning(
                     "WebSocket upgrade rejected: too many connections from %s",
@@ -1463,6 +1597,13 @@ class EmbeddedServer:
                     pop_prewarm_audio=self.pop_prewarm_audio,
                     pop_prewarmed_connections=self.pop_prewarmed_connections,
                     openai_key=self.config.openai_key,
+                    # SECURITY (#204): validate the <Parameter>-borne token
+                    # (start.customParameters) against the token minted for this
+                    # call_id BEFORE the provider session opens. Fail-closed by
+                    # default; the opt-out path allows + warns once.
+                    validate_stream_token=(
+                        lambda tok, _ck=call_id: self._check_stream_auth(_ck, tok)
+                    ),
                     on_call_start=_start,
                     on_call_end=_end,
                     on_transcript=_transcript,
@@ -1669,9 +1810,15 @@ class EmbeddedServer:
                     # answer body removes both the ``call.answered`` webhook
                     # round-trip and a second POST (~100-200 ms saved per
                     # inbound call). Incoming legs only — see above.
+                    # SECURITY (#204): mint a per-call token (this webhook is
+                    # Ed25519-verified above) bound to call_control_id (== the
+                    # WS path call_id) and append it to the query string Telnyx
+                    # preserves; the WS handler validates it at accept.
+                    _stream_token = self._mint_stream_token(call_control_id)
                     stream_url = (
                         f"wss://{self.config.webhook_url}/ws/telnyx/stream/{_quote(call_control_id, safe='')}"
                         f"?caller={_quote(caller)}&callee={_quote(callee)}"
+                        f"&{STREAM_TOKEN_PARAM}={_quote(_stream_token, safe='')}"
                     )
                     logger.info(
                         "Telnyx call.initiated %s — answering with inline stream",
@@ -1711,9 +1858,13 @@ class EmbeddedServer:
                         # this POST is the ONLY place outbound audio is wired.
                         out_caller = str(payload.get("from", "") or "")
                         out_callee = str(payload.get("to", "") or "")
+                        # SECURITY (#204): outbound leg minted here (verified
+                        # webhook), keyed to call_control_id == WS path call_id.
+                        _stream_token = self._mint_stream_token(call_control_id)
                         stream_url = (
                             f"wss://{self.config.webhook_url}/ws/telnyx/stream/{_quote(call_control_id, safe='')}"
                             f"?caller={_quote(out_caller)}&callee={_quote(out_callee)}"
+                            f"&{STREAM_TOKEN_PARAM}={_quote(_stream_token, safe='')}"
                         )
                         logger.info(
                             "Telnyx call.answered %s (outgoing) — starting media stream",
@@ -1894,14 +2045,35 @@ class EmbeddedServer:
 
         @app.websocket("/ws/telnyx/stream/{call_id}")
         async def telnyx_stream_handler(websocket: WebSocket, call_id: str):
-            # Per-IP DoS cap (mirrors TS server.ts:1041-1064).
+            # DoS cap only — see the Twilio handler note: the per-IP key trusts
+            # tunnel headers, so auth is enforced separately (the query token
+            # validated below) and MAX_TOTAL_WS is the global flood backstop.
             client_ip = _client_ip_for_ws(websocket)
+            if len(self._active_connections) >= MAX_TOTAL_WS:
+                logger.warning(
+                    "WebSocket upgrade rejected: server at capacity (%d open)",
+                    MAX_TOTAL_WS,
+                )
+                await websocket.close(code=1008, reason="Server at capacity")
+                return
             if self._ws_conn_counts[client_ip] >= MAX_WS_PER_IP:
                 logger.warning(
                     "WebSocket upgrade rejected: too many connections from %s",
                     client_ip,
                 )
                 await websocket.close(code=1008, reason="Too Many Requests")
+                return
+            # SECURITY (#204): Telnyx carries the token on the query string it
+            # preserves, so validate as early as possible — at accept, before
+            # any frame is read and before the provider session is opened. On a
+            # missing/invalid/expired token, close with 1008 and never call the
+            # bridge (no provider connection, no TTS). No PII / no token logged.
+            _presented = websocket.query_params.get(STREAM_TOKEN_PARAM, "")
+            if not self._check_stream_auth(call_id, _presented):
+                logger.warning(
+                    "Telnyx media stream rejected: stream authentication failed"
+                )
+                await websocket.close(code=1008, reason="Stream auth failed")
                 return
             self._ws_conn_counts[client_ip] += 1
             self._active_connections.add(websocket)
@@ -2010,8 +2182,18 @@ class EmbeddedServer:
             request_uuid = form.get("RequestUUID", "")
             if request_uuid and call_uuid:
                 self.alias_call_id(request_uuid, call_uuid)
+            # SECURITY (#204): this route is V3-signature-validated above. Mint a
+            # per-call token keyed to the same call_id used for the WS path
+            # (``call_uuid or "outbound"``) and deliver it via extra_headers so
+            # the media WS can prove provenance before any provider session.
+            _stream_call_key = call_uuid or "outbound"
+            stream_token = self._mint_stream_token(_stream_call_key)
             xml = plivo_webhook_handler(
-                call_uuid or "outbound", caller, callee, self.config.webhook_url
+                _stream_call_key,
+                caller,
+                callee,
+                self.config.webhook_url,
+                stream_token=stream_token,
             )
             return Response(content=xml, media_type="text/xml")
 
@@ -2146,8 +2328,17 @@ class EmbeddedServer:
 
         @app.websocket("/ws/plivo/stream/{call_id}")
         async def plivo_stream_websocket(websocket: WebSocket, call_id: str):
-            # Per-IP DoS cap (mirrors the Twilio / Telnyx handlers).
+            # DoS cap only — see the Twilio handler note: header-trusted per-IP
+            # key, auth enforced separately (the extra-header token validated in
+            # the bridge before handler.start()), MAX_TOTAL_WS as flood backstop.
             client_ip = _client_ip_for_ws(websocket)
+            if len(self._active_connections) >= MAX_TOTAL_WS:
+                logger.warning(
+                    "WebSocket upgrade rejected: server at capacity (%d open)",
+                    MAX_TOTAL_WS,
+                )
+                await websocket.close(code=1008, reason="Server at capacity")
+                return
             if self._ws_conn_counts[client_ip] >= MAX_WS_PER_IP:
                 logger.warning(
                     "WebSocket upgrade rejected: too many connections from %s",
@@ -2167,6 +2358,12 @@ class EmbeddedServer:
                     pop_prewarm_audio=self.pop_prewarm_audio,
                     pop_prewarmed_connections=self.pop_prewarmed_connections,
                     openai_key=self.config.openai_key,
+                    # SECURITY (#204): validate the X-Patter-Stream-Token
+                    # extra-header against the token minted for this call_id
+                    # BEFORE the provider session opens. Fail-closed by default.
+                    validate_stream_token=(
+                        lambda tok, _ck=call_id: self._check_stream_auth(_ck, tok)
+                    ),
                     on_call_start=_start,
                     on_call_end=_end,
                     on_transcript=_transcript,

--- a/libraries/python/getpatter/telemetry/stack.py
+++ b/libraries/python/getpatter/telemetry/stack.py
@@ -42,6 +42,7 @@ STACK_VENDORS: frozenset[str] = frozenset(
         "lmnt",
         "rime",
         "inworld",
+        "sarvam",
         "telnyx",
         "other",
     }
@@ -54,6 +55,7 @@ _VENDOR_ALIASES: dict[str, str] = {
     "openai_tts": "openai",
     "openai_transcribe": "openai",
     "elevenlabs_ws": "elevenlabs",
+    "soniox_tts": "soniox",
     "telnyx_stt": "telnyx",
     "telnyx_tts": "telnyx",
 }

--- a/libraries/python/getpatter/telephony/common.py
+++ b/libraries/python/getpatter/telephony/common.py
@@ -9,6 +9,19 @@ import re
 
 from getpatter.providers.base import STTProvider, TTSProvider
 
+# SECURITY (#204): names of the per-call media-stream auth token as it travels
+# on each carrier's custom-param channel. Kept in one place so the mint sites
+# (server / adapters) and the WS read sites stay in lock-step. Mirrors the
+# TypeScript SDK constants of the same value.
+#
+#   * Twilio: a ``<Parameter name="patter_stream_token" .../>`` that arrives in
+#     ``start.customParameters`` (Twilio strips query params from <Stream>).
+#   * Telnyx: a ``?...&patter_stream_token=`` query param on the stream URL
+#     (Telnyx preserves the query string), read at WS accept.
+#   * Plivo: an ``X-Patter-Stream-Token`` extra header echoed on the start frame.
+STREAM_TOKEN_PARAM = "patter_stream_token"
+STREAM_TOKEN_HEADER = "X-Patter-Stream-Token"
+
 
 def _validate_e164(number: str) -> bool:
     """Return True if *number* is a valid E.164 phone number."""

--- a/libraries/python/getpatter/telephony/common.py
+++ b/libraries/python/getpatter/telephony/common.py
@@ -250,7 +250,43 @@ def _create_tts_from_config(config):
         # ``api_key`` carries the Base64 ``Authorization: Basic`` token.
         return InworldTTS(auth_token=config.api_key, voice=config.voice, **kwargs)
 
+    if provider == "soniox_tts":
+        from getpatter.providers.soniox_tts import SonioxTTS  # type: ignore[import]
+
+        allowed = {
+            "model",
+            "language",
+            "audio_format",
+            "sample_rate",
+            "bitrate",
+            "speed",
+            "base_url",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        return SonioxTTS(api_key=config.api_key, voice=config.voice, **kwargs)
+
+    if provider == "sarvam":
+        from getpatter.providers.sarvam_tts import SarvamTTS  # type: ignore[import]
+
+        allowed = {
+            "model",
+            "language",
+            "codec",
+            "sample_rate",
+            "pace",
+            "pitch",
+            "loudness",
+            "temperature",
+            "enable_preprocessing",
+            "dict_id",
+            "base_url",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        # The Sarvam adapter calls the user-facing ``voice`` a ``speaker``.
+        return SarvamTTS(api_key=config.api_key, speaker=config.voice, **kwargs)
+
     raise ValueError(
         f"Unknown TTS provider '{provider}'. "
-        "Supported: elevenlabs, openai, cartesia, rime, lmnt, inworld."
+        "Supported: elevenlabs, openai, cartesia, rime, lmnt, inworld, "
+        "soniox_tts, sarvam."
     )

--- a/libraries/python/getpatter/telephony/plivo.py
+++ b/libraries/python/getpatter/telephony/plivo.py
@@ -39,6 +39,7 @@ from getpatter.stream_handler import (
     resolve_agent_prompt,
 )
 from getpatter.telephony.common import (
+    STREAM_TOKEN_HEADER,
     _create_stt_from_config,  # noqa: F401 — re-exported for tests and external callers
     _create_tts_from_config,  # noqa: F401 — re-exported for tests and external callers
     _resolve_variables,  # noqa: F401 — re-exported for tests and external callers
@@ -148,6 +149,7 @@ def plivo_webhook_handler(
     caller: str,
     callee: str,
     webhook_base_url: str,
+    stream_token: str = "",
 ) -> str:
     """Generate Plivo answer XML for an incoming (or answered outbound) call.
 
@@ -161,6 +163,9 @@ def plivo_webhook_handler(
         caller: The calling number (From).
         callee: The called number (To).
         webhook_base_url: Hostname (no scheme), e.g. ``"abc.ngrok.io"``.
+        stream_token: Per-call media-stream auth token (#204). When non-empty it
+            is delivered as an ``X-Patter-Stream-Token`` extra header (echoed on
+            the start frame); the bridge validates it before the provider session.
     """
     # Lazy import — provider adapter may be created by the parallel agent.
     from getpatter.providers.plivo_adapter import PlivoAdapter  # type: ignore[import]
@@ -170,6 +175,8 @@ def plivo_webhook_handler(
     # Fallback channel: Plivo echoes these on the ``start`` frame's
     # ``extra_headers`` when the query string is unavailable.
     extra_headers = {"X-PH-caller": caller, "X-PH-callee": callee}
+    if stream_token:
+        extra_headers[STREAM_TOKEN_HEADER] = stream_token
     return PlivoAdapter.generate_stream_xml(
         stream_url,
         content_type="audio/x-mulaw;rate=8000",
@@ -362,6 +369,7 @@ async def plivo_stream_bridge(
     patter_side: str = "uut",
     pop_prewarm_audio=None,
     pop_prewarmed_connections=None,
+    validate_stream_token=None,
 ) -> None:
     """Bridge a Plivo WebSocket media stream to the configured AI provider.
 
@@ -423,6 +431,25 @@ async def plivo_stream_bridge(
                 # template variables. Plivo echoes the ``<Stream
                 # extraHeaders="...">`` payload back on the start frame.
                 hdrs = _parse_plivo_extra_headers(data.get("extra_headers", ""))
+                # SECURITY (#204): pull + strip the per-call stream-auth token
+                # from the echoed extra_headers so it never becomes a prompt
+                # template variable or reaches logs, then validate BEFORE the
+                # provider session opens. On missing/invalid/expired token, close
+                # with WS 1008 and return without connecting a provider or
+                # synthesising TTS. No PII / no token value logged.
+                _presented_token = hdrs.pop(STREAM_TOKEN_HEADER, "")
+                if validate_stream_token is not None and not validate_stream_token(
+                    _presented_token
+                ):
+                    logger.warning(
+                        "Plivo media stream rejected: stream authentication failed"
+                    )
+                    await websocket.close(code=1008, reason="Stream auth failed")
+                    # Neutralise the finally-block so a rejected peer triggers NO
+                    # on_call_end callback and NO carrier cost query.
+                    on_call_end = None
+                    _call_start_monotonic = None
+                    return
                 # Recover caller / callee: query string first (Plivo preserves
                 # it on the Stream URL), then the ``extra_headers`` fallback.
                 if not caller or not callee:

--- a/libraries/python/getpatter/telephony/telnyx.py
+++ b/libraries/python/getpatter/telephony/telnyx.py
@@ -15,7 +15,7 @@ from urllib.parse import quote
 from starlette.websockets import WebSocketDisconnect
 
 from getpatter.observability.attributes import patter_call_scope
-from getpatter.telephony.common import _validate_e164
+from getpatter.telephony.common import STREAM_TOKEN_PARAM, _validate_e164
 from getpatter.utils.log_sanitize import mask_phone_number
 from getpatter.stream_handler import (
     AudioSender,
@@ -128,6 +128,7 @@ def telnyx_webhook_handler(
     callee: str,
     webhook_base_url: str,
     connection_id: str = "",
+    stream_token: str = "",
 ) -> dict:
     """Generate Telnyx Call Control response for an incoming call.
 
@@ -141,11 +142,16 @@ def telnyx_webhook_handler(
         callee: The called number.
         webhook_base_url: Hostname (no scheme) of this server, e.g. "abc.ngrok.io".
         connection_id: Telnyx TeXML App / Call Control App ID (optional).
+        stream_token: Per-call media-stream auth token (#204). Telnyx preserves
+            the query string, so it rides as ``&patter_stream_token=...``; the
+            WS handler validates it at accept before any provider session.
     """
     stream_url = (
         f"wss://{webhook_base_url}/ws/telnyx/stream/{call_id}"
         f"?caller={quote(caller)}&callee={quote(callee)}"
     )
+    if stream_token:
+        stream_url += f"&{STREAM_TOKEN_PARAM}={quote(stream_token, safe='')}"
     # Telnyx Call Control: answer first, then stream_start.
     # ``inbound_track`` halves WS upstream bandwidth — the bridge already
     # filters outbound media downstream, so requesting only inbound at the

--- a/libraries/python/getpatter/telephony/twilio.py
+++ b/libraries/python/getpatter/telephony/twilio.py
@@ -26,6 +26,7 @@ from getpatter.stream_handler import (
     resolve_agent_prompt,
 )
 from getpatter.telephony.common import (
+    STREAM_TOKEN_PARAM,
     _create_stt_from_config,  # noqa: F401 — re-exported for tests and external callers
     _create_tts_from_config,  # noqa: F401 — re-exported for tests and external callers
     _resolve_variables,  # noqa: F401 — re-exported for tests and external callers
@@ -239,6 +240,7 @@ def twilio_webhook_handler(
     caller: str,
     callee: str,
     webhook_base_url: str,
+    stream_token: str = "",
 ) -> str:
     """Generate TwiML response for an incoming Twilio call.
 
@@ -249,18 +251,26 @@ def twilio_webhook_handler(
         caller: The calling number (From).
         callee: The called number (To).
         webhook_base_url: Hostname (no scheme) of this server, e.g. "abc.ngrok.io".
+        stream_token: Per-call media-stream auth token (#204). When non-empty it
+            is delivered as a ``<Parameter name="patter_stream_token">`` (Twilio
+            strips query params, so it must ride the customParameters channel);
+            the WS handler validates it before opening the provider session.
     """
     # Lazy import — provider adapter may be created by the parallel agent
     from getpatter.providers.twilio_adapter import TwilioAdapter  # type: ignore[import]
+    from getpatter.telephony.common import STREAM_TOKEN_PARAM
 
     # Twilio Media Streams strips the query string from ``<Stream url=...>``
     # before opening the WS, so caller/callee must travel as
     # ``<Parameter>`` children — the bridge then reads them from
     # ``start.customParameters`` on the WS ``start`` frame.
     stream_url = f"wss://{webhook_base_url}/ws/stream/{call_sid}"
+    parameters = {"caller": caller, "callee": callee}
+    if stream_token:
+        parameters[STREAM_TOKEN_PARAM] = stream_token
     return TwilioAdapter.generate_stream_twiml(
         stream_url,
-        parameters={"caller": caller, "callee": callee},
+        parameters=parameters,
     )
 
 
@@ -443,6 +453,7 @@ async def twilio_stream_bridge(
     pop_prewarmed_connections=None,
     webhook_host: str = "",
     agent_number: str = "",
+    validate_stream_token=None,
 ) -> None:
     """Bridge a Twilio WebSocket media stream to the configured AI provider.
 
@@ -535,6 +546,29 @@ async def twilio_stream_bridge(
                 start_data = data.get("start", {})
                 call_sid_actual = start_data.get("callSid", "")
                 custom_params: dict = start_data.get("customParameters", {})
+                # SECURITY (#204): pull the per-call stream-auth token out of
+                # customParameters and REMOVE it so it never reaches logs, the
+                # prompt template, or the on_call_start payload.
+                _presented_token = ""
+                if isinstance(custom_params, dict):
+                    _presented_token = str(custom_params.pop(STREAM_TOKEN_PARAM, ""))
+                # Validate BEFORE opening any provider session (the billable
+                # part). On missing/invalid/expired token, close the socket with
+                # WS 1008 and return without synthesising TTS or connecting a
+                # provider. No PII / no token value logged.
+                if validate_stream_token is not None and not validate_stream_token(
+                    _presented_token
+                ):
+                    logger.warning(
+                        "Twilio media stream rejected: stream authentication failed"
+                    )
+                    await websocket.close(code=1008, reason="Stream auth failed")
+                    # Neutralise the finally-block so a rejected peer triggers NO
+                    # on_call_end callback and NO carrier cost query — the call
+                    # never really started.
+                    on_call_end = None
+                    _call_start_monotonic = None
+                    return
                 # Inbound path: caller / callee travel via TwiML
                 # ``<Parameter>`` tags (Twilio strips query params from
                 # ``<Stream url=...>``), so the WS-level query-param read

--- a/libraries/python/getpatter/tts/__init__.py
+++ b/libraries/python/getpatter/tts/__init__.py
@@ -19,4 +19,6 @@ __all__ = [
     "rime",
     "lmnt",
     "inworld",
+    "soniox",
+    "sarvam",
 ]

--- a/libraries/python/getpatter/tts/sarvam.py
+++ b/libraries/python/getpatter/tts/sarvam.py
@@ -1,0 +1,75 @@
+"""Sarvam AI TTS for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar, Optional, Union
+
+from getpatter.providers.sarvam_tts import (
+    SarvamAudioCodec,
+    SarvamLanguage,
+    SarvamModel,
+    SarvamSampleRate,
+    SarvamTTS as _SarvamTTS,
+)
+
+__all__ = ["TTS"]
+
+
+class TTS(_SarvamTTS):
+    """Sarvam Bulbul TTS for Indian languages — defaults to the bulbul:v3 model.
+
+    Synthesizes Hindi, Bengali, Tamil, Telugu, Kannada, Malayalam, Marathi,
+    Gujarati, Punjabi, Odia and Indian English (plus code-mixed text). Select
+    the language via ``language`` (a Sarvam BCP-47 code such as ``"hi-IN"`` —
+    see :class:`~getpatter.providers.sarvam_tts.SarvamLanguage`).
+
+    Example::
+
+        from getpatter.tts import sarvam
+
+        tts = sarvam.TTS()                                  # reads SARVAM_API_KEY
+        tts = sarvam.TTS(api_key="...", language="hi-IN", speaker="shubh")
+
+        # Telephony (mu-law @ 8 kHz, carrier-native passthrough):
+        tts = sarvam.TTS.for_twilio(language="ta-IN")
+    """
+
+    provider_key: ClassVar[str] = "sarvam"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: Union[SarvamModel, str] = SarvamModel.BULBUL_V3,
+        speaker: str = "shubh",
+        language: Union[SarvamLanguage, str] = SarvamLanguage.ENGLISH,
+        codec: Union[SarvamAudioCodec, str] = SarvamAudioCodec.LINEAR16,
+        sample_rate: Union[SarvamSampleRate, int] = SarvamSampleRate.HZ_16000,
+        pace: Optional[float] = None,
+        pitch: Optional[float] = None,
+        loudness: Optional[float] = None,
+        temperature: Optional[float] = None,
+        enable_preprocessing: Optional[bool] = None,
+        dict_id: Optional[str] = None,
+    ) -> None:
+        key = api_key or os.environ.get("SARVAM_API_KEY")
+        if not key:
+            raise ValueError(
+                "Sarvam TTS requires an api_key. Pass api_key='...' or "
+                "set SARVAM_API_KEY in the environment."
+            )
+        super().__init__(
+            api_key=key,
+            model=model,
+            speaker=speaker,
+            language=language,
+            codec=codec,
+            sample_rate=sample_rate,
+            pace=pace,
+            pitch=pitch,
+            loudness=loudness,
+            temperature=temperature,
+            enable_preprocessing=enable_preprocessing,
+            dict_id=dict_id,
+        )

--- a/libraries/python/getpatter/tts/soniox.py
+++ b/libraries/python/getpatter/tts/soniox.py
@@ -1,0 +1,121 @@
+"""Soniox TTS for Patter pipeline mode."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar, Optional
+
+from getpatter.providers.soniox_tts import SonioxTTS as _SonioxTTS
+
+__all__ = ["TTS"]
+
+
+def _resolve_api_key(api_key: str | None) -> str:
+    # Shared credential with Soniox STT — same SONIOX_API_KEY env var.
+    key = api_key or os.environ.get("SONIOX_API_KEY")
+    if not key:
+        raise ValueError(
+            "Soniox TTS requires an api_key. Pass api_key='...' or "
+            "set SONIOX_API_KEY in the environment."
+        )
+    return key
+
+
+class TTS(_SonioxTTS):
+    """Soniox HTTP TTS (``tts-rt-v1``, default voice ``Adrian``).
+
+    Shares the ``SONIOX_API_KEY`` credential with the Soniox STT adapter.
+
+    Example::
+
+        from getpatter.tts import soniox
+
+        tts = soniox.TTS()                          # reads SONIOX_API_KEY
+        tts = soniox.TTS(api_key="...", voice="Maya", language="en")
+
+    Telephony optimization
+    ----------------------
+    Use :meth:`for_twilio` or :meth:`for_telnyx` on phone calls. Both emit
+    mu-law @ 8 kHz natively (Soniox supports G.711 directly), so the pipeline
+    skips resampling and PCM -> mu-law encoding entirely (bit-clean
+    passthrough).
+    """
+
+    provider_key: ClassVar[str] = "soniox_tts"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "tts-rt-v1",
+        voice: str = "Adrian",
+        language: str = "en",
+        audio_format: str = "pcm_s16le",
+        sample_rate: int = 16000,
+        bitrate: Optional[int] = None,
+        speed: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            api_key=_resolve_api_key(api_key),
+            model=model,
+            voice=voice,
+            language=language,
+            audio_format=audio_format,
+            sample_rate=sample_rate,
+            bitrate=bitrate,
+            speed=speed,
+        )
+
+    @classmethod
+    def for_twilio(
+        cls,
+        api_key: str | None = None,
+        *,
+        model: str = "tts-rt-v1",
+        voice: str = "Adrian",
+        language: str = "en",
+        speed: Optional[float] = None,
+    ) -> "TTS":
+        """Pipeline TTS pre-configured for Twilio Media Streams.
+
+        Emits mu-law @ 8 kHz natively — Twilio's wire codec — so the pipeline
+        passes the bytes straight through (no resample, no PCM -> mu-law
+        encode). Falls back to ``SONIOX_API_KEY`` from the env when ``api_key``
+        is omitted.
+        """
+        return cls(
+            api_key=_resolve_api_key(api_key),
+            model=model,
+            voice=voice,
+            language=language,
+            audio_format="pcm_mulaw",
+            sample_rate=8000,
+            speed=speed,
+        )
+
+    @classmethod
+    def for_telnyx(
+        cls,
+        api_key: str | None = None,
+        *,
+        model: str = "tts-rt-v1",
+        voice: str = "Adrian",
+        language: str = "en",
+        speed: Optional[float] = None,
+    ) -> "TTS":
+        """Pipeline TTS pre-configured for Telnyx bidirectional media.
+
+        Emits mu-law @ 8 kHz natively — the SDK pins the Telnyx wire to
+        PCMU/mu-law @ 8 kHz — so audio flows end-to-end with zero resampling or
+        transcoding. Falls back to ``SONIOX_API_KEY`` from the env when
+        ``api_key`` is omitted.
+        """
+        return cls(
+            api_key=_resolve_api_key(api_key),
+            model=model,
+            voice=voice,
+            language=language,
+            audio_format="pcm_mulaw",
+            sample_rate=8000,
+            speed=speed,
+        )

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getpatter"
-version = "0.7.0"
+version = "0.7.1"
 description = "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -139,6 +139,10 @@ background-audio = [
 rime = ["aiohttp>=3.10"]
 lmnt = ["aiohttp>=3.10"]
 inworld = ["aiohttp>=3.10"]
+# Sarvam AI Bulbul TTS provider (Indian languages; pure-aiohttp REST, no vendor SDK).
+sarvam = ["aiohttp>=3.10"]
+# Soniox TTS reuses the existing ``[soniox]`` extra above (only needs aiohttp,
+# the same dep already pinned there for Soniox STT) — no separate extra needed.
 gemini-live = [
     "google-genai>=1.55",
 ]

--- a/libraries/python/tests/security/test_stream_auth.py
+++ b/libraries/python/tests/security/test_stream_auth.py
@@ -1,0 +1,592 @@
+"""Security tests for the per-call media-stream authentication token (#204).
+
+The media WebSocket endpoints (/ws/stream, /ws/telnyx/stream, /ws/plivo/stream)
+used to accept ANY peer with an attacker-chosen call_id and drive a full
+STT/LLM/TTS session on the operator's provider keys (toll fraud) or extract the
+agent prompt. These tests prove the fix:
+
+  * a token is minted only by the SIGNATURE-VALIDATED webhook / outbound path
+    and delivered on each carrier's custom-param channel;
+  * the media WS validates it BEFORE any provider session opens, closing with
+    WS 1008 on missing/invalid/expired token (the #204 repro must fail to start
+    a session);
+  * ``require_stream_auth=False`` opts out (allow + loud one-time warning);
+  * the token value never appears in logs.
+
+Only the WS/transport is mocked — no real carrier or provider keys are used.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from getpatter.local_config import LocalConfig
+from getpatter.server import EmbeddedServer
+from getpatter.telephony.common import STREAM_TOKEN_HEADER, STREAM_TOKEN_PARAM
+from tests.conftest import make_agent
+
+pytestmark = pytest.mark.security
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_server(require_stream_auth: bool = True) -> EmbeddedServer:
+    """An EmbeddedServer with the dashboard off (light, no I/O)."""
+    return EmbeddedServer(
+        config=LocalConfig(require_stream_auth=require_stream_auth),
+        agent=make_agent(),
+        dashboard=False,
+    )
+
+
+def _twilio_ws(messages: list[str]) -> AsyncMock:
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    ws.query_params = {}
+    ws.receive_text = AsyncMock(side_effect=messages + [Exception("stop")])
+    ws.send_text = AsyncMock()
+    return ws
+
+
+def _twilio_start(call_sid: str, token: str | None = None) -> str:
+    params: dict = {"caller": "+15551112222", "callee": "+15553334444"}
+    if token is not None:
+        params[STREAM_TOKEN_PARAM] = token
+    return json.dumps(
+        {
+            "event": "start",
+            "streamSid": "MZ_test",
+            "start": {"callSid": call_sid, "customParameters": params},
+        }
+    )
+
+
+def _stop() -> str:
+    return json.dumps({"event": "stop"})
+
+
+def _plivo_ws(messages: list[str]) -> AsyncMock:
+    ws = AsyncMock()
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    ws.query_params = {}
+    ws.receive_text = AsyncMock(side_effect=messages + [Exception("stop")])
+    ws.send_text = AsyncMock()
+    return ws
+
+
+def _plivo_start(call_id: str, token: str | None = None) -> str:
+    headers: dict = {"X-PH-caller": "+15551112222", "X-PH-callee": "+15553334444"}
+    if token is not None:
+        headers[STREAM_TOKEN_HEADER] = token
+    return json.dumps(
+        {
+            "event": "start",
+            "start": {
+                "callId": call_id,
+                "streamId": "ST1",
+                "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000},
+            },
+            "extra_headers": json.dumps(headers),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Token map primitives (mint / validate / check)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamTokenMap:
+    def test_mint_returns_high_entropy_token_and_stores(self):
+        server = _make_server()
+        token = server._mint_stream_token("CALL_1")
+        assert isinstance(token, str)
+        assert len(token) >= 32  # token_urlsafe(32) -> ~43 chars
+        assert "CALL_1" in server._stream_tokens
+
+    def test_two_mints_differ(self):
+        server = _make_server()
+        assert server._mint_stream_token("A") != server._mint_stream_token("B")
+
+    def test_validate_accepts_minted_token(self):
+        server = _make_server()
+        token = server._mint_stream_token("CALL_1")
+        assert server._validate_stream_token("CALL_1", token) is True
+
+    def test_validate_rejects_wrong_token(self):
+        server = _make_server()
+        server._mint_stream_token("CALL_1")
+        assert server._validate_stream_token("CALL_1", "not-the-token") is False
+
+    def test_validate_rejects_empty_token(self):
+        server = _make_server()
+        server._mint_stream_token("CALL_1")
+        assert server._validate_stream_token("CALL_1", "") is False
+
+    def test_validate_rejects_unknown_call_key(self):
+        server = _make_server()
+        token = server._mint_stream_token("CALL_1")
+        assert server._validate_stream_token("OTHER", token) is False
+
+    def test_validate_rejects_non_ascii_without_raising(self):
+        server = _make_server()
+        server._mint_stream_token("CALL_1")
+        # An attacker-supplied non-ASCII token must not raise (compare as bytes).
+        assert server._validate_stream_token("CALL_1", "tökén-ÿ") is False
+
+    def test_validate_rejects_expired_token(self):
+        server = _make_server()
+        token = server._mint_stream_token("CALL_1")
+        # Force the stored entry to be already expired.
+        tok, _exp = server._stream_tokens["CALL_1"]
+        server._stream_tokens["CALL_1"] = (tok, 0.0)
+        assert server._validate_stream_token("CALL_1", token) is False
+        # Expired entry is pruned on access.
+        assert "CALL_1" not in server._stream_tokens
+
+    def test_token_reusable_within_ttl_not_single_use(self):
+        """A legitimate carrier reconnect within the TTL must still validate."""
+        server = _make_server()
+        token = server._mint_stream_token("CALL_1")
+        assert server._validate_stream_token("CALL_1", token) is True
+        assert server._validate_stream_token("CALL_1", token) is True
+
+    def test_check_stream_auth_fail_closed_by_default(self):
+        server = _make_server(require_stream_auth=True)
+        # No token minted -> rejected.
+        assert server._check_stream_auth("CALL_1", "") is False
+        assert server._check_stream_auth("CALL_1", "guessed") is False
+
+    def test_check_stream_auth_opt_out_allows_and_warns_once(self, caplog):
+        server = _make_server(require_stream_auth=False)
+        with caplog.at_level(logging.WARNING, logger="getpatter"):
+            assert server._check_stream_auth("CALL_1", "") is True
+            assert server._check_stream_auth("CALL_2", "") is True
+        disabled_warnings = [
+            r for r in caplog.records if "authentication is DISABLED" in r.message
+        ]
+        # Loud, but only once.
+        assert len(disabled_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Mint delivery — each carrier's webhook embeds the token on its channel
+# ---------------------------------------------------------------------------
+
+
+class TestMintDelivery:
+    def test_twilio_webhook_embeds_token_parameter(self):
+        from getpatter.telephony.twilio import twilio_webhook_handler
+
+        twiml = twilio_webhook_handler(
+            "CA" + "a" * 32, "+1", "+2", "abc.ngrok.io", stream_token="TOK123"
+        )
+        assert STREAM_TOKEN_PARAM in twiml
+        assert "TOK123" in twiml
+        # caller/callee still travel alongside.
+        assert "caller" in twiml and "callee" in twiml
+
+    def test_twilio_webhook_no_token_when_empty(self):
+        """Backward compatible: no token param when none supplied."""
+        from getpatter.telephony.twilio import twilio_webhook_handler
+
+        twiml = twilio_webhook_handler("CA" + "a" * 32, "+1", "+2", "abc.ngrok.io")
+        assert STREAM_TOKEN_PARAM not in twiml
+
+    def test_telnyx_webhook_appends_token_query(self):
+        from getpatter.telephony.telnyx import telnyx_webhook_handler
+
+        result = telnyx_webhook_handler(
+            "ctrl_1", "+1", "+2", "abc.ngrok.io", stream_token="TOK123"
+        )
+        stream_url = result["commands"][1]["params"]["stream_url"]
+        assert f"{STREAM_TOKEN_PARAM}=TOK123" in stream_url
+
+    def test_telnyx_webhook_no_token_when_empty(self):
+        from getpatter.telephony.telnyx import telnyx_webhook_handler
+
+        result = telnyx_webhook_handler("ctrl_1", "+1", "+2", "abc.ngrok.io")
+        stream_url = result["commands"][1]["params"]["stream_url"]
+        assert STREAM_TOKEN_PARAM not in stream_url
+
+    def test_plivo_webhook_adds_token_header(self):
+        from getpatter.telephony.plivo import plivo_webhook_handler
+
+        xml = plivo_webhook_handler(
+            "CU1", "+1", "+2", "abc.ngrok.io", stream_token="TOK123"
+        )
+        assert STREAM_TOKEN_HEADER in xml
+        assert "TOK123" in xml
+
+    def test_plivo_webhook_no_token_when_empty(self):
+        from getpatter.telephony.plivo import plivo_webhook_handler
+
+        xml = plivo_webhook_handler("CU1", "+1", "+2", "abc.ngrok.io")
+        assert STREAM_TOKEN_HEADER not in xml
+
+
+# ---------------------------------------------------------------------------
+# 3. Twilio bridge — validates the <Parameter> token before the provider opens
+# ---------------------------------------------------------------------------
+
+
+@patch("getpatter.telephony.twilio.OpenAIRealtimeStreamHandler")
+@patch("getpatter.telephony.twilio.create_metrics_accumulator")
+@patch("getpatter.telephony.twilio.resolve_agent_prompt", return_value="prompt")
+@patch("getpatter.telephony.twilio.fetch_deepgram_cost", new_callable=AsyncMock)
+class TestTwilioBridgeStreamAuth:
+    async def test_rejects_missing_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.twilio import twilio_stream_bridge
+
+        server = _make_server()  # fail-closed, no token minted
+        call_sid = "CA" + "a" * 32
+        ws = _twilio_ws([_twilio_start(call_sid, token=None)])
+        on_call_start = AsyncMock()
+
+        await twilio_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            on_call_start=on_call_start,
+            validate_stream_token=lambda tok: server._check_stream_auth(call_sid, tok),
+        )
+
+        # #204 repro: NO provider session, NO on_call_start, socket closed 1008.
+        mock_handler_cls.assert_not_called()
+        on_call_start.assert_not_awaited()
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args.kwargs.get("code") == 1008
+
+    async def test_rejects_wrong_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.twilio import twilio_stream_bridge
+
+        server = _make_server()
+        call_sid = "CA" + "b" * 32
+        server._mint_stream_token(call_sid)  # a real token exists
+        ws = _twilio_ws([_twilio_start(call_sid, token="attacker-guess")])
+
+        await twilio_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            validate_stream_token=lambda tok: server._check_stream_auth(call_sid, tok),
+        )
+
+        mock_handler_cls.assert_not_called()
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args.kwargs.get("code") == 1008
+
+    async def test_accepts_valid_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.twilio import twilio_stream_bridge
+
+        server = _make_server()
+        call_sid = "CA" + "c" * 32
+        token = server._mint_stream_token(call_sid)
+        mock_handler = AsyncMock()
+        mock_handler.audio_sender = None
+        mock_handler.stt = None
+        mock_handler_cls.return_value = mock_handler
+        mock_metrics.return_value = MagicMock()
+
+        ws = _twilio_ws([_twilio_start(call_sid, token=token), _stop()])
+
+        await twilio_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            validate_stream_token=lambda tok: server._check_stream_auth(call_sid, tok),
+        )
+
+        # Session starts normally; socket not force-closed for auth.
+        mock_handler.start.assert_awaited_once()
+        for c in ws.close.await_args_list:
+            assert c.kwargs.get("code") != 1008
+
+    async def test_opt_out_allows_without_token_and_warns(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls, caplog
+    ):
+        from getpatter.telephony.twilio import twilio_stream_bridge
+
+        server = _make_server(require_stream_auth=False)
+        call_sid = "CA" + "d" * 32
+        mock_handler = AsyncMock()
+        mock_handler.audio_sender = None
+        mock_handler.stt = None
+        mock_handler_cls.return_value = mock_handler
+        mock_metrics.return_value = MagicMock()
+
+        ws = _twilio_ws([_twilio_start(call_sid, token=None), _stop()])
+
+        with caplog.at_level(logging.WARNING, logger="getpatter"):
+            await twilio_stream_bridge(
+                websocket=ws,
+                agent=make_agent(provider="openai_realtime"),
+                openai_key="sk-test",
+                validate_stream_token=lambda tok: server._check_stream_auth(
+                    call_sid, tok
+                ),
+            )
+
+        mock_handler.start.assert_awaited_once()
+        assert any(
+            "authentication is DISABLED" in r.message for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Plivo bridge — validates the X-Patter-Stream-Token extra header
+# ---------------------------------------------------------------------------
+
+
+@patch("getpatter.telephony.plivo.OpenAIRealtimeStreamHandler")
+@patch("getpatter.telephony.plivo.create_metrics_accumulator")
+@patch("getpatter.telephony.plivo.resolve_agent_prompt", return_value="prompt")
+@patch("getpatter.telephony.plivo.fetch_deepgram_cost", new_callable=AsyncMock)
+class TestPlivoBridgeStreamAuth:
+    async def test_rejects_missing_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.plivo import plivo_stream_bridge
+
+        server = _make_server()
+        call_id = "CU" + "a" * 30
+        ws = _plivo_ws([_plivo_start(call_id, token=None)])
+        on_call_start = AsyncMock()
+
+        await plivo_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            on_call_start=on_call_start,
+            validate_stream_token=lambda tok: server._check_stream_auth(call_id, tok),
+        )
+
+        mock_handler_cls.assert_not_called()
+        on_call_start.assert_not_awaited()
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args.kwargs.get("code") == 1008
+
+    async def test_rejects_wrong_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.plivo import plivo_stream_bridge
+
+        server = _make_server()
+        call_id = "CU" + "b" * 30
+        server._mint_stream_token(call_id)
+        ws = _plivo_ws([_plivo_start(call_id, token="attacker-guess")])
+
+        await plivo_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            validate_stream_token=lambda tok: server._check_stream_auth(call_id, tok),
+        )
+
+        mock_handler_cls.assert_not_called()
+        ws.close.assert_awaited_once()
+        assert ws.close.call_args.kwargs.get("code") == 1008
+
+    async def test_accepts_valid_token(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls
+    ):
+        from getpatter.telephony.plivo import plivo_stream_bridge
+
+        server = _make_server()
+        call_id = "CU" + "c" * 30
+        token = server._mint_stream_token(call_id)
+        mock_handler = AsyncMock()
+        mock_handler.audio_sender = None
+        mock_handler.stt = None
+        mock_handler_cls.return_value = mock_handler
+        mock_metrics.return_value = MagicMock()
+
+        ws = _plivo_ws([_plivo_start(call_id, token=token), _stop()])
+
+        await plivo_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            validate_stream_token=lambda tok: server._check_stream_auth(call_id, tok),
+        )
+
+        mock_handler.start.assert_awaited_once()
+
+    async def test_opt_out_allows_without_token_and_warns(
+        self, mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls, caplog
+    ):
+        from getpatter.telephony.plivo import plivo_stream_bridge
+
+        server = _make_server(require_stream_auth=False)
+        call_id = "CU" + "d" * 30
+        mock_handler = AsyncMock()
+        mock_handler.audio_sender = None
+        mock_handler.stt = None
+        mock_handler_cls.return_value = mock_handler
+        mock_metrics.return_value = MagicMock()
+
+        ws = _plivo_ws([_plivo_start(call_id, token=None), _stop()])
+
+        with caplog.at_level(logging.WARNING, logger="getpatter"):
+            await plivo_stream_bridge(
+                websocket=ws,
+                agent=make_agent(provider="openai_realtime"),
+                openai_key="sk-test",
+                validate_stream_token=lambda tok: server._check_stream_auth(
+                    call_id, tok
+                ),
+            )
+
+        mock_handler.start.assert_awaited_once()
+        assert any(
+            "authentication is DISABLED" in r.message for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Telnyx route — the WS handler validates the query token at accept
+#    (before the bridge / provider session). Exercised end-to-end through the
+#    real FastAPI route with only the provider bridge mocked.
+# ---------------------------------------------------------------------------
+
+
+class TestTelnyxRouteStreamAuth:
+    def _app_with_fake_bridge(self, server: EmbeddedServer, called: dict):
+        from starlette.testclient import TestClient
+
+        async def _fake_bridge(websocket, **kwargs):  # noqa: ANN001
+            called["hit"] = True
+            await websocket.accept()
+            try:
+                while True:
+                    await websocket.receive_text()
+            except Exception:
+                pass
+
+        # Patch before _create_app so the route closure binds the fake bridge.
+        with patch(
+            "getpatter.telephony.telnyx.telnyx_stream_bridge", new=_fake_bridge
+        ):
+            app = server._create_app()
+        return TestClient(app)
+
+    def test_rejects_missing_token(self):
+        from starlette.testclient import WebSocketDisconnect
+
+        server = _make_server()
+        called: dict = {}
+        client = self._app_with_fake_bridge(server, called)
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws/telnyx/stream/ctrl_1"):
+                pass
+        assert called.get("hit") is not True  # bridge/provider never reached
+
+    def test_rejects_wrong_token(self):
+        from starlette.testclient import WebSocketDisconnect
+
+        server = _make_server()
+        server._mint_stream_token("ctrl_1")
+        called: dict = {}
+        client = self._app_with_fake_bridge(server, called)
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                "/ws/telnyx/stream/ctrl_1?patter_stream_token=wrong"
+            ):
+                pass
+        assert called.get("hit") is not True
+
+    def test_accepts_valid_token(self):
+        server = _make_server()
+        token = server._mint_stream_token("ctrl_1")
+        called: dict = {}
+        client = self._app_with_fake_bridge(server, called)
+        with client.websocket_connect(
+            f"/ws/telnyx/stream/ctrl_1?patter_stream_token={token}"
+        ):
+            pass
+        assert called.get("hit") is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Outbound Twilio — initiate_call embeds the token as a <Parameter>
+# ---------------------------------------------------------------------------
+
+
+async def test_twilio_outbound_initiate_call_embeds_token_parameter():
+    from getpatter.providers.twilio_adapter import TwilioAdapter
+
+    adapter = TwilioAdapter("AC" + "0" * 32, "auth-token")
+    captured: dict = {}
+
+    def _fake_create(**kwargs):
+        captured.update(kwargs)
+        result = MagicMock()
+        result.sid = "CA" + "e" * 32
+        return result
+
+    adapter._twilio_client.calls.create = _fake_create
+    await adapter.initiate_call(
+        "+15550001111",
+        "+15550002222",
+        "wss://host/ws/stream/outbound",
+        parameters={"patter_stream_token": "OUTBOUND_TOK"},
+    )
+    twiml = captured["twiml"]
+    assert STREAM_TOKEN_PARAM in twiml
+    assert "OUTBOUND_TOK" in twiml
+
+
+# ---------------------------------------------------------------------------
+# 7. The token value never appears in logs
+# ---------------------------------------------------------------------------
+
+
+@patch("getpatter.telephony.twilio.OpenAIRealtimeStreamHandler")
+@patch("getpatter.telephony.twilio.create_metrics_accumulator")
+@patch("getpatter.telephony.twilio.resolve_agent_prompt", return_value="prompt")
+@patch("getpatter.telephony.twilio.fetch_deepgram_cost", new_callable=AsyncMock)
+async def test_token_never_appears_in_logs(
+    mock_fetch_dg, mock_resolve, mock_metrics, mock_handler_cls, caplog
+):
+    from getpatter.telephony.twilio import twilio_stream_bridge
+
+    server = _make_server()
+    call_sid = "CA" + "f" * 32
+    token = server._mint_stream_token(call_sid)
+    mock_handler = AsyncMock()
+    mock_handler.audio_sender = None
+    mock_handler.stt = None
+    mock_handler_cls.return_value = mock_handler
+    mock_metrics.return_value = MagicMock()
+
+    ws = _twilio_ws([_twilio_start(call_sid, token=token), _stop()])
+
+    with caplog.at_level(logging.DEBUG, logger="getpatter"):
+        await twilio_stream_bridge(
+            websocket=ws,
+            agent=make_agent(provider="openai_realtime"),
+            openai_key="sk-test",
+            validate_stream_token=lambda tok: server._check_stream_auth(call_sid, tok),
+        )
+
+    # The token was accepted (session started) yet is absent from every record,
+    # including the "Custom params" debug dump (it is stripped before logging).
+    mock_handler.start.assert_awaited_once()
+    assert token not in caplog.text
+    for record in caplog.records:
+        assert token not in record.getMessage()

--- a/libraries/python/tests/unit/test_sarvam_tts.py
+++ b/libraries/python/tests/unit/test_sarvam_tts.py
@@ -1,0 +1,295 @@
+"""Unit tests for the Sarvam AI TTS provider.
+
+Mock the aiohttp boundary; everything else (payload assembly, per-model field
+gating, base64 decoding, telephony factories, env-var fallback) runs against
+real code. NO PII: tests never assert on synthesized audio as text beyond the
+mock round-trip bytes.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from getpatter.audio.format import AudioFormat
+from getpatter.providers.sarvam_tts import (
+    SARVAM_BASE_URL,
+    SarvamLanguage,
+    SarvamModel,
+    SarvamTTS,
+)
+from getpatter.tts import sarvam as sarvam_ns
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status: int,
+        payload: dict[str, Any] | None = None,
+        body: str = "",
+    ) -> None:
+        self.status = status
+        self._payload = payload if payload is not None else {}
+        self._body = body
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+    async def text(self) -> str:
+        return self._body
+
+    async def read(self) -> bytes:
+        return self._body.encode()
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.last_url: str | None = None
+        self.last_json: dict[str, Any] | None = None
+        self.last_headers: dict[str, str] | None = None
+        self.closed = False
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],  # noqa: A002 - aiohttp signature compat
+        timeout: Any = None,
+    ) -> _FakeResponse:
+        self.last_url = url
+        self.last_headers = headers
+        self.last_json = json
+        return self.response
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        timeout: Any = None,
+    ) -> _FakeResponse:
+        self.last_url = url
+        self.last_headers = headers
+        return self.response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _audio_response(*payloads: bytes) -> _FakeResponse:
+    """Build a Sarvam REST JSON response carrying base64 ``audios``."""
+    audios = [base64.b64encode(p).decode() for p in payloads]
+    return _FakeResponse(200, {"request_id": "req-1", "audios": audios})
+
+
+@pytest.mark.unit
+class TestPayloadAndAuth:
+    async def test_posts_to_endpoint_with_subscription_key_header(self) -> None:
+        fake = _FakeSession(_audio_response(b"hello", b"world"))
+        tts = SarvamTTS(api_key="key", session=fake)  # type: ignore[arg-type]
+
+        out = b"".join([c async for c in tts.synthesize("namaste")])
+
+        assert out == b"helloworld"
+        assert fake.last_url == SARVAM_BASE_URL
+        assert fake.last_headers is not None
+        assert fake.last_headers["api-subscription-key"] == "key"
+        assert fake.last_headers["Content-Type"] == "application/json"
+
+    async def test_default_payload_uses_bulbul_v3_linear16_16k(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS(api_key="key", session=fake)  # type: ignore[arg-type]
+        async for _ in tts.synthesize("hi"):
+            pass
+
+        body = fake.last_json
+        assert body is not None
+        assert body["model"] == SarvamModel.BULBUL_V3.value
+        assert body["speaker"] == "shubh"
+        assert body["target_language_code"] == SarvamLanguage.ENGLISH.value
+        assert body["output_audio_codec"] == "linear16"
+        assert body["speech_sample_rate"] == 16000
+        # No optional / per-model fields unless explicitly configured.
+        for key in ("pace", "pitch", "loudness", "temperature",
+                    "enable_preprocessing", "dict_id"):
+            assert key not in body
+
+    async def test_language_selection_sets_target_language_code(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS(api_key="key", session=fake, language="hi-IN")  # type: ignore[arg-type]
+        async for _ in tts.synthesize("नमस्ते"):
+            pass
+        assert fake.last_json is not None
+        assert fake.last_json["target_language_code"] == "hi-IN"
+
+    async def test_pace_sent_when_set(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS(api_key="key", session=fake, pace=1.25)  # type: ignore[arg-type]
+        async for _ in tts.synthesize("hi"):
+            pass
+        assert fake.last_json is not None
+        assert fake.last_json["pace"] == 1.25
+
+    async def test_v2_only_params_gated_to_bulbul_v2(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS(
+            api_key="key",
+            session=fake,  # type: ignore[arg-type]
+            model="bulbul:v2",
+            speaker="anushka",
+            pitch=0.2,
+            loudness=1.5,
+            enable_preprocessing=True,
+            # temperature is v3-only — must be dropped on v2.
+            temperature=0.9,
+        )
+        async for _ in tts.synthesize("hi"):
+            pass
+        body = fake.last_json
+        assert body is not None
+        assert body["model"] == "bulbul:v2"
+        assert body["pitch"] == 0.2
+        assert body["loudness"] == 1.5
+        assert body["enable_preprocessing"] is True
+        assert "temperature" not in body
+        assert "dict_id" not in body
+
+    async def test_v3_only_params_gated_to_bulbul_v3(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS(
+            api_key="key",
+            session=fake,  # type: ignore[arg-type]
+            model="bulbul:v3",
+            temperature=0.8,
+            dict_id="dict-42",
+            # pitch / loudness are v2-only — must be dropped on v3.
+            pitch=0.2,
+            loudness=1.5,
+            enable_preprocessing=True,
+        )
+        async for _ in tts.synthesize("hi"):
+            pass
+        body = fake.last_json
+        assert body is not None
+        assert body["temperature"] == 0.8
+        assert body["dict_id"] == "dict-42"
+        assert "pitch" not in body
+        assert "loudness" not in body
+        assert "enable_preprocessing" not in body
+
+    async def test_non_200_raises_with_body_excerpt(self) -> None:
+        fake = _FakeSession(_FakeResponse(429, body="rate limited"))
+        tts = SarvamTTS(api_key="key", session=fake)  # type: ignore[arg-type]
+        with pytest.raises(RuntimeError, match=r"Sarvam TTS error 429"):
+            async for _ in tts.synthesize("hi"):
+                pass
+
+    async def test_malformed_body_yields_nothing(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, {"request_id": "x"}))
+        tts = SarvamTTS(api_key="key", session=fake)  # type: ignore[arg-type]
+        out = [c async for c in tts.synthesize("hi")]
+        assert out == []
+
+    def test_requires_api_key_or_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SARVAM_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="SARVAM_API_KEY"):
+            SarvamTTS()
+
+    def test_repr_does_not_leak_key(self) -> None:
+        tts = SarvamTTS(api_key="super-secret")
+        assert "super-secret" not in repr(tts)
+
+
+@pytest.mark.unit
+class TestTelephonyFactories:
+    def test_for_twilio_emits_mulaw_8k_natively(self) -> None:
+        tts = SarvamTTS.for_twilio(api_key="x")
+        assert tts.sample_rate == 8000
+        assert str(tts.codec) == "mulaw"
+
+    async def test_for_twilio_payload_requests_mulaw_8k(self) -> None:
+        fake = _FakeSession(_audio_response(b"x"))
+        tts = SarvamTTS.for_twilio(api_key="x")
+        tts._session = fake  # type: ignore[assignment]
+        tts._owns_session = False
+        async for _ in tts.synthesize("hi"):
+            pass
+        body = fake.last_json
+        assert body is not None
+        assert body["output_audio_codec"] == "mulaw"
+        assert body["speech_sample_rate"] == 8000
+
+    def test_for_twilio_declares_mulaw_source_format(self) -> None:
+        tts = SarvamTTS.for_twilio(api_key="x")
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="mulaw", sample_rate=8000
+        )
+
+    def test_for_twilio_respects_overrides(self) -> None:
+        tts = SarvamTTS.for_twilio(api_key="x", language="ta-IN", speaker="kavya")
+        assert tts.sample_rate == 8000
+        assert str(tts.codec) == "mulaw"
+        assert str(tts.language) == "ta-IN"
+        assert tts.speaker == "kavya"
+
+    def test_for_twilio_ignores_caller_sample_rate(self) -> None:
+        tts = SarvamTTS.for_twilio(api_key="x", sample_rate=24000)
+        assert tts.sample_rate == 8000
+
+    def test_for_telnyx_emits_mulaw_8k_natively(self) -> None:
+        tts = SarvamTTS.for_telnyx(api_key="x")
+        assert tts.sample_rate == 8000
+        assert str(tts.codec) == "mulaw"
+
+    def test_constructor_default_unchanged(self) -> None:
+        tts = SarvamTTS(api_key="x")
+        assert tts.sample_rate == 16000
+        assert str(tts.codec) == "linear16"
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="pcm_s16le", sample_rate=16000
+        )
+
+
+@pytest.mark.unit
+class TestNamespacePublicTTS:
+    def test_requires_api_key_or_env_var(self) -> None:
+        with patch.dict("os.environ", {}, clear=False):
+            import os as _os
+
+            _os.environ.pop("SARVAM_API_KEY", None)
+            with pytest.raises(ValueError, match="SARVAM_API_KEY"):
+                sarvam_ns.TTS()
+
+    def test_env_var_fallback(self) -> None:
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "env-key"}, clear=False):
+            tts = sarvam_ns.TTS()
+            assert tts.api_key == "env-key"
+
+    def test_explicit_api_key_wins(self) -> None:
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "env-key"}, clear=False):
+            tts = sarvam_ns.TTS(api_key="explicit")
+            assert tts.api_key == "explicit"
+
+    def test_namespace_for_twilio_uses_env_key(self) -> None:
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "env-key"}, clear=False):
+            tts = sarvam_ns.TTS.for_twilio()
+            assert tts.sample_rate == 8000
+            assert str(tts.codec) == "mulaw"
+            assert tts.api_key == "env-key"
+
+    def test_namespace_defaults_bulbul_v3(self) -> None:
+        with patch.dict("os.environ", {"SARVAM_API_KEY": "env-key"}, clear=False):
+            tts = sarvam_ns.TTS()
+            assert str(tts.model) == "bulbul:v3"
+            assert tts.speaker == "shubh"

--- a/libraries/python/tests/unit/test_soniox_stt_v5.py
+++ b/libraries/python/tests/unit/test_soniox_stt_v5.py
@@ -1,0 +1,119 @@
+"""Unit tests for Soniox v5 real-time STT adoption.
+
+Mocks ``aiohttp.ClientSession`` so the test can assert the model string and the
+new opt-in v5 endpoint controls land in the initial Soniox config message sent
+over the WebSocket — without any network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from getpatter.providers.soniox_stt import SonioxModel, SonioxSTT
+
+
+class _FakeWebSocket:
+    """Captures ``send_str`` payloads (the Soniox config message)."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.sent_text: list[str] = []
+        self.sent_bytes: list[bytes] = []
+
+    async def send_str(self, payload: str) -> None:
+        self.sent_text.append(payload)
+
+    async def send_bytes(self, payload: bytes) -> None:
+        self.sent_bytes.append(payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeSession:
+    """Stand-in for ``aiohttp.ClientSession`` returning a fixed fake ws."""
+
+    def __init__(self, ws: _FakeWebSocket) -> None:
+        self._ws = ws
+        self.closed = False
+
+    async def ws_connect(self, *_a: Any, **_kw: Any) -> _FakeWebSocket:
+        return self._ws
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _connect_and_capture(stt: SonioxSTT) -> dict[str, Any]:
+    """Connect with a mocked ClientSession; return the parsed config payload."""
+    fake_ws = _FakeWebSocket()
+    fake_session = _FakeSession(fake_ws)
+    with patch(
+        "getpatter.providers.soniox_stt.aiohttp.ClientSession",
+        return_value=fake_session,
+    ):
+        await stt.connect()
+        try:
+            assert fake_ws.sent_text, "no config frame sent over the WebSocket"
+            return json.loads(fake_ws.sent_text[0])
+        finally:
+            await stt.close()
+
+
+@pytest.mark.unit
+def test_v5_enum_value_and_older_models_reachable() -> None:
+    assert SonioxModel.STT_RT_V5 == "stt-rt-v5"
+    # Older models remain reachable for back-compat.
+    assert SonioxModel.STT_RT_V4 == "stt-rt-v4"
+    assert SonioxModel.STT_RT_V3 == "stt-rt-v3"
+    assert SonioxModel.STT_RT_V2 == "stt-rt-v2"
+
+
+@pytest.mark.unit
+def test_default_model_is_v5() -> None:
+    assert SonioxSTT(api_key="sx_test").model == SonioxModel.STT_RT_V5
+    assert SonioxSTT.for_twilio(api_key="sx_test").model == SonioxModel.STT_RT_V5
+
+
+@pytest.mark.unit
+async def test_default_config_sends_v5_model() -> None:
+    config = await _connect_and_capture(SonioxSTT(api_key="sx_test"))
+    assert config["model"] == "stt-rt-v5"
+
+
+@pytest.mark.unit
+async def test_explicit_older_model_is_honored() -> None:
+    config = await _connect_and_capture(
+        SonioxSTT(api_key="sx_test", model=SonioxModel.STT_RT_V4)
+    )
+    assert config["model"] == "stt-rt-v4"
+
+
+@pytest.mark.unit
+async def test_v5_endpoint_controls_are_opt_in() -> None:
+    # Unset by default -> omitted (config stays byte-compatible with pre-v5).
+    base = await _connect_and_capture(SonioxSTT(api_key="sx_test"))
+    assert "endpoint_sensitivity" not in base
+    assert "endpoint_latency_adjustment_level" not in base
+
+    tuned = await _connect_and_capture(
+        SonioxSTT(
+            api_key="sx_test",
+            endpoint_sensitivity=0.5,
+            endpoint_latency_adjustment_level=2,
+        )
+    )
+    assert tuned["endpoint_sensitivity"] == 0.5
+    assert tuned["endpoint_latency_adjustment_level"] == 2
+
+
+@pytest.mark.unit
+def test_endpoint_control_validation() -> None:
+    with pytest.raises(ValueError, match="endpoint_sensitivity"):
+        SonioxSTT(api_key="sx_test", endpoint_sensitivity=1.5)
+    with pytest.raises(ValueError, match="endpoint_latency_adjustment_level"):
+        SonioxSTT(api_key="sx_test", endpoint_latency_adjustment_level=4)

--- a/libraries/python/tests/unit/test_soniox_tts.py
+++ b/libraries/python/tests/unit/test_soniox_tts.py
@@ -1,0 +1,286 @@
+"""Unit tests for the Soniox TTS provider.
+
+Mock the aiohttp boundary; everything else (payload assembly, Bearer auth,
+telephony factories, source-format declaration, env-var fallback) runs against
+real code. See ``.claude/rules/authentic-tests.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from getpatter.audio.format import AudioFormat
+from getpatter.providers.soniox_tts import (
+    SONIOX_TTS_REST_URL,
+    SonioxTTS,
+    SonioxTTSModel,
+)
+from getpatter.tts import soniox as soniox_ns
+
+
+# ---------------------------------------------------------------------------
+# aiohttp fakes — only the network boundary is mocked.
+# ---------------------------------------------------------------------------
+
+
+class _AsyncChunks:
+    """Async iterator over a list of byte chunks (emulates iter_chunked)."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def __aiter__(self) -> "_AsyncChunks":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+class _FakeContent:
+    """Stand-in for ``aiohttp.StreamReader`` exposing ``iter_chunked``."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def iter_chunked(self, _size: int) -> _AsyncChunks:
+        return _AsyncChunks(self._chunks)
+
+
+class _FakeResponse:
+    def __init__(self, status: int, chunks: list[bytes], body: str = "") -> None:
+        self.status = status
+        self.content = _FakeContent(chunks)
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.last_url: str | None = None
+        self.last_json: dict[str, Any] | None = None
+        self.last_headers: dict[str, str] | None = None
+        self.closed = False
+
+    def post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],  # noqa: A002 - aiohttp signature compat
+        timeout: Any = None,
+    ) -> _FakeResponse:
+        self.last_url = url
+        self.last_headers = headers
+        self.last_json = json
+        return self.response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# Request shape + auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPayloadAndAuth:
+    async def test_posts_to_rest_endpoint_with_bearer_auth(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, [b"hello", b"world"]))
+        tts = SonioxTTS(api_key="sk-key", session=fake)  # type: ignore[arg-type]
+
+        out = b"".join([c async for c in tts.synthesize("ciao")])
+
+        assert out == b"helloworld"
+        assert fake.last_url == SONIOX_TTS_REST_URL
+        assert fake.last_headers is not None
+        assert fake.last_headers["Authorization"] == "Bearer sk-key"
+        assert fake.last_headers["Content-Type"] == "application/json"
+
+    async def test_default_payload_uses_v1_pcm16_16k_adrian(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, []))
+        tts = SonioxTTS(api_key="sk-key", session=fake)  # type: ignore[arg-type]
+        async for _ in tts.synthesize("hi"):
+            pass
+        body = fake.last_json
+        assert body is not None
+        assert body["model"] == SonioxTTSModel.TTS_RT_V1.value
+        assert body["voice"] == "Adrian"
+        assert body["language"] == "en"
+        assert body["audio_format"] == "pcm_s16le"
+        assert body["sample_rate"] == 16000
+        assert "bitrate" not in body
+        assert "speed" not in body
+
+    async def test_optional_fields_only_added_when_set(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, []))
+        tts = SonioxTTS(
+            api_key="sk-key",
+            session=fake,  # type: ignore[arg-type]
+            language="it",
+            voice="Maya",
+            bitrate=128000,
+            speed=1.1,
+        )
+        async for _ in tts.synthesize("ciao"):
+            pass
+        body = fake.last_json
+        assert body is not None
+        assert body["language"] == "it"
+        assert body["voice"] == "Maya"
+        assert body["bitrate"] == 128000
+        assert body["speed"] == 1.1
+
+    async def test_non_200_raises_with_body_excerpt(self) -> None:
+        fake = _FakeSession(_FakeResponse(429, [], body="rate limited"))
+        tts = SonioxTTS(api_key="sk-key", session=fake)  # type: ignore[arg-type]
+        with pytest.raises(RuntimeError, match=r"Soniox TTS error 429"):
+            async for _ in tts.synthesize("hi"):
+                pass
+
+    def test_provider_key_is_soniox_tts(self) -> None:
+        assert SonioxTTS.provider_key == "soniox_tts"
+
+
+# ---------------------------------------------------------------------------
+# Source-format declaration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSourceAudioFormat:
+    def test_default_declares_pcm16_at_configured_rate(self) -> None:
+        tts = SonioxTTS(api_key="x", sample_rate=24000)
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="pcm_s16le", sample_rate=24000
+        )
+
+    def test_mulaw_declares_mulaw(self) -> None:
+        tts = SonioxTTS(api_key="x", audio_format="pcm_mulaw", sample_rate=8000)
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="mulaw", sample_rate=8000
+        )
+
+    def test_alaw_declares_alaw(self) -> None:
+        tts = SonioxTTS(api_key="x", audio_format="pcm_alaw", sample_rate=8000)
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="alaw", sample_rate=8000
+        )
+
+
+# ---------------------------------------------------------------------------
+# Telephony factories (provider-level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProviderTelephonyFactories:
+    def test_for_twilio_emits_mulaw_8k_natively(self) -> None:
+        tts = SonioxTTS.for_twilio(api_key="x")
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+
+    def test_for_twilio_payload_requests_mulaw_8k(self) -> None:
+        tts = SonioxTTS.for_twilio(api_key="x")
+        payload = tts._build_payload("hello")
+        assert payload["sample_rate"] == 8000
+        assert payload["audio_format"] == "pcm_mulaw"
+
+    def test_for_twilio_declares_mulaw_source_format(self) -> None:
+        tts = SonioxTTS.for_twilio(api_key="x")
+        assert tts.source_audio_format() == AudioFormat(
+            encoding="mulaw", sample_rate=8000
+        )
+
+    def test_for_twilio_respects_overrides(self) -> None:
+        tts = SonioxTTS.for_twilio(
+            api_key="x", voice="Maya", language="es", speed=1.2
+        )
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+        assert tts.voice == "Maya"
+        assert tts.language == "es"
+        assert tts.speed == 1.2
+
+    def test_for_twilio_ignores_caller_sample_rate_and_format(self) -> None:
+        tts = SonioxTTS.for_twilio(
+            api_key="x", sample_rate=24000, audio_format="mp3"
+        )
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+
+    def test_for_telnyx_emits_mulaw_8k_natively(self) -> None:
+        tts = SonioxTTS.for_telnyx(api_key="x")
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+
+    def test_constructor_default_unchanged(self) -> None:
+        tts = SonioxTTS(api_key="x")
+        assert tts.sample_rate == 16000
+        assert tts.audio_format == "pcm_s16le"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-mode public TTS wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNamespacePublicTTS:
+    def test_requires_api_key_or_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SONIOX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match=r"SONIOX_API_KEY"):
+            soniox_ns.TTS()
+
+    def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONIOX_API_KEY", "env-key")
+        tts = soniox_ns.TTS()
+        assert tts.api_key == "env-key"
+
+    def test_explicit_api_key_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SONIOX_API_KEY", "env-key")
+        tts = soniox_ns.TTS(api_key="explicit")
+        assert tts.api_key == "explicit"
+
+    def test_provider_key_is_soniox_tts(self) -> None:
+        assert soniox_ns.TTS.provider_key == "soniox_tts"
+
+    def test_for_twilio_emits_mulaw_8k(self) -> None:
+        tts = soniox_ns.TTS.for_twilio(api_key="x")
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+
+    def test_for_telnyx_emits_mulaw_8k(self) -> None:
+        tts = soniox_ns.TTS.for_telnyx(api_key="x")
+        assert tts.sample_rate == 8000
+        assert tts.audio_format == "pcm_mulaw"
+
+    def test_for_twilio_requires_api_key_or_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SONIOX_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="SONIOX_API_KEY"):
+            soniox_ns.TTS.for_twilio()
+
+    def test_for_twilio_uses_env_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SONIOX_API_KEY", "env-key")
+        tts = soniox_ns.TTS.for_twilio()
+        assert tts.sample_rate == 8000
+        assert tts.api_key == "env-key"

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "getpatter",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "getpatter",
-      "version": "0.6.9",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",
@@ -16,6 +16,7 @@
         "getpatter": "dist/cli.js"
       },
       "devDependencies": {
+        "@google/genai": "^2.8.0",
         "@types/express": "^5.0.6",
         "@types/ws": "^8.5.0",
         "@vitest/coverage-v8": "^3.2.4",
@@ -34,7 +35,7 @@
         "onnxruntime-node": "~1.18.0"
       },
       "peerDependencies": {
-        "@google/genai": "^0.3.0"
+        "@google/genai": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "@google/genai": {
@@ -558,6 +559,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
+      "integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -702,6 +728,72 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1194,6 +1286,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -1400,6 +1499,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1500,6 +1609,37 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1536,6 +1676,13 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1785,6 +1932,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1841,6 +1998,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2063,6 +2230,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2103,6 +2277,30 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/finalhandler": {
@@ -2155,6 +2353,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2195,6 +2406,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2302,6 +2543,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2383,6 +2652,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2546,6 +2829,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2559,6 +2852,29 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2589,6 +2905,13 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2805,6 +3128,46 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2870,6 +3233,20 @@
       "dependencies": {
         "onnxruntime-common": "1.18.0",
         "tar": "^7.0.1"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -3066,6 +3443,30 @@
         }
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3162,6 +3563,16 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -3222,6 +3633,27 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4055,6 +4487,16 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getpatter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open-source voice AI SDK — connect any AI agent to real phone calls in 4 lines of code",
   "license": "MIT",
   "author": {

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -77,7 +77,7 @@
     "onnxruntime-node": "~1.18.0"
   },
   "peerDependencies": {
-    "@google/genai": "^0.3.0"
+    "@google/genai": ">=2.0.0"
   },
   "peerDependenciesMeta": {
     "@google/genai": {
@@ -85,6 +85,7 @@
     }
   },
   "devDependencies": {
+    "@google/genai": "^2.8.0",
     "@types/express": "^5.0.6",
     "@types/ws": "^8.5.0",
     "@vitest/coverage-v8": "^3.2.4",

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -44,6 +44,9 @@ import { Carrier as PlivoCarrier } from "./telephony/plivo";
 import { Realtime as OpenAIRealtime } from "./engines/openai";
 import { Realtime2 as OpenAIRealtime2 } from "./engines/openai-2";
 import { ConvAI as ElevenLabsConvAI } from "./engines/elevenlabs";
+import { GeminiLive } from "./engines/gemini";
+import { GeminiCascade } from "./engines/gemini-cascade";
+import { InworldRealtime } from "./engines/inworld";
 import { CloudflareTunnel, Static as StaticTunnel } from "./tunnels";
 import { resolveLogRoot } from "./services/call-log";
 import { validateAllToolSchemas } from "./tools/schema-validation";
@@ -746,10 +749,39 @@ export class Patter {
           provider: 'elevenlabs_convai',
           voice: working.voice ?? engine.voice,
         };
+      } else if (engine instanceof GeminiLive) {
+        working = {
+          ...working,
+          provider: 'gemini_live',
+          // Explicit agent() kwargs win over the engine marker value.
+          model: working.model ?? engine.model,
+          voice: working.voice ?? engine.voice,
+        };
+      } else if (engine instanceof GeminiCascade) {
+        working = {
+          ...working,
+          provider: 'gemini_cascade',
+          // Explicit agent() kwargs win over the engine marker value.
+          model: working.model ?? engine.liveModel,
+          voice: working.voice ?? engine.voice,
+        };
+      } else if (engine instanceof InworldRealtime) {
+        working = {
+          ...working,
+          provider: 'inworld_realtime',
+          // Explicit agent() kwargs win over the engine marker value.
+          model: working.model ?? engine.model,
+          voice: working.voice ?? engine.voice,
+          realtimeTurnDetection:
+            working.realtimeTurnDetection ?? engine.turnDetection,
+          openaiRealtimeGateResponseOnTranscript:
+            working.openaiRealtimeGateResponseOnTranscript ??
+            engine.gateResponseOnTranscript,
+        };
       } else {
         this.recordConfigIncomplete('engine_config');
         throw new Error(
-          "Unknown engine. Expected OpenAIRealtime, OpenAIRealtime2, or ElevenLabsConvAI instance.",
+          "Unknown engine. Expected OpenAIRealtime, OpenAIRealtime2, ElevenLabsConvAI, GeminiLive, GeminiCascade, or InworldRealtime instance.",
         );
       }
     } else if (
@@ -765,7 +797,7 @@ export class Patter {
 
     // Validate provider
     if (working.provider) {
-      const valid = ['openai_realtime', 'elevenlabs_convai', 'pipeline'];
+      const valid = ['openai_realtime', 'elevenlabs_convai', 'gemini_live', 'gemini_cascade', 'inworld_realtime', 'pipeline'];
       if (!valid.includes(working.provider)) {
         this.recordConfigIncomplete('engine_config');
         throw new Error(`provider must be one of: ${valid.join(', ')}. Got: '${working.provider}'`);
@@ -993,8 +1025,8 @@ export class Patter {
     }
 
     // Validate provider
-    const validProviders = ['openai_realtime', 'elevenlabs_convai', 'pipeline'] as const;
-    if (opts.agent.provider && !validProviders.includes(opts.agent.provider)) {
+    const validProviders = ['openai_realtime', 'elevenlabs_convai', 'gemini_live', 'gemini_cascade', 'inworld_realtime', 'pipeline'] as const;
+    if (opts.agent.provider && !validProviders.includes(opts.agent.provider as typeof validProviders[number])) {
       throw new Error(`agent.provider must be one of: ${validProviders.join(', ')}`);
     }
 

--- a/libraries/typescript/src/client.ts
+++ b/libraries/typescript/src/client.ts
@@ -1121,6 +1121,10 @@ export class Patter {
         telnyxPublicKey: carrier.kind === 'telnyx' ? carrier.publicKey : undefined,
         plivoAuthId: carrier.kind === 'plivo' ? carrier.authId : undefined,
         plivoAuthToken: carrier.kind === 'plivo' ? carrier.authToken : undefined,
+        // SECURITY (#204): fail closed by default. `undefined` is treated as
+        // `true` by the server (`requireStreamAuth !== false`); only an explicit
+        // `false` disables per-call stream auth.
+        requireStreamAuth: opts.requireStreamAuth,
         persistRoot: this.localConfig.persistRoot,
       },
       opts.agent,
@@ -1919,7 +1923,18 @@ export class Patter {
     // (``libraries/python/getpatter/providers/twilio_adapter.py``) which uses
     // ``twiml=...`` for outbound calls.
     const streamUrl = `wss://${webhookUrl}/ws/stream/outbound`;
-    const inlineTwiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${streamUrl}"/></Connect></Response>`;
+    // SECURITY (#204): mint a per-call stream-auth token and deliver it as a
+    // <Parameter> (Twilio strips the query string from <Stream url=...>). It is
+    // registered against the real CallSid once the Twilio REST response returns
+    // it below, so the media WS 'start' frame is authenticated before any
+    // provider session opens. Token is base64url (XML-safe). When no embedded
+    // server is running there is nothing to validate against, so the token is
+    // simply omitted.
+    const streamToken = this.embeddedServer ? this.embeddedServer.generateStreamToken() : '';
+    const tokenParam = streamToken
+      ? `<Parameter name="patter_stream_token" value="${streamToken}"/>`
+      : '';
+    const inlineTwiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${streamUrl}">${tokenParam}</Stream></Connect></Response>`;
     const params = new URLSearchParams({
       To: options.to,
       From: phoneNumber,
@@ -1992,6 +2007,13 @@ export class Patter {
         status: 'initiated',
       } as const;
       if (this.embeddedServer) {
+        // SECURITY (#204): now that Twilio has assigned the CallSid, bind the
+        // stream-auth token minted for the inline TwiML to it so the media WS
+        // 'start' frame (which carries this CallSid) validates. Empty token =>
+        // no-op (embedded server absent at TwiML build time).
+        if (streamToken) {
+          this.embeddedServer.registerStreamToken(twilioCallSid, streamToken);
+        }
         this.embeddedServer.metricsStore.recordCallInitiated(initiatedPayload);
         // Register the per-callSid AMD callback now that we have the CallSid.
         // Keying by callSid avoids a single-slot race when multiple outbound

--- a/libraries/typescript/src/engines/gemini-cascade.ts
+++ b/libraries/typescript/src/engines/gemini-cascade.ts
@@ -1,0 +1,63 @@
+/**
+ * Gemini Cascade engine — marker class for Patter client dispatch.
+ *
+ * Selects the cascade voice architecture: Gemini Live for STT + reasoning
+ * (TEXT modality, returns transcript) piped into a Gemini TTS leg for
+ * high-quality voice synthesis. The two legs communicate inside
+ * {@link import('../providers/gemini-cascade').GeminiCascadeAdapter}.
+ *
+ * Like other engine markers this is a tiny immutable config object. The
+ * runtime session lives in `GeminiCascadeAdapter` (constructed server-side
+ * by `buildAIAdapter`).
+ *
+ * @example
+ * ```ts
+ * import { Patter, Twilio, GeminiCascade } from "getpatter";
+ *
+ * const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+1..." });
+ * const agent = phone.agent({
+ *   engine: new GeminiCascade({ voice: "Kore" }),
+ *   systemPrompt: "You are a helpful assistant.",
+ *   firstMessage: "Hi, how can I help you today?",
+ * });
+ * ```
+ */
+
+/** Constructor options for the `GeminiCascade` engine marker. */
+export interface GeminiCascadeOptions {
+  /** API key. Falls back to GEMINI_API_KEY / GOOGLE_API_KEY env vars when omitted. */
+  apiKey?: string;
+  /** Prebuilt TTS voice name. Defaults to `Kore`. */
+  voice?: string;
+  /** Gemini Live model (STT+brain leg, TEXT modality). Defaults to `gemini-3.1-flash-live-preview`. */
+  liveModel?: string;
+  /** Gemini TTS model (voice synthesis leg). Defaults to `gemini-3.1-flash-tts-preview`. */
+  ttsModel?: string;
+}
+
+/**
+ * Gemini Cascade engine marker — selects the Gemini Live (STT) + Gemini TTS
+ * cascade architecture for higher-quality voice synthesis than native-audio mode.
+ */
+export class GeminiCascade {
+  readonly kind = 'gemini_cascade' as const;
+  readonly apiKey: string;
+  readonly voice: string;
+  readonly liveModel: string;
+  readonly ttsModel: string;
+
+  constructor(opts: GeminiCascadeOptions = {}) {
+    const key =
+      opts.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    if (!key) {
+      throw new Error(
+        'Gemini Cascade requires an apiKey. Pass { apiKey: \'...\' } or set ' +
+          'GEMINI_API_KEY (or GOOGLE_API_KEY) in the environment.',
+      );
+    }
+    this.apiKey = key;
+    this.voice = opts.voice ?? 'Kore';
+    this.liveModel = opts.liveModel ?? 'gemini-3.1-flash-live-preview';
+    this.ttsModel = opts.ttsModel ?? 'gemini-3.1-flash-tts-preview';
+  }
+}

--- a/libraries/typescript/src/engines/gemini.ts
+++ b/libraries/typescript/src/engines/gemini.ts
@@ -1,0 +1,133 @@
+/**
+ * Gemini Live engine — marker class for Patter client dispatch.
+ *
+ * Selects Google's Gemini Live native-audio API (audio-in → audio-out,
+ * emotion-aware). Separate marker from the OpenAI / ElevenLabs engines
+ * because the client dispatches to {@link import('../providers/gemini-live').GeminiLiveAdapter}
+ * when this marker is passed to ``Patter.agent({ engine })``.
+ *
+ * Like the other engine markers this is a tiny immutable config object: it
+ * carries credentials / voice / model only. The runtime session lives in
+ * ``GeminiLiveAdapter`` (constructed server-side by ``buildAIAdapter``).
+ *
+ * @example
+ * ```ts
+ * import { Patter, Twilio, GeminiLive } from "getpatter";
+ *
+ * const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+1..." });
+ * const agent = phone.agent({
+ *   engine: new GeminiLive({ voice: "Puck", model: "gemini-3.1-flash-live-preview" }),
+ *   systemPrompt: "You are a friendly receptionist.",
+ *   firstMessage: "Hello! How can I help?",
+ * });
+ * ```
+ */
+
+/** Constructor options for the `GeminiLive` engine marker. */
+export interface GeminiLiveOptions {
+  /** API key. Falls back to GEMINI_API_KEY / GOOGLE_API_KEY env vars when omitted. */
+  apiKey?: string;
+  /** Gemini Live model. Defaults to the adapter's native-audio default when omitted. */
+  model?: string;
+  /** Prebuilt voice name. Defaults to `Puck`. */
+  voice?: string;
+  /** Language code. Defaults to `en-US`. */
+  language?: string;
+  /** Sampling temperature. Defaults to `0.8`. */
+  temperature?: number;
+  /**
+   * Enable native-audio affective dialog — the model adapts its tone/prosody to
+   * the caller's emotion. Opt-in (default off) for backward compatibility.
+   */
+  affectiveDialog?: boolean;
+  /**
+   * Enable native-audio proactive audio — the model decides when to respond and
+   * can stay silent to non-directed speech. Opt-in (default off).
+   */
+  proactiveAudio?: boolean;
+  /**
+   * Tune the server-side voice-activity detector. `startSensitivity: 'LOW'`
+   * rejects background noise/breathing; `endSensitivity: 'HIGH'` + a lower
+   * `silenceDurationMs` cut the wait before the model replies. Opt-in.
+   */
+  vad?: GeminiVadOptions;
+  /**
+   * Enable the model's "thinking" (chain-of-thought) on this voice session.
+   *
+   * `false` (DEFAULT) — thinking is disabled (`thinkingBudget: 0`). A voice
+   * agent must never speak or transcribe its private reasoning; on the
+   * Gemini 3.x native-audio models the chain-of-thought otherwise leaks into
+   * BOTH the spoken audio and the transcript (e.g. "**Initiating Call
+   * Protocol**…" before the real reply). Keep this off for telephony.
+   *
+   * `true` — re-enables dynamic thinking (the model decides how much to
+   * think). Only do this for non-voice / latency-tolerant flows.
+   */
+  thinking?: boolean;
+  /**
+   * Explicit Gemini thinking budget (tokens). Takes precedence over
+   * {@link thinking}. `0` disables thinking, `-1` lets the model decide
+   * (dynamic). Omit to use the {@link thinking}-derived default (0 = off).
+   */
+  thinkingBudget?: number;
+  /**
+   * Gemini API version for the Live channel. Auto-detected from the model
+   * name when omitted: native-audio output models — including
+   * `gemini-3.1-flash-live-preview` — are served on `v1alpha`; all others use
+   * the SDK default (`v1beta`). Pass `'v1alpha'` / `'v1beta'` to override when
+   * a model is unavailable on the auto-detected channel.
+   */
+  apiVersion?: string;
+}
+
+/** Server-side VAD tuning for the Gemini Live native-audio engine. */
+export interface GeminiVadOptions {
+  /** 'LOW' = less sensitive (ignores noise); 'HIGH' = triggers on quieter sound. */
+  startSensitivity?: 'HIGH' | 'LOW';
+  /** 'HIGH' = detects end-of-turn faster (lower latency); 'LOW' = waits longer. */
+  endSensitivity?: 'HIGH' | 'LOW';
+  /** Silence (ms) before the turn is considered over. Lower = snappier replies. */
+  silenceDurationMs?: number;
+  /** Audio (ms) retained before detected speech start. */
+  prefixPaddingMs?: number;
+}
+
+/**
+ * Gemini Live engine marker — selects Google's native-audio Live API.
+ */
+export class GeminiLive {
+  readonly kind = "gemini_live" as const;
+  readonly apiKey: string;
+  readonly model?: string;
+  readonly voice?: string;
+  readonly language?: string;
+  readonly temperature?: number;
+  readonly affectiveDialog?: boolean;
+  readonly proactiveAudio?: boolean;
+  readonly vad?: GeminiVadOptions;
+  readonly thinking?: boolean;
+  readonly thinkingBudget?: number;
+  readonly apiVersion?: string;
+
+  constructor(opts: GeminiLiveOptions = {}) {
+    const key =
+      opts.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Gemini Live requires an apiKey. Pass { apiKey: '...' } or set " +
+          "GEMINI_API_KEY (or GOOGLE_API_KEY) in the environment.",
+      );
+    }
+    this.apiKey = key;
+    this.model = opts.model;
+    this.voice = opts.voice;
+    this.language = opts.language;
+    this.temperature = opts.temperature;
+    this.affectiveDialog = opts.affectiveDialog;
+    this.proactiveAudio = opts.proactiveAudio;
+    this.vad = opts.vad;
+    this.thinking = opts.thinking;
+    this.thinkingBudget = opts.thinkingBudget;
+    this.apiVersion = opts.apiVersion;
+  }
+}

--- a/libraries/typescript/src/engines/inworld.ts
+++ b/libraries/typescript/src/engines/inworld.ts
@@ -1,0 +1,106 @@
+/**
+ * Inworld Realtime engine — marker class for Patter client dispatch.
+ *
+ * Selects Inworld's Realtime speech-to-speech API. Inworld advertises an
+ * "OpenAI Realtime migration" path — the event schema, session structure, and
+ * client/server events are compatible with OpenAI's Realtime API, so the
+ * session can be driven with the same `session.update` / `response.create` /
+ * streaming-delta wire shape. The runtime lives in
+ * {@link import('../providers/inworld-realtime').InworldRealtimeAdapter},
+ * which subclasses `OpenAIRealtimeAdapter` and only swaps the endpoint + auth.
+ *
+ * Like the other engine markers this is a tiny immutable config object: it
+ * carries credentials / voice / model only. The session is constructed
+ * server-side by `buildAIAdapter`.
+ *
+ * @example
+ * ```ts
+ * import { Patter, Twilio, InworldRealtime } from "getpatter";
+ *
+ * const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+1..." });
+ * const agent = phone.agent({
+ *   engine: new InworldRealtime({ voice: "Ashley" }), // reads INWORLD_API_KEY
+ *   systemPrompt: "You are a friendly receptionist.",
+ *   firstMessage: "Hello! How can I help?",
+ * });
+ * ```
+ */
+
+import type { RealtimeTurnDetection } from '../types';
+import { validateRealtimeTurnDetection } from '../providers/openai-realtime';
+
+/** Constructor options for the `InworldRealtime` engine marker. */
+export interface InworldRealtimeOptions {
+  /**
+   * Inworld Realtime API key (JWT / Bearer "Realtime key"). Falls back to the
+   * `INWORLD_API_KEY` env var when omitted.
+   */
+  apiKey?: string;
+  /**
+   * Realtime model id. Inworld is OpenAI-Realtime-compatible; the model is
+   * passed through as the `?model=` query param. Defaults to
+   * `"inworld-realtime"` — override with the exact model id from your Inworld
+   * dashboard.
+   */
+  model?: string;
+  /** Voice name (e.g. `"Ashley"`, `"Olivia"`). Defaults to `"Ashley"`. */
+  voice?: string;
+  /**
+   * Override the WebSocket base URL (no query string). Defaults to
+   * `wss://api.inworld.ai/v1/realtime`. Use this to point at an alternate /
+   * on-prem deployment, or to supply a session-scoped URL if your Inworld
+   * account requires the `/api/v1/realtime/session?key=<session-id>` flow.
+   */
+  baseUrl?: string;
+  /**
+   * ISO-639-1 language hint for input transcription (e.g. `"it"`, `"en"`).
+   * Pins the transcription model to one language instead of auto-detecting
+   * per utterance. Omit to keep auto-detect (default). Display-only.
+   */
+  transcriptionLanguage?: string;
+  /**
+   * Turn-detection tuning. `undefined` (default) keeps the server VAD
+   * defaults. Raise the threshold or switch to `semantic_vad` eagerness
+   * `'low'` to stop speakerphone noise from triggering false barge-ins.
+   */
+  turnDetection?: RealtimeTurnDetection;
+  /**
+   * Gate the model's response on the input transcript (legacy behavior).
+   * `false` (default) — the model responds on `speech_stopped`, independent
+   * of the transcript. `true` — restore transcript-gated responses.
+   */
+  gateResponseOnTranscript?: boolean;
+}
+
+/**
+ * Inworld Realtime engine marker — selects Inworld's OpenAI-Realtime-compatible
+ * speech-to-speech API.
+ */
+export class InworldRealtime {
+  readonly kind = 'inworld_realtime' as const;
+  readonly apiKey: string;
+  readonly model?: string;
+  readonly voice?: string;
+  readonly baseUrl?: string;
+  readonly transcriptionLanguage?: string;
+  readonly turnDetection?: RealtimeTurnDetection;
+  readonly gateResponseOnTranscript?: boolean;
+
+  constructor(opts: InworldRealtimeOptions = {}) {
+    const key = opts.apiKey ?? process.env.INWORLD_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Inworld Realtime requires an apiKey. Pass { apiKey: '...' } or set " +
+          'INWORLD_API_KEY in the environment.',
+      );
+    }
+    validateRealtimeTurnDetection(opts.turnDetection);
+    this.apiKey = key;
+    this.model = opts.model;
+    this.voice = opts.voice;
+    this.baseUrl = opts.baseUrl;
+    this.transcriptionLanguage = opts.transcriptionLanguage;
+    this.turnDetection = opts.turnDetection;
+    this.gateResponseOnTranscript = opts.gateResponseOnTranscript;
+  }
+}

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -109,10 +109,19 @@ export {
 export { TestSession } from "./test-mode";
 export { ElevenLabsConvAIAdapter } from "./providers/elevenlabs-convai";
 export { OpenAIRealtimeAdapter } from "./providers/openai-realtime";
-export { GeminiLiveAdapter, GEMINI_DEFAULT_INPUT_SR, GEMINI_DEFAULT_OUTPUT_SR } from "./providers/gemini-live";
+export { GeminiLiveAdapter, GEMINI_DEFAULT_INPUT_SR, GEMINI_DEFAULT_OUTPUT_SR, GEMINI_LIVE_3_1_FLASH_PREVIEW } from "./providers/gemini-live";
 export type { GeminiLiveEventHandler } from "./providers/gemini-live";
+export { GeminiCascadeAdapter } from "./providers/gemini-cascade";
+export type { GeminiCascadeEventHandler, GeminiCascadeAdapterOptions } from "./providers/gemini-cascade";
 export { UltravoxRealtimeAdapter, ULTRAVOX_DEFAULT_API_BASE, ULTRAVOX_DEFAULT_SR } from "./providers/ultravox-realtime";
 export type { UltravoxEventHandler } from "./providers/ultravox-realtime";
+export {
+  InworldRealtimeAdapter,
+  INWORLD_REALTIME_WS_URL,
+  INWORLD_REALTIME_DEFAULT_MODEL,
+  INWORLD_REALTIME_DEFAULT_VOICE,
+} from "./providers/inworld-realtime";
+export type { InworldRealtimeAdapterOptions } from "./providers/inworld-realtime";
 export { scheduleCron, scheduleOnce, scheduleInterval } from "./scheduler";
 export type { ScheduleHandle, JobCallback } from "./scheduler";
 // Provider adapter types (re-exported for advanced users who build custom
@@ -155,6 +164,8 @@ export { STT as AssemblyAISTT } from "./stt/assemblyai";
 export type { AssemblyAISTTOptions } from "./stt/assemblyai";
 export { STT as SpeechmaticsSTT } from "./stt/speechmatics";
 export type { SpeechmaticsSTTOptions } from "./stt/speechmatics";
+export { STT as GeminiSTT } from "./stt/gemini";
+export type { GeminiSTTOptions } from "./stt/gemini";
 export {
   TurnDetectionMode as SpeechmaticsTurnDetectionMode,
   SpeechmaticsSampleRate,
@@ -182,6 +193,8 @@ export { TTS as LMNTTTS } from "./tts/lmnt";
 export type { LMNTTTSOptions } from "./tts/lmnt";
 export { TTS as InworldTTS } from "./tts/inworld";
 export type { InworldTTSOptions } from "./tts/inworld";
+export { TTS as GeminiTTS } from "./tts/gemini";
+export type { GeminiTTSOptions } from "./tts/gemini";
 
 // New namespaced LLM classes (Phase 2 of the v0.5.x API refactor).
 export { LLM as OpenAILLM } from "./llm/openai";
@@ -267,6 +280,12 @@ export type { Realtime2Options as OpenAIRealtime2Options } from "./engines/opena
 export { OpenAIRealtime2Adapter } from "./providers/openai-realtime-2";
 export { ConvAI as ElevenLabsConvAI } from "./engines/elevenlabs";
 export type { ConvAIOptions as ElevenLabsConvAIOptions } from "./engines/elevenlabs";
+export { GeminiLive } from "./engines/gemini";
+export type { GeminiLiveOptions } from "./engines/gemini";
+export { GeminiCascade } from "./engines/gemini-cascade";
+export type { GeminiCascadeOptions } from "./engines/gemini-cascade";
+export { InworldRealtime } from "./engines/inworld";
+export type { InworldRealtimeOptions } from "./engines/inworld";
 
 // Tunnel markers.
 export { CloudflareTunnel, Ngrok, Static as StaticTunnel } from "./tunnels";

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -65,6 +65,9 @@ export {
   cartesia,
   rime,
   lmnt,
+  inworld,
+  sonioxTts,
+  sarvam,
   ultravox,
   geminiLive,
 } from "./providers";
@@ -195,6 +198,10 @@ export { TTS as InworldTTS } from "./tts/inworld";
 export type { InworldTTSOptions } from "./tts/inworld";
 export { TTS as GeminiTTS } from "./tts/gemini";
 export type { GeminiTTSOptions } from "./tts/gemini";
+export { TTS as SonioxTTS } from "./tts/soniox";
+export type { SonioxTTSOptions, SonioxCarrierOptions } from "./tts/soniox";
+export { TTS as SarvamTTS } from "./tts/sarvam";
+export type { SarvamTTSOptions, SarvamCarrierOptions } from "./tts/sarvam";
 
 // New namespaced LLM classes (Phase 2 of the v0.5.x API refactor).
 export { LLM as OpenAILLM } from "./llm/openai";

--- a/libraries/typescript/src/pricing.ts
+++ b/libraries/typescript/src/pricing.ts
@@ -171,6 +171,10 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
   // Previous $0.0173 default reflected a legacy Standard tier that was
   // retired; users were being over-billed ~4.3x.
   speechmatics: { unit: PricingUnit.MINUTE, price: 0.004 },
+  // Gemini multimodal STT (gemini-2.5-flash, audio in → text out). Audio input
+  // ~$0.30/1M tokens at ~32 tokens/sec ≈ $0.00058/min; round to a small flat
+  // per-minute estimate. Preview pricing — verify before GA.
+  gemini_stt: { unit: PricingUnit.MINUTE, price: 0.001 },
   // TTS — per 1,000 characters synthesized.
   // Source: https://elevenlabs.io/pricing/api (verified 2026-05-11). The
   // per-1K-character API/overage rate is flat across all plan tiers (Free
@@ -256,6 +260,16 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
       'inworld-tts-1.5-mini': { price: 0.015 },
     },
   },
+  // Gemini TTS (gemini-3.1-flash-tts-preview). Output audio ~$20/1M audio
+  // tokens (~25 tok/sec) + ~$1/1M text input ≈ ~$0.034 per 1K chars spoken.
+  // Preview pricing — verify before GA.
+  gemini_tts: {
+    unit: PricingUnit.THOUSAND_CHARS,
+    price: 0.034,
+    models: {
+      'gemini-3.1-flash-tts-preview': { price: 0.034 },
+    },
+  },
   // OpenAI Realtime — per token. Provider defaults match
   // gpt-realtime-mini / gpt-4o-mini-realtime-preview (Patter's default).
   // Per-model overrides under ``models`` are auto-resolved when the
@@ -321,6 +335,30 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
         text_output_per_token: 0.000020,
         cached_audio_input_per_token: 0.0000020,
         cached_text_input_per_token: 0.0000025,
+      },
+    },
+  },
+  // Gemini Cascade — two-leg architecture: Live leg (text in/out per token)
+  // and TTS leg (text-in / audio-out per token). Rates per 1M tokens (USD).
+  // Sources: Google AI Studio pricing page (verified 2026-06-18).
+  //   gemini-3.1-flash-live-preview: $0.30/M text input, $2.50/M text output.
+  //   gemini-3.1-flash-tts-preview:  $1.00/M text input, $20.00/M audio output.
+  // Provider defaults represent the Live leg; TTS leg rates are per-model.
+  gemini_cascade: {
+    unit: PricingUnit.TOKEN,
+    // Live leg defaults (gemini-3.1-flash-live-preview): text in/out only.
+    text_input_per_token: 0.00000030,   // $0.30 per 1M text input tokens
+    text_output_per_token: 0.0000025,   // $2.50 per 1M text output tokens
+    models: {
+      // Live STT+brain leg (TEXT modality — no audio output from this leg).
+      'gemini-3.1-flash-live-preview': {
+        text_input_per_token: 0.00000030,
+        text_output_per_token: 0.0000025,
+      },
+      // TTS voice-synthesis leg: text in → audio out.
+      'gemini-3.1-flash-tts-preview': {
+        text_input_per_token: 0.0000010,    // $1.00 per 1M text input tokens
+        audio_output_per_token: 0.000020,   // $20.00 per 1M audio output tokens
       },
     },
   },
@@ -626,6 +664,7 @@ export const llmPricing: Record<string, Record<string, LlmModelPricing>> = {
     'gemini-2.5-pro': { input: 1.25, output: 10.0 },
     'gemini-2.5-flash': { input: 0.30, output: 2.50 },
     'gemini-live-2.5-flash-native-audio': { input: 0.30, output: 2.50 },
+    'gemini-3.1-flash-live-preview': { input: 0.30, output: 2.50 },
   },
   groq: {
     // Rates as of 2026-05-08; verify against groq.com/pricing.

--- a/libraries/typescript/src/pricing.ts
+++ b/libraries/typescript/src/pricing.ts
@@ -270,6 +270,26 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
       'gemini-3.1-flash-tts-preview': { price: 0.034 },
     },
   },
+  // Soniox real-time TTS. Soniox publishes a $0.70/hr headline for generated
+  // speech (native billing is token-based: input text $4/1M + output audio
+  // $21.50/1M). Patter's TTS cost model is per-character, so we express the rate
+  // per 1k chars: at a typical ~900 chars/min spoken (~150 wpm) ≈ 54,000
+  // chars/hr, $0.70/hr ÷ 54 ≈ $0.013 / 1k chars. Source:
+  // https://soniox.com/pricing (also https://soniox.com/text-to-speech).
+  soniox_tts: { unit: PricingUnit.THOUSAND_CHARS, price: 0.013 },
+  // Sarvam AI Bulbul TTS — per 1,000 characters. INR is authoritative; USD is an
+  // indicative FX conversion (~Rs 83-84/USD). Bulbul v3 (default): Rs 30 / 10k
+  // chars ≈ $0.036/1k; Bulbul v2: Rs 15 / 10k ≈ $0.018/1k. Billed per character,
+  // rounded up per request. Source: https://www.sarvam.ai/api-pricing
+  sarvam: {
+    unit: PricingUnit.THOUSAND_CHARS,
+    // Default = bulbul:v3.
+    price: 0.036,
+    models: {
+      'bulbul:v3': { price: 0.036 },
+      'bulbul:v2': { price: 0.018 },
+    },
+  },
   // OpenAI Realtime — per token. Provider defaults match
   // gpt-realtime-mini / gpt-4o-mini-realtime-preview (Patter's default).
   // Per-model overrides under ``models`` are auto-resolved when the

--- a/libraries/typescript/src/providers.ts
+++ b/libraries/typescript/src/providers.ts
@@ -147,6 +147,26 @@ export function inworld(opts: { apiKey: string; voice?: string }): TTSConfig {
   return new TTSConfigImpl("inworld", opts.apiKey, opts.voice ?? "Ashley");
 }
 
+/**
+ * Soniox TTS config helper (parity with Python ``getpatter.providers.soniox_tts``).
+ * Shares the ``SONIOX_API_KEY`` credential family with Soniox STT. For pipeline
+ * use the documented path is the direct adapter ``new SonioxTTS({...})`` from
+ * ``getpatter``.
+ */
+export function sonioxTts(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl("soniox_tts", opts.apiKey, opts.voice ?? "Adrian");
+}
+
+/**
+ * Sarvam AI TTS config helper for Indian languages (parity with Python
+ * ``getpatter.providers.sarvam``). ``voice`` is the Sarvam speaker id (default
+ * ``shubh``). For pipeline use the documented path is the direct adapter
+ * ``new SarvamTTS({...})`` from ``getpatter``.
+ */
+export function sarvam(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl("sarvam", opts.apiKey, opts.voice ?? "shubh");
+}
+
 // ---------------------------------------------------------------------------
 // Realtime / ConvAI helpers
 // ---------------------------------------------------------------------------

--- a/libraries/typescript/src/providers/gemini-cascade-playback.ts
+++ b/libraries/typescript/src/providers/gemini-cascade-playback.ts
@@ -1,0 +1,382 @@
+/**
+ * Gemini Cascade playback state machine.
+ *
+ * Manages the output audio pipeline for {@link GeminiCascadeAdapter}:
+ * - IDLE       — no audio playing; waiting for barge-in or turn-end
+ * - FILLER     — draining a pre-synthesised filler clip
+ * - SPEAKING   — draining TTS audio frames
+ * - INTERRUPTED — barge-in detected; dropping buffered frames
+ *
+ * All outbound audio (filler, TTS, silence padding) passes through ONE
+ * timestamp-corrected ~20 ms drive loop. The loop compensates for clock
+ * drift by emitting 0, 1, or 2 frames per tick (capped at 2 to bound jitter).
+ *
+ * Filler clips are pre-synthesised at engine start and cached as
+ * 8 kHz mulaw 160-byte-frame arrays. The adapter owns clip synthesis;
+ * this module only owns the playback state machine.
+ */
+
+import { getLogger } from '../logger';
+
+/** One mulaw frame expected by the carrier playout scheduler: 20 ms @ 8 kHz. */
+const MULAW_FRAME_BYTES = 160;
+/** Drive loop tick interval in milliseconds. */
+const TICK_MS = 20;
+/** Maximum frames emitted per tick to bound burst jitter. */
+const MAX_FRAMES_PER_TICK = 2;
+/** Silence byte for mulaw (G.711 encoding of zero). */
+const MULAW_SILENCE = 0xff;
+/** ~40 ms silence after barge-in before resuming (2 frames). */
+const POST_BARGE_IN_SILENCE_FRAMES = 2;
+
+/** Playback state. */
+export type PlaybackState = 'IDLE' | 'FILLER' | 'SPEAKING' | 'INTERRUPTED';
+
+/** Callback invoked per 160-byte mulaw frame that should be sent to the carrier. */
+export type FrameEmitter = (frame: Buffer) => void;
+
+/** Options for the playback machine. */
+export interface CascadePlaybackOptions {
+  /** Called with each 160-byte mulaw frame to send to the carrier. */
+  onFrame: FrameEmitter;
+}
+
+/**
+ * Playback state machine for GeminiCascadeAdapter.
+ *
+ * Call {@link start} once after constructing; call {@link stop} at session close.
+ * Feed TTS output via {@link enqueueTtsFrames}. Signal filler selection via
+ * {@link startFiller}. Signal barge-in via {@link interrupt}.
+ */
+export class CascadePlaybackMachine {
+  private state: PlaybackState = 'IDLE';
+  /** Filler frames queued for draining (pre-synthesised clip). */
+  private fillerQueue: Buffer[] = [];
+  /** TTS frames queued for draining (from Gemini TTS leg). */
+  private ttsQueue: Buffer[] = [];
+  /** Whether TTS turn is complete (flush remaining + return to IDLE). */
+  private ttsComplete = false;
+  /** Silence frames to emit after barge-in before returning to IDLE. */
+  private postBargeInSilenceRemaining = 0;
+  /** Drive loop timer handle. */
+  private ticker: ReturnType<typeof setInterval> | null = null;
+  /** Timestamp of the previous tick for drift compensation. */
+  private lastTickAt = 0;
+  /** Accumulated fractional frame deficit from drift. */
+  private frameDebt = 0;
+  private readonly onFrame: FrameEmitter;
+
+  constructor(opts: CascadePlaybackOptions) {
+    this.onFrame = opts.onFrame;
+  }
+
+  /** Current playback state (read-only). */
+  get currentState(): PlaybackState {
+    return this.state;
+  }
+
+  /** Start the ~20 ms drive loop. Must be called once at session open. */
+  start(): void {
+    if (this.ticker !== null) return;
+    this.lastTickAt = Date.now();
+    this.frameDebt = 0;
+    this.ticker = setInterval(() => this.tick(), TICK_MS);
+  }
+
+  /** Stop the drive loop and reset all state. Call at session close. */
+  stop(): void {
+    if (this.ticker !== null) {
+      clearInterval(this.ticker);
+      this.ticker = null;
+    }
+    this.state = 'IDLE';
+    this.fillerQueue = [];
+    this.ttsQueue = [];
+    this.ttsComplete = false;
+    this.postBargeInSilenceRemaining = 0;
+    this.frameDebt = 0;
+  }
+
+  /**
+   * Begin draining a filler clip.
+   *
+   * Only transitions if the machine is currently IDLE — otherwise the
+   * caller already received audio (TTS in SPEAKING, or still FILLER).
+   */
+  startFiller(frames: Buffer[]): void {
+    if (this.state !== 'IDLE') return;
+    this.fillerQueue = [...frames];
+    this.ttsQueue = [];
+    this.ttsComplete = false;
+    this.state = 'FILLER';
+    getLogger().debug('Gemini Cascade playback: IDLE -> FILLER');
+  }
+
+  /**
+   * Enqueue TTS frames for playback.
+   *
+   * If we are in FILLER state, transitions to SPEAKING at the next frame
+   * boundary (the tick loop handles the crossfade — it finishes the current
+   * 160-byte frame first before switching queues).
+   */
+  enqueueTtsFrames(frames: Buffer[], turnComplete: boolean): void {
+    for (const f of frames) this.ttsQueue.push(f);
+    if (turnComplete) this.ttsComplete = true;
+
+    if (this.state === 'FILLER' && frames.length > 0) {
+      // Drain filler in the tick loop; it will crossfade at next frame boundary.
+    } else if (this.state === 'IDLE' && frames.length > 0) {
+      this.state = 'SPEAKING';
+      getLogger().debug('Gemini Cascade playback: IDLE -> SPEAKING');
+    }
+  }
+
+  /**
+   * Signal turn complete without new frames (flush tail of TTS turn).
+   * If already SPEAKING this will drain remaining ttsQueue then go IDLE.
+   */
+  markTtsComplete(): void {
+    this.ttsComplete = true;
+    if (this.state === 'IDLE') {
+      // Nothing to drain — already done.
+    }
+  }
+
+  /**
+   * Barge-in detected. Drop queued frames and emit ~40 ms silence,
+   * then return to IDLE. Transitions from any state.
+   */
+  interrupt(): void {
+    if (this.state === 'INTERRUPTED') return;
+    getLogger().debug(`Gemini Cascade playback: ${this.state} -> INTERRUPTED`);
+    this.state = 'INTERRUPTED';
+    this.fillerQueue = [];
+    this.ttsQueue = [];
+    this.ttsComplete = false;
+    this.postBargeInSilenceRemaining = POST_BARGE_IN_SILENCE_FRAMES;
+  }
+
+  /** Reset to IDLE without emitting silence (new turn started). */
+  resetToIdle(): void {
+    this.state = 'IDLE';
+    this.fillerQueue = [];
+    this.ttsQueue = [];
+    this.ttsComplete = false;
+    this.postBargeInSilenceRemaining = 0;
+    getLogger().debug('Gemini Cascade playback: -> IDLE');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drive loop
+  // ---------------------------------------------------------------------------
+
+  private tick(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastTickAt;
+    this.lastTickAt = now;
+
+    // Compute how many frames we should emit this tick based on elapsed time.
+    // frameDebt accumulates fractional frames across ticks to avoid drift.
+    const idealFrames = elapsed / TICK_MS + this.frameDebt;
+    const framesToEmit = Math.min(Math.round(idealFrames), MAX_FRAMES_PER_TICK);
+    this.frameDebt = idealFrames - framesToEmit;
+
+    for (let i = 0; i < framesToEmit; i++) {
+      this.emitOneFrame();
+    }
+  }
+
+  private emitOneFrame(): void {
+    switch (this.state) {
+      case 'IDLE':
+        return; // Nothing to emit.
+
+      case 'INTERRUPTED':
+        if (this.postBargeInSilenceRemaining > 0) {
+          this.onFrame(Buffer.alloc(MULAW_FRAME_BYTES, MULAW_SILENCE));
+          this.postBargeInSilenceRemaining--;
+        } else {
+          this.state = 'IDLE';
+          getLogger().debug('Gemini Cascade playback: INTERRUPTED -> IDLE');
+        }
+        return;
+
+      case 'FILLER': {
+        // If TTS frames are available, crossfade at current frame boundary
+        // by switching to SPEAKING before draining the next filler frame.
+        if (this.ttsQueue.length > 0) {
+          this.state = 'SPEAKING';
+          getLogger().debug('Gemini Cascade playback: FILLER -> SPEAKING (TTS ready)');
+          this.emitOneTtsFrame();
+          return;
+        }
+        if (this.fillerQueue.length > 0) {
+          this.onFrame(this.fillerQueue.shift()!);
+          return;
+        }
+        // Filler exhausted, TTS not yet ready — emit silence (never loop filler).
+        this.onFrame(Buffer.alloc(MULAW_FRAME_BYTES, MULAW_SILENCE));
+        return;
+      }
+
+      case 'SPEAKING':
+        this.emitOneTtsFrame();
+        return;
+    }
+  }
+
+  private emitOneTtsFrame(): void {
+    if (this.ttsQueue.length > 0) {
+      this.onFrame(this.ttsQueue.shift()!);
+      return;
+    }
+    if (this.ttsComplete) {
+      this.state = 'IDLE';
+      this.ttsComplete = false;
+      getLogger().debug('Gemini Cascade playback: SPEAKING -> IDLE (TTS turn complete)');
+      return;
+    }
+    // TTS stalled mid-turn — emit silence to maintain timing.
+    this.onFrame(Buffer.alloc(MULAW_FRAME_BYTES, MULAW_SILENCE));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chunked TTS text splitter
+// ---------------------------------------------------------------------------
+
+/** Abbreviations that contain a period but should NOT trigger a split. */
+const ABBREV_BLOCKLIST = new Set([
+  'dr.', 'mr.', 'mrs.', 'ms.', 'vs.', 'approx.', 'est.',
+]);
+
+/**
+ * Split accumulated text into TTS chunks.
+ *
+ * Priority order:
+ * 1. Sentence boundary `/[.!?]\s/` (guards: digit-before, abbrev, lowercase-after)
+ * 2. Clause boundary `/[,;:]\s+(?=[A-Z])/`
+ * 3. Conjunction boundary (only if buffer >= 60 chars)
+ * 4. Length fallback: split before position 120
+ *
+ * Min chunk: 15 chars / 3 words (unless `flush` is true).
+ *
+ * @returns [chunk, remainder] or [null, text] if no split point found yet.
+ */
+export function splitTtsChunk(
+  text: string,
+  flush: boolean,
+): [string | null, string] {
+  if (flush && text.trim().length > 0) return [text, ''];
+
+  const minLen = 15;
+  const wordCount = text.trim().split(/\s+/).length;
+  if (text.length < minLen || wordCount < 3) return [null, text];
+
+  // 1. Sentence boundary
+  const sentMatch = findSentenceBoundary(text);
+  if (sentMatch !== -1) {
+    return [text.slice(0, sentMatch), text.slice(sentMatch)];
+  }
+
+  // 2. Clause boundary: [,;:] followed by whitespace then uppercase
+  const clauseRe = /[,;:]\s+(?=[A-Z])/g;
+  let clauseMatch: RegExpExecArray | null;
+  while ((clauseMatch = clauseRe.exec(text)) !== null) {
+    const pos = clauseMatch.index + 1; // after the punctuation
+    if (pos >= minLen) return [text.slice(0, pos), text.slice(pos)];
+  }
+
+  // 3. Conjunction boundary (only if long enough)
+  if (text.length >= 60) {
+    const conjRe = /\s+(and|but|so|because|however|therefore|although)\s+/gi;
+    let conjMatch: RegExpExecArray | null;
+    while ((conjMatch = conjRe.exec(text)) !== null) {
+      const pos = conjMatch.index;
+      if (pos >= minLen) return [text.slice(0, pos), text.slice(pos)];
+    }
+  }
+
+  // 4. Length fallback: split before position 120
+  if (text.length >= 120) {
+    const splitPos = text.lastIndexOf(' ', 119);
+    if (splitPos > minLen) return [text.slice(0, splitPos), text.slice(splitPos + 1)];
+    return [text.slice(0, 120), text.slice(120)];
+  }
+
+  return [null, text];
+}
+
+/** Find the first valid sentence boundary index in `text`. Returns -1 if none. */
+function findSentenceBoundary(text: string): number {
+  const sentRe = /[.!?]\s/g;
+  let m: RegExpExecArray | null;
+  while ((m = sentRe.exec(text)) !== null) {
+    const pos = m.index;
+    const ch = text[pos];
+    // Guard: digit before period (e.g. "3.5 times")
+    if (ch === '.' && pos > 0 && /\d/.test(text[pos - 1])) continue;
+    // Guard: lowercase after period (abbreviation mid-sentence)
+    if (ch === '.' && pos + 2 < text.length && /[a-z]/.test(text[pos + 2])) continue;
+    // Guard: known abbreviation blocklist
+    if (ch === '.') {
+      const before = text.slice(Math.max(0, pos - 5), pos + 1).toLowerCase();
+      if (ABBREV_BLOCKLIST.has(before.split(/\s+/).pop() ?? '')) continue;
+    }
+    const splitAt = pos + 1; // include the punctuation, split before the space
+    if (splitAt >= 15) return splitAt;
+  }
+  return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Filler selection
+// ---------------------------------------------------------------------------
+
+/** Names of the pre-synthesised filler clips. */
+export type FillerKey =
+  | 'mhm'
+  | 'got_it'
+  | 'sure_one_sec'
+  | 'let_me_check'
+  | 'let_me_think'
+  | 'okay_moment';
+
+/** The round-robin cursor is module-level state (simple, not shared across calls). */
+let _rrCursor = 0;
+const RR_FILLERS: FillerKey[] = ['sure_one_sec', 'got_it'];
+
+/**
+ * Select a filler clip key based on the last ~30 tokens of input text.
+ *
+ * Rules (in priority order):
+ * 1. Question word at any position → 'let_me_check'
+ * 2. >60 chars or 2+ clause boundaries → 'let_me_think'
+ * 3. Urgency token → 'okay_moment'
+ * 4. Closure token → 'got_it'
+ * 5. <15 chars → 'mhm'
+ * 6. Default: round-robin 'sure_one_sec' / 'got_it'
+ */
+export function selectFiller(recentInputText: string): FillerKey {
+  const text = recentInputText.toLowerCase().trim();
+  if (text.length === 0) return 'mhm';
+
+  const QUESTION_RE = /\b(what|where|when|who|how|why|which|can you|could you|do you|is there|are there)\b/;
+  if (QUESTION_RE.test(text)) return 'let_me_check';
+
+  const clauseBoundaries = (text.match(/[.!?,;:]/g) ?? []).length;
+  if (text.length > 60 || clauseBoundaries >= 2) return 'let_me_think';
+
+  const URGENCY_RE = /\b(urgent|asap|right away|immediately|emergency|as soon as)\b/;
+  if (URGENCY_RE.test(text)) return 'okay_moment';
+
+  const CLOSURE_RE = /\b(thanks|thank you|got it|understood|perfect|great|sounds good|okay|alright)\b/;
+  if (CLOSURE_RE.test(text)) return 'got_it';
+
+  if (text.length < 15) return 'mhm';
+
+  // Round-robin fallback
+  const chosen = RR_FILLERS[_rrCursor % RR_FILLERS.length];
+  _rrCursor++;
+  return chosen;
+}

--- a/libraries/typescript/src/providers/gemini-cascade.ts
+++ b/libraries/typescript/src/providers/gemini-cascade.ts
@@ -1,0 +1,550 @@
+/**
+ * Gemini Cascade realtime adapter.
+ *
+ * STT+brain leg: Gemini Live (TEXT modality) — audio in, text tokens out.
+ * Voice leg: Gemini TTS (generateContentStream) — text chunks → PCM L16 24kHz.
+ * Playback: CascadePlaybackMachine drives one ~20 ms tick loop.
+ *
+ * The adapter SELF-TRIGGERS the latency-mask layer from the Live message
+ * stream (the StreamHandler only knows the generic adapter interface):
+ *   - caller turn-end (ACTIVITY_END / inputTranscription.finished) → play a
+ *     pre-synth filler clip while Live+TTS compute the real reply;
+ *   - caller mid-turn partials → optional short backchannel ("mhm"/"right");
+ *   - firstMessage → play the pre-synth intro clip instantly (no Live round-trip).
+ *
+ * Clips are synthesised ONCE per process+voice into a module-level cache
+ * (never per call, never blocking connect) so an always-on line stays instant.
+ *
+ * CRITICAL: Live is TEXT modality — no speechConfig, no outputAudioTranscription
+ * (both broke setupComplete in the spike). setupComplete gates _ready; pre-setup
+ * turns are silently dropped (prod incident 2026-06-18).
+ *
+ * Install peer dep:  npm install @google/genai
+ */
+
+import { getLogger } from '../logger';
+import { sanitizeGeminiSchema } from './google-llm';
+import { mulawToPcm16, pcm16ToMulaw, StatefulResampler } from '../audio/transcoding';
+import {
+  CascadePlaybackMachine,
+  splitTtsChunk,
+  selectFiller,
+  type FillerKey,
+} from './gemini-cascade-playback';
+
+const CARRIER_SR = 8000;
+const LIVE_INPUT_SR = 16000;
+const TTS_OUTPUT_SR = 24000;
+const MULAW_FRAME = 160;
+const INBOUND_GAIN = 2;
+const CONNECT_TIMEOUT_MS = 8000;
+const BACKCHANNEL_COOLDOWN_MS = 4000;
+
+type ClipKey = FillerKey | 'intro' | 'bc_mhm' | 'bc_right' | 'bc_aha';
+type BackchannelKey = 'bc_mhm' | 'bc_right' | 'bc_aha';
+
+/** Texts for pre-synthesised clips, keyed by clip name. */
+const CLIP_TEXTS: Record<ClipKey, string> = {
+  intro: "Hi, this is Ashley over at Patter. Thanks for calling in. So — what are you building these days?",
+  mhm: "Mhm.", got_it: "Got it.", sure_one_sec: "Sure, one sec.",
+  let_me_check: "Let me check that for you.",
+  let_me_think: "Right, let me think about that for a second.",
+  okay_moment: "Okay, give me just a moment.",
+  bc_mhm: "Mhm.", bc_right: "Right.", bc_aha: "Aha, interesting.",
+};
+
+const BACKCHANNEL_PIVOT_RE =
+  /\b(actually|so basically|the thing is|what happened|i should mention|to be honest)\b/;
+
+/**
+ * Process+voice-scoped clip cache. Clips are identical across calls for a given
+ * voice, so synthesise each once and share. Keyed by `${voice}::${text}`.
+ */
+const clipCache = new Map<string, Buffer[]>();
+const clipInFlight = new Map<string, Promise<Buffer[]>>();
+
+/** Callback signature for events emitted by {@link GeminiCascadeAdapter}. */
+export type GeminiCascadeEventHandler = (
+  type:
+    | 'audio' | 'transcript_input' | 'transcript_output'
+    | 'function_call' | 'speech_started' | 'response_done' | 'error',
+  data: unknown,
+) => void | Promise<void>;
+
+/** Constructor options (mirrors GeminiLiveAdapter shape). */
+export interface GeminiCascadeAdapterOptions {
+  model?: string;
+  voice?: string;
+  instructions?: string;
+  language?: string;
+  tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+  inputSampleRate?: number;
+  temperature?: number;
+  ttsModel?: string;
+}
+
+/** Realtime adapter for Gemini Cascade (Live STT + Gemini TTS). */
+export class GeminiCascadeAdapter {
+  private readonly apiKey: string;
+  private readonly liveModel: string;
+  private readonly ttsModel: string;
+  private readonly voice: string;
+  private readonly instructions: string;
+  private readonly temperature: number;
+  private readonly tools?: Array<{ name: string; description: string; parameters: Record<string, unknown> }>;
+
+  private client: unknown = null;
+  private liveSession: unknown = null;
+  /** Serial chain — Live messages processed in arrival order. */
+  private recvChain: Promise<void> = Promise.resolve();
+  /** Serial chain — TTS chunks synthesised and enqueued in text order. */
+  private ttsChain: Promise<void> = Promise.resolve();
+  private pendingToolCalls = new Map<string, string>();
+  private handlers: GeminiCascadeEventHandler[] = [];
+  private running = false;
+  private _readyResolve: (() => void) | null = null;
+  private readonly _ready: Promise<void>;
+
+  private inboundResampler: StatefulResampler | null = null;
+
+  private readonly playback: CascadePlaybackMachine;
+  private pendingText = '';
+
+  // Caller-turn tracking → drives filler/backchannel timing.
+  private callerTurnInput = '';
+  private fillerArmed = false;
+  private bcCursor = 0;
+  private lastBackchannelAt = new Map<string, number>();
+  private lastAnyBcAt = 0;
+
+  // Intro clip playback (deferred until the first onEvent handler is attached,
+  // so the very first frames are not dropped before the carrier path is wired).
+  private pendingIntro = false;
+  private introStarted = false;
+
+  constructor(apiKey: string, options: GeminiCascadeAdapterOptions = {}) {
+    this.apiKey = apiKey;
+    this.liveModel = options.model ?? 'gemini-3.1-flash-live-preview';
+    this.ttsModel = options.ttsModel ?? 'gemini-3.1-flash-tts-preview';
+    this.voice = options.voice ?? 'Kore';
+    this.instructions = options.instructions ?? '';
+    this.temperature = options.temperature ?? 0.8;
+    this.tools = options.tools;
+    this._ready = new Promise<void>((res) => { this._readyResolve = res; });
+    this.playback = new CascadePlaybackMachine({
+      onFrame: (f) => { void this.emit('audio', f); },
+    });
+  }
+
+  async connect(): Promise<void> {
+    await this.ensureClient();
+
+    const config = this.buildLiveConfig();
+    const liveApi = (this.client as { live?: { connect?: (a: unknown) => Promise<unknown> } }).live;
+    if (!liveApi?.connect) throw new Error('@google/genai: live.connect unavailable');
+
+    this.liveSession = await liveApi.connect({
+      model: this.liveModel,
+      config,
+      callbacks: {
+        onopen: () => getLogger().debug('Gemini Cascade: socket open, awaiting setupComplete'),
+        onmessage: (msg: unknown) => {
+          this.recvChain = this.recvChain
+            .then(() => this.handleLiveMessage(msg))
+            .catch((e) => getLogger().error(`Gemini Cascade msg error: ${String(e)}`));
+        },
+        onerror: (e: unknown) => { void this.emit('error', e); },
+        onclose: () => { this.running = false; },
+      },
+    });
+    this.running = true;
+
+    try {
+      await Promise.race([
+        this._ready,
+        new Promise<never>((_, rej) =>
+          setTimeout(() => rej(new Error('Gemini Cascade: session ready timeout')), CONNECT_TIMEOUT_MS),
+        ),
+      ]);
+    } catch (err) {
+      await this.close();
+      throw err;
+    }
+
+    // Start the playout loop and warm the clip cache in the BACKGROUND — never
+    // block connect() (a caller waiting on clip synthesis = dead air at pickup).
+    this.playback.start();
+    void this.ensureClips();
+  }
+
+  /**
+   * Pre-warm the clip cache out of band (e.g. at server boot) so the first
+   * caller hears an instant intro/fillers. Safe to call without a Live session.
+   */
+  async prewarm(): Promise<void> {
+    await this.ensureClient();
+    await this.ensureClips();
+  }
+
+  sendAudio(mulaw8k: Buffer): void {
+    if (!this.liveSession || !this.running) return;
+    const pcm = this.transcodeInbound(mulaw8k);
+    if (pcm.length === 0) return;
+    const result = (this.liveSession as { sendRealtimeInput?: (a: unknown) => unknown })
+      .sendRealtimeInput?.({
+        audio: { data: pcm.toString('base64'), mimeType: `audio/pcm;rate=${LIVE_INPUT_SR}` },
+      });
+    if (result instanceof Promise) {
+      void result.catch((e) => getLogger().warn(`Gemini Cascade sendAudio: ${String(e)}`));
+    }
+  }
+
+  /**
+   * The greeting. Plays the pre-synth intro clip instantly instead of routing
+   * the firstMessage through Live→TTS (which would add seconds). The clip is
+   * enqueued when the first onEvent handler attaches (see {@link onEvent}) so
+   * no frames are emitted before the carrier path is wired.
+   */
+  async sendFirstMessage(text: string): Promise<void> {
+    await this.getClip('intro'); // ensure ready (cache hit after warm)
+    this.pendingIntro = true;
+    this.maybeStartIntro();
+    // Prime Live history with the spoken greeting so the model knows it already
+    // opened the call and responds to the caller instead of greeting again.
+    if (this.liveSession && text) {
+      try {
+        await (this.liveSession as { sendClientContent?: (a: unknown) => Promise<void> })
+          .sendClientContent?.({ turns: [{ role: 'model', parts: [{ text }] }], turnComplete: true });
+      } catch (e) {
+        getLogger().warn(`Gemini Cascade prime greeting: ${String(e)}`);
+      }
+    }
+  }
+
+  /** Legacy entry point — also used for greeting on older call paths. */
+  async sendText(text: string): Promise<void> {
+    if (!this.liveSession) return;
+    await (this.liveSession as { sendClientContent?: (a: unknown) => Promise<void> })
+      .sendClientContent?.({ turns: { role: 'user', parts: [{ text }] }, turnComplete: true });
+  }
+
+  async sendFunctionResult(callId: string, result: string): Promise<void> {
+    if (!this.liveSession) return;
+    const name = this.pendingToolCalls.get(callId) ?? callId;
+    this.pendingToolCalls.delete(callId);
+    await (this.liveSession as { sendToolResponse?: (a: unknown) => Promise<void> })
+      .sendToolResponse?.({
+        functionResponses: [{ id: callId, name, response: { result } }],
+      });
+  }
+
+  cancelResponse(): void {
+    getLogger().debug('Gemini Cascade: cancelResponse is implicit via VAD');
+  }
+
+  onEvent(handler: GeminiCascadeEventHandler): void {
+    this.handlers.push(handler);
+    this.maybeStartIntro(); // first handler attached → safe to play the intro
+  }
+
+  async close(): Promise<void> {
+    this.running = false;
+    this.playback.stop();
+    const sess = this.liveSession as { close?: () => Promise<void> | void } | null;
+    if (sess) {
+      try { await sess.close?.(); } catch { /* ignore */ }
+      this.liveSession = null;
+    }
+    this.client = null;
+    await this.recvChain.catch(() => undefined);
+    await this.ttsChain.catch(() => undefined);
+    this.recvChain = Promise.resolve();
+    this.ttsChain = Promise.resolve();
+    this.pendingToolCalls.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Live message handling — self-triggers fillers/backchannels/intro
+  // ---------------------------------------------------------------------------
+
+  private async handleLiveMessage(response: unknown): Promise<void> {
+    const r = response as {
+      setupComplete?: unknown;
+      serverContent?: {
+        modelTurn?: { parts?: Array<{ text?: string }> };
+        inputTranscription?: { text?: string; finished?: boolean };
+        turnComplete?: boolean;
+        interrupted?: boolean;
+      };
+      voiceActivity?: { voiceActivityType?: string };
+      goAway?: { timeLeft?: string };
+      toolCall?: { functionCalls?: Array<{ id?: string; name?: string; args?: unknown }> };
+      toolCallCancellation?: { ids?: string[] };
+    };
+
+    if (r.setupComplete) { this._readyResolve?.(); this._readyResolve = null; }
+
+    const sc = r.serverContent;
+    if (sc) {
+      for (const part of sc.modelTurn?.parts ?? []) {
+        if (part.text) {
+          await this.emit('transcript_output', part.text);
+          this.pendingText += part.text;
+          this.drainText(false);
+        }
+      }
+      const it = sc.inputTranscription;
+      if (it?.text) {
+        await this.emit('transcript_input', it.text);
+        this.callerTurnInput += it.text;
+        this.fillerArmed = true;
+        if (!it.finished) this.maybeBackchannel();
+      }
+      if (it?.finished) this.fireFiller();
+      if (sc.turnComplete) { this.drainText(true); await this.emit('response_done', null); }
+      if (sc.interrupted) { this.onBargeIn(); }
+    }
+
+    const vat = r.voiceActivity?.voiceActivityType;
+    if (vat === 'ACTIVITY_START') { this.onBargeIn(); }
+    else if (vat === 'ACTIVITY_END') { this.fireFiller(); }
+
+    if (r.goAway) {
+      getLogger().warn(`Gemini Cascade goAway — ends in ${r.goAway.timeLeft ?? 'unknown'}`);
+      await this.close();
+    }
+
+    for (const fn of r.toolCall?.functionCalls ?? []) {
+      const callId = fn.id ?? ''; const fnName = fn.name ?? '';
+      if (callId && fnName) this.pendingToolCalls.set(callId, fnName);
+      const args = fn.args ?? {};
+      await this.emit('function_call', {
+        call_id: callId, name: fnName,
+        arguments: typeof args === 'string' ? args : JSON.stringify(args),
+      });
+    }
+
+    for (const id of r.toolCallCancellation?.ids ?? []) this.pendingToolCalls.delete(id);
+  }
+
+  /** Caller started/resumed speaking → barge-in: stop playout, reset turn. */
+  private onBargeIn(): void {
+    this.playback.interrupt();
+    this.callerTurnInput = '';
+    this.fillerArmed = true;
+    void this.emit('speech_started', null);
+  }
+
+  /** Caller turn ended → play a contextual filler while Live+TTS compute. */
+  private fireFiller(): void {
+    if (!this.fillerArmed) return;
+    this.fillerArmed = false;
+    const key = selectFiller(this.callerTurnInput);
+    this.callerTurnInput = '';
+    this.playback.startFiller(this.cachedFrames(key));
+  }
+
+  /** Optional short backchannel while the caller is mid-utterance. */
+  private maybeBackchannel(): void {
+    if (this.playback.currentState !== 'IDLE') return;
+    const key = this.pickBackchannel(this.callerTurnInput);
+    const now = Date.now();
+    if (now - (this.lastBackchannelAt.get(key) ?? 0) < BACKCHANNEL_COOLDOWN_MS) return;
+    if (now - this.lastAnyBcAt < BACKCHANNEL_COOLDOWN_MS) return;
+    const frames = this.cachedFrames(key);
+    if (frames.length === 0) return;
+    this.lastBackchannelAt.set(key, now);
+    this.lastAnyBcAt = now;
+    for (const f of frames) void this.emit('audio', f);
+  }
+
+  private pickBackchannel(text: string): BackchannelKey {
+    if (BACKCHANNEL_PIVOT_RE.test(text.toLowerCase())) return 'bc_aha';
+    this.bcCursor++;
+    return this.bcCursor % 2 === 0 ? 'bc_mhm' : 'bc_right';
+  }
+
+  /** Enqueue the pre-synth intro once: pending + a handler attached + ready. */
+  private maybeStartIntro(): void {
+    if (this.introStarted || !this.pendingIntro || this.handlers.length === 0) return;
+    const frames = this.cachedFrames('intro');
+    if (frames.length === 0) return; // not synth'd yet; retry on next attach/getClip
+    this.introStarted = true;
+    this.pendingIntro = false;
+    this.playback.enqueueTtsFrames(frames, true);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: TTS pipeline
+  // ---------------------------------------------------------------------------
+
+  private drainText(flush: boolean): void {
+    let rem = this.pendingText;
+    for (;;) {
+      const [chunk, rest] = splitTtsChunk(rem, flush);
+      if (chunk === null) break;
+      const t = chunk.trim();
+      if (t.length > 0) {
+        this.ttsChain = this.ttsChain.then(() => this.synthAndEnqueue(t));
+      }
+      if (rest === rem) break; // no progress
+      rem = rest;
+      if (flush && rest.trim().length === 0) break;
+    }
+    this.pendingText = rem;
+    if (flush) this.ttsChain = this.ttsChain.then(() => { this.playback.markTtsComplete(); });
+  }
+
+  private async synthAndEnqueue(text: string): Promise<void> {
+    const frames = await this.callTts(text);
+    if (frames.length > 0) this.playback.enqueueTtsFrames(frames, false);
+  }
+
+  private async callTts(text: string): Promise<Buffer[]> {
+    const ai = this.client as {
+      models?: { generateContentStream?: (a: unknown) => Promise<AsyncIterable<unknown>> };
+    };
+    if (!ai?.models?.generateContentStream) return [];
+    // Each TTS call needs its own outbound resampler pair: chunks are
+    // independent synthesis requests, and sharing phase state across them would
+    // corrupt the boundary. Filler/intro clips are pre-synth at 8 kHz already.
+    const r24to16 = new StatefulResampler({ srcRate: TTS_OUTPUT_SR, dstRate: 16000 });
+    const r16to8 = new StatefulResampler({ srcRate: 16000, dstRate: CARRIER_SR });
+    const stream = await ai.models.generateContentStream({
+      model: this.ttsModel,
+      contents: [{ role: 'user', parts: [{ text }] }],
+      config: {
+        responseModalities: ['AUDIO'],
+        speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: this.voice } } },
+      },
+    });
+    const frames: Buffer[] = [];
+    let carry = Buffer.alloc(0);
+    for await (const chunk of stream) {
+      const c = chunk as { candidates?: Array<{ content?: { parts?: Array<{ inlineData?: { data?: string } }> } }> };
+      const data = c.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+      if (!data) continue;
+      const pcm24 = Buffer.from(data, 'base64');
+      if (pcm24.length === 0) continue;
+      const pcm8 = r16to8.process(r24to16.process(pcm24));
+      if (pcm8.length === 0) continue;
+      const mulaw = pcm16ToMulaw(pcm8);
+      carry = Buffer.concat([carry, mulaw]);
+      let off = 0;
+      for (; off + MULAW_FRAME <= carry.length; off += MULAW_FRAME) {
+        frames.push(Buffer.from(carry.subarray(off, off + MULAW_FRAME)));
+      }
+      carry = Buffer.from(carry.subarray(off));
+    }
+    if (carry.length > 0) {
+      const pad = Buffer.alloc(MULAW_FRAME, 0xff);
+      carry.copy(pad, 0);
+      frames.push(pad);
+    }
+    return frames;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: clip cache (process+voice scoped)
+  // ---------------------------------------------------------------------------
+
+  private clipCacheKey(text: string): string { return `${this.voice}::${text}`; }
+
+  private cachedFrames(key: ClipKey): Buffer[] {
+    return clipCache.get(this.clipCacheKey(CLIP_TEXTS[key])) ?? [];
+  }
+
+  private async getClip(key: ClipKey): Promise<Buffer[]> {
+    const text = CLIP_TEXTS[key];
+    const ck = this.clipCacheKey(text);
+    const cached = clipCache.get(ck);
+    if (cached) return cached;
+    let inflight = clipInFlight.get(ck);
+    if (!inflight) {
+      inflight = this.callTts(text)
+        .then((frames) => { clipCache.set(ck, frames); clipInFlight.delete(ck); return frames; })
+        .catch((e) => {
+          clipInFlight.delete(ck);
+          getLogger().warn(`Gemini Cascade: clip "${key}" failed: ${String(e)}`);
+          return [];
+        });
+      clipInFlight.set(ck, inflight);
+    }
+    return inflight;
+  }
+
+  private async ensureClips(): Promise<void> {
+    await Promise.all((Object.keys(CLIP_TEXTS) as ClipKey[]).map((k) => this.getClip(k)));
+    this.maybeStartIntro(); // intro may have been pending while it synthesised
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let genai: { GoogleGenAI: new (a: { apiKey: string }) => unknown };
+    try {
+      genai = (await import('@google/genai')) as typeof genai;
+    } catch {
+      throw new Error(
+        'Gemini Cascade requires "@google/genai". Install: npm install @google/genai',
+      );
+    }
+    this.client = new genai.GoogleGenAI({ apiKey: this.apiKey });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: audio transcoding (inbound caller leg)
+  // ---------------------------------------------------------------------------
+
+  private transcodeInbound(mulaw8k: Buffer): Buffer {
+    const pcm8 = mulawToPcm16(mulaw8k);
+    if (pcm8.length === 0) return Buffer.alloc(0);
+    const boosted = Buffer.allocUnsafe(pcm8.length);
+    for (let i = 0; i < pcm8.length / 2; i++) {
+      const raw = pcm8.readInt16LE(i * 2) * INBOUND_GAIN;
+      boosted.writeInt16LE(Math.max(-32768, Math.min(32767, raw)), i * 2);
+    }
+    if (!this.inboundResampler) {
+      this.inboundResampler = new StatefulResampler({ srcRate: CARRIER_SR, dstRate: LIVE_INPUT_SR });
+    }
+    return this.inboundResampler.process(boosted);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Live config builder
+  // ---------------------------------------------------------------------------
+
+  private buildLiveConfig(): Record<string, unknown> {
+    const config: Record<string, unknown> = {
+      responseModalities: ['TEXT'],
+      inputAudioTranscription: {},
+      enableAffectiveDialog: true,
+      temperature: this.temperature,
+    };
+    if (this.instructions) config.systemInstruction = { parts: [{ text: this.instructions }] };
+    if (this.tools?.length) {
+      config.tools = [{
+        functionDeclarations: this.tools.map((t) => ({
+          name: t.name, description: t.description,
+          parameters: sanitizeGeminiSchema(t.parameters),
+        })),
+      }];
+    }
+    return config;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: event emission
+  // ---------------------------------------------------------------------------
+
+  private async emit(
+    type: 'audio' | 'transcript_input' | 'transcript_output' |
+      'function_call' | 'speech_started' | 'response_done' | 'error',
+    data: unknown,
+  ): Promise<void> {
+    for (const h of this.handlers) {
+      try { await h(type, data); } catch (e) {
+        getLogger().error(`Gemini Cascade handler threw: ${String(e)}`);
+      }
+    }
+  }
+}

--- a/libraries/typescript/src/providers/gemini-live.ts
+++ b/libraries/typescript/src/providers/gemini-live.ts
@@ -18,9 +18,64 @@
 
 import { getLogger } from '../logger';
 import { sanitizeGeminiSchema } from './google-llm';
+import {
+  mulawToPcm16,
+  pcm16ToMulaw,
+  StatefulResampler,
+} from '../audio/transcoding';
 
 export const GEMINI_DEFAULT_INPUT_SR = 16000;
 export const GEMINI_DEFAULT_OUTPUT_SR = 24000;
+
+/**
+ * The carrier (Twilio/Telnyx media stream) always speaks mulaw 8 kHz in
+ * BOTH directions. Gemini Live wants PCM-16-LE at 16 kHz in and emits
+ * PCM-16-LE at 24 kHz out, so the adapter transcodes on both legs.
+ */
+const CARRIER_SAMPLE_RATE = 8000;
+
+/** One mulaw frame Twilio's playout scheduler expects: 20 ms @ 8 kHz = 160 bytes. */
+const MULAW_FRAME_BYTES = 160;
+
+/**
+ * Inbound gain boost applied to telephony audio before sending to Gemini.
+ *
+ * Telephony-band audio decoded from mulaw sits around ±8000 amplitude
+ * (~-12 dB peak), well below the ±16000-±24000 of the studio audio that
+ * server-side VAD is calibrated against — so without a boost inbound
+ * utterances can sit under the speech threshold. 2× brings the level into
+ * the expected band; samples are clamped to ±32767 to avoid Int16 wrap.
+ * Mirrors the OpenAI Realtime 2 adapter. Tunable for the live phone test.
+ */
+const INBOUND_GAIN = 2;
+
+/** Model ID for Gemini 3.1 Flash Live (audio-in → audio-out, emotion-aware). */
+export const GEMINI_LIVE_3_1_FLASH_PREVIEW = 'gemini-3.1-flash-live-preview';
+
+/**
+ * Whether a Gemini Live model must be addressed on the `v1alpha` channel.
+ *
+ * Native-audio OUTPUT models are served only on `v1alpha`. That family is two
+ * naming shapes:
+ *   - the dated `*-native-audio-*` previews (e.g.
+ *     `gemini-2.5-flash-native-audio-preview-09-2025`), and
+ *   - the `*-flash-live-preview` line (e.g. `gemini-3.1-flash-live-preview`),
+ *     which the Live API capabilities guide also classifies as a native-audio
+ *     output model even though the id lacks the literal "native-audio" token.
+ *
+ * The id-substring heuristic used to miss the second shape, so
+ * `gemini-3.1-flash-live-preview` fell through to the SDK default (`v1beta`),
+ * where the model is not served — the socket opened but the server never sent
+ * `setupComplete`, and `connect()` died with "session ready timeout" (dead
+ * air on the call). Matching the live-preview family here selects `v1alpha`
+ * so the handshake completes. The retired half-cascade `*-flash-live-NNN`
+ * models (v1beta) are intentionally NOT matched.
+ *
+ * Callers can always override via the explicit `apiVersion` option.
+ */
+export function geminiRequiresV1Alpha(model: string): boolean {
+  return model.includes('native-audio') || /flash-live-preview/.test(model);
+}
 
 /** Callback signature for events emitted by {@link GeminiLiveAdapter}. */
 export type GeminiLiveEventHandler = (
@@ -44,10 +99,42 @@ interface GeminiLiveOptions {
   inputSampleRate?: number;
   outputSampleRate?: number;
   temperature?: number;
+  /** Gemini API version. Auto-detected from model name when omitted:
+   *  'native-audio' models → 'v1alpha'; all others → SDK default (v1beta). */
+  apiVersion?: string;
+  /** Native-audio affective dialog: model adapts tone to caller emotion. */
+  affectiveDialog?: boolean;
+  /** Native-audio proactive audio: model decides when to respond. */
+  proactiveAudio?: boolean;
+  /**
+   * Enable the model's "thinking" (chain-of-thought). Default OFF for voice
+   * (`thinkingBudget: 0`) — the reasoning otherwise leaks into the spoken
+   * audio and transcript. `true` re-enables dynamic thinking.
+   */
+  thinking?: boolean;
+  /**
+   * Explicit thinking budget (tokens). Overrides {@link thinking}. `0` = off,
+   * `-1` = dynamic (model decides). Omit to use the thinking-derived default.
+   */
+  thinkingBudget?: number;
+  /** Server-side VAD tuning (noise rejection + reply latency). */
+  vad?: {
+    startSensitivity?: 'HIGH' | 'LOW';
+    endSensitivity?: 'HIGH' | 'LOW';
+    silenceDurationMs?: number;
+    prefixPaddingMs?: number;
+  };
+  /**
+   * Max time (ms) to wait for `setupComplete` before failing connect with the
+   * actionable error. Internal/testability knob — defaults to 8000 (same
+   * budget as the OpenAI Realtime parked-connection guard).
+   */
+  connectTimeoutMs?: number;
 }
 
 /** Realtime adapter for Google's Gemini Live native-audio API. */
 export class GeminiLiveAdapter {
+  private readonly options: GeminiLiveOptions;
   private readonly model: string;
   private readonly voice: string;
   private readonly instructions: string;
@@ -57,12 +144,54 @@ export class GeminiLiveAdapter {
   /** Output sample rate — exposed so callers can configure downstream transcoding. */
   readonly outputSampleRate: number;
   private readonly temperature: number;
+  private readonly affectiveDialog: boolean;
+  private readonly proactiveAudio: boolean;
+  private readonly vad: GeminiLiveOptions['vad'];
+  private readonly thinking: boolean;
+  private readonly thinkingBudget?: number;
+  /** API version actually used for the Live session — surfaced in connect errors. */
+  private resolvedApiVersion = 'v1beta (SDK default)';
 
   private client: unknown = null;
   private session: unknown = null;
-  private receiveLoop: Promise<void> | null = null;
+  /**
+   * Serial chain that processes inbound server messages in arrival order.
+   * The JS @google/genai SDK delivers each message through the synchronous
+   * `callbacks.onmessage` handler; we hand off to the async
+   * {@link handleServerMessage} via this chain so audio frames reach the
+   * carrier in order (out-of-order emits would scramble playback).
+   */
+  private recvChain: Promise<void> = Promise.resolve();
+
+  /**
+   * Inbound (carrier → Gemini) upsampler: mulaw 8 kHz is decoded to PCM-16
+   * @ 8 kHz then resampled up to the model input rate (16 kHz default).
+   * Created lazily per session.
+   *
+   * CRITICAL: this MUST be a separate instance from the outbound chain
+   * below. The resamplers carry phase/history state across chunks; sharing
+   * one across both directions interleaves unrelated sample streams and
+   * corrupts the audio on BOTH legs.
+   */
+  private inboundResampler: StatefulResampler | null = null;
+
+  /**
+   * Outbound (Gemini → carrier) downsampling chain: PCM-16 @ 24 kHz →
+   * 16 kHz → 8 kHz. We chain through 16 kHz instead of a direct 24k→8k
+   * decimation because the 16k→8k stage applies a 5-tap FIR anti-alias
+   * filter; without it, model voice energy above 4 kHz aliases down into
+   * the audible band and is heard as raspy/scratchy speech. Created lazily
+   * per session, separate from the inbound resampler (see above).
+   */
+  private outboundResampler24To16: StatefulResampler | null = null;
+  private outboundResampler16To8: StatefulResampler | null = null;
   private handlers: GeminiLiveEventHandler[] = [];
   private running = false;
+  private _readyResolve: (() => void) | null = null;
+  private _readyReject: ((err: Error) => void) | null = null;
+  /** Whether the connect-time ready gate has settled (setupComplete OR failed). */
+  private setupSettled = false;
+  private readonly _ready: Promise<void>;
   /**
    * Tracks call_id -> function name so tool responses can be sent back with
    * the correct `name` field (Gemini expects the original function name,
@@ -74,6 +203,7 @@ export class GeminiLiveAdapter {
     private readonly apiKey: string,
     options: GeminiLiveOptions = {},
   ) {
+    this.options = options;
     // gemini-2.0-flash-exp was experimental preview retired Dec 2024.
     // gemini-live-2.5-flash-preview was shut down Dec 9, 2025.
     // Current native-audio live model (v1alpha-only) is the dated preview.
@@ -87,6 +217,31 @@ export class GeminiLiveAdapter {
     this.inputSampleRate = options.inputSampleRate ?? GEMINI_DEFAULT_INPUT_SR;
     this.outputSampleRate = options.outputSampleRate ?? GEMINI_DEFAULT_OUTPUT_SR;
     this.temperature = options.temperature ?? 0.8;
+    this.affectiveDialog = options.affectiveDialog ?? false;
+    this.proactiveAudio = options.proactiveAudio ?? false;
+    this.vad = options.vad;
+    this.thinking = options.thinking ?? false;
+    this.thinkingBudget = options.thinkingBudget;
+    this._ready = new Promise<void>((resolve, reject) => {
+      this._readyResolve = resolve;
+      this._readyReject = reject;
+    });
+  }
+
+  /**
+   * Resolve the Gemini `thinkingConfig`.
+   *
+   * Voice default is thinking OFF (`{ thinkingBudget: 0 }`): the model's
+   * chain-of-thought must never reach the caller's ear or transcript. An
+   * explicit `thinkingBudget` wins (0 = off, -1 = dynamic, N = fixed).
+   * Otherwise `thinking: true` re-enables dynamic thinking (`-1`), and the
+   * default stays at `0`.
+   */
+  private resolveThinkingConfig(): { thinkingBudget: number } {
+    if (this.thinkingBudget !== undefined) {
+      return { thinkingBudget: this.thinkingBudget };
+    }
+    return { thinkingBudget: this.thinking ? -1 : 0 };
   }
 
   /** Lazily import @google/genai, open a Live session, and start the receive loop. */
@@ -108,10 +263,19 @@ export class GeminiLiveAdapter {
     }
 
     const { GoogleGenAI } = genaiModule;
-    // Native-audio models require the v1alpha endpoint — see module doc.
+    // Auto-detect the Live API version. Native-audio output models — the dated
+    // `*-native-audio-*` previews AND the `*-flash-live-preview` family
+    // (gemini-3.1-flash-live-preview) — are served only on v1alpha; all others
+    // use the SDK default (v1beta). An explicit option always wins. Selecting
+    // the wrong channel makes the server never send `setupComplete`, surfacing
+    // as the "session ready timeout" dead-air bug (see geminiRequiresV1Alpha).
+    const apiVersion =
+      this.options?.apiVersion ??
+      (geminiRequiresV1Alpha(this.model) ? 'v1alpha' : undefined);
+    this.resolvedApiVersion = apiVersion ?? 'v1beta (SDK default)';
     this.client = new GoogleGenAI({
       apiKey: this.apiKey,
-      httpOptions: { apiVersion: 'v1alpha' },
+      ...(apiVersion ? { httpOptions: { apiVersion } } : {}),
     });
 
     const config: Record<string, unknown> = {
@@ -121,12 +285,40 @@ export class GeminiLiveAdapter {
         languageCode: this.language,
       },
       temperature: this.temperature,
+      // Disable the model's "thinking" by default for voice. Gemini 3.x
+      // native-audio models otherwise emit their chain-of-thought before the
+      // reply, in BOTH the spoken audio and the transcript (e.g. "**Initiating
+      // Call Protocol**…"). `{ thinkingBudget: 0 }` turns it off; the opt-in
+      // `thinking` / `thinkingBudget` options re-enable it. This is the
+      // proactive half of the fix; handleServerMessage also defensively drops
+      // any `thought` parts the model returns regardless.
+      thinkingConfig: this.resolveThinkingConfig(),
       // Without these, native-audio sessions produced NO user transcript
       // ever and no assistant transcript in AUDIO modality — logs/history/
       // metrics got nothing for Gemini Live calls. Mirrors Python.
       inputAudioTranscription: {},
       outputAudioTranscription: {},
     };
+    // Native-audio humanization knobs (opt-in). enableAffectiveDialog makes the
+    // model adapt prosody to the caller's emotion; proactivity lets it choose
+    // when to speak. Both are v1alpha native-audio features.
+    if (this.affectiveDialog) {
+      config.enableAffectiveDialog = true;
+    }
+    if (this.proactiveAudio) {
+      config.proactivity = { proactiveAudio: true };
+    }
+    // Tune turn-taking: LOW start sensitivity ignores background noise/breathing
+    // (a known demo-line issue), HIGH end sensitivity + a shorter silence window
+    // cut the wait before the model replies.
+    if (this.vad) {
+      const ad: Record<string, unknown> = {};
+      if (this.vad.startSensitivity) ad.startOfSpeechSensitivity = `START_SENSITIVITY_${this.vad.startSensitivity}`;
+      if (this.vad.endSensitivity) ad.endOfSpeechSensitivity = `END_SENSITIVITY_${this.vad.endSensitivity}`;
+      if (this.vad.silenceDurationMs !== undefined) ad.silenceDurationMs = this.vad.silenceDurationMs;
+      if (this.vad.prefixPaddingMs !== undefined) ad.prefixPaddingMs = this.vad.prefixPaddingMs;
+      config.realtimeInputConfig = { automaticActivityDetection: ad };
+    }
     if (this.instructions) {
       config.systemInstruction = { parts: [{ text: this.instructions }] };
     }
@@ -145,34 +337,177 @@ export class GeminiLiveAdapter {
       ];
     }
 
-    // The genai live surface is organised as client.live.connect({model, config, callbacks?}).
-    // Some SDK versions return a Session-like object with send*/receive methods.
+    // The genai live surface is client.live.connect({model, config, callbacks}).
+    // CRITICAL: the JS SDK delivers server messages ONLY through
+    // `callbacks.onmessage` — the returned Session has NO async-iterable
+    // `receive()` (that is the Python SDK's shape). Registering callbacks
+    // here is what makes the agent hear/speak; without them the session
+    // connects but no audio ever flows (prod incident 2026-06-18: 20 s of
+    // silence). See https://ai.google.dev/gemini-api/docs/live (JS sample).
     const liveApi = (this.client as { live?: { connect?: (args: unknown) => Promise<unknown> } }).live;
     if (!liveApi?.connect) {
       throw new Error('@google/genai: live.connect is not available in this version');
     }
-    this.session = await liveApi.connect({ model: this.model, config });
+    this.session = await liveApi.connect({
+      model: this.model,
+      config,
+      callbacks: {
+        onopen: () => {
+          // Socket open — but the session is NOT yet configured. Do NOT
+          // unblock connect() here: the caller would send its firstMessage /
+          // first audio before the server processes setup, and the server
+          // SILENTLY DROPS pre-setup turns. The ready-gate resolves on
+          // `setupComplete` instead (handled in handleServerMessage).
+          getLogger().debug('Gemini Live: socket open, awaiting setupComplete');
+        },
+        onmessage: (msg: unknown) => {
+          // Process strictly in arrival order (audio frame ordering matters).
+          this.recvChain = this.recvChain
+            .then(() => this.handleServerMessage(msg))
+            .catch((err) =>
+              getLogger().error(`Gemini Live message handler error: ${String(err)}`),
+            );
+        },
+        onerror: (e: unknown) => {
+          // A transport/server error BEFORE setupComplete is a connect
+          // failure — fail the ready gate fast (with the underlying cause)
+          // instead of waiting out the timeout. After setup it is a
+          // mid-session error and flows to consumers as usual.
+          if (this.failReadyGate(e)) return;
+          void this.emit('error', e);
+        },
+        onclose: () => {
+          this.running = false;
+          // Socket closed before the session was ever configured — surface it
+          // as a connect failure rather than a silent dead-air timeout.
+          this.failReadyGate(new Error('Gemini Live socket closed before setupComplete'));
+        },
+      },
+    });
     this.running = true;
 
-    // Start the receive pump.
-    this.receiveLoop = this.pumpReceive().catch((err) => {
-      getLogger().error(`Gemini Live receive loop error: ${String(err)}`);
-    });
+    // Block until the session is open (onopen) before returning, so the caller
+    // does not stream audio into a half-open session.
+    // Timeout after 8 s — same budget as the parked-connection guard in
+    // OpenAIRealtime2Adapter so callers get consistent failure behaviour.
+    //
+    // On timeout, tear down the already-opened session BEFORE rejecting —
+    // otherwise a slow handshake leaks a live WebSocket for the rest of the
+    // process.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const connectTimeoutMs = this.options.connectTimeoutMs ?? 8000;
+    try {
+      await Promise.race([
+        this._ready,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error(`session ready timeout (no setupComplete within ${connectTimeoutMs}ms)`),
+              ),
+            connectTimeoutMs,
+          );
+        }),
+      ]);
+    } catch (err) {
+      await this.close();
+      // Surface a CLEAR, actionable error instead of a bare timeout: a dropped
+      // call with dead air is almost always a wrong model id, the wrong
+      // apiVersion for the model, or bad/insufficient credentials — name all
+      // three so the operator can act. NEVER include transcript / thought text.
+      throw this.buildConnectError(err);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
-  /** Send a PCM audio chunk to Gemini as base64 inline data. */
-  sendAudio(pcm: Buffer): void {
+  /**
+   * Fail the connect-time ready gate exactly once. Returns `true` when this
+   * call settled the gate (i.e. it was still pending), so the caller can stop
+   * treating the event as a mid-session error. No-op after `setupComplete`.
+   */
+  private failReadyGate(cause: unknown): boolean {
+    if (this.setupSettled) return false;
+    this.setupSettled = true;
+    const reject = this._readyReject;
+    this._readyResolve = null;
+    this._readyReject = null;
+    reject?.(cause instanceof Error ? cause : new Error(String(cause)));
+    return true;
+  }
+
+  /**
+   * Wrap a connect failure (timeout or pre-setup error) with actionable
+   * guidance. Mentions the model id + resolved apiVersion and the three
+   * common root causes. Contains no PII (no transcript / thought text).
+   */
+  private buildConnectError(err: unknown): Error {
+    const base = err instanceof Error ? err.message : String(err);
+    return new Error(
+      `Gemini Live failed to start a session for model "${this.model}" ` +
+        `(apiVersion: ${this.resolvedApiVersion}): ${base}. Likely causes: ` +
+        `(1) the model id is wrong or not enabled for this API key; ` +
+        `(2) the model needs a different apiVersion — native-audio / ` +
+        `*-flash-live-preview models are served on v1alpha (pass ` +
+        `{ apiVersion: 'v1alpha' } to override); ` +
+        `(3) the API key is invalid or lacks Gemini Live access.`,
+    );
+  }
+
+  /**
+   * Send a chunk of carrier audio to Gemini.
+   *
+   * The carrier always hands us mulaw 8 kHz (Twilio/Telnyx media stream),
+   * but Gemini Live only accepts PCM-16-LE at its configured input rate
+   * (16 kHz default). We transcode mulaw8 → PCM16 → upsample to
+   * `inputSampleRate` and send it as base64 inline data with the matching
+   * MIME rate. Without this conversion the model receives mulaw bytes
+   * labelled as 16 kHz PCM and the call is pure static.
+   */
+  sendAudio(mulaw8: Buffer): void {
     if (!this.session || !this.running) return;
+    const pcmIn = this.transcodeInboundMulaw8ToPcm(mulaw8);
+    if (pcmIn.length === 0) return; // resampler warmup — nothing to send yet
     const mime = `audio/pcm;rate=${this.inputSampleRate}`;
     const sess = this.session as { sendRealtimeInput?: (args: unknown) => unknown };
     const result = sess.sendRealtimeInput?.({
-      media: { data: pcm.toString('base64'), mimeType: mime },
+      audio: { data: pcmIn.toString('base64'), mimeType: mime },
     });
     if (result instanceof Promise) {
       void result.catch((err) =>
         getLogger().warn(`Gemini Live sendAudio error: ${String(err)}`),
       );
     }
+  }
+
+  /**
+   * mulaw 8 kHz Buffer → PCM-16-LE Buffer at `inputSampleRate`.
+   *
+   * Decodes mulaw to PCM-16 @ 8 kHz, applies the {@link INBOUND_GAIN} boost
+   * (clamped to Int16), then upsamples 8 kHz → `inputSampleRate` via the
+   * lazily-created inbound {@link StatefulResampler} so chunk boundaries do
+   * not click. When `inputSampleRate === 8000` no resampling is needed.
+   */
+  private transcodeInboundMulaw8ToPcm(mulaw8: Buffer): Buffer {
+    const pcm8 = mulawToPcm16(mulaw8);
+    const sampleCount = pcm8.length / 2;
+    if (sampleCount === 0) return Buffer.alloc(0);
+
+    const boosted = Buffer.allocUnsafe(pcm8.length);
+    for (let i = 0; i < sampleCount; i++) {
+      const raw = pcm8.readInt16LE(i * 2) * INBOUND_GAIN;
+      boosted.writeInt16LE(Math.max(-32768, Math.min(32767, raw)), i * 2);
+    }
+
+    if (this.inputSampleRate === CARRIER_SAMPLE_RATE) return boosted;
+
+    if (!this.inboundResampler) {
+      this.inboundResampler = new StatefulResampler({
+        srcRate: CARRIER_SAMPLE_RATE,
+        dstRate: this.inputSampleRate,
+      });
+    }
+    return this.inboundResampler.process(boosted);
   }
 
   /** Send a text turn to Gemini and mark the turn complete. */
@@ -232,85 +567,138 @@ export class GeminiLiveAdapter {
     }
   }
 
-  private async pumpReceive(): Promise<void> {
-    if (!this.session) return;
-    const sess = this.session as { receive?: () => AsyncIterable<unknown> };
-    if (typeof sess.receive !== 'function') {
-      getLogger().warn('Gemini Live: session.receive() not available');
-      return;
-    }
-    try {
-      for await (const response of sess.receive()) {
-        if (!this.running) break;
-        const r = response as {
-          serverContent?: {
-            modelTurn?: {
-              parts?: Array<{
-                inlineData?: { data?: string };
-                text?: string;
-              }>;
-            };
-            inputTranscription?: { text?: string };
-            outputTranscription?: { text?: string };
-            turnComplete?: boolean;
-            interrupted?: boolean;
-          };
-          goAway?: { timeLeft?: string };
-          toolCall?: {
-            functionCalls?: Array<{
-              id?: string;
-              name?: string;
-              args?: Record<string, unknown> | string;
-            }>;
-          };
+  /**
+   * Handle one server message delivered via {@link connect}'s
+   * `callbacks.onmessage`. Dispatches audio (transcoded PCM →
+   * mulaw 8 kHz, split into 20 ms frames), transcripts, turn-complete /
+   * interrupted signals, goAway warnings, and tool calls. Invoked in arrival
+   * order through {@link recvChain}.
+   */
+  private async handleServerMessage(response: unknown): Promise<void> {
+    const r = response as {
+      setupComplete?: unknown;
+      serverContent?: {
+        modelTurn?: {
+          parts?: Array<{
+            inlineData?: { data?: string };
+            text?: string;
+            /** Gemini marks chain-of-thought parts with thought=true. */
+            thought?: boolean;
+          }>;
         };
+        inputTranscription?: { text?: string };
+        outputTranscription?: { text?: string };
+        turnComplete?: boolean;
+        interrupted?: boolean;
+      };
+      goAway?: { timeLeft?: string };
+      toolCall?: {
+        functionCalls?: Array<{
+          id?: string;
+          name?: string;
+          args?: Record<string, unknown> | string;
+        }>;
+      };
+    };
 
-        const sc = r.serverContent;
-        if (sc) {
-          for (const part of sc.modelTurn?.parts ?? []) {
-            if (part.inlineData?.data) {
-              await this.emit('audio', Buffer.from(part.inlineData.data, 'base64'));
-            }
-            if (part.text) await this.emit('transcript_output', part.text);
-          }
-          if (sc.inputTranscription?.text) {
-            await this.emit('transcript_input', sc.inputTranscription.text);
-          }
-          if (sc.outputTranscription?.text) {
-            await this.emit('transcript_output', sc.outputTranscription.text);
-          }
-          if (sc.turnComplete) await this.emit('response_done', null);
-          if (sc.interrupted) await this.emit('speech_started', null);
-        }
-        if (r.goAway) {
-          // Gemini Live hard-caps session length (~10-15 min without
-          // resumption); goAway is the only warning before the server drops
-          // the connection. Surface it loudly.
-          getLogger().warn(
-            `Gemini Live goAway received — session ends in ${r.goAway.timeLeft ?? 'unknown'}`,
-          );
-        }
-        if (r.toolCall) {
-          for (const fn of r.toolCall.functionCalls ?? []) {
-            const args = fn.args ?? {};
-            const callId = fn.id ?? '';
-            const fnName = fn.name ?? '';
-            if (callId && fnName) {
-              this.pendingToolCalls.set(callId, fnName);
-            }
-            await this.emit('function_call', {
-              call_id: callId,
-              name: fnName,
-              arguments: typeof args === 'string' ? args : JSON.stringify(args),
-            });
-          }
-        }
-      }
-    } catch (err) {
-      if (this.running) await this.emit('error', err);
-    } finally {
-      this.running = false;
+    // setupComplete is the definitive "session configured" signal; unblock
+    // connect() here too in case the onopen callback was missed.
+    if (r.setupComplete) {
+      this.setupSettled = true;
+      this._readyResolve?.();
+      this._readyResolve = null;
+      this._readyReject = null;
     }
+
+    const sc = r.serverContent;
+    if (sc) {
+      for (const part of sc.modelTurn?.parts ?? []) {
+        // DEFENSIVE: never surface the model's chain-of-thought to the caller.
+        // A voice agent must not speak OR transcribe its private reasoning.
+        // Gemini marks thought parts with `thought: true`; drop them from BOTH
+        // the audio stream and the text transcript. This backstops the
+        // `thinkingBudget: 0` default — even if a thought slips through, it
+        // never reaches the carrier. We deliberately do NOT log the thought
+        // text (no PII).
+        if (part.thought === true) continue;
+        if (part.inlineData?.data) {
+          // Gemini emits PCM-16-LE at outputSampleRate (24 kHz default);
+          // the carrier wants mulaw 8 kHz in 20 ms (160-byte) frames.
+          // Transcode + split so Twilio's playout scheduler does not
+          // stall on an oversized frame.
+          const mulaw = this.transcodeOutboundPcmToMulaw8(part.inlineData.data);
+          for (let off = 0; off < mulaw.length; off += MULAW_FRAME_BYTES) {
+            const frame = mulaw.subarray(off, Math.min(off + MULAW_FRAME_BYTES, mulaw.length));
+            await this.emit('audio', Buffer.from(frame));
+          }
+        }
+        if (part.text) await this.emit('transcript_output', part.text);
+      }
+      if (sc.inputTranscription?.text) {
+        await this.emit('transcript_input', sc.inputTranscription.text);
+      }
+      if (sc.outputTranscription?.text) {
+        await this.emit('transcript_output', sc.outputTranscription.text);
+      }
+      if (sc.turnComplete) await this.emit('response_done', null);
+      if (sc.interrupted) await this.emit('speech_started', null);
+    }
+    if (r.goAway) {
+      // Gemini Live hard-caps session length (~10-15 min without
+      // resumption); goAway is the only warning before the server drops
+      // the connection. Surface it loudly.
+      getLogger().warn(
+        `Gemini Live goAway received — session ends in ${r.goAway.timeLeft ?? 'unknown'}`,
+      );
+    }
+    if (r.toolCall) {
+      for (const fn of r.toolCall.functionCalls ?? []) {
+        const args = fn.args ?? {};
+        const callId = fn.id ?? '';
+        const fnName = fn.name ?? '';
+        if (callId && fnName) {
+          this.pendingToolCalls.set(callId, fnName);
+        }
+        await this.emit('function_call', {
+          call_id: callId,
+          name: fnName,
+          arguments: typeof args === 'string' ? args : JSON.stringify(args),
+        });
+      }
+    }
+  }
+
+  /**
+   * Base64 PCM-16-LE @ `outputSampleRate` → mulaw 8 kHz Buffer.
+   *
+   * Resamples `outputSampleRate` → 16 kHz → 8 kHz through the lazily-created
+   * outbound resampler pair (anti-aliased 16k→8k stage), then mulaw-encodes.
+   * The resamplers are reused across all deltas in the session so phase
+   * carries across chunk boundaries and there are no per-frame clicks. When
+   * `outputSampleRate === 8000` only the mulaw encode is needed.
+   */
+  private transcodeOutboundPcmToMulaw8(deltaB64: string): Buffer {
+    const pcm = Buffer.from(deltaB64, 'base64');
+    if (pcm.length === 0) return Buffer.alloc(0);
+
+    if (this.outputSampleRate === CARRIER_SAMPLE_RATE) {
+      return pcm16ToMulaw(pcm);
+    }
+
+    if (!this.outboundResampler24To16) {
+      this.outboundResampler24To16 = new StatefulResampler({
+        srcRate: this.outputSampleRate,
+        dstRate: 16000,
+      });
+      this.outboundResampler16To8 = new StatefulResampler({
+        srcRate: 16000,
+        dstRate: CARRIER_SAMPLE_RATE,
+      });
+    }
+    const pcm16 = this.outboundResampler24To16.process(pcm);
+    const pcm8 = this.outboundResampler16To8!.process(pcm16);
+    if (pcm8.length === 0) return Buffer.alloc(0);
+    return pcm16ToMulaw(pcm8);
   }
 
   /** Close the Gemini Live session and stop the receive loop. */
@@ -326,10 +714,10 @@ export class GeminiLiveAdapter {
       this.session = null;
     }
     this.client = null;
-    if (this.receiveLoop) {
-      await this.receiveLoop.catch(() => undefined);
-      this.receiveLoop = null;
-    }
+    // Drain any in-flight message handling so a closing session doesn't leave
+    // a dangling emit mid-flight.
+    await this.recvChain.catch(() => undefined);
+    this.recvChain = Promise.resolve();
     this.pendingToolCalls.clear();
   }
 }

--- a/libraries/typescript/src/providers/gemini-stt.ts
+++ b/libraries/typescript/src/providers/gemini-stt.ts
@@ -1,0 +1,181 @@
+/**
+ * Gemini multimodal STT adapter for Patter pipeline mode.
+ *
+ * Buffers inbound PCM16 (16 kHz) and, when the turn ends (`finalize()` fired
+ * by the pipeline at VAD speech-end), sends the whole utterance to Google's
+ * `gemini-2.5-flash` as audio. The model both transcribes AND reads the
+ * caller's emotional tone from how they sound, emitting:
+ *
+ *     [tone: <1-2 words>] <verbatim transcript>
+ *
+ * The tone prefix flows downstream to the LLM so the agent can mirror mood
+ * (a flat, tired caller → a gentler reply), which a words-only transcriber
+ * cannot do. Turn-based (not chunked) so tone is judged over the full
+ * utterance.
+ *
+ * Install peer dep:  npm install @google/genai
+ */
+
+import { getLogger } from '../logger';
+
+/** Patter-normalised transcript event. */
+export interface Transcript {
+  readonly text: string;
+  readonly isFinal: boolean;
+  readonly confidence: number;
+}
+
+type TranscriptCallback = (transcript: Transcript) => void;
+
+const TONE_PROMPT =
+  'You are the transcription stage of a live phone call. Transcribe the caller ' +
+  'verbatim, then judge their emotional tone from HOW they sound — energy, pace, ' +
+  'pitch — not just the words. Output exactly one line and nothing else: ' +
+  '[tone: <1-2 words>] <transcript>. If there is no intelligible speech, output an empty line.';
+
+/** Minimal PCM16-mono WAV container (Gemini accepts audio/wav inline). */
+function wrapPcmInWav(pcm: Buffer, sampleRate: number): Buffer {
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20); // PCM
+  header.writeUInt16LE(1, 22); // mono
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
+}
+
+/** Buffered multimodal STT adapter using Gemini for transcription + tone. */
+export class GeminiSTT {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey: string = 'gemini_stt';
+  private client: unknown = null;
+  private chunks: Buffer[] = [];
+  private bufferedBytes = 0;
+  private callbacks = new Set<TranscriptCallback>();
+  private running = false;
+  private pending: Promise<void>[] = [];
+  private readonly ctorArgs: unknown[];
+
+  /**
+   * @param apiKey Google Generative Language API key.
+   * @param model Multimodal model (default `gemini-2.5-flash`).
+   * @param sampleRate Inbound PCM rate from the pipeline (default 16000).
+   */
+  constructor(
+    private readonly apiKey: string,
+    private readonly model: string = 'gemini-2.5-flash',
+    private readonly sampleRate: number = 16000,
+  ) {
+    this.ctorArgs = [apiKey, model, sampleRate];
+  }
+
+  /** Per-call fresh adapter so concurrent calls never share buffers. */
+  clone(): this {
+    const Ctor = this.constructor as new (...args: unknown[]) => this;
+    return new Ctor(...this.ctorArgs);
+  }
+
+  async connect(): Promise<void> {
+    await this.ensureClient();
+    this.running = true;
+    this.chunks = [];
+    this.bufferedBytes = 0;
+  }
+
+  /** Buffer a PCM16 chunk (transcription happens at turn-end via finalize). */
+  sendAudio(pcm: Buffer): void {
+    if (!this.running || pcm.length === 0) return;
+    this.chunks.push(pcm);
+    this.bufferedBytes += pcm.length;
+  }
+
+  onTranscript(callback: TranscriptCallback): void {
+    this.callbacks.add(callback);
+  }
+
+  offTranscript(callback: TranscriptCallback): void {
+    this.callbacks.delete(callback);
+  }
+
+  /** Turn ended (VAD speech-end): transcribe the buffered utterance. */
+  finalize(): void {
+    if (this.bufferedBytes === 0) return;
+    this.track(this.transcribe(this.flush()));
+  }
+
+  async close(): Promise<void> {
+    this.running = false;
+    if (this.bufferedBytes > 0) this.track(this.transcribe(this.flush()));
+    await Promise.allSettled(this.pending);
+    this.callbacks.clear();
+  }
+
+  // ------------------------------------------------------------------ private
+
+  private flush(): Buffer {
+    const pcm = this.chunks.length === 1 ? this.chunks[0] : Buffer.concat(this.chunks, this.bufferedBytes);
+    this.chunks = [];
+    this.bufferedBytes = 0;
+    return pcm;
+  }
+
+  private track(promise: Promise<void>): void {
+    const wrapped = promise.finally(() => {
+      const idx = this.pending.indexOf(wrapped);
+      if (idx !== -1) this.pending.splice(idx, 1);
+    });
+    this.pending.push(wrapped);
+  }
+
+  private async transcribe(pcm: Buffer): Promise<void> {
+    try {
+      await this.ensureClient();
+      const ai = this.client as {
+        models?: { generateContent?: (a: unknown) => Promise<unknown> };
+      };
+      if (!ai?.models?.generateContent) return;
+      const wav = wrapPcmInWav(pcm, this.sampleRate);
+      const res = await ai.models.generateContent({
+        model: this.model,
+        contents: [{ role: 'user', parts: [
+          { text: TONE_PROMPT },
+          { inlineData: { mimeType: 'audio/wav', data: wav.toString('base64') } },
+        ] }],
+        config: { temperature: 0.2, maxOutputTokens: 300 },
+      });
+      const text = extractText(res).trim();
+      if (!text) return;
+      const transcript: Transcript = { text, isFinal: true, confidence: 1.0 };
+      for (const cb of this.callbacks) cb(transcript);
+    } catch (err) {
+      getLogger().error(`GeminiSTT transcribe error: ${String(err)}`);
+    }
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let genai: { GoogleGenAI: new (a: { apiKey: string }) => unknown };
+    try {
+      genai = (await import('@google/genai')) as typeof genai;
+    } catch {
+      throw new Error('GeminiSTT requires "@google/genai". Install: npm install @google/genai');
+    }
+    this.client = new genai.GoogleGenAI({ apiKey: this.apiKey });
+  }
+}
+
+function extractText(res: unknown): string {
+  const direct = (res as { text?: string }).text;
+  if (typeof direct === 'string') return direct;
+  const parts = (res as { candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> })
+    .candidates?.[0]?.content?.parts;
+  return (parts ?? []).map((p) => p.text ?? '').join('');
+}

--- a/libraries/typescript/src/providers/gemini-tts.ts
+++ b/libraries/typescript/src/providers/gemini-tts.ts
@@ -1,0 +1,106 @@
+/**
+ * Gemini TTS adapter for Patter pipeline mode.
+ *
+ * Wraps Google's `gemini-3.1-flash-tts-preview` speech model via
+ * `@google/genai` `generateContentStream`. Streams PCM L16 24 kHz and
+ * resamples to the pipeline's expected 16 kHz (the stream handler does the
+ * final 16k→8k mulaw step for the carrier).
+ *
+ * Inline square-bracket delivery tags in the text — `[warm]`, `[short pause]`,
+ * `[sigh]` — are honoured by the model and shape prosody rather than being
+ * spoken, which is why the demo persona annotates its replies.
+ *
+ * Install peer dep:  npm install @google/genai
+ */
+
+import { getLogger } from '../logger';
+import { StatefulResampler } from '../audio/transcoding';
+
+/** Native Gemini TTS output rate. */
+const TTS_SOURCE_SR = 24000;
+/** Default pipeline-facing rate (stream handler resamples 16k→8k for Twilio). */
+const DEFAULT_TARGET_SR = 16000;
+
+/** Streaming Gemini TTS adapter (Kore voice by default). */
+export class GeminiTTS {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey: string = 'gemini_tts';
+  private client: unknown = null;
+
+  /**
+   * @param apiKey Google Generative Language API key.
+   * @param voice Prebuilt TTS voice name (default `Kore`).
+   * @param model TTS model (default `gemini-3.1-flash-tts-preview`).
+   * @param targetSampleRate Output PCM rate: 8000 or 16000 (default 16000).
+   */
+  constructor(
+    private readonly apiKey: string,
+    private readonly voice: string = 'Kore',
+    private readonly model: string = 'gemini-3.1-flash-tts-preview',
+    private readonly targetSampleRate: number = DEFAULT_TARGET_SR,
+  ) {
+    if (targetSampleRate !== 8000 && targetSampleRate !== 16000) {
+      throw new Error('GeminiTTS: targetSampleRate must be 8000 or 16000');
+    }
+  }
+
+  /** Force the model connection warm so the first real synth is fast. */
+  async warmup(): Promise<void> {
+    try {
+      // Drain a tiny synthesis to establish the HTTP/2 connection + model warm.
+      for await (const _ of this.synthesizeStream('Hello.')) { /* discard */ }
+    } catch (e) {
+      getLogger().warn(`GeminiTTS warmup: ${String(e)}`);
+    }
+  }
+
+  /** Synthesise `text` and yield PCM16-LE chunks at {@link targetSampleRate}. */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    if (!text.trim()) return;
+    await this.ensureClient();
+    const ai = this.client as {
+      models?: { generateContentStream?: (a: unknown) => Promise<AsyncIterable<unknown>> };
+    };
+    if (!ai?.models?.generateContentStream) {
+      throw new Error('GeminiTTS: @google/genai generateContentStream unavailable');
+    }
+    // Fresh resampler per call: each synthesis is an independent PCM stream, so
+    // carrying phase state across calls would corrupt the first frames.
+    const resampler =
+      this.targetSampleRate === TTS_SOURCE_SR
+        ? null
+        : new StatefulResampler({ srcRate: TTS_SOURCE_SR, dstRate: this.targetSampleRate });
+
+    const stream = await ai.models.generateContentStream({
+      model: this.model,
+      contents: [{ role: 'user', parts: [{ text }] }],
+      config: {
+        responseModalities: ['AUDIO'],
+        speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: this.voice } } },
+      },
+    });
+
+    for await (const chunk of stream) {
+      const c = chunk as {
+        candidates?: Array<{ content?: { parts?: Array<{ inlineData?: { data?: string } }> } }>;
+      };
+      const data = c.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+      if (!data) continue;
+      const pcm24 = Buffer.from(data, 'base64');
+      if (pcm24.length === 0) continue;
+      const out = resampler ? resampler.process(pcm24) : pcm24;
+      if (out.length > 0) yield out;
+    }
+  }
+
+  private async ensureClient(): Promise<void> {
+    if (this.client) return;
+    let genai: { GoogleGenAI: new (a: { apiKey: string }) => unknown };
+    try {
+      genai = (await import('@google/genai')) as typeof genai;
+    } catch {
+      throw new Error('GeminiTTS requires "@google/genai". Install: npm install @google/genai');
+    }
+    this.client = new genai.GoogleGenAI({ apiKey: this.apiKey });
+  }
+}

--- a/libraries/typescript/src/providers/google-llm.ts
+++ b/libraries/typescript/src/providers/google-llm.ts
@@ -300,7 +300,23 @@ export function sanitizeGeminiSchema(schema: unknown): unknown {
   if (schema !== null && typeof schema === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
-      if (GEMINI_SCHEMA_KEYS.has(k)) out[k] = sanitizeGeminiSchema(v);
+      if (!GEMINI_SCHEMA_KEYS.has(k)) continue;
+      if (k === 'properties' && v !== null && typeof v === 'object' && !Array.isArray(v)) {
+        // `properties` is a map of PROPERTY NAME -> subschema. The names are
+        // arbitrary (query, to, subject, …) — NOT schema keywords — so they
+        // must be preserved; only each subschema VALUE gets sanitized.
+        // Recursing generically here strips the names (they aren't in
+        // GEMINI_SCHEMA_KEYS), leaving `properties: {}` while `required` still
+        // lists them — which makes Gemini Live reject setup with WS close 1007
+        // "required[0]: property is not defined" (prod 2026-06-18 silence).
+        const props: Record<string, unknown> = {};
+        for (const [propName, propSchema] of Object.entries(v as Record<string, unknown>)) {
+          props[propName] = sanitizeGeminiSchema(propSchema);
+        }
+        out[k] = props;
+      } else {
+        out[k] = sanitizeGeminiSchema(v);
+      }
     }
     return out;
   }

--- a/libraries/typescript/src/providers/inworld-realtime.ts
+++ b/libraries/typescript/src/providers/inworld-realtime.ts
@@ -1,0 +1,178 @@
+/**
+ * Inworld Realtime WebSocket adapter.
+ *
+ * Inworld's Realtime API is OpenAI-Realtime-compatible — Inworld documents an
+ * "OpenAI Realtime migration" path where the event schema, session structure,
+ * and client/server events match OpenAI's Realtime API, so migrating is
+ * "swap the endpoint and auth credentials". This adapter therefore SUBCLASSES
+ * {@link OpenAIRealtimeAdapter} and overrides ONLY the transport:
+ *   - the WebSocket endpoint (`wss://api.inworld.ai/v1/realtime`), and
+ *   - the auth header (`Authorization: Bearer <Inworld Realtime key>`).
+ *
+ * Everything else — the `session.created` → `session.update` → `session.updated`
+ * handshake, audio-delta dispatch, barge-in / truncate semantics, heartbeat,
+ * tool calling, `sendText` / `sendFirstMessage` / `sendReassurance` — is
+ * inherited unchanged. Because it `extends OpenAIRealtimeAdapter`, every
+ * `instanceof OpenAIRealtimeAdapter` feature gate in the stream handler fires
+ * for Inworld too, with no per-provider branches.
+ *
+ * Audio: defaults to `g711_ulaw` pass-through (the Twilio/Telnyx carrier wire
+ * format), matching OpenAI's v1-beta Realtime shape that Inworld mirrors. If a
+ * given Inworld deployment only accepts PCM, pass `audioFormat: 'pcm16'` or
+ * front this with a transcode — see the TODO below.
+ *
+ * TODO(inworld-spec): the exact production wire details (whether Inworld
+ * requires a session-scoped `?key=<session-id>` obtained from a prior REST
+ * call, and the accepted audio formats) are not fully public. The defaults
+ * here are the OpenAI-compatible ones; override `baseUrl` / `audioFormat` per
+ * your Inworld account, or extend `connect()` with the session-create step.
+ */
+
+import WebSocket from 'ws';
+import { getLogger } from '../logger';
+import {
+  OpenAIRealtimeAdapter,
+  OpenAIRealtimeAudioFormat,
+  type OpenAIRealtimeOptions,
+} from './openai-realtime';
+
+/** Default Inworld Realtime WebSocket base URL (no query string). */
+export const INWORLD_REALTIME_WS_URL = 'wss://api.inworld.ai/v1/realtime';
+/** Default model id — override with the exact id from the Inworld dashboard. */
+export const INWORLD_REALTIME_DEFAULT_MODEL = 'inworld-realtime';
+/** Default voice — an Inworld voice name (mirrors the Inworld TTS default). */
+export const INWORLD_REALTIME_DEFAULT_VOICE = 'Ashley';
+
+/** Constructor options for {@link InworldRealtimeAdapter}. */
+export interface InworldRealtimeAdapterOptions extends OpenAIRealtimeOptions {
+  /** Realtime model id (passed through as `?model=`). */
+  model?: string;
+  /** Voice name. */
+  voice?: string;
+  /** System prompt / instructions. */
+  instructions?: string;
+  /** Tool/function declarations advertised to the model. */
+  tools?: Array<{ name: string; description: string; parameters: Record<string, unknown>; strict?: boolean }>;
+  /** Override the WebSocket base URL (no query string). */
+  baseUrl?: string;
+  /** Wire audio format. Defaults to `g711_ulaw` (carrier-native pass-through). */
+  audioFormat?: OpenAIRealtimeAudioFormat;
+}
+
+/** Realtime WebSocket adapter for Inworld's OpenAI-compatible Realtime API. */
+export class InworldRealtimeAdapter extends OpenAIRealtimeAdapter {
+  /** Stable pricing/dashboard key — matches the Inworld TTS provider key. */
+  static readonly providerKey = 'inworld';
+  private readonly wsBase: string;
+
+  constructor(apiKey: string, opts: InworldRealtimeAdapterOptions = {}) {
+    super(
+      apiKey,
+      opts.model ?? INWORLD_REALTIME_DEFAULT_MODEL,
+      opts.voice ?? INWORLD_REALTIME_DEFAULT_VOICE,
+      opts.instructions ?? '',
+      opts.tools,
+      opts.audioFormat ?? OpenAIRealtimeAudioFormat.G711_ULAW,
+      // The base reads only the OpenAIRealtimeOptions keys off this object;
+      // the Inworld-specific extras (model/voice/baseUrl/...) are ignored there.
+      opts,
+    );
+    this.wsBase = (opts.baseUrl ?? INWORLD_REALTIME_WS_URL).replace(/\/+$/, '');
+  }
+
+  /**
+   * Open the Inworld Realtime WebSocket and apply the (OpenAI-compatible)
+   * session configuration. Same `session.created` → `session.update` →
+   * `session.updated` handshake the base v1 adapter performs, but against the
+   * Inworld endpoint with a Bearer Realtime key. An explicit `error` frame
+   * during setup is surfaced immediately so the caller gets an actionable
+   * reason instead of a 15 s timeout.
+   */
+  async connect(): Promise<void> {
+    const url = `${this.wsBase}?model=${encodeURIComponent(this.model)}`;
+    this.ws = new WebSocket(url, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      let sessionCreated = false;
+      let settled = false;
+      const ws = this.ws!;
+
+      const onSetupMessage = (raw: Buffer | string): void => {
+        if (settled) return;
+        let msg: { type: string; error?: { message?: string } };
+        try {
+          msg = JSON.parse(raw.toString()) as { type: string; error?: { message?: string } };
+        } catch (e) {
+          getLogger().warn(`Inworld Realtime: failed to parse message: ${String(e)}`);
+          return;
+        }
+        if (msg.type === 'session.created' && !sessionCreated) {
+          sessionCreated = true;
+          ws.send(JSON.stringify({ type: 'session.update', session: this.buildSessionConfig() }));
+        } else if (msg.type === 'session.updated') {
+          cleanup();
+          resolve();
+        } else if (msg.type === 'error') {
+          cleanup();
+          try { ws.close(); } catch { /* ignore */ }
+          reject(
+            new Error(
+              `Inworld Realtime setup error: ${msg.error?.message ?? JSON.stringify(msg)}`,
+            ),
+          );
+        }
+      };
+
+      const onSetupError = (err: Error): void => {
+        cleanup();
+        try { ws.close(); } catch { /* ignore */ }
+        reject(err);
+      };
+
+      const cleanup = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        ws.off('message', onSetupMessage);
+        ws.off('error', onSetupError);
+      };
+
+      const timer = setTimeout(() => {
+        cleanup();
+        try { ws.close(); } catch { /* ignore */ }
+        reject(
+          new Error(
+            `Inworld Realtime connect timeout (no session.updated within 15s) for ` +
+              `model "${this.model}" at ${this.wsBase}. Check the model id, the ` +
+              `Realtime API key, and the endpoint.`,
+          ),
+        );
+      }, 15000);
+
+      ws.on('message', onSetupMessage);
+      ws.on('error', onSetupError);
+    });
+
+    this.armHeartbeatAndListener();
+  }
+
+  /**
+   * No-op warmup. The base {@link OpenAIRealtimeAdapter.warmup} opens a socket
+   * to OpenAI's endpoint, which is wrong for an Inworld key. Inworld is not
+   * wired into the prewarm pipeline, so we simply skip warmup here.
+   */
+  override async warmup(): Promise<void> {
+    getLogger().debug('Inworld Realtime: warmup is a no-op (not parked)');
+  }
+
+  /**
+   * Parking is not supported for Inworld — the base implementation targets the
+   * OpenAI endpoint. Reject so any caller treats it as a cache miss and falls
+   * through to the cold {@link connect} path.
+   */
+  override async openParkedConnection(): Promise<WebSocket> {
+    throw new Error('Inworld Realtime: openParkedConnection is not supported');
+  }
+}

--- a/libraries/typescript/src/providers/openai-realtime.ts
+++ b/libraries/typescript/src/providers/openai-realtime.ts
@@ -340,8 +340,12 @@ export class OpenAIRealtimeAdapter {
    * Build the production session.update body. Mirrors the body sent
    * inside `connect()` so warmup can apply identical configuration to
    * the upstream session and prime it without billing.
+   *
+   * `protected` (not `private`) so OpenAI-Realtime-compatible subclasses can
+   * reuse the v1 session shape verbatim — e.g. `InworldRealtimeAdapter`, which
+   * speaks the same wire protocol against a different endpoint.
    */
-  private buildSessionConfig(): Record<string, unknown> {
+  protected buildSessionConfig(): Record<string, unknown> {
     const config: Record<string, unknown> = {
       input_audio_format: this.audioFormat,
       output_audio_format: this.audioFormat,

--- a/libraries/typescript/src/providers/plivo-adapter.ts
+++ b/libraries/typescript/src/providers/plivo-adapter.ts
@@ -76,7 +76,12 @@ export function plivoInboundCustomParams(
   const headers = parsePlivoExtraHeaders(extraHeadersRaw);
   const params: Record<string, string> = { caller, callee };
   for (const [k, v] of Object.entries(headers)) {
-    if (k !== 'X-PH-caller' && k !== 'X-PH-callee') params[k] = v;
+    // Drop internal markers: caller/callee are re-exposed above under canonical
+    // keys, and X-Patter-Stream-Token is the SECURITY (#204) stream-auth token —
+    // it must never leak into prompt template variables.
+    if (k !== 'X-PH-caller' && k !== 'X-PH-callee' && k !== 'X-Patter-Stream-Token') {
+      params[k] = v;
+    }
   }
   return params;
 }

--- a/libraries/typescript/src/providers/sarvam-tts.ts
+++ b/libraries/typescript/src/providers/sarvam-tts.ts
@@ -1,0 +1,327 @@
+/**
+ * Sarvam AI TTS provider — HTTP REST one-shot endpoint.
+ *
+ * Sarvam's Bulbul models synthesize 11 Indian languages (Hindi, Bengali,
+ * Tamil, Telugu, Kannada, Malayalam, Marathi, Gujarati, Punjabi, Odia, Indian
+ * English) plus code-mixed text. This adapter targets the REST one-shot
+ * endpoint `POST https://api.sarvam.ai/text-to-speech`, which returns JSON of
+ * the form `{ "request_id": "...", "audios": ["<base64-audio>", ...] }` — we
+ * base64-decode each entry and yield the raw bytes, mapping cleanly onto
+ * Patter's `synthesize(text)` contract with no vendor SDK (just `fetch`).
+ *
+ * Sarvam also exposes a WebSocket streaming transport
+ * (`wss://api.sarvam.ai/text-to-speech/ws?model=<model_id>`); like the Cartesia
+ * adapter we use the REST path because it already meets Patter's TTFB target
+ * while keeping the provider dependency-free.
+ *
+ * Auth is an API subscription key sent as the `api-subscription-key` HTTP
+ * header (no Bearer scheme), read from the constructor or `SARVAM_API_KEY`.
+ *
+ * The default config requests `codec="linear16"` (raw PCM_S16LE) at 16 kHz so
+ * the output drops straight into the Patter pipeline without transcoding. For
+ * real phone calls the {@link SarvamTTS.forTwilio} / {@link SarvamTTS.forTelnyx}
+ * factories request `mulaw` @ 8 kHz directly (Sarvam supports both natively),
+ * so the pipeline takes the carrier-native passthrough path.
+ *
+ * Bulbul v3 is the default model (latest; 35+ voices; `temperature` control).
+ * Pass `model: "bulbul:v2"` for the legacy generation, which instead exposes
+ * `pitch` / `loudness` / `enablePreprocessing`. Those controls are gated
+ * per-model so we never send fields the selected model rejects.
+ */
+
+import { getLogger } from '../logger';
+
+const SARVAM_BASE_URL = 'https://api.sarvam.ai/text-to-speech';
+
+/** Sarvam Bulbul TTS model families. */
+export const SarvamModel = {
+  BULBUL_V3: 'bulbul:v3',
+  BULBUL_V2: 'bulbul:v2',
+} as const;
+export type SarvamModel = (typeof SarvamModel)[keyof typeof SarvamModel];
+
+/**
+ * `output_audio_codec` values accepted by the REST API. `LINEAR16` is
+ * headerless 16-bit PCM (the pipeline-friendly default); `MULAW` / `ALAW` are
+ * G.711 telephony codecs.
+ */
+export const SarvamAudioCodec = {
+  WAV: 'wav',
+  MP3: 'mp3',
+  LINEAR16: 'linear16',
+  MULAW: 'mulaw',
+  ALAW: 'alaw',
+  OPUS: 'opus',
+  FLAC: 'flac',
+  AAC: 'aac',
+} as const;
+export type SarvamAudioCodec = (typeof SarvamAudioCodec)[keyof typeof SarvamAudioCodec];
+
+/**
+ * BCP-47 `target_language_code` values for the 11 supported languages. Note
+ * Sarvam uses `od-IN` for Odia (not the more common `or-IN`).
+ */
+export const SarvamLanguage = {
+  HINDI: 'hi-IN',
+  BENGALI: 'bn-IN',
+  TAMIL: 'ta-IN',
+  TELUGU: 'te-IN',
+  KANNADA: 'kn-IN',
+  MALAYALAM: 'ml-IN',
+  MARATHI: 'mr-IN',
+  GUJARATI: 'gu-IN',
+  PUNJABI: 'pa-IN',
+  ODIA: 'od-IN',
+  ENGLISH: 'en-IN',
+} as const;
+export type SarvamLanguage = (typeof SarvamLanguage)[keyof typeof SarvamLanguage];
+
+/** Output sample rates (Hz) accepted by the REST `speech_sample_rate`. */
+export const SarvamSampleRate = {
+  HZ_8000: 8000,
+  HZ_16000: 16000,
+  HZ_22050: 22050,
+  HZ_24000: 24000,
+  HZ_32000: 32000,
+  HZ_44100: 44100,
+  HZ_48000: 48000,
+} as const;
+export type SarvamSampleRate = (typeof SarvamSampleRate)[keyof typeof SarvamSampleRate];
+
+/** Constructor options for {@link SarvamTTS}. */
+export interface SarvamTTSOptions {
+  /** Model id. Defaults to `"bulbul:v3"`. */
+  model?: SarvamModel | string;
+  /** Speaker name (lowercase). Defaults to `"shubh"` (a bulbul:v3 voice). */
+  speaker?: string;
+  /** BCP-47 language code, e.g. `"hi-IN"`, `"ta-IN"`, `"en-IN"`. Default `"en-IN"`. */
+  language?: SarvamLanguage | string;
+  /**
+   * Output audio codec. Default `linear16` (raw PCM16). Set `mulaw` with
+   * `sampleRate=8000` to emit Twilio/Telnyx wire-native μ-law directly — the
+   * pipeline then skips resampling and PCM → μ-law encoding entirely (see
+   * {@link SarvamTTS.forTwilio}).
+   */
+  codec?: SarvamAudioCodec | string;
+  /** Output sample rate in Hz. Defaults to 16000. */
+  sampleRate?: SarvamSampleRate | number;
+  /** Speaking pace multiplier (v3: 0.5–2.0, v2: 0.3–3.0; default 1.0 server-side). */
+  pace?: number;
+  /** Pitch shift (bulbul:v2 ONLY; −0.75 to 0.75). Ignored on v3. */
+  pitch?: number;
+  /** Loudness multiplier (bulbul:v2 ONLY; 0.3–3.0). Ignored on v3. */
+  loudness?: number;
+  /** Sampling temperature (bulbul:v3 ONLY; 0.01–2.0). Ignored on v2. */
+  temperature?: number;
+  /** Normalise numbers/entities (bulbul:v2 ONLY). Ignored on v3. */
+  enablePreprocessing?: boolean;
+  /** Custom pronunciation dictionary id (bulbul:v3 ONLY). Ignored on v2. */
+  dictId?: string;
+  /** Override the REST endpoint. */
+  baseUrl?: string;
+}
+
+/** Audio format declared back to the pipeline sender via {@link SarvamTTS.sourceAudioFormat}. */
+type SourceAudioFormat = { encoding: 'pcm_s16le' | 'mulaw' | 'alaw'; sampleRate: number };
+
+/** Sarvam TTS provider backed by the HTTP REST `/text-to-speech` endpoint. */
+export class SarvamTTS {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey = 'sarvam';
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly speaker: string;
+  private readonly language: string;
+  private readonly codec: string;
+  private readonly sampleRate: number;
+  private readonly pace?: number;
+  private readonly pitch?: number;
+  private readonly loudness?: number;
+  private readonly temperature?: number;
+  private readonly enablePreprocessing?: boolean;
+  private readonly dictId?: string;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, opts: SarvamTTSOptions = {}) {
+    if (!apiKey) {
+      throw new Error('Sarvam TTS: apiKey is required');
+    }
+    this.apiKey = apiKey;
+    this.model = opts.model ?? SarvamModel.BULBUL_V3;
+    this.speaker = opts.speaker ?? 'shubh';
+    this.language = opts.language ?? SarvamLanguage.ENGLISH;
+    this.codec = opts.codec ?? SarvamAudioCodec.LINEAR16;
+    this.sampleRate = opts.sampleRate ?? SarvamSampleRate.HZ_16000;
+    this.pace = opts.pace;
+    this.pitch = opts.pitch;
+    this.loudness = opts.loudness;
+    this.temperature = opts.temperature;
+    this.enablePreprocessing = opts.enablePreprocessing;
+    this.dictId = opts.dictId;
+    this.baseUrl = opts.baseUrl ?? SARVAM_BASE_URL;
+  }
+
+  /**
+   * Declare the audio format this adapter emits, so the pipeline sender can
+   * derive the correct resample ratio (or skip it for μ-law/a-law passthrough)
+   * instead of assuming a fixed 16 kHz source. See `audio/format.ts`.
+   */
+  sourceAudioFormat(): SourceAudioFormat {
+    if (this.codec === SarvamAudioCodec.MULAW) {
+      return { encoding: 'mulaw', sampleRate: this.sampleRate };
+    }
+    if (this.codec === SarvamAudioCodec.ALAW) {
+      return { encoding: 'alaw', sampleRate: this.sampleRate };
+    }
+    return { encoding: 'pcm_s16le', sampleRate: this.sampleRate };
+  }
+
+  /**
+   * Construct an instance pre-configured for Twilio Media Streams.
+   *
+   * Emits `mulaw` @ 8 kHz — exactly Twilio's wire codec — so the pipeline takes
+   * the passthrough path: zero resampling, zero PCM → μ-law encoding. Sarvam
+   * supports μ-law / 8 kHz natively, so this is a true carrier-native path.
+   */
+  static forTwilio(
+    apiKey: string,
+    options: Omit<SarvamTTSOptions, 'codec' | 'sampleRate'> = {},
+  ): SarvamTTS {
+    return new SarvamTTS(apiKey, {
+      ...options,
+      codec: SarvamAudioCodec.MULAW,
+      sampleRate: SarvamSampleRate.HZ_8000,
+    });
+  }
+
+  /**
+   * Construct an instance pre-configured for Telnyx bidirectional media.
+   *
+   * Telnyx pins the wire to PCMU/μ-law @ 8 kHz, so emitting `mulaw` @ 8 kHz
+   * flows end-to-end with zero resampling — the same passthrough win as
+   * {@link SarvamTTS.forTwilio}.
+   */
+  static forTelnyx(
+    apiKey: string,
+    options: Omit<SarvamTTSOptions, 'codec' | 'sampleRate'> = {},
+  ): SarvamTTS {
+    return new SarvamTTS(apiKey, {
+      ...options,
+      codec: SarvamAudioCodec.MULAW,
+      sampleRate: SarvamSampleRate.HZ_8000,
+    });
+  }
+
+  /** True when the configured model is the legacy `bulbul:v2`. */
+  private isV2(): boolean {
+    return this.model === SarvamModel.BULBUL_V2;
+  }
+
+  /** Build the JSON payload for the Sarvam `/text-to-speech` endpoint. */
+  private buildPayload(text: string): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      text,
+      target_language_code: this.language,
+      model: this.model,
+      speaker: this.speaker,
+      output_audio_codec: this.codec,
+      speech_sample_rate: this.sampleRate,
+    };
+
+    if (this.pace !== undefined) payload.pace = this.pace;
+
+    // Per-model controls: pitch / loudness / enable_preprocessing are
+    // bulbul:v2-only; temperature / dict_id are bulbul:v3-only. Gate them so we
+    // never POST a field the selected model rejects.
+    if (this.isV2()) {
+      if (this.pitch !== undefined) payload.pitch = this.pitch;
+      if (this.loudness !== undefined) payload.loudness = this.loudness;
+      if (this.enablePreprocessing !== undefined)
+        payload.enable_preprocessing = this.enablePreprocessing;
+    } else {
+      if (this.temperature !== undefined) payload.temperature = this.temperature;
+      if (this.dictId !== undefined) payload.dict_id = this.dictId;
+    }
+
+    return payload;
+  }
+
+  /**
+   * Pre-call HTTP warmup for the Sarvam TTS API.
+   *
+   * Issues a lightweight `GET` against the API origin so DNS, TLS, and HTTP/2
+   * are already up by the time the first `synthesizeStream()` POST lands.
+   * Best-effort: 5 s timeout, all exceptions swallowed at debug level.
+   *
+   * Billing safety: Sarvam does not document a free voice/metadata GET, so this
+   * only primes the connection against the API origin root — it never hits the
+   * synthesis endpoint, so no characters are billed. Synthesis is billed only
+   * when `POST /text-to-speech` runs with non-empty `text`.
+   */
+  async warmup(): Promise<void> {
+    try {
+      const origin = new URL(this.baseUrl).origin + '/';
+      await fetch(origin, {
+        method: 'GET',
+        headers: { 'api-subscription-key': this.apiKey },
+        signal: AbortSignal.timeout(5_000),
+      });
+    } catch (err) {
+      getLogger().debug(`Sarvam TTS warmup failed (best-effort): ${String(err)}`);
+    }
+  }
+
+  /** Synthesize text and return the concatenated audio buffer. */
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /**
+   * Synthesize text and yield decoded audio chunks. With the default
+   * `codec="linear16"` these are raw PCM_S16LE bytes at `sampleRate`. The REST
+   * endpoint returns the whole clip in one JSON response (`audios` is a list of
+   * base64 strings); we decode and yield each entry in order.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'api-subscription-key': this.apiKey,
+      },
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Sarvam TTS error ${response.status}: ${body}`);
+    }
+
+    const data = (await response.json()) as unknown;
+    for (const audioB64 of iterAudioB64(data)) {
+      const decoded = Buffer.from(audioB64, 'base64');
+      if (decoded.length > 0) yield decoded;
+    }
+  }
+}
+
+/**
+ * Extract the base64 audio strings from a Sarvam REST response. Accepts the
+ * documented `{ audios: [...] }` shape and is defensive about a single-string
+ * `audios` value. Returns `[]` for anything unexpected so the caller yields
+ * nothing rather than throwing on a malformed body.
+ */
+function iterAudioB64(data: unknown): string[] {
+  if (typeof data !== 'object' || data === null) return [];
+  const audios = (data as { audios?: unknown }).audios;
+  if (typeof audios === 'string') return audios ? [audios] : [];
+  if (Array.isArray(audios)) {
+    return audios.filter((a): a is string => typeof a === 'string' && a.length > 0);
+  }
+  return [];
+}

--- a/libraries/typescript/src/providers/soniox-stt.ts
+++ b/libraries/typescript/src/providers/soniox-stt.ts
@@ -11,8 +11,17 @@ import { getLogger } from '../logger';
 
 const SONIOX_WS_URL = 'wss://stt-rt.soniox.com/transcribe-websocket';
 
-/** Known Soniox real-time STT models. */
+/**
+ * Known Soniox real-time STT models.
+ *
+ * `STT_RT_V5` is the current default (GA 2026-06-16). It is fully
+ * API-compatible with v4 — same WebSocket URL, in-band `api_key`, request
+ * params and token-stream shape — so adopting it is a pure model-id swap.
+ * Older ids stay reachable for back-compat (Soniox auto-routes retired
+ * v4/v3 ids to v5 server-side).
+ */
 export const SonioxModel = {
+  STT_RT_V5: 'stt-rt-v5',
   STT_RT_V4: 'stt-rt-v4',
   STT_RT_V3: 'stt-rt-v3',
   STT_RT_V2: 'stt-rt-v2',
@@ -119,6 +128,17 @@ export interface SonioxSTTOptions {
   readonly enableSpeakerDiarization?: boolean;
   readonly enableLanguageIdentification?: boolean;
   readonly maxEndpointDelayMs?: number;
+  /**
+   * Optional v5 endpoint control in `[-1.0, 1.0]` (Soniox default `0.0`).
+   * Higher = more/sooner endpoints, lower = wait longer. Omitted from the
+   * config when undefined so default behaviour is unchanged.
+   */
+  readonly endpointSensitivity?: number;
+  /**
+   * Optional v5 latency-reduction aggressiveness, one of `0 | 1 | 2 | 3`
+   * (Soniox default `0`). Omitted from the config when undefined.
+   */
+  readonly endpointLatencyAdjustmentLevel?: number;
   readonly clientReferenceId?: string;
   readonly baseUrl?: string;
 }
@@ -142,6 +162,8 @@ export class SonioxSTT {
   private readonly enableSpeakerDiarization: boolean;
   private readonly enableLanguageIdentification: boolean;
   private readonly maxEndpointDelayMs: number;
+  private readonly endpointSensitivity?: number;
+  private readonly endpointLatencyAdjustmentLevel?: number;
   private readonly clientReferenceId?: string;
   private readonly baseUrl: string;
 
@@ -157,9 +179,22 @@ export class SonioxSTT {
     if (maxEndpointDelayMs < 500 || maxEndpointDelayMs > 3000) {
       throw new Error('maxEndpointDelayMs must be between 500 and 3000');
     }
+    const { endpointSensitivity, endpointLatencyAdjustmentLevel } = options;
+    if (
+      endpointSensitivity !== undefined &&
+      (endpointSensitivity < -1.0 || endpointSensitivity > 1.0)
+    ) {
+      throw new Error('endpointSensitivity must be between -1.0 and 1.0');
+    }
+    if (
+      endpointLatencyAdjustmentLevel !== undefined &&
+      ![0, 1, 2, 3].includes(endpointLatencyAdjustmentLevel)
+    ) {
+      throw new Error('endpointLatencyAdjustmentLevel must be 0, 1, 2, or 3');
+    }
 
     this.apiKey = apiKey;
-    this.model = options.model ?? SonioxModel.STT_RT_V4;
+    this.model = options.model ?? SonioxModel.STT_RT_V5;
     this.languageHints = options.languageHints;
     this.languageHintsStrict = options.languageHintsStrict ?? false;
     this.sampleRate = options.sampleRate ?? SonioxSampleRate.HZ_16000;
@@ -167,6 +202,8 @@ export class SonioxSTT {
     this.enableSpeakerDiarization = options.enableSpeakerDiarization ?? false;
     this.enableLanguageIdentification = options.enableLanguageIdentification ?? true;
     this.maxEndpointDelayMs = maxEndpointDelayMs;
+    this.endpointSensitivity = endpointSensitivity;
+    this.endpointLatencyAdjustmentLevel = endpointLatencyAdjustmentLevel;
     this.clientReferenceId = options.clientReferenceId;
     this.baseUrl = options.baseUrl ?? SONIOX_WS_URL;
   }
@@ -191,6 +228,14 @@ export class SonioxSTT {
       enable_language_identification: this.enableLanguageIdentification,
       max_endpoint_delay_ms: this.maxEndpointDelayMs,
     };
+    // v5 endpoint controls — opt-in; omitted when unset so the wire config
+    // stays byte-identical to the pre-v5 default.
+    if (this.endpointSensitivity !== undefined) {
+      config.endpoint_sensitivity = this.endpointSensitivity;
+    }
+    if (this.endpointLatencyAdjustmentLevel !== undefined) {
+      config.endpoint_latency_adjustment_level = this.endpointLatencyAdjustmentLevel;
+    }
     if (this.languageHints) {
       config.language_hints = this.languageHints;
       config.language_hints_strict = this.languageHintsStrict;

--- a/libraries/typescript/src/providers/soniox-tts.ts
+++ b/libraries/typescript/src/providers/soniox-tts.ts
@@ -1,0 +1,256 @@
+/**
+ * Soniox TTS provider — HTTP one-shot `/tts` bytes endpoint.
+ *
+ * Calls `POST https://tts-rt.soniox.com/tts`. The response is raw audio bytes
+ * whose Content-Type matches the requested `audio_format` (e.g. `audio/pcm`,
+ * `audio/wav`, `audio/mpeg`). This maps cleanly onto Patter's
+ * `synthesize(text)` contract and keeps the provider dependency-free (just
+ * `fetch`).
+ *
+ * Soniox also exposes a WebSocket streaming mode
+ * (`wss://tts-rt.soniox.com/tts-websocket`) for lower TTFB; this provider uses
+ * the REST bytes path which already maps onto Patter's streaming contract —
+ * the same trade-off `CartesiaTTS` makes versus Cartesia's WebSocket variant.
+ *
+ * Credential: Soniox TTS shares the `SONIOX_API_KEY` env var / key family with
+ * the existing Soniox STT integration (host `*.soniox.com`). REST auth is an
+ * `Authorization: Bearer <key>` header.
+ *
+ * **Telephony optimization** — the constructor default
+ * `audioFormat="pcm_s16le"` @ `sampleRate=16000` is correct for web playback,
+ * dashboard previews, and 16 kHz pipelines. For real phone calls use the
+ * carrier-specific factories instead:
+ *
+ * - {@link SonioxTTS.forTwilio} emits `pcm_mulaw` @ 8 kHz — Twilio's exact wire
+ *   codec — so the pipeline skips resampling AND PCM → μ-law encoding
+ *   (bit-clean passthrough). Soniox supports G.711 μ-law @ 8 kHz natively, so
+ *   this is true carrier-native synthesis (no downsampling).
+ * - {@link SonioxTTS.forTelnyx} emits `pcm_mulaw` @ 8 kHz. The SDK pins the
+ *   Telnyx wire to PCMU/μ-law @ 8 kHz, so this flows end-to-end with zero
+ *   resampling — same passthrough win as the Twilio factory.
+ */
+
+const SONIOX_TTS_BASE_URL = 'https://tts-rt.soniox.com/tts';
+// WebSocket streaming endpoint (documented for reference; not used by this
+// HTTP-bytes adapter).
+export const SONIOX_TTS_WS_URL = 'wss://tts-rt.soniox.com/tts-websocket';
+
+/** Soniox default voice — keeps its timbre across 60+ languages. */
+const SONIOX_DEFAULT_VOICE = 'Adrian';
+
+/** Known Soniox real-time TTS models. */
+export const SonioxTTSModel = {
+  TTS_RT_V1: 'tts-rt-v1',
+  // Deprecated alias retained for back-compat — now points at tts-rt-v1.
+  TTS_RT_V1_PREVIEW: 'tts-rt-v1-preview',
+} as const;
+export type SonioxTTSModel = (typeof SonioxTTSModel)[keyof typeof SonioxTTSModel];
+
+/**
+ * Output encodings accepted by the Soniox `audio_format` field. `PCM_MULAW` /
+ * `PCM_ALAW` @ 8 kHz are the carrier-native G.711 codecs (telephony
+ * passthrough); the rest target web/dashboard use.
+ */
+export const SonioxTTSAudioFormat = {
+  PCM_S16LE: 'pcm_s16le',
+  PCM_F32LE: 'pcm_f32le',
+  PCM_MULAW: 'pcm_mulaw',
+  PCM_ALAW: 'pcm_alaw',
+  WAV: 'wav',
+  MP3: 'mp3',
+  AAC: 'aac',
+  OPUS: 'opus',
+  FLAC: 'flac',
+} as const;
+export type SonioxTTSAudioFormat =
+  (typeof SonioxTTSAudioFormat)[keyof typeof SonioxTTSAudioFormat];
+
+/** Sample rates (Hz) accepted by the Soniox `sample_rate` field. */
+export const SonioxTTSSampleRate = {
+  HZ_8000: 8000,
+  HZ_16000: 16000,
+  HZ_24000: 24000,
+  HZ_44100: 44100,
+  HZ_48000: 48000,
+} as const;
+export type SonioxTTSSampleRate =
+  (typeof SonioxTTSSampleRate)[keyof typeof SonioxTTSSampleRate];
+
+/** Constructor options for {@link SonioxTTS}. */
+export interface SonioxTTSOptions {
+  /** Model id. Defaults to `"tts-rt-v1"`. */
+  model?: SonioxTTSModel | string;
+  /** Voice name (e.g. `"Adrian"`, `"Maya"`) or a cloned-voice id. */
+  voice?: string;
+  /** BCP-47 language tag, e.g. `"en"`, `"it"`, `"es"`. Defaults to `"en"`. */
+  language?: string;
+  /**
+   * Output audio encoding. Default `pcm_s16le` (linear PCM16). Set
+   * `pcm_mulaw` with `sampleRate=8000` to emit Twilio/Telnyx wire-native
+   * μ-law directly — the pipeline then skips resampling and PCM → μ-law
+   * encoding entirely (see {@link SonioxTTS.forTwilio}).
+   */
+  audioFormat?: SonioxTTSAudioFormat | string;
+  /** Output sample rate in Hz. Defaults to 16000. */
+  sampleRate?: SonioxTTSSampleRate | number;
+  /** Bitrate hint (bits/sec) for compressed formats (mp3/aac/opus). */
+  bitrate?: number;
+  /** Speaking-rate multiplier (optional). */
+  speed?: number;
+  /** Override the REST endpoint (e.g. for tests). */
+  baseUrl?: string;
+}
+
+/** Soniox TTS adapter backed by the HTTP one-shot `/tts` bytes endpoint. */
+export class SonioxTTS {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey = 'soniox_tts';
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly language: string;
+  private readonly audioFormat: string;
+  private readonly sampleRate: number;
+  private readonly bitrate?: number;
+  private readonly speed?: number;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, opts: SonioxTTSOptions = {}) {
+    if (!apiKey) {
+      throw new Error('Soniox TTS: apiKey is required');
+    }
+    this.apiKey = apiKey;
+    this.model = opts.model ?? SonioxTTSModel.TTS_RT_V1;
+    this.voice = opts.voice ?? SONIOX_DEFAULT_VOICE;
+    this.language = opts.language ?? 'en';
+    this.audioFormat = opts.audioFormat ?? SonioxTTSAudioFormat.PCM_S16LE;
+    this.sampleRate = opts.sampleRate ?? SonioxTTSSampleRate.HZ_16000;
+    this.bitrate = opts.bitrate;
+    this.speed = opts.speed;
+    this.baseUrl = opts.baseUrl ?? SONIOX_TTS_BASE_URL;
+  }
+
+  /**
+   * Declare the audio format this adapter emits, so the pipeline sender can
+   * derive the correct resample ratio (or skip it for μ-law passthrough)
+   * instead of assuming a fixed 16 kHz source. See `audio/format.ts`.
+   *
+   * - `pcm_mulaw` → `{ encoding: 'mulaw', sampleRate }` (carrier-native).
+   * - `pcm_alaw`  → `{ encoding: 'alaw',  sampleRate }`.
+   * - everything else → `{ encoding: 'pcm_s16le', sampleRate }`.
+   */
+  sourceAudioFormat(): {
+    encoding: 'pcm_s16le' | 'mulaw' | 'alaw';
+    sampleRate: number;
+  } {
+    if (this.audioFormat === SonioxTTSAudioFormat.PCM_MULAW) {
+      return { encoding: 'mulaw', sampleRate: this.sampleRate };
+    }
+    if (this.audioFormat === SonioxTTSAudioFormat.PCM_ALAW) {
+      return { encoding: 'alaw', sampleRate: this.sampleRate };
+    }
+    return { encoding: 'pcm_s16le', sampleRate: this.sampleRate };
+  }
+
+  /**
+   * Construct an instance pre-configured for Twilio Media Streams.
+   *
+   * Emits `pcm_mulaw` @ 8 kHz — exactly Twilio's wire codec — so the pipeline
+   * takes the passthrough path: zero resampling, zero PCM → μ-law encoding,
+   * bit-clean audio. Soniox supports μ-law @ 8 kHz natively, so this is true
+   * carrier-native synthesis (no downsampling from a PCM-only model).
+   */
+  static forTwilio(
+    apiKey: string,
+    options: Omit<SonioxTTSOptions, 'sampleRate' | 'audioFormat'> = {},
+  ): SonioxTTS {
+    return new SonioxTTS(apiKey, {
+      ...options,
+      audioFormat: SonioxTTSAudioFormat.PCM_MULAW,
+      sampleRate: SonioxTTSSampleRate.HZ_8000,
+    });
+  }
+
+  /**
+   * Construct an instance pre-configured for Telnyx bidirectional media.
+   *
+   * The SDK pins the Telnyx wire to PCMU/μ-law @ 8 kHz, so emitting
+   * `pcm_mulaw` @ 8 kHz flows end-to-end with zero resampling or transcoding —
+   * the same passthrough win as {@link SonioxTTS.forTwilio}.
+   */
+  static forTelnyx(
+    apiKey: string,
+    options: Omit<SonioxTTSOptions, 'sampleRate' | 'audioFormat'> = {},
+  ): SonioxTTS {
+    return new SonioxTTS(apiKey, {
+      ...options,
+      audioFormat: SonioxTTSAudioFormat.PCM_MULAW,
+      sampleRate: SonioxTTSSampleRate.HZ_8000,
+    });
+  }
+
+  /** Build the JSON payload for the Soniox `/tts` endpoint. */
+  private buildPayload(text: string): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      model: this.model,
+      text,
+      voice: this.voice,
+      language: this.language,
+      audio_format: this.audioFormat,
+      sample_rate: this.sampleRate,
+    };
+    if (this.bitrate !== undefined) payload.bitrate = this.bitrate;
+    if (this.speed !== undefined) payload.speed = this.speed;
+    return payload;
+  }
+
+  /** Synthesize text and return the concatenated audio buffer. */
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /**
+   * Synthesize text and yield raw audio chunks as they arrive from Soniox.
+   * With the default `audioFormat="pcm_s16le"` these are PCM_S16LE bytes at
+   * the configured `sampleRate`; with `pcm_mulaw` (see {@link SonioxTTS.forTwilio})
+   * they are carrier-native G.711 μ-law bytes.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Soniox TTS error ${response.status}: ${body}`);
+    }
+    if (!response.body) {
+      throw new Error('Soniox TTS: no response body');
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      if (typeof reader.cancel === 'function')
+        await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+}

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -16,7 +16,7 @@ import { ElevenLabsConvAIAdapter } from './providers/elevenlabs-convai';
 import { GeminiLiveAdapter } from './providers/gemini-live';
 import { GeminiCascadeAdapter } from './providers/gemini-cascade';
 import { InworldRealtimeAdapter } from './providers/inworld-realtime';
-import { PlivoAdapter, dropPlivoVoicemail, plivoInboundCustomParams } from './providers/plivo-adapter';
+import { PlivoAdapter, dropPlivoVoicemail, plivoInboundCustomParams, parsePlivoExtraHeaders } from './providers/plivo-adapter';
 import { TwilioAdapter } from './providers/twilio-adapter';
 import { PlivoBridge, classifyPlivoAmd, validatePlivoSignature } from './telephony/plivo';
 // Re-export so existing imports from './server' keep working after the
@@ -37,6 +37,7 @@ import {
   buildHandoffTool,
 } from './stream-handler';
 import { buildUseSkillTool } from './skills';
+import { StreamTokenStore, generateStreamToken } from './stream-auth';
 import { getLogger } from './logger';
 import type { TelephonyBridge } from './stream-handler';
 import type {
@@ -83,6 +84,19 @@ export interface LocalConfig {
    * Set to false only for local development against mock providers.
    */
   requireSignature?: boolean;
+  /**
+   * SECURITY (#204): require a valid per-call stream-authentication token on
+   * every media-stream WebSocket before any provider (STT/LLM/TTS/Realtime)
+   * session is opened. When `true` (the default — fail closed), a missing /
+   * invalid / expired / mismatched token causes the WS to be closed with code
+   * 1008 and NO provider connection is opened. When explicitly `false` (for
+   * operators serving custom TwiML/XML that cannot carry the token), the WS is
+   * accepted without a token and a loud one-time warning is logged. The
+   * standard `serve()` path mints, embeds, and validates the token itself, so
+   * normal inbound AND outbound Twilio/Telnyx/Plivo calls keep working with
+   * zero operator action.
+   */
+  requireStreamAuth?: boolean;
   /**
    * Resolved on-disk persistence root for the dashboard's call history,
    * or ``null`` to disable. Computed by ``client.ts`` from the public
@@ -1287,6 +1301,14 @@ export class EmbeddedServer {
   }
   private twilioTokenWarningLogged = false;
   private telnyxSigWarningLogged = false;
+  /**
+   * Per-call media-stream authentication tokens (GitHub issue #204). Minted in
+   * the signature-validated carrier webhooks / outbound dial and required by the
+   * media WS before the provider session opens. See {@link StreamTokenStore}.
+   */
+  private readonly streamTokens = new StreamTokenStore();
+  /** Guards the one-time "stream auth disabled" warning (requireStreamAuth=false). */
+  private streamAuthDisabledWarned = false;
   readonly metricsStore: MetricsStore;
   /** Anonymous telemetry client, set by ``client.ts`` ``serve()``; emits the
    * per-call ``call_completed`` event from the call-end path. */
@@ -2083,7 +2105,13 @@ export class EmbeddedServer {
       const callee = (req.body.To as string) || '';
       const rawStreamUrl = `wss://${this.config.webhookUrl}/ws/stream/${callSid}`;
       const xmlStreamUrl = xmlEscape(rawStreamUrl);
-      const twiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${xmlStreamUrl}"><Parameter name="caller" value="${xmlEscape(caller)}"/><Parameter name="callee" value="${xmlEscape(callee)}"/></Stream></Connect></Response>`;
+      // SECURITY (#204): mint a per-call token bound to the CallSid. Twilio
+      // strips the query string from <Stream url=...>, so the token rides as a
+      // <Parameter> and arrives in start.customParameters on the WS 'start'
+      // frame. This webhook is signature-validated above, so only a legitimate
+      // carrier ever receives the token.
+      const streamToken = this.streamTokens.mint(callSid);
+      const twiml = `<?xml version="1.0" encoding="UTF-8"?><Response><Connect><Stream url="${xmlStreamUrl}"><Parameter name="caller" value="${xmlEscape(caller)}"/><Parameter name="callee" value="${xmlEscape(callee)}"/><Parameter name="patter_stream_token" value="${xmlEscape(streamToken)}"/></Stream></Connect></Response>`;
       res.type('text/xml').send(twiml);
     });
 
@@ -2315,9 +2343,15 @@ export class EmbeddedServer {
           // see above.
           const caller = payload.from ?? '';
           const callee = payload.to ?? '';
+          // SECURITY (#204): Telnyx's stream URL already carries query params,
+          // so the per-call token rides alongside caller/callee and is read from
+          // websocket.query_params at WS accept. This webhook is Ed25519-verified
+          // above, so only a legitimate carrier ever receives the token.
+          const streamToken = this.streamTokens.mint(callControlId);
           const streamUrl =
             `wss://${this.config.webhookUrl}/ws/stream/${encodeURIComponent(callControlId)}` +
-            `?caller=${encodeURIComponent(caller)}&callee=${encodeURIComponent(callee)}`;
+            `?caller=${encodeURIComponent(caller)}&callee=${encodeURIComponent(callee)}` +
+            `&patter_stream_token=${encodeURIComponent(streamToken)}`;
           getLogger().info(`Telnyx call.initiated ${callControlId} — answering with inline stream`);
           const resp = await fetch(`${apiBase}/calls/${encodeURIComponent(callControlId)}/actions/answer`, {
             method: 'POST',
@@ -2346,9 +2380,14 @@ export class EmbeddedServer {
             // is the ONLY place outbound audio is wired.
             const outCaller = payload.from ?? '';
             const outCallee = payload.to ?? '';
+            // SECURITY (#204): mint the per-call token for this outbound leg on
+            // the Ed25519-verified call.answered webhook (the only place
+            // outbound audio is wired), delivered via the stream URL query.
+            const streamToken = this.streamTokens.mint(callControlId);
             const streamUrl =
               `wss://${this.config.webhookUrl}/ws/stream/${encodeURIComponent(callControlId)}` +
-              `?caller=${encodeURIComponent(outCaller)}&callee=${encodeURIComponent(outCallee)}`;
+              `?caller=${encodeURIComponent(outCaller)}&callee=${encodeURIComponent(outCallee)}` +
+              `&patter_stream_token=${encodeURIComponent(streamToken)}`;
             getLogger().info(
               `Telnyx call.answered ${callControlId} (outgoing) — starting media stream`,
             );
@@ -2440,9 +2479,16 @@ export class EmbeddedServer {
       if (requestUuid && callUuid) this.aliasCallId(requestUuid, callUuid);
       const qs = `?caller=${encodeURIComponent(caller)}&callee=${encodeURIComponent(callee)}`;
       const streamUrl = `wss://${this.config.webhookUrl}/ws/plivo/stream/${callUuid || 'outbound'}${qs}`;
+      // SECURITY (#204): Plivo carries custom metadata via extra_headers (the
+      // same channel as X-PH-caller/callee), echoed back on the WS 'start'
+      // frame. Mint the per-call token here on the V3-signature-validated
+      // webhook (inbound AND answered-outbound share this route) and deliver it
+      // as X-Patter-Stream-Token.
+      const streamToken = this.streamTokens.mint(callUuid || 'outbound');
       const xml = PlivoAdapter.generateStreamXml(streamUrl, 'audio/x-mulaw;rate=8000', {
         'X-PH-caller': caller,
         'X-PH-callee': callee,
+        'X-Patter-Stream-Token': streamToken,
       });
       res.type('text/xml').send(xml);
     });
@@ -2566,7 +2612,15 @@ export class EmbeddedServer {
     // Telephony providers (Twilio/Telnyx) only open 1 connection per call;
     // a limit of 10 concurrent connections per IP is generous but blocks abuse.
     const MAX_WS_PER_IP = 10;
+    // Global concurrent-WS backstop (#204 XFF hardening). The per-IP cap keys on
+    // a header-derived IP that a peer behind a non-Cloudflare proxy can forge to
+    // get a fresh bucket per connection; this absolute ceiling bounds the total
+    // open sockets regardless of the (spoofable) IP key, so a header-forging
+    // flood cannot open unbounded connections. Sized well above any realistic
+    // concurrent-call count for a single embedded server.
+    const MAX_WS_TOTAL = 500;
     const wsConnectionsByIp = new Map<string, number>();
+    let wsConnectionsTotal = 0;
 
     this.server.on('upgrade', (req, socket, head) => {
       let remoteIp = (req.socket?.remoteAddress ?? 'unknown').replace(/^::ffff:/, '');
@@ -2574,6 +2628,18 @@ export class EmbeddedServer {
       // WS arrives from loopback — keying the cap on the socket peer put all
       // calls in one shared bucket (legitimate call #11 rejected; one remote
       // abuser could exhaust it). Prefer the tunnel-provided client IP.
+      //
+      // SECURITY (#204): this tunnel-header trust is a DoS-CAP KEY ONLY — it is
+      // NOT authentication and MUST NOT be relied on for identity. A peer behind
+      // a non-Cloudflare proxy can forge cf-connecting-ip / x-forwarded-for to
+      // land in a fresh per-IP bucket. That is acceptable here because the real
+      // access control is the per-call stream-auth token, enforced separately in
+      // the WS handlers BEFORE any provider session opens (authorizeStream):
+      // an unauthenticated peer is rejected regardless of which bucket it lands
+      // in. We keep trusting the header for the rate-limit key so legitimate
+      // tunneled calls (all arriving from loopback) do not share one bucket, and
+      // add the absolute MAX_WS_TOTAL backstop below to bound a forged-header
+      // connection flood.
       if (remoteIp === '127.0.0.1' || remoteIp === '::1') {
         const fwd =
           (req.headers['cf-connecting-ip'] as string | undefined) ??
@@ -2581,6 +2647,14 @@ export class EmbeddedServer {
           '';
         const firstHop = fwd.split(',')[0]?.trim();
         if (firstHop) remoteIp = firstHop.replace(/^::ffff:/, '');
+      }
+      if (wsConnectionsTotal >= MAX_WS_TOTAL) {
+        getLogger().warn(
+          `WebSocket upgrade rejected: global connection ceiling (${MAX_WS_TOTAL}) reached`,
+        );
+        socket.write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
+        socket.destroy();
+        return;
       }
       const currentCount = wsConnectionsByIp.get(remoteIp) ?? 0;
       if (currentCount >= MAX_WS_PER_IP) {
@@ -2591,6 +2665,7 @@ export class EmbeddedServer {
       }
       this.wss!.handleUpgrade(req, socket, head, (ws) => {
         wsConnectionsByIp.set(remoteIp, (wsConnectionsByIp.get(remoteIp) ?? 0) + 1);
+        wsConnectionsTotal += 1;
         ws.once('close', () => {
           const count = (wsConnectionsByIp.get(remoteIp) ?? 1) - 1;
           if (count <= 0) {
@@ -2598,6 +2673,7 @@ export class EmbeddedServer {
           } else {
             wsConnectionsByIp.set(remoteIp, count);
           }
+          wsConnectionsTotal = Math.max(0, wsConnectionsTotal - 1);
         });
         this.wss!.emit('connection', ws, req);
       });
@@ -3044,6 +3120,74 @@ export class EmbeddedServer {
   }
 
   // ---------------------------------------------------------------------------
+  // Per-call media-stream authentication (GitHub issue #204)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate a fresh stream-auth token WITHOUT storing it. Used by the outbound
+   * Twilio path in `client.ts`, which embeds the token in inline TwiML before
+   * the carrier REST response reveals the CallSid the WS will present, then
+   * calls {@link registerStreamToken} once the CallSid is known.
+   */
+  generateStreamToken(): string {
+    return generateStreamToken();
+  }
+
+  /**
+   * Store a pre-generated stream-auth token under `callKey` (outbound path).
+   * Inbound webhooks mint + store in a single step via `this.streamTokens.mint`.
+   */
+  registerStreamToken(callKey: string, token: string): void {
+    if (!callKey || !token) return;
+    this.streamTokens.register(callKey, token);
+  }
+
+  /**
+   * Authorize a media-stream WebSocket BEFORE any provider session is opened.
+   *
+   * Fail-closed by default (`requireStreamAuth`): on a missing / invalid /
+   * expired / mismatched token the socket is closed with code 1008 (policy
+   * violation) and `false` is returned so the caller opens NO provider
+   * connection and synthesises NO TTS. When `requireStreamAuth` is explicitly
+   * `false`, the connection is allowed and a loud one-time warning is logged.
+   *
+   * NEVER logs the presented token, the stored token, or any transcript.
+   */
+  private authorizeStream(
+    ws: WSWebSocket,
+    callKey: string,
+    presented: string | undefined | null,
+    carrierLabel: string,
+  ): boolean {
+    if (this.config.requireStreamAuth === false) {
+      if (!this.streamAuthDisabledWarned) {
+        this.streamAuthDisabledWarned = true;
+        getLogger().warn(
+          'Stream authentication is DISABLED (requireStreamAuth=false). Media-stream ' +
+            'WebSockets are accepted WITHOUT a per-call token — an unauthenticated peer ' +
+            'that reaches this host can drive a session on your provider keys. Only keep ' +
+            'this off when serving custom TwiML/XML that cannot carry the token, behind ' +
+            'your own access control.',
+        );
+      }
+      return true;
+    }
+    if (this.streamTokens.validate(callKey, presented)) {
+      return true;
+    }
+    // No PII, no token value: only the carrier label and a generic reason.
+    getLogger().warn(
+      `Rejected ${carrierLabel} media stream: missing or invalid stream-auth token`,
+    );
+    try {
+      ws.close(1008, 'stream authentication required');
+    } catch {
+      /* socket may already be closing */
+    }
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------
   // Twilio WebSocket message parser (thin layer)
   // ---------------------------------------------------------------------------
 
@@ -3092,8 +3236,16 @@ export class EmbeddedServer {
           handler.setStreamSid(data.streamSid ?? '');
           const callSid = data.start?.callSid ?? '';
           const customParameters = data.start?.customParameters ?? {};
+          // SECURITY (#204): validate the per-call token BEFORE opening any
+          // provider session (the billable part). The token was minted by the
+          // signature-validated /webhooks/twilio/voice handler (inbound) or the
+          // outbound call() dial and delivered as a <Parameter>. Strip it from
+          // customParameters so it never reaches the prompt/template vars, logs,
+          // or metadata.json.
+          const { patter_stream_token: presentedToken, ...cleanParameters } = customParameters;
+          if (!this.authorizeStream(ws, callSid, presentedToken, 'Twilio')) return;
           if (callSid) this.activeCallIds.set(ws, callSid);
-          await handler.handleCallStart(callSid, customParameters);
+          await handler.handleCallStart(callSid, cleanParameters);
         } else if (event === 'media') {
           const payload = data.media?.payload ?? '';
           // ``await`` keeps a rejection inside the outer try/catch — un-awaited
@@ -3142,6 +3294,15 @@ export class EmbeddedServer {
   private handleTelnyxStream(ws: WSWebSocket, url: URL): void {
     const caller = url.searchParams.get('caller') ?? '';
     const callee = url.searchParams.get('callee') ?? '';
+    // SECURITY (#204): Telnyx delivers the token in the stream-URL query, so we
+    // can validate as early as possible — at accept, before any frame is read
+    // or provider session opened. The call_control_id is the last path segment
+    // (the key the token was minted under in the signed webhook).
+    const callControlId = decodeURIComponent(
+      url.pathname.split('/').filter(Boolean).pop() ?? '',
+    );
+    const presentedToken = url.searchParams.get('patter_stream_token');
+    if (!this.authorizeStream(ws, callControlId, presentedToken, 'Telnyx')) return;
     const bridge = new TelnyxBridge(this.config);
     const handler = new StreamHandler(this.buildStreamHandlerDeps(bridge), ws, caller, callee);
     let streamStarted = false;
@@ -3302,6 +3463,12 @@ export class EmbeddedServer {
           // hangup / transfer / recording / cost REST calls.
           handler.setStreamSid(data.start?.streamId ?? '');
           const callId = data.start?.callId ?? '';
+          // SECURITY (#204): the per-call token arrives in extra_headers as
+          // X-Patter-Stream-Token (minted on the V3-signed webhook). Validate
+          // BEFORE opening any provider session. plivoInboundCustomParams strips
+          // the token so it never becomes a prompt/template variable.
+          const presentedToken = parsePlivoExtraHeaders(data.extra_headers ?? '')['X-Patter-Stream-Token'];
+          if (!this.authorizeStream(ws, callId, presentedToken, 'Plivo')) return;
           if (callId) this.activeCallIds.set(ws, callId);
           // Plivo's extra_headers are the metadata channel mirroring Twilio's
           // <Parameter> customParameters: developer-supplied headers become

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -13,6 +13,9 @@ import type { TelemetryClient } from './telemetry/client';
 import { OpenAIRealtimeAdapter } from './providers/openai-realtime';
 import { OpenAIRealtime2Adapter } from './providers/openai-realtime-2';
 import { ElevenLabsConvAIAdapter } from './providers/elevenlabs-convai';
+import { GeminiLiveAdapter } from './providers/gemini-live';
+import { GeminiCascadeAdapter } from './providers/gemini-cascade';
+import { InworldRealtimeAdapter } from './providers/inworld-realtime';
 import { PlivoAdapter, dropPlivoVoicemail, plivoInboundCustomParams } from './providers/plivo-adapter';
 import { TwilioAdapter } from './providers/twilio-adapter';
 import { PlivoBridge, classifyPlivoAmd, validatePlivoSignature } from './telephony/plivo';
@@ -90,7 +93,7 @@ export interface LocalConfig {
   persistRoot?: string | null;
 }
 
-type AIAdapter = OpenAIRealtimeAdapter | ElevenLabsConvAIAdapter;
+type AIAdapter = OpenAIRealtimeAdapter | ElevenLabsConvAIAdapter | GeminiLiveAdapter | GeminiCascadeAdapter;
 
 export const TRANSFER_CALL_TOOL = {
   name: 'transfer_call',
@@ -645,6 +648,82 @@ export function buildAIAdapter(config: LocalConfig, agent: AgentOptions, resolve
   // ``handleUseSkillFunctionCall``). Mirrors the Python Realtime ``start()``.
   if (agent.skills && agent.skills.length > 0) {
     tools.push(buildUseSkillTool(agent.skills));
+  }
+  // Gemini Live mode: construct GeminiLiveAdapter from the engine marker's
+  // own credentials/voice/model. Mirrors the ElevenLabs branch above — a
+  // distinct (non-OpenAI) adapter built from the engine's own apiKey — but
+  // placed here because Gemini advertises the same tool list (agent tools +
+  // transfer_call/end_call/handoff) as the OpenAI path.
+  if (agent.provider === 'gemini_live') {
+    if (!engine || engine.kind !== 'gemini_live') {
+      throw new Error(
+        "Gemini Live mode requires `agent.engine = new GeminiLive({...})`.",
+      );
+    }
+    return new GeminiLiveAdapter(engine.apiKey, {
+      ...(agent.model ?? engine.model ? { model: agent.model ?? engine.model } : {}),
+      ...(agent.voice ?? engine.voice ? { voice: agent.voice ?? engine.voice } : {}),
+      ...(agent.language ? { language: agent.language } : {}),
+      ...(engine.temperature !== undefined ? { temperature: engine.temperature } : {}),
+      ...(engine.affectiveDialog !== undefined ? { affectiveDialog: engine.affectiveDialog } : {}),
+      ...(engine.proactiveAudio !== undefined ? { proactiveAudio: engine.proactiveAudio } : {}),
+      ...(engine.vad !== undefined ? { vad: engine.vad } : {}),
+      // Thinking is OFF by default for voice (adapter applies thinkingBudget:0)
+      // — only forward the opt-in overrides when the marker set them.
+      ...(engine.thinking !== undefined ? { thinking: engine.thinking } : {}),
+      ...(engine.thinkingBudget !== undefined ? { thinkingBudget: engine.thinkingBudget } : {}),
+      ...(engine.apiVersion !== undefined ? { apiVersion: engine.apiVersion } : {}),
+      instructions: resolvedPrompt ?? agent.systemPrompt,
+      tools,
+    });
+  }
+  if (agent.provider === 'gemini_cascade') {
+    if (!engine || engine.kind !== 'gemini_cascade') {
+      throw new Error(
+        "Gemini Cascade mode requires `agent.engine = new GeminiCascade({...})`.",
+      );
+    }
+    return new GeminiCascadeAdapter(engine.apiKey, {
+      model: agent.model ?? engine.liveModel,
+      ttsModel: engine.ttsModel,
+      voice: agent.voice ?? engine.voice,
+      instructions: resolvedPrompt ?? agent.systemPrompt,
+      tools,
+    });
+  }
+  // Inworld Realtime mode: construct InworldRealtimeAdapter from the engine
+  // marker. Inworld's Realtime API is OpenAI-Realtime-compatible, so the
+  // adapter subclasses OpenAIRealtimeAdapter and advertises the SAME tool list
+  // (agent tools + transfer_call/end_call/handoff/use_skill) built above.
+  if (agent.provider === 'inworld_realtime') {
+    if (!engine || engine.kind !== 'inworld_realtime') {
+      throw new Error(
+        "Inworld Realtime mode requires `agent.engine = new InworldRealtime({...})`.",
+      );
+    }
+    const agentOpts = agent as {
+      realtimeTurnDetection?: import('./types').RealtimeTurnDetection;
+      openaiRealtimeGateResponseOnTranscript?: boolean;
+    };
+    return new InworldRealtimeAdapter(engine.apiKey, {
+      ...(agent.model ?? engine.model ? { model: agent.model ?? engine.model } : {}),
+      ...(agent.voice ?? engine.voice ? { voice: agent.voice ?? engine.voice } : {}),
+      ...(engine.baseUrl ? { baseUrl: engine.baseUrl } : {}),
+      ...(engine.transcriptionLanguage !== undefined
+        ? { transcriptionLanguage: engine.transcriptionLanguage }
+        : {}),
+      ...((agentOpts.realtimeTurnDetection ?? engine.turnDetection) !== undefined
+        ? { turnDetection: agentOpts.realtimeTurnDetection ?? engine.turnDetection }
+        : {}),
+      ...((agentOpts.openaiRealtimeGateResponseOnTranscript ?? engine.gateResponseOnTranscript) !== undefined
+        ? {
+            gateResponseOnTranscript:
+              agentOpts.openaiRealtimeGateResponseOnTranscript ?? engine.gateResponseOnTranscript,
+          }
+        : {}),
+      instructions: resolvedPrompt ?? agent.systemPrompt,
+      tools,
+    });
   }
   const isOpenAIEngine = engine && (engine.kind === 'openai_realtime' || engine.kind === 'openai_realtime_2');
   const openaiKey = isOpenAIEngine ? engine.apiKey : (config.openaiKey ?? '');

--- a/libraries/typescript/src/stream-auth.ts
+++ b/libraries/typescript/src/stream-auth.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-call media-stream authentication (GitHub issue #204).
+ *
+ * The media-stream WebSocket endpoints (`/ws/stream/{call_id}` and the Telnyx /
+ * Plivo variants) are reachable by any peer that can hit the public host. The
+ * HTTP carrier webhooks are signature-validated and fail closed, but the WS
+ * upgrade previously had no authentication — an unauthenticated peer could send
+ * a `start` frame and drive a full STT→LLM→TTS session on the operator's
+ * provider keys (toll fraud) or converse to extract the agent's system prompt
+ * and tool list.
+ *
+ * The fix mints a high-entropy, per-call token inside the SIGNATURE-VALIDATED
+ * carrier webhook (inbound) or the operator-initiated outbound dial, stores it
+ * in this short-TTL map keyed by the call id, and requires the media WS to
+ * present it before any provider session opens. Because the token only ever
+ * leaves via an authenticated channel, an unsigned attacker can never obtain a
+ * valid one.
+ *
+ * Mirrors the Python `getpatter.stream_auth.StreamTokenStore`.
+ */
+
+import crypto from 'node:crypto';
+
+/**
+ * TTL for a minted per-call stream-auth token. The signed-webhook → media-WS
+ * handshake completes in seconds; 120 s is a generous ceiling that still allows
+ * a legitimate carrier reconnect within the window (the token is kept valid —
+ * NOT single-use — so a carrier reconnect inside the TTL is not rejected).
+ */
+export const STREAM_TOKEN_TTL_MS = 120_000;
+
+interface StreamTokenEntry {
+  readonly token: string;
+  /** Unix epoch milliseconds after which the entry is invalid. */
+  readonly expiresAt: number;
+}
+
+/**
+ * Generate a high-entropy, URL-safe stream-auth token.
+ *
+ * 32 random bytes, base64url-encoded (no padding) — parity with the Python
+ * `secrets.token_urlsafe(32)`.
+ */
+export function generateStreamToken(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Constant-time string comparison. Returns `false` for unequal-length inputs
+ * (the token length is fixed, so this leaks nothing an attacker can use) and
+ * uses `crypto.timingSafeEqual` for the equal-length case. Mirrors Python's
+ * `hmac.compare_digest`.
+ */
+export function constantTimeEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+  if (bufA.length !== bufB.length) return false;
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * In-memory `{ callKey -> { token, expiresAt } }` store, one instance per
+ * embedded server. Entries are minted by the signed webhook / outbound dial and
+ * validated by the media-stream WS handler before the billable provider session
+ * opens. Expired entries are pruned opportunistically on every operation, so
+ * the map cannot grow unbounded even under a mint-heavy load.
+ */
+export class StreamTokenStore {
+  private readonly entries = new Map<string, StreamTokenEntry>();
+
+  constructor(private readonly ttlMs: number = STREAM_TOKEN_TTL_MS) {}
+
+  /**
+   * Mint a fresh token for `callKey`, store it, and return it. The stored
+   * token replaces any previous one for the same key (a re-issued webhook wins).
+   */
+  mint(callKey: string, now: number = Date.now()): string {
+    const token = generateStreamToken();
+    this.register(callKey, token, now);
+    return token;
+  }
+
+  /**
+   * Store an already-generated token for `callKey`. Used by the outbound Twilio
+   * path, where the token is embedded in inline TwiML before the carrier REST
+   * response reveals the call id the WS will present.
+   */
+  register(callKey: string, token: string, now: number = Date.now()): void {
+    this.prune(now);
+    this.entries.set(callKey, { token, expiresAt: now + this.ttlMs });
+  }
+
+  /**
+   * Return `true` iff `presented` matches the stored, unexpired token for
+   * `callKey`. Constant-time compare; the entry is KEPT valid within the TTL so
+   * a legitimate carrier reconnect inside the window is accepted. Missing,
+   * expired, or mismatched tokens return `false`.
+   */
+  validate(callKey: string, presented: string | undefined | null, now: number = Date.now()): boolean {
+    this.prune(now);
+    const entry = this.entries.get(callKey);
+    if (!entry) return false;
+    if (entry.expiresAt <= now) {
+      this.entries.delete(callKey);
+      return false;
+    }
+    if (!presented) return false;
+    return constantTimeEquals(presented, entry.token);
+  }
+
+  /** Drop every expired entry. Invoked opportunistically on mint/register/validate. */
+  prune(now: number = Date.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key);
+    }
+  }
+
+  /** Number of live (possibly-expired-but-not-yet-pruned) entries. Test/introspection only. */
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -10,6 +10,8 @@
 import { WebSocket as WSWebSocket } from 'ws';
 import { OpenAIRealtimeAdapter } from './providers/openai-realtime';
 import { ElevenLabsConvAIAdapter } from './providers/elevenlabs-convai';
+import { GeminiLiveAdapter } from './providers/gemini-live';
+import { GeminiCascadeAdapter } from './providers/gemini-cascade';
 import { DeepgramSTT } from './providers/deepgram-stt';
 import { createTTS } from './provider-factory';
 import type { STTAdapter, TTSAdapter, STTTranscript } from './provider-factory';
@@ -52,7 +54,7 @@ import {
   startSpan,
 } from './observability/tracing';
 
-type AIAdapter = OpenAIRealtimeAdapter | ElevenLabsConvAIAdapter;
+type AIAdapter = OpenAIRealtimeAdapter | ElevenLabsConvAIAdapter | GeminiLiveAdapter | GeminiCascadeAdapter;
 
 // ---------------------------------------------------------------------------
 // Tool-call preambles (OpenAI Realtime)
@@ -5815,6 +5817,14 @@ export class StreamHandler {
             ? (this.adapter as unknown as { sendFirstMessage: (t: string) => Promise<void> }).sendFirstMessage.bind(this.adapter)
             : this.adapter.sendText.bind(this.adapter);
         await sender(this.deps.agent.firstMessage);
+      } else if (this.adapter instanceof GeminiLiveAdapter) {
+        // Gemini has no dedicated sendFirstMessage; sendText(role=user)
+        // primes the opening turn so the model speaks first.
+        await this.adapter.sendText(this.deps.agent.firstMessage);
+      } else if (this.adapter instanceof GeminiCascadeAdapter) {
+        // Cascade plays a pre-synthesised intro clip instantly (no Live→TTS
+        // round-trip) and primes Live history so the model doesn't re-greet.
+        await this.adapter.sendFirstMessage(this.deps.agent.firstMessage);
       }
       // ElevenLabs ConvAI sends firstMessage via connection config (handled in adapter.connect())
     }
@@ -5844,7 +5854,17 @@ export class StreamHandler {
     interruption: async () => this.onAdapterSpeechInterrupt(),
     error: async (eventData) => this.onAdapterError(eventData),
     function_call: async (eventData) => {
-      if (this.adapter instanceof OpenAIRealtimeAdapter) {
+      if (
+        this.adapter instanceof OpenAIRealtimeAdapter ||
+        this.adapter instanceof GeminiLiveAdapter ||
+        this.adapter instanceof GeminiCascadeAdapter
+      ) {
+        // GeminiLiveAdapter and GeminiCascadeAdapter share the same function_call
+        // event shape ({call_id, name, arguments}) and expose sendFunctionResult
+        // with the identical signature, so the OpenAI tool round-trip applies
+        // unchanged. The OpenAI-only niceties inside handleFunctionCall
+        // (reassurance / progress sendText) are themselves instanceof-gated
+        // and silently skipped for Gemini adapters.
         await this.handleFunctionCall(eventData as { call_id: string; name: string; arguments: string });
       } else if (this.adapter instanceof ElevenLabsConvAIAdapter) {
         await this.handleConvAIClientTool(

--- a/libraries/typescript/src/stt/gemini.ts
+++ b/libraries/typescript/src/stt/gemini.ts
@@ -1,0 +1,36 @@
+/** Gemini multimodal STT for Patter pipeline mode. */
+import { GeminiSTT as _GeminiSTT } from "../providers/gemini-stt";
+
+/** Constructor options for the Gemini `STT` adapter. */
+export interface GeminiSTTOptions {
+  /** API key. Falls back to GEMINI_API_KEY / GOOGLE_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Multimodal model (default `gemini-2.5-flash`). */
+  model?: string;
+  /** Inbound PCM rate from the pipeline (default 16000). */
+  sampleRate?: number;
+}
+
+/**
+ * Gemini multimodal STT (`gemini-2.5-flash`) — transcribes AND tags the
+ * caller's vocal tone (`[tone: ...]`) so the agent can mirror mood.
+ *
+ * @example
+ * ```ts
+ * import * as gemini from "getpatter/stt/gemini";
+ * const stt = new gemini.STT();              // reads GEMINI_API_KEY
+ * ```
+ */
+export class STT extends _GeminiSTT {
+  static readonly providerKey = "gemini_stt";
+  constructor(opts: GeminiSTTOptions = {}) {
+    const key = opts.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Gemini STT requires an apiKey. Pass { apiKey: '...' } or set " +
+          "GEMINI_API_KEY / GOOGLE_API_KEY in the environment.",
+      );
+    }
+    super(key, opts.model ?? "gemini-2.5-flash", opts.sampleRate ?? 16000);
+  }
+}

--- a/libraries/typescript/src/telemetry/stack.ts
+++ b/libraries/typescript/src/telemetry/stack.ts
@@ -34,6 +34,7 @@ export const STACK_VENDORS: ReadonlySet<string> = new Set([
   'lmnt',
   'rime',
   'inworld',
+  'sarvam',
   'telnyx',
   'other',
 ]);
@@ -45,6 +46,7 @@ const VENDOR_ALIASES: Record<string, string> = {
   openai_tts: 'openai',
   openai_transcribe: 'openai',
   elevenlabs_ws: 'elevenlabs',
+  soniox_tts: 'soniox',
   telnyx_stt: 'telnyx',
   telnyx_tts: 'telnyx',
 };

--- a/libraries/typescript/src/tts/gemini.ts
+++ b/libraries/typescript/src/tts/gemini.ts
@@ -1,0 +1,38 @@
+/** Gemini TTS for Patter pipeline mode. */
+import { GeminiTTS as _GeminiTTS } from "../providers/gemini-tts";
+
+/** Constructor options for the Gemini `TTS` adapter. */
+export interface GeminiTTSOptions {
+  /** API key. Falls back to GEMINI_API_KEY / GOOGLE_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** Prebuilt voice name (default `Kore`). */
+  voice?: string;
+  /** TTS model (default `gemini-3.1-flash-tts-preview`). */
+  model?: string;
+  /** Output PCM rate: 8000 or 16000 (default 16000). */
+  targetSampleRate?: number;
+}
+
+/**
+ * Gemini TTS (`gemini-3.1-flash-tts-preview`).
+ *
+ * @example
+ * ```ts
+ * import * as gemini from "getpatter/tts/gemini";
+ * const tts = new gemini.TTS();                       // reads GEMINI_API_KEY
+ * const tts = new gemini.TTS({ voice: "Kore" });
+ * ```
+ */
+export class TTS extends _GeminiTTS {
+  static readonly providerKey = "gemini_tts";
+  constructor(opts: GeminiTTSOptions = {}) {
+    const key = opts.apiKey ?? process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Gemini TTS requires an apiKey. Pass { apiKey: '...' } or set " +
+          "GEMINI_API_KEY / GOOGLE_API_KEY in the environment.",
+      );
+    }
+    super(key, opts.voice ?? "Kore", opts.model ?? "gemini-3.1-flash-tts-preview", opts.targetSampleRate ?? 16000);
+  }
+}

--- a/libraries/typescript/src/tts/sarvam.ts
+++ b/libraries/typescript/src/tts/sarvam.ts
@@ -1,0 +1,103 @@
+/** Sarvam AI TTS for Patter pipeline mode. */
+import {
+  SarvamTTS as _SarvamTTS,
+  SarvamAudioCodec,
+  SarvamSampleRate,
+  type SarvamLanguage,
+  type SarvamModel,
+} from '../providers/sarvam-tts';
+
+/** Constructor options for the Sarvam `TTS` adapter. */
+export interface SarvamTTSOptions {
+  /** API key. Falls back to SARVAM_API_KEY env var when omitted. */
+  apiKey?: string;
+  model?: SarvamModel | string;
+  speaker?: string;
+  /** BCP-47 language code, e.g. `"hi-IN"`, `"ta-IN"`, `"en-IN"`. Default `"en-IN"`. */
+  language?: SarvamLanguage | string;
+  /** Audio codec. Default `linear16`; `mulaw` @ 8 kHz = carrier-native. */
+  codec?: SarvamAudioCodec | string;
+  sampleRate?: SarvamSampleRate | number;
+  pace?: number;
+  pitch?: number;
+  loudness?: number;
+  temperature?: number;
+  enablePreprocessing?: boolean;
+  dictId?: string;
+  baseUrl?: string;
+}
+
+/** Options for the carrier-specific factories — same as the constructor minus `codec`/`sampleRate`. */
+export type SarvamCarrierOptions = Omit<SarvamTTSOptions, 'codec' | 'sampleRate'>;
+
+function resolveApiKey(apiKey: string | undefined): string {
+  const key = apiKey ?? process.env.SARVAM_API_KEY;
+  if (!key) {
+    throw new Error(
+      "Sarvam TTS requires an apiKey. Pass { apiKey: '...' } or " +
+        'set SARVAM_API_KEY in the environment.',
+    );
+  }
+  return key;
+}
+
+/**
+ * Sarvam Bulbul TTS for Indian languages — defaults to the bulbul:v3 model.
+ *
+ * Synthesizes Hindi, Bengali, Tamil, Telugu, Kannada, Malayalam, Marathi,
+ * Gujarati, Punjabi, Odia and Indian English (plus code-mixed text). Select the
+ * language via `language` (a Sarvam BCP-47 code such as `"hi-IN"`).
+ *
+ * @example
+ * ```ts
+ * import * as sarvam from "getpatter/tts/sarvam";
+ * const tts = new sarvam.TTS();                               // reads SARVAM_API_KEY
+ * const tts = new sarvam.TTS({ language: "hi-IN", speaker: "shubh" });
+ * ```
+ *
+ * **Telephony** — use {@link TTS.forTwilio} or {@link TTS.forTelnyx} on phone
+ * calls. Both emit μ-law @ 8 kHz natively (Sarvam supports it), so the pipeline
+ * skips resampling and PCM → μ-law encoding entirely (bit-clean passthrough).
+ */
+export class TTS extends _SarvamTTS {
+  static readonly providerKey = 'sarvam';
+  constructor(opts: SarvamTTSOptions = {}) {
+    const key = resolveApiKey(opts.apiKey);
+    const { apiKey: _ignored, ...rest } = opts;
+    void _ignored;
+    super(key, rest);
+  }
+
+  /** Pipeline TTS pre-configured for Twilio Media Streams (μ-law @ 8 kHz native — carrier-wire passthrough). */
+  static override forTwilio(opts?: SarvamCarrierOptions): TTS;
+  // Parent-compatible overload — accepts the legacy positional form too.
+  static override forTwilio(apiKey: string, options?: SarvamCarrierOptions): TTS;
+  static override forTwilio(
+    arg1?: string | SarvamCarrierOptions,
+    arg2?: SarvamCarrierOptions,
+  ): TTS {
+    const opts: SarvamCarrierOptions =
+      typeof arg1 === 'string' ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({
+      ...opts,
+      codec: SarvamAudioCodec.MULAW,
+      sampleRate: SarvamSampleRate.HZ_8000,
+    });
+  }
+
+  /** Pipeline TTS pre-configured for Telnyx (μ-law @ 8 kHz native — PCMU wire passthrough). */
+  static override forTelnyx(opts?: SarvamCarrierOptions): TTS;
+  static override forTelnyx(apiKey: string, options?: SarvamCarrierOptions): TTS;
+  static override forTelnyx(
+    arg1?: string | SarvamCarrierOptions,
+    arg2?: SarvamCarrierOptions,
+  ): TTS {
+    const opts: SarvamCarrierOptions =
+      typeof arg1 === 'string' ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({
+      ...opts,
+      codec: SarvamAudioCodec.MULAW,
+      sampleRate: SarvamSampleRate.HZ_8000,
+    });
+  }
+}

--- a/libraries/typescript/src/tts/soniox.ts
+++ b/libraries/typescript/src/tts/soniox.ts
@@ -1,0 +1,100 @@
+/** Soniox TTS for Patter pipeline mode. */
+import {
+  SonioxTTS as _SonioxTTS,
+  SonioxTTSAudioFormat,
+  type SonioxTTSModel,
+  type SonioxTTSSampleRate,
+} from '../providers/soniox-tts';
+
+/** Constructor options for the Soniox `TTS` adapter. */
+export interface SonioxTTSOptions {
+  /** API key. Falls back to SONIOX_API_KEY env var when omitted (shared with Soniox STT). */
+  apiKey?: string;
+  model?: SonioxTTSModel | string;
+  voice?: string;
+  language?: string;
+  /** Audio encoding. Default `pcm_s16le`; `pcm_mulaw` @ 8 kHz = carrier-native. */
+  audioFormat?: SonioxTTSAudioFormat | string;
+  sampleRate?: SonioxTTSSampleRate | number;
+  bitrate?: number;
+  speed?: number;
+  baseUrl?: string;
+}
+
+/** Options for the carrier-specific factories — same as the constructor minus `sampleRate`/`audioFormat`. */
+export type SonioxCarrierOptions = Omit<
+  SonioxTTSOptions,
+  'sampleRate' | 'audioFormat'
+>;
+
+function resolveApiKey(apiKey: string | undefined): string {
+  // Shared credential with Soniox STT — same SONIOX_API_KEY env var.
+  const key = apiKey ?? process.env.SONIOX_API_KEY;
+  if (!key) {
+    throw new Error(
+      "Soniox TTS requires an apiKey. Pass { apiKey: '...' } or " +
+        'set SONIOX_API_KEY in the environment.',
+    );
+  }
+  return key;
+}
+
+/**
+ * Soniox TTS (`tts-rt-v1`, default voice `Adrian`).
+ *
+ * Shares the `SONIOX_API_KEY` credential with the Soniox STT adapter.
+ *
+ * @example
+ * ```ts
+ * import * as soniox from "getpatter/tts/soniox";
+ * const tts = new soniox.TTS();                          // reads SONIOX_API_KEY
+ * const tts = new soniox.TTS({ apiKey: "...", voice: "Maya", language: "en" });
+ * ```
+ *
+ * **Telephony** — use {@link TTS.forTwilio} or {@link TTS.forTelnyx} on phone
+ * calls. Both emit μ-law @ 8 kHz natively (Soniox supports G.711 directly), so
+ * the pipeline skips resampling and PCM → μ-law encoding entirely (bit-clean
+ * passthrough).
+ */
+export class TTS extends _SonioxTTS {
+  static readonly providerKey = 'soniox_tts';
+  constructor(opts: SonioxTTSOptions = {}) {
+    const key = resolveApiKey(opts.apiKey);
+    const { apiKey: _ignored, ...rest } = opts;
+    void _ignored;
+    super(key, rest);
+  }
+
+  /** Pipeline TTS pre-configured for Twilio Media Streams (μ-law @ 8 kHz native — carrier-wire passthrough, no resample/encode). */
+  static override forTwilio(opts?: SonioxCarrierOptions): TTS;
+  // Parent-compatible overload — accepts the legacy positional form too.
+  static override forTwilio(apiKey: string, options?: SonioxCarrierOptions): TTS;
+  static override forTwilio(
+    arg1?: string | SonioxCarrierOptions,
+    arg2?: SonioxCarrierOptions,
+  ): TTS {
+    const opts: SonioxCarrierOptions =
+      typeof arg1 === 'string' ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({
+      ...opts,
+      audioFormat: SonioxTTSAudioFormat.PCM_MULAW,
+      sampleRate: 8000,
+    });
+  }
+
+  /** Pipeline TTS pre-configured for Telnyx (μ-law @ 8 kHz native — PCMU wire passthrough). */
+  static override forTelnyx(opts?: SonioxCarrierOptions): TTS;
+  static override forTelnyx(apiKey: string, options?: SonioxCarrierOptions): TTS;
+  static override forTelnyx(
+    arg1?: string | SonioxCarrierOptions,
+    arg2?: SonioxCarrierOptions,
+  ): TTS {
+    const opts: SonioxCarrierOptions =
+      typeof arg1 === 'string' ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({
+      ...opts,
+      audioFormat: SonioxTTSAudioFormat.PCM_MULAW,
+      sampleRate: 8000,
+    });
+  }
+}

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -1181,6 +1181,27 @@ export interface ServeOptions {
    * for the rare case where unauthenticated public exposure is intentional.
    */
   readonly allowInsecureDashboard?: boolean;
+  /**
+   * SECURITY (#204): require a valid per-call stream-authentication token on
+   * every media-stream WebSocket before any provider (STT/LLM/TTS/Realtime)
+   * session is opened.
+   *
+   * Defaults to `true` (fail closed). The SDK mints the token inside the
+   * signature-validated carrier webhook (inbound) or the outbound dial,
+   * embeds it via each carrier's custom-parameter channel (Twilio
+   * `<Parameter>`, Telnyx query string, Plivo `extra_headers`), and validates
+   * it at the WS before opening the billable provider session. A missing /
+   * invalid / expired / mismatched token closes the socket with code 1008 and
+   * opens NO provider connection — this blocks the toll-fraud /
+   * prompt-extraction attack in GitHub issue #204. Standard inbound AND
+   * outbound Twilio/Telnyx/Plivo calls keep working with zero operator action.
+   *
+   * Set to `false` ONLY when serving custom TwiML/XML that cannot carry the
+   * token (the SDK then accepts unauthenticated media streams and logs a loud
+   * one-time warning). Prefer keeping this on and letting the SDK own the
+   * TwiML/XML.
+   */
+  readonly requireStreamAuth?: boolean;
   /** Path to SQLite database for dashboard persistence (not used in TS yet). */
   readonly dashboardDb?: string;
   /** When true (default), persist dashboard data. */

--- a/libraries/typescript/src/types.ts
+++ b/libraries/typescript/src/types.ts
@@ -15,6 +15,9 @@ export type CarrierKind = "twilio" | "telnyx" | "plivo";
 import type { Realtime } from "./engines/openai";
 import type { Realtime2 } from "./engines/openai-2";
 import type { ConvAI } from "./engines/elevenlabs";
+import type { GeminiLive } from "./engines/gemini";
+import type { GeminiCascade } from "./engines/gemini-cascade";
+import type { InworldRealtime } from "./engines/inworld";
 import type { CloudflareTunnel, Static as StaticTunnel } from "./tunnels";
 import type { Tool as ToolInstance } from "./public-api";
 import type { STTAdapter, TTSAdapter } from "./provider-factory";
@@ -845,13 +848,13 @@ export interface AgentOptions {
    * matching mode (``openai_realtime`` or ``elevenlabs_convai``). When absent,
    * pipeline mode is selected if ``stt`` and ``tts`` are provided.
    */
-  readonly engine?: Realtime | Realtime2 | ConvAI;
+  readonly engine?: Realtime | Realtime2 | ConvAI | GeminiLive | GeminiCascade | InworldRealtime;
   /**
    * Provider mode. Normally derived from ``engine`` / ``stt`` + ``tts``. Pass
    * ``'pipeline'`` explicitly when building a pipeline-mode agent without
    * an engine instance.
    */
-  readonly provider?: 'openai_realtime' | 'elevenlabs_convai' | 'pipeline';
+  readonly provider?: 'openai_realtime' | 'elevenlabs_convai' | 'gemini_live' | 'gemini_cascade' | 'inworld_realtime' | 'pipeline';
   /** Pre-instantiated STT adapter (e.g. ``new DeepgramSTT({ apiKey })``). */
   readonly stt?: STTAdapter;
   /** Pre-instantiated TTS adapter (e.g. ``new ElevenLabsTTS({ apiKey })``). */

--- a/libraries/typescript/tests/gemini-live-thinking.mocked.test.ts
+++ b/libraries/typescript/tests/gemini-live-thinking.mocked.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GeminiLiveAdapter,
+  GEMINI_LIVE_3_1_FLASH_PREVIEW,
+  geminiRequiresV1Alpha,
+} from '../src/providers/gemini-live';
+
+// [mocked] GeminiLiveAdapter — Phase-2 fixes: thinking-leak suppression,
+// gemini-3.1-flash-live-preview apiVersion selection, and actionable connect
+// errors. Mocks the @google/genai boundary only (the real JS SDK delivers
+// server messages through `callbacks.onmessage` and has no async `receive()`).
+
+interface LiveCbs {
+  onopen?: () => void;
+  onmessage?: (e: unknown) => void;
+  onerror?: (e: unknown) => void;
+  onclose?: (e: unknown) => void;
+}
+
+interface CbHolder {
+  cbs: LiveCbs | null;
+}
+
+interface ConnectCapture {
+  configs: Array<Record<string, unknown>>;
+  apiVersions: Array<string | undefined>;
+}
+
+function makeFakeSession() {
+  return {
+    sendRealtimeInput: vi.fn(),
+    sendClientContent: vi.fn(),
+    sendToolResponse: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+/**
+ * Mock of @google/genai.
+ *
+ * `sendSetupComplete` (default true) mirrors the real handshake: socket opens,
+ * THEN the server sends `setupComplete`. Pass false to simulate a model that
+ * never completes setup (drives the "session ready timeout" path).
+ */
+function makeGenAIMock(
+  session: unknown,
+  capture: ConnectCapture,
+  holder: CbHolder = { cbs: null },
+  sendSetupComplete = true,
+) {
+  return {
+    GoogleGenAI: vi.fn().mockImplementation((opts: { httpOptions?: { apiVersion?: string } }) => {
+      capture.apiVersions.push(opts.httpOptions?.apiVersion);
+      return {
+        live: {
+          connect: vi.fn(async (args: { config?: Record<string, unknown>; callbacks?: LiveCbs }) => {
+            if (args.config) capture.configs.push(args.config);
+            holder.cbs = args.callbacks ?? null;
+            args.callbacks?.onopen?.();
+            if (sendSetupComplete) args.callbacks?.onmessage?.({ setupComplete: {} });
+            return session;
+          }),
+        },
+      };
+    }),
+  };
+}
+
+/** 20 ms of PCM-16-LE @ 24 kHz (a low sine so the anti-alias filter has content). */
+function pcm24Tone(samples = 480): Buffer {
+  const buf = Buffer.alloc(samples * 2);
+  for (let i = 0; i < samples; i++) {
+    buf.writeInt16LE(Math.round(8000 * Math.sin((2 * Math.PI * 200 * i) / 24000)), i * 2);
+  }
+  return buf;
+}
+
+function newCapture(): ConnectCapture {
+  return { configs: [], apiVersions: [] };
+}
+
+describe('[mocked] GeminiLiveAdapter — thinking suppression', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('disables thinking by default for voice (thinkingBudget: 0)', async () => {
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    await adapter.connect();
+
+    expect(capture.configs).toHaveLength(1);
+    const cfg = capture.configs[0] as { thinkingConfig?: { thinkingBudget?: number } };
+    expect(cfg.thinkingConfig).toEqual({ thinkingBudget: 0 });
+    await adapter.close();
+  });
+
+  it('thinking: true re-enables dynamic thinking (thinkingBudget: -1)', async () => {
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      thinking: true,
+    });
+    await adapter.connect();
+
+    const cfg = capture.configs[0] as { thinkingConfig?: { thinkingBudget?: number } };
+    expect(cfg.thinkingConfig).toEqual({ thinkingBudget: -1 });
+    // It is explicitly NOT the voice-default off value.
+    expect(cfg.thinkingConfig?.thinkingBudget).not.toBe(0);
+    await adapter.close();
+  });
+
+  it('explicit thinkingBudget wins over the thinking flag', async () => {
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      thinking: false,
+      thinkingBudget: 512,
+    });
+    await adapter.connect();
+
+    const cfg = capture.configs[0] as { thinkingConfig?: { thinkingBudget?: number } };
+    expect(cfg.thinkingConfig).toEqual({ thinkingBudget: 512 });
+    await adapter.close();
+  });
+
+  it('NEVER emits a thought part — drops it from BOTH transcript and audio', async () => {
+    // The model can still return a `thought: true` part even with thinking
+    // disabled. The adapter must defensively suppress it on BOTH legs.
+    const captureA = newCapture();
+    const holderA: CbHolder = { cbs: null };
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), captureA, holderA));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    const transcripts: string[] = [];
+    const audio: Buffer[] = [];
+    adapter.onEvent((type, data) => {
+      if (type === 'transcript_output') transcripts.push(data as string);
+      if (type === 'audio') audio.push(data as Buffer);
+    });
+    await adapter.connect();
+
+    // One server message carrying BOTH a thought part (audio + text) and a
+    // normal part (audio + text) — exactly the leak shape from the live call.
+    holderA.cbs!.onmessage!({
+      serverContent: {
+        modelTurn: {
+          parts: [
+            { thought: true, text: 'Initiating Call Protocol — SECRET REASONING' },
+            { thought: true, inlineData: { data: pcm24Tone().toString('base64') } },
+            { text: 'Buongiorno, come posso aiutarla?' },
+            { inlineData: { data: pcm24Tone().toString('base64') } },
+          ],
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(audio.length).toBeGreaterThan(0);
+    });
+
+    // Only the real reply text — never the chain-of-thought.
+    expect(transcripts).toEqual(['Buongiorno, come posso aiutarla?']);
+    expect(transcripts.join(' ')).not.toContain('SECRET REASONING');
+    const withThoughtBytes = audio.reduce((n, f) => n + f.length, 0);
+    await adapter.close();
+
+    // Baseline: the SAME message minus the thought parts must yield the SAME
+    // audio byte count — proving the thought audio was dropped, not merged.
+    vi.resetModules();
+    const captureB = newCapture();
+    const holderB: CbHolder = { cbs: null };
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), captureB, holderB));
+    const adapter2 = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    const audio2: Buffer[] = [];
+    adapter2.onEvent((type, data) => {
+      if (type === 'audio') audio2.push(data as Buffer);
+    });
+    await adapter2.connect();
+    holderB.cbs!.onmessage!({
+      serverContent: {
+        modelTurn: {
+          parts: [
+            { text: 'Buongiorno, come posso aiutarla?' },
+            { inlineData: { data: pcm24Tone().toString('base64') } },
+          ],
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(audio2.length).toBeGreaterThan(0);
+    });
+    const baselineBytes = audio2.reduce((n, f) => n + f.length, 0);
+    expect(withThoughtBytes).toBe(baselineBytes);
+    await adapter2.close();
+  });
+});
+
+describe('[mocked] GeminiLiveAdapter — apiVersion selection (issue: 3.1 session ready timeout)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('geminiRequiresV1Alpha matches native-audio AND the 3.1 flash-live-preview family', () => {
+    expect(geminiRequiresV1Alpha('gemini-2.5-flash-native-audio-preview-09-2025')).toBe(true);
+    expect(geminiRequiresV1Alpha(GEMINI_LIVE_3_1_FLASH_PREVIEW)).toBe(true);
+    // Retired half-cascade live models stayed on v1beta — must NOT match.
+    expect(geminiRequiresV1Alpha('gemini-2.0-flash-live-001')).toBe(false);
+    expect(geminiRequiresV1Alpha('gemini-2.5-flash')).toBe(false);
+  });
+
+  it('selects v1alpha for native-audio models', async () => {
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: 'gemini-2.5-flash-native-audio-preview-09-2025',
+    });
+    await adapter.connect();
+    expect(capture.apiVersions).toContain('v1alpha');
+    await adapter.close();
+  });
+
+  it('selects v1alpha for gemini-3.1-flash-live-preview (the fix)', async () => {
+    // BEFORE: the id lacked the "native-audio" substring, so it fell to the
+    // SDK default (v1beta), the server never sent setupComplete, and connect()
+    // died with "session ready timeout". It must now resolve to v1alpha.
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+    const adapter = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    await adapter.connect();
+    expect(capture.apiVersions).toEqual(['v1alpha']);
+    await adapter.close();
+  });
+
+  it('explicit apiVersion override wins over auto-detection', async () => {
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      apiVersion: 'v1beta',
+    });
+    await adapter.connect();
+    expect(capture.apiVersions).toEqual(['v1beta']);
+    await adapter.close();
+  });
+});
+
+describe('[mocked] GeminiLiveAdapter — actionable connect errors', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('surfaces an actionable error when the socket errors before setupComplete', async () => {
+    const holder: CbHolder = { cbs: null };
+    const capture = newCapture();
+    // Never send setupComplete; the test fires onerror itself.
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture, holder, false));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    const p = adapter.connect();
+    // Wait until the SDK mock has handed us the callbacks, then fail the socket.
+    await vi.waitFor(() => expect(holder.cbs).not.toBeNull());
+    holder.cbs!.onerror!(new Error('1007 invalid model'));
+
+    await expect(p).rejects.toThrow(/Gemini Live failed to start a session for model/);
+  });
+
+  it('actionable error names the model, apiVersion, and the three root causes', async () => {
+    const holder: CbHolder = { cbs: null };
+    const capture = newCapture();
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture, holder, false));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: GEMINI_LIVE_3_1_FLASH_PREVIEW });
+    const p = adapter.connect();
+    await vi.waitFor(() => expect(holder.cbs).not.toBeNull());
+    holder.cbs!.onerror!(new Error('boom'));
+
+    const err = await p.catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).toContain(GEMINI_LIVE_3_1_FLASH_PREVIEW);
+    expect(msg).toContain('v1alpha'); // resolved apiVersion for the 3.1 model
+    expect(msg).toContain('apiVersion');
+    expect(msg).toContain('API key');
+    expect(msg).toContain('boom');
+  });
+
+  it('a session-ready timeout surfaces the actionable error (not a bare timeout)', async () => {
+    const holder: CbHolder = { cbs: null };
+    const capture = newCapture();
+    // onopen fires but setupComplete never arrives -> the ready gate trips.
+    // Use the internal short connectTimeoutMs knob so the test is fast.
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture, holder, false));
+
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      connectTimeoutMs: 40,
+    });
+    const err = await adapter.connect().catch((e: Error) => e);
+    const msg = (err as Error).message;
+    expect(msg).toMatch(/session ready timeout/);
+    expect(msg).toMatch(/Likely causes/);
+    expect(msg).toContain(GEMINI_LIVE_3_1_FLASH_PREVIEW);
+    expect(msg).toContain('v1alpha');
+  });
+});

--- a/libraries/typescript/tests/inworld-realtime.mocked.test.ts
+++ b/libraries/typescript/tests/inworld-realtime.mocked.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the 'ws' module so connect() makes no real network connection. The mock
+// records constructor args (url + headers) and lets tests drive server frames.
+vi.mock('ws', () => {
+  const EventEmitter = require('events');
+  class MockWebSocket extends EventEmitter {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+    readyState = MockWebSocket.OPEN;
+    sent: string[] = [];
+    url: string;
+    options: unknown;
+    constructor(url: string, options?: unknown) {
+      super();
+      this.url = url;
+      this.options = options;
+      MockWebSocket.instances.push(this);
+    }
+    send(data: string): void {
+      this.sent.push(data);
+    }
+    ping(): void {
+      /* heartbeat no-op */
+    }
+    close(): void {
+      this.readyState = MockWebSocket.CLOSED;
+    }
+  }
+  return { default: MockWebSocket };
+});
+
+import {
+  InworldRealtimeAdapter,
+  INWORLD_REALTIME_WS_URL,
+  INWORLD_REALTIME_DEFAULT_MODEL,
+  INWORLD_REALTIME_DEFAULT_VOICE,
+} from '../src/providers/inworld-realtime';
+import { OpenAIRealtimeAdapter } from '../src/providers/openai-realtime';
+import { InworldRealtime } from '../src/engines/inworld';
+import { buildAIAdapter, type LocalConfig } from '../src/server';
+import type { AgentOptions } from '../src/types';
+import { Patter } from '../src/client';
+import { Twilio } from '../src/index';
+
+type MockWS = {
+  readonly sent: string[];
+  readonly url: string;
+  readonly options: { headers?: Record<string, string> };
+  emit: (event: string, ...args: unknown[]) => void;
+};
+
+async function getWsCtor(): Promise<{ instances: MockWS[] }> {
+  const mod = (await import('ws')).default as unknown as { instances: MockWS[] };
+  return mod;
+}
+
+const CONFIG: LocalConfig = {
+  phoneNumber: '+15555550100',
+  webhookUrl: 'https://example.com/voice',
+};
+
+describe('[unit] InworldRealtime engine marker', () => {
+  it('throws without an apiKey and no env', () => {
+    const prev = process.env.INWORLD_API_KEY;
+    delete process.env.INWORLD_API_KEY;
+    try {
+      expect(() => new InworldRealtime()).toThrow(/Inworld Realtime requires an apiKey/);
+    } finally {
+      if (prev !== undefined) process.env.INWORLD_API_KEY = prev;
+    }
+  });
+
+  it('reads INWORLD_API_KEY from the environment', () => {
+    const prev = process.env.INWORLD_API_KEY;
+    process.env.INWORLD_API_KEY = 'rt_env_key';
+    try {
+      const engine = new InworldRealtime();
+      expect(engine.apiKey).toBe('rt_env_key');
+      expect(engine.kind).toBe('inworld_realtime');
+    } finally {
+      if (prev === undefined) delete process.env.INWORLD_API_KEY;
+      else process.env.INWORLD_API_KEY = prev;
+    }
+  });
+
+  it('validates turnDetection eagerly (rejects bad values)', () => {
+    expect(
+      () =>
+        new InworldRealtime({
+          apiKey: 'k',
+          // @ts-expect-error intentionally invalid for the runtime guard
+          turnDetection: { type: 'nope' },
+        }),
+    ).toThrow(/server_vad|semantic_vad/);
+  });
+});
+
+describe('[unit] InworldRealtime dispatch', () => {
+  it('Patter.agent({ engine: new InworldRealtime() }) selects provider inworld_realtime', () => {
+    const phone = new Patter({
+      carrier: new Twilio({ accountSid: 'AC_test', authToken: 'tok_test' }),
+      phoneNumber: '+15550000000',
+      webhookUrl: 'abc.ngrok.io',
+    });
+    const agent = phone.agent({
+      engine: new InworldRealtime({ apiKey: 'rt_key', voice: 'Olivia' }),
+      systemPrompt: 'You are helpful.',
+    });
+    expect(agent.provider).toBe('inworld_realtime');
+    expect(agent.voice).toBe('Olivia');
+  });
+
+  it('buildAIAdapter routes inworld_realtime to InworldRealtimeAdapter (and OpenAIRealtimeAdapter subclass)', () => {
+    const agent: AgentOptions = {
+      systemPrompt: 'You are helpful.',
+      engine: new InworldRealtime({ apiKey: 'rt_key' }),
+      provider: 'inworld_realtime',
+    };
+    const adapter = buildAIAdapter(CONFIG, agent);
+    expect(adapter).toBeInstanceOf(InworldRealtimeAdapter);
+    // Subclass of the OpenAI adapter, so every `instanceof OpenAIRealtimeAdapter`
+    // feature gate in the stream handler (barge-in, sendText, function_call,
+    // truncate) fires for Inworld too — no per-provider branches needed.
+    expect(adapter).toBeInstanceOf(OpenAIRealtimeAdapter);
+  });
+
+  it('throws a clear error when provider is inworld_realtime but the engine is missing', () => {
+    const agent = {
+      systemPrompt: 'hi',
+      provider: 'inworld_realtime',
+    } as unknown as AgentOptions;
+    expect(() => buildAIAdapter(CONFIG, agent)).toThrow(/Inworld Realtime mode requires/);
+  });
+});
+
+describe('[mocked] InworldRealtimeAdapter connect', () => {
+  beforeEach(async () => {
+    const ws = await getWsCtor();
+    ws.instances.length = 0;
+  });
+
+  it('connects to the Inworld endpoint with a Bearer key and OpenAI-compatible handshake', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key', { model: 'inworld-realtime', voice: 'Ashley' });
+    const p = adapter.connect();
+    const ws = (await getWsCtor()).instances[0];
+
+    // Endpoint + auth.
+    expect(ws.url).toBe(`${INWORLD_REALTIME_WS_URL}?model=inworld-realtime`);
+    expect(ws.options.headers?.Authorization).toBe('Bearer rt_key');
+
+    // Handshake: server says session.created -> adapter sends session.update.
+    ws.emit('message', JSON.stringify({ type: 'session.created' }));
+    const update = JSON.parse(ws.sent[0]) as { type: string; session: Record<string, unknown> };
+    expect(update.type).toBe('session.update');
+    expect(update.session.voice).toBe('Ashley');
+
+    // session.updated -> connect resolves.
+    ws.emit('message', JSON.stringify({ type: 'session.updated' }));
+    await p;
+    adapter.close();
+  });
+
+  it('uses the default model + voice when none supplied', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key');
+    const p = adapter.connect();
+    const ws = (await getWsCtor()).instances[0];
+    expect(ws.url).toBe(
+      `${INWORLD_REALTIME_WS_URL}?model=${encodeURIComponent(INWORLD_REALTIME_DEFAULT_MODEL)}`,
+    );
+    ws.emit('message', JSON.stringify({ type: 'session.created' }));
+    const update = JSON.parse(ws.sent[0]) as { session: { voice: string } };
+    expect(update.session.voice).toBe(INWORLD_REALTIME_DEFAULT_VOICE);
+    ws.emit('message', JSON.stringify({ type: 'session.updated' }));
+    await p;
+    adapter.close();
+  });
+
+  it('honors a baseUrl override', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key', {
+      baseUrl: 'wss://example.test/rt/',
+      model: 'm1',
+    });
+    const p = adapter.connect();
+    const ws = (await getWsCtor()).instances[0];
+    // Trailing slash trimmed.
+    expect(ws.url).toBe('wss://example.test/rt?model=m1');
+    ws.emit('message', JSON.stringify({ type: 'session.created' }));
+    ws.emit('message', JSON.stringify({ type: 'session.updated' }));
+    await p;
+    adapter.close();
+  });
+
+  it('surfaces a setup error frame as a clear rejection', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key', { model: 'bad-model' });
+    const p = adapter.connect();
+    const ws = (await getWsCtor()).instances[0];
+    ws.emit('message', JSON.stringify({ type: 'session.created' }));
+    ws.emit('message', JSON.stringify({ type: 'error', error: { message: 'model not found' } }));
+    await expect(p).rejects.toThrow(/Inworld Realtime setup error: model not found/);
+  });
+
+  it('dispatches audio after the session attaches (a call can hear the model)', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key', { model: 'm1' });
+    const audio: Buffer[] = [];
+    adapter.onEvent((type, data) => {
+      if (type === 'audio') audio.push(data as Buffer);
+    });
+    const p = adapter.connect();
+    const ws = (await getWsCtor()).instances[0];
+    ws.emit('message', JSON.stringify({ type: 'session.created' }));
+    ws.emit('message', JSON.stringify({ type: 'session.updated' }));
+    await p;
+
+    const payload = Buffer.from([0xff, 0x7f, 0x00, 0x10]).toString('base64');
+    ws.emit('message', JSON.stringify({ type: 'response.audio.delta', delta: payload }));
+    await vi.waitFor(() => expect(audio.length).toBe(1));
+    expect(Buffer.compare(audio[0], Buffer.from([0xff, 0x7f, 0x00, 0x10]))).toBe(0);
+    adapter.close();
+  });
+
+  it('warmup is a no-op and openParkedConnection is unsupported (no OpenAI endpoint hit)', async () => {
+    const adapter = new InworldRealtimeAdapter('rt_key');
+    await expect(adapter.warmup()).resolves.toBeUndefined();
+    await expect(adapter.openParkedConnection()).rejects.toThrow(/not supported/);
+    // No socket should have been opened by either call.
+    const ws = await getWsCtor();
+    expect(ws.instances.length).toBe(0);
+  });
+});

--- a/libraries/typescript/tests/unit/sarvam-tts.mocked.test.ts
+++ b/libraries/typescript/tests/unit/sarvam-tts.mocked.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SarvamTTS,
+  SarvamModel,
+  SarvamLanguage,
+} from "../../src/providers/sarvam-tts";
+import { TTS as SarvamPipelineTTS } from "../../src/tts/sarvam";
+
+/**
+ * [mocked] Sarvam AI TTS — request shape, per-model field gating, base64
+ * decoding and telephony factories.
+ *
+ * The Sarvam REST endpoint is mocked at the global `fetch` boundary; every
+ * other code path (payload assembly, model gating, base64 decoding) runs for
+ * real. NO PII: we only round-trip the mock's bytes.
+ */
+describe("[mocked] Sarvam AI TTS", () => {
+  const ORIGINAL_FETCH = global.fetch;
+  let lastBody: Record<string, unknown> | null = null;
+  let lastHeaders: Record<string, string> | null = null;
+  let lastUrl: string | null = null;
+
+  function jsonAudioResponse(...payloads: string[]): Response {
+    const audios = payloads.map((p) => Buffer.from(p).toString("base64"));
+    return new Response(JSON.stringify({ request_id: "req-1", audios }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  beforeEach(() => {
+    lastBody = null;
+    lastHeaders = null;
+    lastUrl = null;
+    global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastUrl = typeof input === "string" ? input : input.toString();
+      lastBody = JSON.parse(init?.body as string);
+      lastHeaders = init?.headers as Record<string, string>;
+      return jsonAudioResponse("hello", "world");
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  describe("low-level SarvamTTS", () => {
+    it("posts to the REST endpoint with the api-subscription-key header", async () => {
+      const tts = new SarvamTTS("key");
+      await tts.synthesize("namaste");
+      expect(lastUrl).toBe("https://api.sarvam.ai/text-to-speech");
+      expect(lastHeaders?.["api-subscription-key"]).toBe("key");
+      expect(lastHeaders?.["Content-Type"]).toBe("application/json");
+    });
+
+    it("defaults to bulbul:v3, speaker shubh, linear16 @ 16 kHz, en-IN", async () => {
+      const tts = new SarvamTTS("key");
+      await tts.synthesize("hi");
+      expect(lastBody?.model).toBe(SarvamModel.BULBUL_V3);
+      expect(lastBody?.speaker).toBe("shubh");
+      expect(lastBody?.target_language_code).toBe(SarvamLanguage.ENGLISH);
+      expect(lastBody?.output_audio_codec).toBe("linear16");
+      expect(lastBody?.speech_sample_rate).toBe(16000);
+      for (const key of [
+        "pace",
+        "pitch",
+        "loudness",
+        "temperature",
+        "enable_preprocessing",
+        "dict_id",
+      ]) {
+        expect(lastBody).not.toHaveProperty(key);
+      }
+    });
+
+    it("maps the language option to target_language_code", async () => {
+      const tts = new SarvamTTS("key", { language: "hi-IN" });
+      await tts.synthesize("hi");
+      expect(lastBody?.target_language_code).toBe("hi-IN");
+    });
+
+    it("sends pace only when set", async () => {
+      const tts = new SarvamTTS("key", { pace: 1.25 });
+      await tts.synthesize("hi");
+      expect(lastBody?.pace).toBe(1.25);
+    });
+
+    it("gates pitch/loudness/enablePreprocessing to bulbul:v2 (drops temperature)", async () => {
+      const tts = new SarvamTTS("key", {
+        model: "bulbul:v2",
+        speaker: "anushka",
+        pitch: 0.2,
+        loudness: 1.5,
+        enablePreprocessing: true,
+        temperature: 0.9, // v3-only → must be dropped
+      });
+      await tts.synthesize("hi");
+      expect(lastBody?.model).toBe("bulbul:v2");
+      expect(lastBody?.pitch).toBe(0.2);
+      expect(lastBody?.loudness).toBe(1.5);
+      expect(lastBody?.enable_preprocessing).toBe(true);
+      expect(lastBody).not.toHaveProperty("temperature");
+      expect(lastBody).not.toHaveProperty("dict_id");
+    });
+
+    it("gates temperature/dictId to bulbul:v3 (drops pitch/loudness)", async () => {
+      const tts = new SarvamTTS("key", {
+        model: "bulbul:v3",
+        temperature: 0.8,
+        dictId: "dict-42",
+        pitch: 0.2, // v2-only → must be dropped
+        loudness: 1.5,
+        enablePreprocessing: true,
+      });
+      await tts.synthesize("hi");
+      expect(lastBody?.temperature).toBe(0.8);
+      expect(lastBody?.dict_id).toBe("dict-42");
+      expect(lastBody).not.toHaveProperty("pitch");
+      expect(lastBody).not.toHaveProperty("loudness");
+      expect(lastBody).not.toHaveProperty("enable_preprocessing");
+    });
+
+    it("decodes base64 audios and concatenates in order", async () => {
+      const tts = new SarvamTTS("key");
+      const out = await tts.synthesize("hi");
+      expect(out.toString("utf8")).toBe("helloworld");
+    });
+
+    it("yields one Buffer per audios entry via synthesizeStream", async () => {
+      const tts = new SarvamTTS("key");
+      const collected: string[] = [];
+      for await (const chunk of tts.synthesizeStream("hi")) {
+        collected.push(chunk.toString("utf8"));
+      }
+      expect(collected).toEqual(["hello", "world"]);
+    });
+
+    it("yields nothing on a malformed body", async () => {
+      global.fetch = async () =>
+        new Response(JSON.stringify({ request_id: "x" }), { status: 200 });
+      const tts = new SarvamTTS("key");
+      const out = await tts.synthesize("hi");
+      expect(out.length).toBe(0);
+    });
+
+    it("surfaces non-200 responses with status + body", async () => {
+      global.fetch = async () => new Response("rate limited", { status: 429 });
+      const tts = new SarvamTTS("key");
+      await expect(tts.synthesize("hi")).rejects.toThrow(/Sarvam TTS error 429/);
+    });
+
+    it("throws when constructed without an apiKey", () => {
+      expect(() => new SarvamTTS("")).toThrow(/apiKey is required/);
+    });
+  });
+
+  describe("telephony factories", () => {
+    it("forTwilio emits μ-law @ 8 kHz natively (carrier-wire passthrough)", async () => {
+      const tts = SarvamTTS.forTwilio("key");
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("mulaw");
+      expect(lastBody?.speech_sample_rate).toBe(8000);
+      expect(tts.sourceAudioFormat()).toEqual({ encoding: "mulaw", sampleRate: 8000 });
+    });
+
+    it("forTwilio honours overrides but pins the μ-law 8 kHz wire", async () => {
+      const tts = SarvamTTS.forTwilio("key", { language: "ta-IN", speaker: "kavya" });
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("mulaw");
+      expect(lastBody?.speech_sample_rate).toBe(8000);
+      expect(lastBody?.target_language_code).toBe("ta-IN");
+      expect(lastBody?.speaker).toBe("kavya");
+    });
+
+    it("forTelnyx emits μ-law @ 8 kHz natively (PCMU wire passthrough)", async () => {
+      const tts = SarvamTTS.forTelnyx("key");
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("mulaw");
+      expect(lastBody?.speech_sample_rate).toBe(8000);
+    });
+
+    it("constructor default unchanged (linear16 @ 16000)", async () => {
+      const tts = new SarvamTTS("key");
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("linear16");
+      expect(lastBody?.speech_sample_rate).toBe(16000);
+      expect(tts.sourceAudioFormat()).toEqual({
+        encoding: "pcm_s16le",
+        sampleRate: 16000,
+      });
+    });
+  });
+
+  describe("pipeline-mode TTS class", () => {
+    it("requires SARVAM_API_KEY (or apiKey opt) and forwards to provider", async () => {
+      const prev = process.env.SARVAM_API_KEY;
+      delete process.env.SARVAM_API_KEY;
+      try {
+        expect(() => new SarvamPipelineTTS()).toThrow(/SARVAM_API_KEY/);
+
+        const tts = new SarvamPipelineTTS({ apiKey: "tok-from-opt" });
+        await tts.synthesize("hi");
+        expect(lastHeaders?.["api-subscription-key"]).toBe("tok-from-opt");
+
+        process.env.SARVAM_API_KEY = "tok-from-env";
+        const tts2 = new SarvamPipelineTTS();
+        await tts2.synthesize("hi");
+        expect(lastHeaders?.["api-subscription-key"]).toBe("tok-from-env");
+      } finally {
+        if (prev === undefined) delete process.env.SARVAM_API_KEY;
+        else process.env.SARVAM_API_KEY = prev;
+      }
+    });
+
+    it("forTwilio (options-object form) emits μ-law @ 8 kHz natively", async () => {
+      const tts = SarvamPipelineTTS.forTwilio({ apiKey: "key" });
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("mulaw");
+      expect(lastBody?.speech_sample_rate).toBe(8000);
+    });
+
+    it("forTwilio (positional form) is parent-compatible", async () => {
+      const tts = SarvamPipelineTTS.forTwilio("key");
+      await tts.synthesize("hi");
+      expect(lastBody?.output_audio_codec).toBe("mulaw");
+      expect(lastBody?.speech_sample_rate).toBe(8000);
+    });
+
+    it("forTwilio falls back to SARVAM_API_KEY env var", async () => {
+      const prev = process.env.SARVAM_API_KEY;
+      process.env.SARVAM_API_KEY = "env-key";
+      try {
+        const tts = SarvamPipelineTTS.forTwilio();
+        await tts.synthesize("hi");
+        expect(lastHeaders?.["api-subscription-key"]).toBe("env-key");
+        expect(lastBody?.speech_sample_rate).toBe(8000);
+      } finally {
+        if (prev === undefined) delete process.env.SARVAM_API_KEY;
+        else process.env.SARVAM_API_KEY = prev;
+      }
+    });
+
+    it("forTwilio without apiKey or env throws", () => {
+      const prev = process.env.SARVAM_API_KEY;
+      delete process.env.SARVAM_API_KEY;
+      try {
+        expect(() => SarvamPipelineTTS.forTwilio()).toThrow(/SARVAM_API_KEY/);
+      } finally {
+        if (prev !== undefined) process.env.SARVAM_API_KEY = prev;
+      }
+    });
+  });
+});

--- a/libraries/typescript/tests/unit/soniox-stt.test.ts
+++ b/libraries/typescript/tests/unit/soniox-stt.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for Soniox v5 real-time STT adoption (TypeScript).
+ *
+ * Mocks the `ws` module so the test can assert the model string and the new
+ * opt-in v5 endpoint controls land in the initial Soniox config frame sent
+ * over the WebSocket — without any network I/O. Mirrors the Python
+ * `test_soniox_stt_v5.py` coverage.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SonioxSTT, SonioxModel } from '../../src/providers/soniox-stt';
+import type { SonioxSTTOptions } from '../../src/providers/soniox-stt';
+
+// ---------------------------------------------------------------------------
+// Mock the ws module
+// ---------------------------------------------------------------------------
+
+const mockWsInstances: Array<{
+  handlers: Map<string, Array<(...args: unknown[]) => void>>;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+  once: (event: string, cb: (...args: unknown[]) => void) => void;
+  emit: (event: string, ...args: unknown[]) => void;
+}> = [];
+
+vi.mock('ws', () => {
+  const OPEN = 1;
+  const CLOSED = 3;
+
+  class MockWebSocket {
+    static OPEN = OPEN;
+    static CLOSED = CLOSED;
+    readyState = OPEN;
+    handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+    send = vi.fn();
+    close = vi.fn();
+
+    constructor(_url: string, _opts?: unknown) {
+      mockWsInstances.push(this as unknown as (typeof mockWsInstances)[number]);
+    }
+
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (!this.handlers.has(event)) {
+        this.handlers.set(event, []);
+      }
+      this.handlers.get(event)!.push(cb);
+    }
+
+    once(event: string, cb: (...args: unknown[]) => void) {
+      this.on(event, cb);
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      const cbs = this.handlers.get(event) ?? [];
+      for (const cb of cbs) {
+        cb(...args);
+      }
+    }
+  }
+
+  return { default: MockWebSocket, __esModule: true };
+});
+
+function latestWs() {
+  return mockWsInstances[mockWsInstances.length - 1];
+}
+
+/** Connect a SonioxSTT against the mock ws and return the parsed config frame. */
+async function connectAndCapture(
+  apiKey: string,
+  options: SonioxSTTOptions = {},
+): Promise<Record<string, unknown>> {
+  const stt = new SonioxSTT(apiKey, options);
+  const connectPromise = stt.connect();
+  const ws = latestWs();
+  ws.emit('open');
+  await connectPromise;
+  // First send after open is the JSON config frame.
+  const firstSend = ws.send.mock.calls[0]?.[0] as string;
+  const config = JSON.parse(firstSend) as Record<string, unknown>;
+  stt.close(); // clear the keepalive interval
+  return config;
+}
+
+describe('SonioxSTT v5', () => {
+  beforeEach(() => {
+    mockWsInstances.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes the v5 model id and keeps older models reachable', () => {
+    expect(SonioxModel.STT_RT_V5).toBe('stt-rt-v5');
+    expect(SonioxModel.STT_RT_V4).toBe('stt-rt-v4');
+    expect(SonioxModel.STT_RT_V3).toBe('stt-rt-v3');
+    expect(SonioxModel.STT_RT_V2).toBe('stt-rt-v2');
+  });
+
+  it('sends the v5 model in the config by default', async () => {
+    const config = await connectAndCapture('sx_test');
+    expect(config.model).toBe('stt-rt-v5');
+  });
+
+  it('forTwilio() defaults to the v5 model', () => {
+    const stt = SonioxSTT.forTwilio('sx_test');
+    expect(stt).toBeInstanceOf(SonioxSTT);
+  });
+
+  it('honors an explicit older model', async () => {
+    const config = await connectAndCapture('sx_test', { model: SonioxModel.STT_RT_V4 });
+    expect(config.model).toBe('stt-rt-v4');
+  });
+
+  it('omits the v5 endpoint controls unless set, then forwards them', async () => {
+    const base = await connectAndCapture('sx_test');
+    expect(base.endpoint_sensitivity).toBeUndefined();
+    expect(base.endpoint_latency_adjustment_level).toBeUndefined();
+
+    const tuned = await connectAndCapture('sx_test', {
+      endpointSensitivity: 0.5,
+      endpointLatencyAdjustmentLevel: 2,
+    });
+    expect(tuned.endpoint_sensitivity).toBe(0.5);
+    expect(tuned.endpoint_latency_adjustment_level).toBe(2);
+  });
+
+  it('validates the v5 endpoint controls', () => {
+    expect(() => new SonioxSTT('sx_test', { endpointSensitivity: 1.5 })).toThrow(
+      /endpointSensitivity/,
+    );
+    expect(
+      () => new SonioxSTT('sx_test', { endpointLatencyAdjustmentLevel: 4 }),
+    ).toThrow(/endpointLatencyAdjustmentLevel/);
+  });
+});

--- a/libraries/typescript/tests/unit/soniox-tts.mocked.test.ts
+++ b/libraries/typescript/tests/unit/soniox-tts.mocked.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  SonioxTTS,
+  SonioxTTSModel,
+} from '../../src/providers/soniox-tts';
+import { TTS as SonioxPipelineTTS } from '../../src/tts/soniox';
+
+/**
+ * [mocked] Soniox TTS — request shape, Bearer auth, telephony factories.
+ *
+ * The Soniox REST `/tts` endpoint is mocked at the global `fetch` boundary;
+ * every other code path (payload assembly, byte streaming, source-format
+ * declaration, env-var fallback) runs for real.
+ */
+describe('[mocked] Soniox TTS — request + streaming', () => {
+  const ORIGINAL_FETCH = global.fetch;
+  let lastBody: Record<string, unknown> | null = null;
+  let lastHeaders: Record<string, string> | null = null;
+  let lastUrl: string | null = null;
+
+  /** Build a Response that streams each string as its own byte chunk. */
+  function mockBytesResponse(chunks: string[], status = 200): Response {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder();
+        for (const c of chunks) controller.enqueue(enc.encode(c));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status });
+  }
+
+  beforeEach(() => {
+    lastBody = null;
+    lastHeaders = null;
+    lastUrl = null;
+    global.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastUrl = typeof input === 'string' ? input : input.toString();
+      lastBody = JSON.parse(init?.body as string);
+      lastHeaders = init?.headers as Record<string, string>;
+      return mockBytesResponse(['hello', 'world']);
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  describe('low-level SonioxTTS', () => {
+    it('posts to the REST endpoint with a Bearer auth header', async () => {
+      const tts = new SonioxTTS('sk-key');
+      await tts.synthesize('ciao');
+      expect(lastUrl).toBe('https://tts-rt.soniox.com/tts');
+      expect(lastHeaders?.Authorization).toBe('Bearer sk-key');
+      expect(lastHeaders?.['Content-Type']).toBe('application/json');
+    });
+
+    it('defaults to tts-rt-v1, voice Adrian, pcm_s16le @ 16 kHz, language en', async () => {
+      const tts = new SonioxTTS('tok');
+      await tts.synthesize('hi');
+      expect(lastBody?.model).toBe(SonioxTTSModel.TTS_RT_V1);
+      expect(lastBody?.voice).toBe('Adrian');
+      expect(lastBody?.language).toBe('en');
+      expect(lastBody?.audio_format).toBe('pcm_s16le');
+      expect(lastBody?.sample_rate).toBe(16000);
+    });
+
+    it('forwards optional bitrate / speed only when set', async () => {
+      const tts = new SonioxTTS('tok');
+      await tts.synthesize('hi');
+      expect(lastBody).not.toHaveProperty('bitrate');
+      expect(lastBody).not.toHaveProperty('speed');
+
+      const tts2 = new SonioxTTS('tok', { bitrate: 128000, speed: 1.1, voice: 'Maya' });
+      await tts2.synthesize('ciao');
+      expect(lastBody?.bitrate).toBe(128000);
+      expect(lastBody?.speed).toBe(1.1);
+      expect(lastBody?.voice).toBe('Maya');
+    });
+
+    it('concatenates streamed bytes in order via synthesize', async () => {
+      const tts = new SonioxTTS('tok');
+      const out = await tts.synthesize('hi');
+      expect(out.toString('utf8')).toBe('helloworld');
+    });
+
+    it('yields one Buffer per chunk via synthesizeStream', async () => {
+      const tts = new SonioxTTS('tok');
+      const collected: string[] = [];
+      for await (const chunk of tts.synthesizeStream('hi')) {
+        collected.push(chunk.toString('utf8'));
+      }
+      expect(collected).toEqual(['hello', 'world']);
+    });
+
+    it('surfaces non-200 responses with status + body', async () => {
+      global.fetch = async () => new Response('rate limited', { status: 429 });
+      const tts = new SonioxTTS('tok');
+      await expect(tts.synthesize('hi')).rejects.toThrow(/Soniox TTS error 429/);
+    });
+
+    it('exposes the stable provider key', () => {
+      expect(SonioxTTS.providerKey).toBe('soniox_tts');
+    });
+  });
+
+  describe('source audio format', () => {
+    it('default declares pcm_s16le at its configured rate', () => {
+      const tts = new SonioxTTS('k', { sampleRate: 24000 });
+      expect(tts.sourceAudioFormat()).toEqual({
+        encoding: 'pcm_s16le',
+        sampleRate: 24000,
+      });
+    });
+
+    it('pcm_mulaw declares mulaw', () => {
+      const tts = new SonioxTTS('k', { audioFormat: 'pcm_mulaw', sampleRate: 8000 });
+      expect(tts.sourceAudioFormat()).toEqual({ encoding: 'mulaw', sampleRate: 8000 });
+    });
+
+    it('pcm_alaw declares alaw', () => {
+      const tts = new SonioxTTS('k', { audioFormat: 'pcm_alaw', sampleRate: 8000 });
+      expect(tts.sourceAudioFormat()).toEqual({ encoding: 'alaw', sampleRate: 8000 });
+    });
+  });
+
+  describe('telephony factories (low-level)', () => {
+    it('forTwilio emits μ-law @ 8 kHz natively (carrier-wire passthrough)', async () => {
+      const tts = SonioxTTS.forTwilio('sk-key');
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+      expect(tts.sourceAudioFormat()).toEqual({ encoding: 'mulaw', sampleRate: 8000 });
+    });
+
+    it('forTwilio honours overrides (voice, language, speed) but pins μ-law 8 kHz', async () => {
+      const tts = SonioxTTS.forTwilio('sk-key', {
+        voice: 'Maya',
+        language: 'es',
+        speed: 1.2,
+      });
+      await tts.synthesize('hola');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+      expect(lastBody?.voice).toBe('Maya');
+      expect(lastBody?.language).toBe('es');
+    });
+
+    it('forTelnyx emits μ-law @ 8 kHz natively (PCMU wire passthrough)', async () => {
+      const tts = SonioxTTS.forTelnyx('sk-key');
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+    });
+
+    it('constructor default unchanged (pcm_s16le @ 16000)', async () => {
+      const tts = new SonioxTTS('sk-key');
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_s16le');
+      expect(lastBody?.sample_rate).toBe(16000);
+    });
+  });
+
+  describe('pipeline-mode TTS class', () => {
+    it('requires SONIOX_API_KEY (or apiKey opt) and forwards to provider', async () => {
+      const prev = process.env.SONIOX_API_KEY;
+      delete process.env.SONIOX_API_KEY;
+      try {
+        expect(() => new SonioxPipelineTTS()).toThrow(/SONIOX_API_KEY/);
+
+        const tts = new SonioxPipelineTTS({ apiKey: 'tok-from-opt' });
+        await tts.synthesize('hi');
+        expect(lastHeaders?.Authorization).toBe('Bearer tok-from-opt');
+
+        process.env.SONIOX_API_KEY = 'tok-from-env';
+        const tts2 = new SonioxPipelineTTS();
+        await tts2.synthesize('hi');
+        expect(lastHeaders?.Authorization).toBe('Bearer tok-from-env');
+      } finally {
+        if (prev === undefined) delete process.env.SONIOX_API_KEY;
+        else process.env.SONIOX_API_KEY = prev;
+      }
+    });
+
+    it('forTwilio (options-object form) emits μ-law @ 8 kHz natively', async () => {
+      const tts = SonioxPipelineTTS.forTwilio({ apiKey: 'sk-key' });
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+    });
+
+    it('forTwilio (positional form) is parent-compatible', async () => {
+      const tts = SonioxPipelineTTS.forTwilio('sk-key');
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+    });
+
+    it('forTelnyx (options-object form) emits μ-law @ 8 kHz natively', async () => {
+      const tts = SonioxPipelineTTS.forTelnyx({ apiKey: 'sk-key' });
+      await tts.synthesize('hello');
+      expect(lastBody?.audio_format).toBe('pcm_mulaw');
+      expect(lastBody?.sample_rate).toBe(8000);
+    });
+
+    it('forTwilio falls back to SONIOX_API_KEY env var', async () => {
+      const prev = process.env.SONIOX_API_KEY;
+      process.env.SONIOX_API_KEY = 'env-key';
+      try {
+        const tts = SonioxPipelineTTS.forTwilio();
+        await tts.synthesize('hello');
+        expect(lastBody?.sample_rate).toBe(8000);
+        expect(lastHeaders?.Authorization).toBe('Bearer env-key');
+      } finally {
+        if (prev === undefined) delete process.env.SONIOX_API_KEY;
+        else process.env.SONIOX_API_KEY = prev;
+      }
+    });
+
+    it('forTwilio without apiKey or env throws', () => {
+      const prev = process.env.SONIOX_API_KEY;
+      delete process.env.SONIOX_API_KEY;
+      try {
+        expect(() => SonioxPipelineTTS.forTwilio()).toThrow(/SONIOX_API_KEY/);
+      } finally {
+        if (prev !== undefined) process.env.SONIOX_API_KEY = prev;
+      }
+    });
+  });
+});

--- a/libraries/typescript/tests/unit/stream-auth.test.ts
+++ b/libraries/typescript/tests/unit/stream-auth.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Media-stream authentication tests (GitHub issue #204).
+ *
+ * Verifies that the per-call stream-auth token minted by the
+ * signature-validated carrier webhook / outbound dial is REQUIRED by the media
+ * WebSocket before any provider (STT/LLM/TTS) session opens, for all three
+ * carriers (Twilio <Parameter>, Telnyx query string, Plivo extra_headers), plus
+ * the fail-closed default, the opt-out escape hatch, and the guarantee that the
+ * token never appears in logs.
+ *
+ * Only the WS transport is mocked — the token is minted through the real
+ * webhook / stream-URL code path on a real EmbeddedServer instance, then
+ * presented (or withheld) on a simulated 'start' frame. The billable provider
+ * session (`StreamHandler.handleCallStart`) is spied so "no session opened" is
+ * asserted directly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import net from 'node:net';
+import type { AddressInfo } from 'node:net';
+
+import { EmbeddedServer } from '../../src/server';
+import type { LocalConfig } from '../../src/server';
+import type { AgentOptions } from '../../src/types';
+import { StreamHandler } from '../../src/stream-handler';
+import {
+  StreamTokenStore,
+  generateStreamToken,
+  constantTimeEquals,
+  STREAM_TOKEN_TTL_MS,
+} from '../../src/stream-auth';
+import { getLogger, setLogger } from '../../src/logger';
+import type { Logger } from '../../src/logger';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getFreePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function makeConfig(overrides: Partial<LocalConfig> = {}): LocalConfig {
+  return {
+    twilioSid: 'AC_test',
+    twilioToken: 'tok_test',
+    openaiKey: 'sk_test',
+    phoneNumber: '+15550000000',
+    webhookUrl: 'abc.ngrok.io',
+    telephonyProvider: 'twilio',
+    requireSignature: false,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<AgentOptions> = {}): AgentOptions {
+  return {
+    systemPrompt: 'You are helpful.',
+    voice: 'alloy',
+    model: 'gpt-4o-mini-realtime-preview',
+    language: 'en',
+    ...overrides,
+  } as AgentOptions;
+}
+
+/** Twilio config with NO auth token so /webhooks/twilio/voice skips signature
+ *  validation (requireSignature=false) and returns TwiML we can mint from. */
+function twilioConfig(overrides: Partial<LocalConfig> = {}): LocalConfig {
+  return makeConfig({ twilioToken: undefined, ...overrides });
+}
+
+/** EventEmitter-backed mock WS with the socket methods the handlers call. */
+class MockWs extends EventEmitter {
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  terminate = vi.fn();
+  ping = vi.fn();
+}
+
+/** Await the per-connection async FIFO used by the WS handlers. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 25));
+
+const VALID_SID = 'CA' + 'abcdef0123456789abcdef0123456789';
+
+/** Install a capturing logger; returns the recorded lines and a restore fn. */
+function captureLogs(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const record = (msg: string, ...args: unknown[]): void => {
+    lines.push([msg, ...args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))].join(' '));
+  };
+  const prev = getLogger();
+  const capturing: Logger = { info: record, warn: record, error: record, debug: record };
+  setLogger(capturing);
+  return { lines, restore: () => setLogger(prev) };
+}
+
+// ---------------------------------------------------------------------------
+// StreamTokenStore (pure unit)
+// ---------------------------------------------------------------------------
+
+describe('StreamTokenStore', () => {
+  it('mints a high-entropy url-safe token that validates for its key', () => {
+    const store = new StreamTokenStore();
+    const token = store.mint('call-1');
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+    expect(token.length).toBeGreaterThanOrEqual(43);
+    expect(store.validate('call-1', token)).toBe(true);
+  });
+
+  it('rejects a wrong token, an unknown key, and a missing token', () => {
+    const store = new StreamTokenStore();
+    const token = store.mint('call-1');
+    expect(store.validate('call-1', token + 'x')).toBe(false);
+    expect(store.validate('call-1', 'totally-different')).toBe(false);
+    expect(store.validate('other-key', token)).toBe(false);
+    expect(store.validate('call-1', undefined)).toBe(false);
+    expect(store.validate('call-1', '')).toBe(false);
+  });
+
+  it('rejects an expired token and prunes it', () => {
+    const store = new StreamTokenStore(1_000);
+    const t0 = 10_000;
+    const token = store.mint('call-1', t0);
+    expect(store.validate('call-1', token, t0 + 999)).toBe(true);
+    // At/after expiry the token is rejected and the entry is dropped.
+    expect(store.validate('call-1', token, t0 + 1_000)).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it('keeps the token valid within the TTL (carrier reconnect allowed)', () => {
+    const store = new StreamTokenStore();
+    const token = store.mint('call-1');
+    expect(store.validate('call-1', token)).toBe(true);
+    // Second presentation inside the window still succeeds (not single-use).
+    expect(store.validate('call-1', token)).toBe(true);
+  });
+
+  it('register() stores an externally generated token (outbound path)', () => {
+    const store = new StreamTokenStore();
+    const token = generateStreamToken();
+    store.register('CA123', token);
+    expect(store.validate('CA123', token)).toBe(true);
+  });
+
+  it('prune() drops only expired entries', () => {
+    const store = new StreamTokenStore(1_000);
+    const t0 = 5_000;
+    store.register('a', generateStreamToken(), t0);
+    store.register('b', generateStreamToken(), t0 + 900);
+    store.prune(t0 + 1_001);
+    expect(store.validate('a', 'x', t0 + 1_001)).toBe(false);
+    expect(store.size).toBe(1); // 'b' survives
+  });
+
+  it('constantTimeEquals is length-safe and value-correct', () => {
+    expect(constantTimeEquals('abc', 'abc')).toBe(true);
+    expect(constantTimeEquals('abc', 'abd')).toBe(false);
+    expect(constantTimeEquals('abc', 'abcd')).toBe(false); // unequal length
+    expect(STREAM_TOKEN_TTL_MS).toBe(120_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Twilio media WS — token via start.customParameters
+// ---------------------------------------------------------------------------
+
+describe('Twilio media-stream auth (#204)', () => {
+  let startSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    startSpy = vi.spyOn(StreamHandler.prototype, 'handleCallStart').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Mint a token through the real /webhooks/twilio/voice TwiML path. */
+  async function mintViaWebhook(server: EmbeddedServer, port: number, callSid: string): Promise<string> {
+    const resp = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ CallSid: callSid, From: '+15551111111', To: '+15552222222' }).toString(),
+    });
+    const twiml = await resp.text();
+    const m = twiml.match(/name="patter_stream_token" value="([^"]+)"/);
+    expect(m, 'TwiML should carry a patter_stream_token <Parameter>').toBeTruthy();
+    return m![1];
+  }
+
+  function startFrame(callSid: string, token?: string): string {
+    const customParameters: Record<string, string> = { caller: '', callee: '' };
+    if (token !== undefined) customParameters.patter_stream_token = token;
+    return JSON.stringify({ event: 'start', streamSid: 'MZ_test', start: { callSid, customParameters } });
+  }
+
+  it('accepts a valid minted token and starts the session', async () => {
+    const server = new EmbeddedServer(twilioConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const token = await mintViaWebhook(server, port, VALID_SID);
+      const ws = new MockWs();
+      (server as any).handleTwilioStream(ws, new URL('http://localhost/ws/stream/outbound'));
+      ws.emit('message', Buffer.from(startFrame(VALID_SID, token)));
+      await flush();
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(startSpy).toHaveBeenCalledWith(VALID_SID, expect.not.objectContaining({ patter_stream_token: token }));
+      expect(ws.close).not.toHaveBeenCalledWith(1008, expect.anything());
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a missing token: closes 1008, opens no session', async () => {
+    const server = new EmbeddedServer(makeConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const ws = new MockWs();
+      (server as any).handleTwilioStream(ws, new URL('http://localhost/ws/stream/outbound'));
+      ws.emit('message', Buffer.from(startFrame(VALID_SID))); // no token
+      await flush();
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a wrong token even for a minted call', async () => {
+    const server = new EmbeddedServer(twilioConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      await mintViaWebhook(server, port, VALID_SID); // mint the real token, then present a forgery
+      const ws = new MockWs();
+      (server as any).handleTwilioStream(ws, new URL('http://localhost/ws/stream/outbound'));
+      ws.emit('message', Buffer.from(startFrame(VALID_SID, 'forged-token-value')));
+      await flush();
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telnyx media WS — token via query string, validated at accept
+// ---------------------------------------------------------------------------
+
+describe('Telnyx media-stream auth (#204)', () => {
+  let startSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    startSpy = vi.spyOn(StreamHandler.prototype, 'handleCallStart').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const CTRL = 'ctrl-accept-1';
+
+  /** Drive the real /webhooks/telnyx/voice call.initiated path and capture the
+   *  stream_url (with the minted token) sent to the Telnyx API. */
+  async function mintViaWebhook(server: EmbeddedServer, port: number): Promise<URL> {
+    const originalFetch = globalThis.fetch;
+    let captured = '';
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('api.telnyx.com')) {
+          const body = JSON.parse(String(init?.body ?? '{}')) as { stream_url?: string };
+          if (body.stream_url) captured = body.stream_url;
+          return { ok: true, status: 200, json: async () => ({ data: {} }), text: async () => '' } as Response;
+        }
+        return originalFetch(input, init);
+      },
+    );
+    try {
+      const rawBody = JSON.stringify({
+        data: { event_type: 'call.initiated', payload: { call_control_id: CTRL, from: '+15551111111', to: '+15552222222' } },
+      });
+      const resp = await fetch(`http://127.0.0.1:${port}/webhooks/telnyx/voice`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: rawBody,
+      });
+      expect(resp.status).toBe(200);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(captured, 'stream_url should have been sent to Telnyx').toContain('patter_stream_token=');
+    const su = new URL(captured);
+    return new URL(su.pathname + su.search, 'http://localhost');
+  }
+
+  function telnyxConfig(): LocalConfig {
+    return makeConfig({ telephonyProvider: 'telnyx', telnyxKey: 'KEY_test', telnyxConnectionId: 'conn_test', twilioSid: undefined, twilioToken: undefined });
+  }
+
+  it('accepts a valid minted token and starts the session', async () => {
+    const server = new EmbeddedServer(telnyxConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const wsUrl = await mintViaWebhook(server, port);
+      const ws = new MockWs();
+      (server as any).handleTelnyxStream(ws, wsUrl);
+      expect(ws.close).not.toHaveBeenCalledWith(1008, expect.anything());
+      ws.emit('message', Buffer.from(JSON.stringify({ event: 'start', start: { call_control_id: CTRL } })));
+      await flush();
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(startSpy).toHaveBeenCalledWith(CTRL);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a missing token at accept: closes 1008, opens no session', async () => {
+    const server = new EmbeddedServer(telnyxConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const ws = new MockWs();
+      // No patter_stream_token in the query → rejected before any frame.
+      (server as any).handleTelnyxStream(ws, new URL(`http://localhost/ws/stream/${CTRL}?caller=&callee=`));
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+      ws.emit('message', Buffer.from(JSON.stringify({ event: 'start', start: { call_control_id: CTRL } })));
+      await flush();
+      expect(startSpy).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a wrong token at accept', async () => {
+    const server = new EmbeddedServer(telnyxConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      await mintViaWebhook(server, port); // mint the real token for CTRL
+      const ws = new MockWs();
+      (server as any).handleTelnyxStream(ws, new URL(`http://localhost/ws/stream/${CTRL}?patter_stream_token=forged`));
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+      expect(startSpy).not.toHaveBeenCalled();
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plivo media WS — token via extra_headers on the start frame
+// ---------------------------------------------------------------------------
+
+describe('Plivo media-stream auth (#204)', () => {
+  let startSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    startSpy = vi.spyOn(StreamHandler.prototype, 'handleCallStart').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const CALL_UUID = 'plivo-uuid-1';
+
+  function plivoConfig(): LocalConfig {
+    // No plivoAuthToken so /webhooks/plivo/voice skips V3 signature validation
+    // (requireSignature=false) and returns the <Stream> XML we mint from.
+    return makeConfig({ telephonyProvider: 'plivo', plivoAuthId: 'MA_test', plivoAuthToken: undefined, twilioSid: undefined, twilioToken: undefined });
+  }
+
+  /** Mint via the real /webhooks/plivo/voice XML path; return the token from
+   *  the delivered extraHeaders. */
+  async function mintViaWebhook(server: EmbeddedServer, port: number): Promise<string> {
+    const resp = await fetch(`http://127.0.0.1:${port}/webhooks/plivo/voice`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ CallUUID: CALL_UUID, From: '+15551111111', To: '+15552222222' }).toString(),
+    });
+    const xml = await resp.text();
+    const m = xml.match(/X-Patter-Stream-Token=([A-Za-z0-9_-]+)/);
+    expect(m, 'stream XML should carry X-Patter-Stream-Token in extraHeaders').toBeTruthy();
+    return m![1];
+  }
+
+  function startFrame(token?: string): string {
+    const headers: Record<string, string> = { 'X-PH-caller': '+15551111111', 'X-PH-callee': '+15552222222' };
+    if (token !== undefined) headers['X-Patter-Stream-Token'] = token;
+    return JSON.stringify({ event: 'start', start: { callId: CALL_UUID, streamId: 'stream-1' }, extra_headers: JSON.stringify(headers) });
+  }
+
+  it('accepts a valid minted token and starts the session', async () => {
+    const server = new EmbeddedServer(plivoConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const token = await mintViaWebhook(server, port);
+      const ws = new MockWs();
+      (server as any).handlePlivoStream(ws, new URL('http://localhost/ws/plivo/stream/x?caller=&callee='));
+      ws.emit('message', Buffer.from(startFrame(token)));
+      await flush();
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      // Token stripped from the custom params handed to the session.
+      const params = startSpy.mock.calls[0][1] as Record<string, string>;
+      expect(params).not.toHaveProperty('X-Patter-Stream-Token');
+      expect(ws.close).not.toHaveBeenCalledWith(1008, expect.anything());
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a missing token: closes 1008, opens no session', async () => {
+    const server = new EmbeddedServer(plivoConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      const ws = new MockWs();
+      (server as any).handlePlivoStream(ws, new URL('http://localhost/ws/plivo/stream/x?caller=&callee='));
+      ws.emit('message', Buffer.from(startFrame())); // no token
+      await flush();
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('rejects a wrong token even for a minted call', async () => {
+    const server = new EmbeddedServer(plivoConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    try {
+      await mintViaWebhook(server, port);
+      const ws = new MockWs();
+      (server as any).handlePlivoStream(ws, new URL('http://localhost/ws/plivo/stream/x?caller=&callee='));
+      ws.emit('message', Buffer.from(startFrame('forged-token')));
+      await flush();
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(ws.close).toHaveBeenCalledWith(1008, expect.any(String));
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Opt-out (requireStreamAuth=false) + never-log-token
+// ---------------------------------------------------------------------------
+
+describe('stream auth opt-out and log hygiene (#204)', () => {
+  let startSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    startSpy = vi.spyOn(StreamHandler.prototype, 'handleCallStart').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requireStreamAuth=false allows an unauthenticated connect but warns loudly (once)', async () => {
+    const server = new EmbeddedServer(makeConfig({ requireStreamAuth: false }), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    const cap = captureLogs();
+    try {
+      const ws = new MockWs();
+      (server as any).handleTwilioStream(ws, new URL('http://localhost/ws/stream/outbound'));
+      ws.emit('message', Buffer.from(JSON.stringify({ event: 'start', streamSid: 'MZ', start: { callSid: VALID_SID, customParameters: {} } })));
+      await flush();
+      // No token, yet the session is allowed to start.
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(ws.close).not.toHaveBeenCalledWith(1008, expect.anything());
+      const warned = cap.lines.filter((l) => /requireStreamAuth=false|Stream authentication is DISABLED/i.test(l));
+      expect(warned.length).toBe(1); // one-time warning
+    } finally {
+      cap.restore();
+      await server.stop();
+    }
+  });
+
+  it('never writes the token value to logs (accept and reject paths)', async () => {
+    const server = new EmbeddedServer(twilioConfig(), makeAgent());
+    const port = await getFreePort();
+    await server.start(port);
+    // Mint outside the capture window (the webhook TwiML response is not a log).
+    const resp = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/voice`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ CallSid: VALID_SID, From: '+1', To: '+2' }).toString(),
+    });
+    const token = (await resp.text()).match(/name="patter_stream_token" value="([^"]+)"/)![1];
+    const cap = captureLogs();
+    try {
+      // Accept path.
+      const wsOk = new MockWs();
+      (server as any).handleTwilioStream(wsOk, new URL('http://localhost/ws/stream/outbound'));
+      wsOk.emit('message', Buffer.from(JSON.stringify({ event: 'start', streamSid: 'MZ', start: { callSid: VALID_SID, customParameters: { patter_stream_token: token } } })));
+      await flush();
+      // Reject path.
+      const wsBad = new MockWs();
+      (server as any).handleTwilioStream(wsBad, new URL('http://localhost/ws/stream/outbound'));
+      wsBad.emit('message', Buffer.from(JSON.stringify({ event: 'start', streamSid: 'MZ', start: { callSid: VALID_SID, customParameters: { patter_stream_token: 'forged' } } })));
+      await flush();
+      expect(startSpy).toHaveBeenCalledTimes(1); // accept started, reject did not
+      for (const line of cap.lines) {
+        expect(line).not.toContain(token);
+      }
+    } finally {
+      cap.restore();
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Release 0.7.1 — Gemini/Inworld engine markers + Gemini Live fixes

Follow-up to 0.7.0. **0.7.0 shipped the pipeline barge-in fix (#200) but did NOT ship the `GeminiLive` engine marker** (so `new GeminiLive({...})` / the engine import threw at runtime — the demo had to vendor an old `.tgz`), and a live-call Gemini "thinking" leak surfaced. This lands the markers + fixes and prepares 0.7.1. **`npm publish` is intentionally NOT run — it's human-gated** (publish happens via the `v0.7.1` tag after merge).

### Engines (new public API)
- **`GeminiLive`** engine marker + richer `GeminiLiveAdapter` (mulaw8↔PCM telephony transcode, apiVersion auto-detect, `GEMINI_LIVE_3_1_FLASH_PREVIEW`), **`GeminiCascade`** engine, **`GeminiSTT`/`GeminiTTS`** — integrated from the `gemini-3.1-live-demo` work onto the 0.7.0 baseline (3-way merge; #200 barge-in + #199 Inworld pricing/exports preserved, verified).
- **`InworldRealtime`** — native engine marker + `InworldRealtimeAdapter` that **subclasses `OpenAIRealtimeAdapter`** and overrides only the transport (`wss://api.inworld.ai/v1/realtime`, Bearer/JWT — Inworld's OpenAI-Realtime migration path). Lets the demo drop its `OpenAIRealtime` monkey-patch.
- Verified at runtime from the built `.tgz`: `require('getpatter')` and ESM named imports both resolve `GeminiLive`, `GeminiCascade`, `InworldRealtime` as functions (the exact 0.7.0 bug, now fixed).

### Fixes (live-call bugs on the Giulia demo vs 0.7.0)
- **Gemini Live spoke the model's chain-of-thought before the reply** (every turn, native-audio). The Live setup now always sends `thinkingConfig` (voice default `thinkingBudget: 0`, OFF; opt-in `thinking`/`thinkingBudget` on `GeminiLiveOptions`), and the adapter defensively drops any `thought===true` part from **both** the audio stream and the text transcript (never logged — no PII).
- **`gemini-3.1-flash-live-preview` → silent "session ready timeout"** (call dropped with dead air). It's a native-audio model served only on `v1alpha` but its id lacks the `native-audio` token, so the heuristic chose `v1beta`. New `geminiRequiresV1Alpha()` selects `v1alpha` for native-audio AND `flash-live-preview` (explicit `apiVersion` overrides); connect failures now throw a clear, actionable error (model id + resolved apiVersion + root causes) instead of dead air.

### Changed
- **`@google/genai` peerDep `^0.3.0` → `>=2.0.0`** (kept optional) for the 2.x unified SDK — `npm install getpatter` with `@google/genai@^2.x` no longer needs `--legacy-peer-deps`.
- **`create-getpatter` launcher realigned to the SDK version (lockstep)** — it pins the `getpatter` version it bootstraps to its own version. It had drifted to 0.6.9 (so `npm create getpatter` was provisioning 0.6.9); bumped to 0.7.1.

### Backward compatibility
OpenAIRealtime / OpenAIRealtime2 / Ultravox / ConvAI unchanged. The `instanceof OpenAIRealtimeAdapter` gates are **extended, not replaced** (`InworldRealtimeAdapter` passes them via subclassing; the Gemini `function_call` dispatch gate is widened). #200 barge-in fix confirmed intact.

### Versioning
All four version files move to **0.7.1** together (Python `__init__.py` + `pyproject.toml`, TS `package.json`, launcher `create-getpatter/package.json`). Per the "0.7.x" ask this is tagged a patch; note it does add new public API (engine markers), which is strictly a minor — call it 0.8.0 instead if you prefer stricter semver.

### Test plan
- [x] `npm run lint` (`tsc --noEmit`) green; `npm test` green — **2334 passed**, 9 skipped (+23 authentic tests: gemini-live-thinking, inworld-realtime, …; mock only the provider WebSocket).
- [x] Built `.tgz` (`npm pack` → `getpatter-0.7.1.tgz`): `GeminiLive`/`GeminiCascade`/`InworldRealtime` resolve at runtime (CJS + ESM).
- [x] Adversarial verification pass (independent re-build + re-test + checklist).
- [ ] Demo (`giulia-three-variants`) verifies against the local `.tgz`, deletes `Giulia/vendor/getpatter-0.6.7.tgz` + the Inworld monkey-patch, reverts the `import type { GeminiLive }` workaround to a value import.
- [ ] **Publish is human-gated** — merge → tag `v0.7.1` → `release.yml` publishes npm + PyPI + the realigned launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D52f6rBsvzicXg45C6MKVM


---

## Also in this PR: media-stream WebSocket authentication (Closes #204)

Fixes a second security report from the same reporter: the media-stream WS endpoints (`/ws/stream/…` Twilio, `/ws/telnyx/stream/…`, `/ws/plivo/stream/…`) were **unauthenticated** — the signed carrier webhook validated HTTP, but any peer reaching the public host could open the WS with an attacker-chosen `call_id`, send a `start` frame, and drive a full STT→LLM→TTS session on the operator's keys (toll fraud) or extract the agent's system prompt.

- **Per-call token**: the signature-validated webhook mints a high-entropy token (short-TTL, keyed to the call) and delivers it on each carrier's existing custom channel (Twilio `<Parameter>`→customParameters, Telnyx URL query, Plivo `extra_headers`). The WS constant-time-validates it **before** opening any provider session; unauthenticated → WS 1008, no provider connect, no TTS.
- **Fail-closed by default** (`require_stream_auth` / `requireStreamAuth`), opt-out for custom-TwiML operators (logs a warning). Token never logged. Backward compatible for the standard `serve()` inbound+outbound path.
- Also added a global concurrent-WS backstop for the forgeable-`X-Forwarded-For` per-IP cap (documented DoS-cap-only).
- Both SDKs, all three carriers. Tests: `tests/security/test_stream_auth.py` (30) + TS `stream-auth` suite. Adversarial security-verify pass (re-ran the #204 repro — an unauthenticated peer is provably blocked). Python 2982 / TS green.

Closes #204.
