### PR TITLE
fix(telnyx): guard native-audio realtime engines against premature model end_call

### DIFF
--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -6,7 +6,7 @@
 
 **Type:** fix
 **Branch:** fix/telnyx-native-audio-bridge
-**PR:** (unreleased)
+**PR:** #203
 
 **What it does:**
 On inbound Telnyx calls with a native-audio realtime engine (GeminiLive /
@@ -56,7 +56,7 @@ the caller speaks, or after the grace window, `end_call` behaves normally.
 
 **Type:** fix
 **Branch:** fix/telnyx-native-audio-bridge
-**PR:** (unreleased)
+**PR:** #203
 
 **What it does:**
 Native-audio realtime engines (GeminiLive / OpenAIRealtime2 / ConvAI) answered

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -2,6 +2,56 @@
 
 ## Log
 
+### [2026-06-30] — Telnyx native-audio realtime keepalive (comfort-noise pump)
+
+**Type:** fix
+**Branch:** fix/telnyx-native-audio-bridge
+**PR:** (unreleased)
+
+**What it does:**
+Native-audio realtime engines (GeminiLive / OpenAIRealtime2 / ConvAI) answered
+over Telnyx but produced no caller audio and the call dropped ~1.6 s in
+(`normal_clearing`, "1 turn"); Twilio worked. Root cause: the realtime path puts
+ZERO bytes on the carrier between the carrier `start` event and the model's first
+audio delta (cold `adapter.connect()` + model TTFT + resampler warmup, often
+>1.5 s). Twilio tolerates that gap; Telnyx clears the idle bidirectional RTP leg.
+The fix pumps paced μ-law-8k silence (the exact frame format already proven on
+Telnyx, 160 bytes / 20 ms, `0xFF` digital zero) from stream-start until the first
+real model frame, keeping the outbound leg primed. Self-cancels the instant real
+model audio arrives. Pipeline mode never arms the pump (it already plays
+firstMessage TTS within ~200 ms); Twilio/Plivo are unaffected (they accept the
+same silence frame and have no such timeout).
+
+**Implementation details:**
+- TS: added `comfortNoiseTimer` state + `MULAW_SILENCE_FRAME`/`COMFORT_NOISE_INTERVAL_MS`
+  constants and `startComfortNoise`/`stopComfortNoise` to `StreamHandler`. Armed at
+  the end of `initRealtimeAdapter` (realtime-only, post-connect); cancelled as the
+  first statement of `onAdapterAudio` and in `handleStop`/`handleWsClose`.
+- Python: added `_comfort_noise_task` + `_MULAW_SILENCE_FRAME`/`_COMFORT_NOISE_INTERVAL_S`
+  and `_start_comfort_noise`/`_stop_comfort_noise` to the base `StreamHandler`. Armed
+  after the `_forward_events` task is spawned in both realtime subclasses'
+  `start()` (`OpenAIRealtimeStreamHandler`, `ElevenLabsConvAIStreamHandler`);
+  cancelled in each `_forward_events` first-audio guard and in each subclass
+  `cleanup()` (the single carrier teardown funnel for stop + ws-close).
+- No change to the transcode chain, `sendAudio` envelopes, streaming negotiation,
+  or `bytesPerMs` bookkeeping — those were already correct.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `libraries/typescript/src/stream-handler.ts` | Comfort-noise pump (constants, state, start/stop, arm/cancel/teardown) |
+| `libraries/python/getpatter/stream_handler.py` | Python parity comfort-noise pump (base helpers + realtime subclass wiring) |
+
+**Tests added:**
+- `libraries/typescript/tests/telnyx-comfort-noise.mocked.test.ts` — 5 cases (silence-frame decode, pump-then-stop, pipeline never arms, stop/ws-close no leak)
+- `libraries/python/tests/test_telnyx_comfort_noise.py` — 5 cases (silence-frame decode, pump-then-stop, idempotent start, stop no leak, cleanup stops pump)
+
+**Breaking changes:** None
+
+**Docs to update:**
+- [ ] None (internal bug fix; no public surface change)
+
 ### [2026-06-18] — Gemini Live Python parity: audio codec transcode + `GeminiLive` marker
 
 **Type:** feat + fix

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -2,6 +2,56 @@
 
 ## Log
 
+### [2026-06-30] — Telnyx native-audio realtime: guard premature model end_call
+
+**Type:** fix
+**Branch:** fix/telnyx-native-audio-bridge
+**PR:** (unreleased)
+
+**What it does:**
+On inbound Telnyx calls with a native-audio realtime engine (GeminiLive /
+OpenAIRealtime2) the model would greet and immediately emit `end_call`
+("no_response") ~1.5 s in, dropping a live caller before their first turn
+registered. Twilio inbound and pipeline mode were unaffected. The realtime
+`end_call` handler executed the hang-up unconditionally, and the `end_call` tool
+description literally listed `'no_response'` as a sample reason — teaching the
+model to bail on perceived silence. On Telnyx the cold realtime connect→
+first-audio window eats the whole opening budget, so the model bails before the
+caller's speech arrives. The fix (a) drops `'no_response'` from the tool
+description, and (b) refuses a model-initiated `end_call` that fires before ANY
+caller speech AND within a 6 s opening grace window, returning a `rejected`
+function result that tells the model to keep listening (session stays open, so
+the caller's audio — which does reach the model — drives the next turn). After
+the caller speaks, or after the grace window, `end_call` behaves normally.
+
+**Implementation details:**
+- `callStartedAtMs` / `_call_started_at_ms` stamped at the per-call start
+  (`handleCallStart` in TS; realtime `start()` in Python — kept out of the base
+  `__init__` so it does not consume a `time.time()` value that timing-brittle
+  pipeline tests script).
+- `userHasSpoken` / `_user_has_spoken` set only AFTER the real Whisper
+  hallucination filter, so echo/silence transcripts never satisfy the guard.
+- Guard is carrier-agnostic and only reachable on the realtime path; Twilio,
+  Plivo, pipeline, and ConvAI paths are untouched.
+- The prior comfort-noise pump on this branch is orthogonal and left in place.
+
+**Files changed:**
+
+| File | Change |
+|------|--------|
+| `libraries/typescript/src/server.ts` | Drop `'no_response'` from `END_CALL_TOOL` description |
+| `libraries/typescript/src/stream-handler.ts` | `callStartedAtMs`/`userHasSpoken` fields, grace const, stamp in `handleCallStart`, flag in `onAdapterTranscriptInput`, guard in realtime `handleFunctionCall` end_call |
+| `libraries/python/getpatter/stream_handler.py` | Python parity: drop `'no_response'`, base fields + `_REALTIME_END_CALL_MIN_AGE_MS`, stamp in realtime `start()`, flag in realtime `transcript_input` branch, guard in realtime `end_call` handler |
+
+**Tests added:**
+- `libraries/typescript/tests/telnyx-premature-endcall.mocked.test.ts` — 4 cases (real StreamHandler + real OpenAIRealtime2Adapter, mock only the OpenAI WS + carrier bridge)
+- `libraries/python/tests/test_telnyx_premature_endcall.py` — 4 cases (real `OpenAIRealtimeStreamHandler._forward_events`, scripted adapter boundary)
+
+**Breaking changes:** None
+
+**Docs to update:**
+- [ ] None (bug fix, no new public surface)
+
 ### [2026-06-30] — Telnyx native-audio realtime keepalive (comfort-noise pump)
 
 **Type:** fix

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -984,6 +984,19 @@ class StreamHandler(ABC):
         # speaking on the wire, for `fire_agent_speech_ended.speech_duration_ms`.
         self._agent_turn_start_ms: float | None = None
         self._background_task: asyncio.Task | None = None
+        # Realtime-engine outbound keepalive (Telnyx bidirectional RTP).
+        # Realtime engines (GeminiLive / OpenAIRealtime2 / ConvAI) put NO
+        # bytes on the carrier between the carrier ``start`` and the model's
+        # first audio delta — cold ``adapter.connect()`` + model TTFT +
+        # resampler warmup is often >1.5 s. Twilio tolerates that gap;
+        # Telnyx's bidirectional RTP leg clears the call (~1.6 s, "1 turn",
+        # normal_clearing). The pipeline path never hits this because it puts
+        # TTS bytes on the wire within ~200 ms. ``_start_comfort_noise`` pumps
+        # paced μ-law-8k silence (the exact format already proven on Telnyx)
+        # from stream-start until the first real model frame, so the outbound
+        # leg stays primed. Twilio/Plivo are unaffected. Self-cancels the
+        # instant the first real audio frame is forwarded.
+        self._comfort_noise_task: asyncio.Task | None = None
         # MCP server connection manager — populated lazily in
         # ``_init_mcp_tools`` when the agent declares ``mcp_servers``.
         # Closed in ``cleanup``/``fire_call_end`` to free open MCP
@@ -1273,6 +1286,46 @@ class StreamHandler(ABC):
             task.cancel()
         self._max_call_watchdog = None
 
+    # One 20 ms μ-law-8k silence frame (160 bytes). 0xFF == μ-law digital
+    # zero. On the realtime path the audio sender is in ``_input_is_mulaw_8k``
+    # pass-through mode, so these bytes reach the carrier unchanged — the exact
+    # format already proven on Telnyx. 20 ms × 8 bytes/ms = 160 bytes.
+    _MULAW_SILENCE_FRAME: bytes = b"\xff" * 160
+    # Pump cadence: one 20 ms frame every 20 ms (real-time μ-law-8k rate).
+    _COMFORT_NOISE_INTERVAL_S: float = 0.02
+
+    def _start_comfort_noise(self) -> None:
+        """Pump paced μ-law-8k silence to the carrier until the first real
+        model frame, keeping the outbound leg primed during the
+        connect→first-delta window (see ``_comfort_noise_task`` doc).
+        Realtime engines only. Idempotent — a second call is a no-op while a
+        pump is already running. Cancelled by ``_stop_comfort_noise`` from the
+        first-frame guard and from teardown.
+        """
+        existing = self._comfort_noise_task
+        if existing is not None and not existing.done():
+            return
+
+        async def _pump() -> None:
+            try:
+                while True:
+                    await self.audio_sender.send_audio(self._MULAW_SILENCE_FRAME)
+                    await asyncio.sleep(self._COMFORT_NOISE_INTERVAL_S)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - carrier WS gone
+                # Carrier WS gone — stop pumping rather than spin on a dead
+                # socket. The first-frame guard / teardown clears the handle.
+                logger.debug("comfort-noise send failed: %s", exc)
+
+        self._comfort_noise_task = asyncio.create_task(_pump())
+
+    def _stop_comfort_noise(self) -> None:
+        """Cancel the comfort-noise pump if running. Idempotent."""
+        task = self._comfort_noise_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._comfort_noise_task = None
 
     async def _safe_on_transcript(self, payload: dict) -> None:
         """Invoke the user's ``on_transcript`` with exception containment.
@@ -1888,6 +1941,10 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
             await sender(self.agent.first_message)
 
         self._background_task = asyncio.create_task(self._forward_events())
+        # Keep the outbound carrier leg primed during the connect→first-delta
+        # window (see ``_comfort_noise_task`` doc). Self-cancels on the first
+        # real model frame in ``_forward_events``.
+        self._start_comfort_noise()
 
     async def _forward_events(self) -> None:
         from getpatter.tools.tool_executor import ToolExecutor  # type: ignore[import]
@@ -1901,6 +1958,11 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
         try:
             async for ev_type, ev_data in self._adapter.receive_events():
                 if ev_type == "audio":
+                    # Real model audio is ready — tear down the pre-first-audio
+                    # comfort-noise pump (no-op if already stopped or never
+                    # armed) before the first real frame goes out, so silence
+                    # and speech never interleave on the wire.
+                    self._stop_comfort_noise()
                     # Fallback: if audio arrives before speech_stopped (which
                     # can happen when JS/async event loop reorders WS frames
                     # under load, or with server VAD disabled) start the turn
@@ -2590,6 +2652,9 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
 
     async def cleanup(self) -> None:
         """Cancel the event-forward task and close the OpenAI Realtime adapter."""
+        # Kill the realtime comfort-noise pump if the call ends before the
+        # model ever produced audio (otherwise the task leaks past teardown).
+        self._stop_comfort_noise()
         self._cancel_max_call_watchdog()
         if self._pending_assistant_timer is not None:
             self._pending_assistant_timer.cancel()
@@ -2747,6 +2812,10 @@ class ElevenLabsConvAIStreamHandler(StreamHandler):
         logger.debug("ElevenLabs ConvAI connected")
 
         self._background_task = asyncio.create_task(self._forward_events())
+        # Keep the outbound carrier leg primed during the connect→first-delta
+        # window (see ``_comfort_noise_task`` doc). Self-cancels on the first
+        # real model frame in ``_forward_events``.
+        self._start_comfort_noise()
 
     async def _forward_events(self) -> None:
         # Arm first-byte capture so that the firstMessage turn (started in
@@ -2757,6 +2826,11 @@ class ElevenLabsConvAIStreamHandler(StreamHandler):
         try:
             async for ev_type, ev_data in self._adapter.receive_events():
                 if ev_type == "audio":
+                    # Real model audio is ready — tear down the pre-first-audio
+                    # comfort-noise pump (no-op if already stopped or never
+                    # armed) before the first real frame goes out, so silence
+                    # and speech never interleave on the wire.
+                    self._stop_comfort_noise()
                     # Fallback: audio before speech_stopped. Parity with TS.
                     if self.metrics is not None and not self.metrics.turn_active:
                         self.metrics.start_turn()
@@ -3036,6 +3110,9 @@ class ElevenLabsConvAIStreamHandler(StreamHandler):
 
     async def cleanup(self) -> None:
         """Cancel the event-forward task and close the ConvAI adapter."""
+        # Kill the realtime comfort-noise pump if the call ends before the
+        # model ever produced audio (otherwise the task leaks past teardown).
+        self._stop_comfort_noise()
         self._cancel_max_call_watchdog()
         if self._background_task:
             self._background_task.cancel()

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -458,7 +458,7 @@ END_CALL_TOOL: dict = {
         "properties": {
             "reason": {
                 "type": "string",
-                "description": "Reason for ending the call (e.g., 'conversation_complete', 'user_requested', 'no_response')",
+                "description": "Reason for ending the call (e.g., 'conversation_complete', 'user_requested')",
             }
         },
     },
@@ -940,6 +940,12 @@ class StreamHandler(ABC):
         self.agent = agent
         self.audio_sender = audio_sender
         self.call_id = call_id
+        # Wall-clock ms of call start — stamped in ``start()`` (the per-call
+        # entry, parity with TS ``handleCallStart``); used to grace-guard a
+        # premature model-initiated end_call. 0.0 until the call actually starts.
+        self._call_started_at_ms = 0.0
+        # True once a genuine (hallucination-filtered) caller transcript is committed.
+        self._user_has_spoken = False
         self.caller = caller
         self.callee = callee
         self.resolved_prompt = resolved_prompt
@@ -1293,6 +1299,13 @@ class StreamHandler(ABC):
     _MULAW_SILENCE_FRAME: bytes = b"\xff" * 160
     # Pump cadence: one 20 ms frame every 20 ms (real-time μ-law-8k rate).
     _COMFORT_NOISE_INTERVAL_S: float = 0.02
+    # A realtime model can emit ``end_call`` the instant its greeting finishes —
+    # before the caller has spoken. On carriers where the realtime connect→
+    # first-audio window eats the opening call budget (Telnyx native-audio), this
+    # hangs up a live caller at ~1.5 s. Refuse a model-initiated hang-up that
+    # fires before ANY caller speech AND within this opening grace window
+    # (connect ~1.5-2 s + greeting ~1 s + human turn-around). Tunable.
+    _REALTIME_END_CALL_MIN_AGE_MS: float = 6000.0
 
     def _start_comfort_noise(self) -> None:
         """Pump paced μ-law-8k silence to the carrier until the first real
@@ -1746,6 +1759,9 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
 
     async def start(self) -> None:
         """Connect to OpenAI Realtime, register tools, and begin event forwarding."""
+        # Stamp the per-call start time for the premature-end_call grace guard
+        # (parity with TS ``handleCallStart``).
+        self._call_started_at_ms = time.time() * 1000
         self._arm_max_call_watchdog()
         # Both ``openai_realtime`` and ``openai_realtime_2`` engines now
         # route through the GA-compatible ``OpenAIRealtime2Adapter`` —
@@ -2083,6 +2099,7 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
                         trigger="vad_silence", transcript_so_far=ev_data
                     )
 
+                    self._user_has_spoken = True
                     self.conversation_history.append(
                         {"role": "user", "text": ev_data, "timestamp": time.time()}
                     )
@@ -2465,6 +2482,41 @@ class OpenAIRealtimeStreamHandler(StreamHandler):
                             )
                             continue
                         reason = args.get("reason", "conversation_complete")
+                        # Premature-hangup guard: a realtime engine can emit
+                        # end_call the moment its greeting finishes, before the
+                        # caller has spoken. On carriers whose realtime connect→
+                        # first-audio window eats the opening budget (Telnyx
+                        # native-audio) this kills a live caller at ~1.5 s. If the
+                        # caller has not spoken yet AND we are inside the opening
+                        # grace window, refuse and tell the model to keep
+                        # listening rather than tearing the call down.
+                        call_age_ms = time.time() * 1000 - self._call_started_at_ms
+                        if (
+                            not self._user_has_spoken
+                            and call_age_ms < self._REALTIME_END_CALL_MIN_AGE_MS
+                        ):
+                            logger.debug(
+                                "Ignoring premature end_call: reason=%s "
+                                "age_ms=%.0f — caller has not spoken yet",
+                                reason,
+                                call_age_ms,
+                            )
+                            keep_alive = json.dumps(
+                                {
+                                    "status": "rejected",
+                                    "reason": "caller_still_connecting",
+                                    "message": (
+                                        "The caller may still be connecting. "
+                                        "Keep the line open and wait for them "
+                                        "to speak."
+                                    ),
+                                }
+                            )
+                            await self._adapter.send_function_result(
+                                func_data["call_id"], keep_alive
+                            )
+                            await self._emit_tool_event("end_call", args, keep_alive)
+                            continue
                         logger.debug("Ending call: %s", reason)
                         result = json.dumps({"status": "ending", "reason": reason})
                         await self._adapter.send_function_result(

--- a/libraries/python/tests/test_telnyx_comfort_noise.py
+++ b/libraries/python/tests/test_telnyx_comfort_noise.py
@@ -1,0 +1,200 @@
+"""Realtime-engine outbound keepalive over Telnyx (comfort-noise pump).
+
+BUG: native-audio realtime engines (GeminiLive / OpenAIRealtime2 / ConvAI) put
+NO bytes on the carrier between the carrier ``start`` and the model's first
+audio delta (cold ``connect()`` + TTFT + resampler warmup, often >1.5 s).
+Twilio tolerates the gap; Telnyx clears the idle bidirectional RTP leg
+(~1.6 s). The fix pumps paced μ-law-8k silence from stream-start until the
+first real model frame.
+
+AUTHENTIC: the real ``OpenAIRealtimeStreamHandler`` (base-class pump helpers
+and the real ``_forward_events`` audio guard) is exercised. The only faked
+surface is the adapter (the provider WebSocket boundary — a real async
+generator over a scripted event list) and the ``AudioSender`` (we cannot place
+phone calls in CI — a real recording test double). We assert on the observable
+outcome: the bytes handed to ``audio_sender.send_audio``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+
+import pytest
+
+from getpatter.stream_handler import OpenAIRealtimeStreamHandler, StreamHandler
+
+# The exact frame the pump emits (private class const — re-derived here).
+SILENCE_FRAME = b"\xff" * 160
+
+
+class _RecordingAudioSender:
+    """Real recording test double for the carrier AudioSender boundary.
+
+    On the realtime path the sender runs in ``_input_is_mulaw_8k`` pass-through
+    mode, so whatever bytes the handler sends are exactly what reaches the
+    carrier — we record them verbatim.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+
+    async def send_audio(self, audio: bytes) -> None:
+        self.sent.append(audio)
+
+    async def send_clear(self) -> None:
+        pass
+
+    async def send_mark(self, mark_name: str) -> None:
+        pass
+
+    def reset_pcm_carry(self) -> None:
+        pass
+
+    def silence_frame_count(self) -> int:
+        return sum(1 for a in self.sent if a == SILENCE_FRAME)
+
+
+class _FakeAdapter:
+    """Real async object standing in for the provider WS boundary.
+
+    ``receive_events`` is a real async generator that first idles (so the pump
+    has a window to emit silence) and then yields one real ``audio`` frame.
+    """
+
+    def __init__(self, idle_before_audio_s: float = 0.06) -> None:
+        self._idle = idle_before_audio_s
+        self.closed = False
+
+    async def receive_events(self):
+        # Simulate the connect→first-delta gap: no events yet. The pump runs
+        # concurrently during this await.
+        await asyncio.sleep(self._idle)
+        yield ("audio", b"\x00\x00" * 240)  # one real model PCM frame
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _make_realtime_handler(adapter: _FakeAdapter, sender: _RecordingAudioSender):
+    """Construct a real handler with the minimal real state the pump and the
+    ``_forward_events`` audio guard touch, bypassing the network-bound
+    constructor (mirrors test_realtime_response_decoupling)."""
+    handler = OpenAIRealtimeStreamHandler.__new__(OpenAIRealtimeStreamHandler)
+    handler._adapter = adapter
+    handler.audio_sender = sender
+    handler.metrics = None
+    handler.on_transcript = None
+    handler.on_transcript_line = None
+    handler.call_id = "CA0000000000000000000000000000a001"
+    handler.conversation_history = deque(maxlen=200)
+    handler.transcript_entries = deque(maxlen=200)
+    handler.speech_events = None
+    handler._user_speech_start_ms = None
+    handler._agent_turn_start_ms = None
+    handler._user_transcript_pending = False
+    handler._pending_assistant_turn = None
+    handler._pending_assistant_timer = None
+    handler._current_turn_index = None
+    handler.local_recorder = None
+    handler._comfort_noise_task = None
+    handler.agent = type("_A", (), {"model": "gpt-realtime", "tools": None})()
+    return handler
+
+
+@pytest.mark.unit
+class TestComfortNoiseFrame:
+    def test_silence_frame_is_160_bytes_of_mulaw_digital_zero(self) -> None:
+        # 20 ms @ 8 kHz μ-law = 160 samples × 1 byte. 0xFF == μ-law digital
+        # zero (decodes to linear PCM 0).
+        from getpatter.audio.transcoding import mulaw_to_pcm16
+
+        frame = StreamHandler._MULAW_SILENCE_FRAME
+        assert frame == SILENCE_FRAME
+        assert len(frame) == 160
+
+        pcm = mulaw_to_pcm16(frame)
+        # 160 μ-law bytes -> 160 PCM16 samples (2 bytes each) = 320 bytes,
+        # every sample exactly 0 (true silence).
+        assert len(pcm) == 320
+        for i in range(0, len(pcm), 2):
+            assert int.from_bytes(pcm[i : i + 2], "little", signed=True) == 0
+
+
+@pytest.mark.mocked
+class TestComfortNoisePump:
+    async def test_pump_emits_silence_then_stops_on_first_frame(self) -> None:
+        sender = _RecordingAudioSender()
+        adapter = _FakeAdapter(idle_before_audio_s=0.06)
+        handler = _make_realtime_handler(adapter, sender)
+
+        # Arm the pump (as start() does after connect), then run the real
+        # event loop concurrently. The loop idles ~60 ms (≥3 pump intervals)
+        # before the first real audio frame, which must stop the pump.
+        handler._start_comfort_noise()
+        await handler._forward_events()
+
+        # At least one silence frame reached the carrier before the model
+        # produced audio.
+        assert sender.silence_frame_count() >= 1
+        # The pump self-cancelled on the first real frame.
+        assert handler._comfort_noise_task is None
+
+        frames_after = sender.silence_frame_count()
+        # No further silence frames are produced after the first real frame.
+        await asyncio.sleep(0.06)
+        assert sender.silence_frame_count() == frames_after
+
+        # The real model frame was forwarded to the carrier.
+        assert any(a == b"\x00\x00" * 240 for a in sender.sent)
+
+    async def test_start_is_idempotent(self) -> None:
+        sender = _RecordingAudioSender()
+        adapter = _FakeAdapter()
+        handler = _make_realtime_handler(adapter, sender)
+
+        handler._start_comfort_noise()
+        first = handler._comfort_noise_task
+        handler._start_comfort_noise()  # no-op while running
+        assert handler._comfort_noise_task is first
+
+        handler._stop_comfort_noise()
+        assert handler._comfort_noise_task is None
+
+    async def test_stop_before_any_audio_clears_the_task_no_leak(self) -> None:
+        sender = _RecordingAudioSender()
+        adapter = _FakeAdapter()
+        handler = _make_realtime_handler(adapter, sender)
+
+        handler._start_comfort_noise()
+        await asyncio.sleep(0.03)  # let it emit a couple frames
+        handler._stop_comfort_noise()
+        assert handler._comfort_noise_task is None
+
+        frames = sender.silence_frame_count()
+        await asyncio.sleep(0.06)
+        # No frames after teardown — the task is truly cancelled, not leaked.
+        assert sender.silence_frame_count() == frames
+
+    async def test_cleanup_before_any_audio_stops_the_pump(self) -> None:
+        sender = _RecordingAudioSender()
+        adapter = _FakeAdapter()
+        handler = _make_realtime_handler(adapter, sender)
+        # cleanup() touches several teardown fields — supply the real ones it
+        # reads so the real cleanup() path runs end-to-end.
+        handler._max_call_watchdog = None
+        handler._background_task = None
+        handler._adapter = adapter  # has a real async close()
+        handler._resampler_16k_to_8k = None
+
+        async def _noop_close_mcp() -> None:
+            return None
+
+        handler._close_mcp = _noop_close_mcp  # external MCP boundary
+        handler._close_local_recorder = lambda: None  # no recording in CI
+
+        handler._start_comfort_noise()
+        await asyncio.sleep(0.03)
+        await handler.cleanup()
+        assert handler._comfort_noise_task is None

--- a/libraries/python/tests/test_telnyx_premature_endcall.py
+++ b/libraries/python/tests/test_telnyx_premature_endcall.py
@@ -1,0 +1,159 @@
+"""Premature end_call guard for native-audio realtime engines over Telnyx.
+
+BUG: a realtime engine (GeminiLive / OpenAIRealtime2) can emit ``end_call`` the
+instant its greeting finishes — before the caller has spoken. On Telnyx the cold
+realtime connect→first-audio window eats the opening call budget, so the model
+greets and immediately bails ("no_response") ~1.5 s in, killing a live caller.
+Twilio and pipeline mode never hit this. The fix refuses a model-initiated
+hang-up that fires before ANY caller speech AND within the opening grace window,
+telling the model to keep listening instead.
+
+AUTHENTIC: the real ``OpenAIRealtimeStreamHandler._forward_events`` end_call
+branch, the real caller-spoke transcript path (incl. the real
+``_is_stt_hallucination`` filter), and the real grace-window arithmetic all run.
+The only faked surfaces are the adapter (the provider WebSocket boundary — a real
+async generator over a scripted event list) and the hang-up callback (we cannot
+place phone calls in CI). We assert on the observable outcomes: whether the
+hang-up fired and the ``send_function_result`` payload the model receives back.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections import deque
+
+import pytest
+
+from getpatter.stream_handler import OpenAIRealtimeStreamHandler
+
+
+class _FakeAdapter:
+    """Real async object standing in for the provider WS boundary.
+
+    ``receive_events`` is a real async generator yielding a scripted list of
+    ``(type, data)`` events. ``send_function_result`` records the payloads the
+    handler hands back to the model.
+    """
+
+    def __init__(self, events: list[tuple[str, object]]) -> None:
+        self._events = events
+        self.function_results: list[tuple[str, str]] = []
+        self.closed = False
+
+    async def receive_events(self):
+        for ev in self._events:
+            yield ev
+
+    async def send_function_result(self, call_id: str, result: str) -> None:
+        self.function_results.append((call_id, result))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _make_realtime_handler(adapter: _FakeAdapter) -> OpenAIRealtimeStreamHandler:
+    """Construct a real handler with the minimal real state the end_call and
+    transcript_input branches touch, bypassing the network-bound constructor
+    (mirrors test_telnyx_comfort_noise)."""
+    handler = OpenAIRealtimeStreamHandler.__new__(OpenAIRealtimeStreamHandler)
+    handler._adapter = adapter
+    handler.audio_sender = None
+    handler.metrics = None
+    handler.on_transcript = None
+    handler.on_transcript_line = None
+    handler.call_id = "CA0000000000000000000000000000a001"
+    handler.conversation_history = deque(maxlen=200)
+    handler.transcript_entries = deque(maxlen=200)
+    handler.speech_events = None
+    handler._user_speech_start_ms = None
+    handler._agent_turn_start_ms = None
+    handler._user_transcript_pending = False
+    handler._pending_assistant_turn = None
+    handler._pending_assistant_timer = None
+    handler._current_turn_index = None
+    handler.local_recorder = None
+    handler._comfort_noise_task = None
+    handler._transfer_fn = None
+    handler.agent = type("_A", (), {"model": "gpt-realtime", "tools": None})()
+    # Guard state under test.
+    handler._call_started_at_ms = time.time() * 1000
+    handler._user_has_spoken = False
+    # Observable hang-up boundary (we cannot place phone calls in CI).
+    handler._hangup_calls = 0
+
+    async def _hangup() -> None:
+        handler._hangup_calls += 1
+
+    handler._hangup_fn = _hangup
+    return handler
+
+
+_END_CALL_EVENT = (
+    "function_call",
+    {"call_id": "fc-1", "name": "end_call", "arguments": json.dumps({"reason": "no_response"})},
+)
+
+
+@pytest.mark.mocked
+class TestPrematureEndCallGuard:
+    async def test_refuses_end_call_before_caller_speaks(self) -> None:
+        adapter = _FakeAdapter([_END_CALL_EVENT])
+        handler = _make_realtime_handler(adapter)
+
+        await handler._forward_events()
+
+        # Call MUST NOT be torn down.
+        assert handler._hangup_calls == 0
+        # Model is told to keep listening (rejection payload, session left open).
+        assert len(adapter.function_results) == 1
+        _, payload = adapter.function_results[0]
+        parsed = json.loads(payload)
+        assert parsed["status"] == "rejected"
+        assert parsed["reason"] == "caller_still_connecting"
+
+    async def test_honors_end_call_after_caller_speaks(self) -> None:
+        adapter = _FakeAdapter(
+            [
+                ("transcript_input", "Hi, I would like to book an appointment."),
+                (
+                    "function_call",
+                    {
+                        "call_id": "fc-2",
+                        "name": "end_call",
+                        "arguments": json.dumps({"reason": "conversation_complete"}),
+                    },
+                ),
+            ]
+        )
+        handler = _make_realtime_handler(adapter)
+
+        await handler._forward_events()
+
+        assert handler._user_has_spoken is True
+        assert handler._hangup_calls == 1
+
+    async def test_honors_end_call_after_grace_window(self) -> None:
+        adapter = _FakeAdapter([_END_CALL_EVENT])
+        handler = _make_realtime_handler(adapter)
+        # Simulate the opening grace window (6 s) having already elapsed.
+        handler._call_started_at_ms = time.time() * 1000 - 7000
+
+        await handler._forward_events()
+
+        assert handler._hangup_calls == 1
+
+    async def test_hallucination_does_not_count_as_caller_speech(self) -> None:
+        adapter = _FakeAdapter(
+            [
+                ("transcript_input", "Thank you for watching."),
+                _END_CALL_EVENT,
+            ]
+        )
+        handler = _make_realtime_handler(adapter)
+
+        await handler._forward_events()
+
+        assert handler._user_has_spoken is False
+        assert handler._hangup_calls == 0
+        assert len(adapter.function_results) == 1

--- a/libraries/typescript/src/server.ts
+++ b/libraries/typescript/src/server.ts
@@ -126,7 +126,7 @@ export const END_CALL_TOOL = {
     properties: {
       reason: {
         type: 'string',
-        description: "Reason for ending the call (e.g., 'conversation_complete', 'user_requested', 'no_response')",
+        description: "Reason for ending the call (e.g., 'conversation_complete', 'user_requested')",
       },
     },
   },

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -1555,6 +1555,10 @@ export class StreamHandler {
   private sttClosed = false;
   private currentAgentText = '';
   private responseAudioStarted = false;
+  /** Wall-clock ms of carrier ``start`` — used to grace-guard premature end_call. */
+  private callStartedAtMs = 0;
+  /** True once a genuine (hallucination-filtered) caller transcript is committed. */
+  private userHasSpoken = false;
 
   // --- Realtime-engine outbound keepalive (Telnyx bidirectional RTP) ----
   // Realtime engines (GeminiLive / OpenAIRealtime2) put NO bytes on the
@@ -1575,6 +1579,15 @@ export class StreamHandler {
     Buffer.alloc(160, 0xff).toString('base64');
   /** Pump cadence: one 20 ms frame every 20 ms (real-time μ-law-8k rate). */
   private static readonly COMFORT_NOISE_INTERVAL_MS = 20;
+  /**
+   * A realtime model can emit ``end_call`` the instant its greeting finishes —
+   * before the caller has spoken. On carriers where the realtime connect→
+   * first-audio window eats the opening call budget (Telnyx native-audio), this
+   * hangs up a live caller at ~1.5 s. Refuse a model-initiated hang-up that
+   * fires before ANY caller speech AND within this opening grace window
+   * (connect ~1.5-2 s + greeting ~1 s + human turn-around). Tunable.
+   */
+  private static readonly REALTIME_END_CALL_MIN_AGE_MS = 6000;
   /**
    * Realtime turn ordering buffer. OpenAI Realtime emits
    * `input_audio_transcription.completed` (user transcript) AFTER
@@ -1983,6 +1996,7 @@ export class StreamHandler {
   /** Initialize per-call state, build the AI adapter, and dispatch the `onCallStart` callback. */
   async handleCallStart(callId: string, customParams: Record<string, string> = {}): Promise<void> {
     this.callId = callId;
+    this.callStartedAtMs = Date.now();
     // metricsAcc.callId is readonly at the public type level but is INTERNAL
     // per-call state — the accumulator is always owned by this handler
     // instance and callId is not known at construction time (it arrives with
@@ -5994,6 +6008,7 @@ export class StreamHandler {
       return;
     }
     getLogger().debug(`User (${this.deps.bridge.label}): ${sanitizeLogValue(inputText)}`);
+    this.userHasSpoken = true;
     this.history.push({ role: 'user', text: inputText, timestamp: Date.now() });
     // FIX-5 (issue #154): emit the live user transcript line the moment it is
     // known and accepted by the filter, keyed by the reserved turn index. The
@@ -6520,6 +6535,26 @@ export class StreamHandler {
         endArgs = {};
       }
       const reason = endArgs.reason ?? 'conversation_complete';
+      // Premature-hangup guard: a realtime engine can emit end_call the moment
+      // its greeting finishes, before the caller has spoken. On carriers whose
+      // realtime connect→first-audio window eats the opening budget (Telnyx
+      // native-audio) this kills a live caller at ~1.5 s. If the caller has not
+      // spoken yet AND we are inside the opening grace window, refuse and tell
+      // the model to keep listening rather than tearing the call down.
+      const callAgeMs = Date.now() - this.callStartedAtMs;
+      if (!this.userHasSpoken && callAgeMs < StreamHandler.REALTIME_END_CALL_MIN_AGE_MS) {
+        getLogger().debug(
+          `Ignoring premature end_call (${this.deps.bridge.label}): reason=${reason} ageMs=${callAgeMs} — caller has not spoken yet`,
+        );
+        const keepAlive = JSON.stringify({
+          status: 'rejected',
+          reason: 'caller_still_connecting',
+          message: 'The caller may still be connecting. Keep the line open and wait for them to speak.',
+        });
+        await adapter.sendFunctionResult(fc.call_id, keepAlive);
+        await this.emitToolEvent('end_call', endArgs, keepAlive);
+        return;
+      }
       getLogger().debug(`Ending call (${this.deps.bridge.label}): ${reason}`);
       const result = JSON.stringify({ status: 'ending', reason });
       await adapter.sendFunctionResult(fc.call_id, result);

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -1555,6 +1555,26 @@ export class StreamHandler {
   private sttClosed = false;
   private currentAgentText = '';
   private responseAudioStarted = false;
+
+  // --- Realtime-engine outbound keepalive (Telnyx bidirectional RTP) ----
+  // Realtime engines (GeminiLive / OpenAIRealtime2) put NO bytes on the
+  // carrier between the ``start`` event and the model's first audio delta
+  // — cold ``adapter.connect()`` + model TTFT + resampler warmup is often
+  // >1.5 s. Twilio tolerates that gap; Telnyx's bidirectional RTP leg
+  // clears the call (~1.6 s, "1 turn", normal_clearing). The pipeline path
+  // never hits this because ``playFirstMessage`` puts TTS bytes on the wire
+  // within ~200 ms. Pump paced μ-law-8k silence (the exact format already
+  // proven on Telnyx) from stream-start until the first real model frame,
+  // so the outbound leg stays primed. Twilio/Plivo are unaffected — they
+  // also accept μ-law-8k silence frames and have no such timeout. The pump
+  // self-cancels the instant ``onAdapterAudio`` fires.
+  private comfortNoiseTimer: ReturnType<typeof setInterval> | null = null;
+  /** One 20 ms μ-law-8k silence frame (160 bytes). 0xFF == μ-law digital
+   *  zero. Allocated once; never mutated. */
+  private static readonly MULAW_SILENCE_FRAME: string =
+    Buffer.alloc(160, 0xff).toString('base64');
+  /** Pump cadence: one 20 ms frame every 20 ms (real-time μ-law-8k rate). */
+  private static readonly COMFORT_NOISE_INTERVAL_MS = 20;
   /**
    * Realtime turn ordering buffer. OpenAI Realtime emits
    * `input_audio_transcription.completed` (user transcript) AFTER
@@ -2774,6 +2794,9 @@ export class StreamHandler {
   }
 
   async handleStop(): Promise<void> {
+    // Kill the realtime comfort-noise pump if the call ends before the model
+    // ever produced audio (otherwise the interval leaks past call teardown).
+    this.stopComfortNoise();
     // Abort any in-flight LLM stream and close any in-flight TTS WS so
     // the runPipelineLlm / synthesizeStream awaits unblock immediately
     // instead of waiting up to 30 s for their own watchdog timers.
@@ -2835,6 +2858,9 @@ export class StreamHandler {
   /** Handle WebSocket close event. */
   /** Tear down adapter, STT/TTS, and per-call state when the carrier WebSocket closes. */
   async handleWsClose(): Promise<void> {
+    // Kill the realtime comfort-noise pump if the WS drops before the model
+    // ever produced audio (otherwise the interval leaks past call teardown).
+    this.stopComfortNoise();
     // Mirror handleStop's in-flight cleanup so a carrier WebSocket drop
     // unblocks LLM / TTS awaits immediately — see comment there.
     if (this.llmAbort !== null) {
@@ -5675,6 +5701,50 @@ export class StreamHandler {
         getLogger().error(`Adapter event handler error (${label}):`, err);
       }
     });
+
+    // Keep the outbound carrier leg primed during the connect→first-delta
+    // window (see ``comfortNoiseTimer`` doc). Realtime engines only — the
+    // pipeline path has ``playFirstMessage`` for this. Self-cancels on the
+    // first real model frame in ``onAdapterAudio``.
+    this.startComfortNoise();
+  }
+
+  /**
+   * Begin pumping paced μ-law-8k silence frames to the carrier so a
+   * realtime engine's pre-first-audio gap does not leave the outbound leg
+   * idle (Telnyx clears an idle bidirectional RTP leg ~1.6 s in). Idempotent
+   * — a second call is a no-op while a pump is already running. Stopped by
+   * ``stopComfortNoise`` from ``onAdapterAudio`` (first real frame) and from
+   * the teardown path.
+   */
+  private startComfortNoise(): void {
+    if (this.comfortNoiseTimer !== null) return;
+    this.comfortNoiseTimer = setInterval(() => {
+      // First real frame already on the wire — pump is obsolete.
+      if (this.responseAudioStarted) {
+        this.stopComfortNoise();
+        return;
+      }
+      try {
+        this.deps.bridge.sendAudio(
+          this.ws,
+          StreamHandler.MULAW_SILENCE_FRAME,
+          this.streamSid,
+        );
+      } catch (err) {
+        // Carrier WS gone — stop pumping rather than spin on a dead socket.
+        getLogger().debug(`comfort-noise send failed: ${String(err)}`);
+        this.stopComfortNoise();
+      }
+    }, StreamHandler.COMFORT_NOISE_INTERVAL_MS);
+  }
+
+  /** Stop the comfort-noise pump if running. Idempotent. */
+  private stopComfortNoise(): void {
+    if (this.comfortNoiseTimer !== null) {
+      clearInterval(this.comfortNoiseTimer);
+      this.comfortNoiseTimer = null;
+    }
   }
 
   private async handleAdapterEvent(type: string, eventData: unknown): Promise<void> {
@@ -5809,6 +5879,10 @@ export class StreamHandler {
   }
 
   private async onAdapterAudio(eventData: Buffer): Promise<void> {
+    // Real model audio is ready — tear down the pre-first-audio comfort-noise
+    // pump (no-op if it already stopped or never armed) before the first real
+    // frame goes out, so silence and speech never interleave on the wire.
+    this.stopComfortNoise();
     // Record time-to-first-audio-byte as latency (Realtime mode). If no
     // startTurn() was called yet (e.g. agent responding again without user
     // input), start a new turn now so latency is still measured.

--- a/libraries/typescript/tests/telnyx-comfort-noise.mocked.test.ts
+++ b/libraries/typescript/tests/telnyx-comfort-noise.mocked.test.ts
@@ -1,0 +1,274 @@
+/**
+ * [mocked] Realtime-engine outbound keepalive over Telnyx (comfort-noise pump).
+ *
+ * BUG: native-audio realtime engines (GeminiLive / OpenAIRealtime2) put NO
+ * bytes on the carrier between the carrier ``start`` and the model's first
+ * audio delta (cold ``connect()`` + TTFT + resampler warmup, often >1.5 s).
+ * Twilio tolerates the gap; Telnyx clears the idle bidirectional RTP leg
+ * (~1.6 s). The fix pumps paced μ-law-8k silence from stream-start until the
+ * first real model frame.
+ *
+ * AUTHENTIC: the StreamHandler and the OpenAIRealtime2Adapter are REAL. The
+ * pump, the silence frame, ``startComfortNoise``/``stopComfortNoise``, and the
+ * real ``mulawToPcm16`` decoder are all exercised. Mocked only at the external
+ * boundary — the OpenAI WebSocket transport (injected mock ``ws``), the network
+ * ``connect()`` (an external-API call we cannot place in CI), and the carrier
+ * ``TelephonyBridge`` (we cannot place phone calls in CI). We assert on the
+ * observable outcome: ``bridge.sendAudio`` calls.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamHandler } from '../src/stream-handler';
+import type { TelephonyBridge, StreamHandlerDeps } from '../src/stream-handler';
+import { OpenAIRealtimeAdapter } from '../src/providers/openai-realtime';
+import { OpenAIRealtime2Adapter } from '../src/providers/openai-realtime-2';
+import { MetricsStore } from '../src/dashboard/store';
+import { RemoteMessageHandler } from '../src/remote-message';
+import { mulawToPcm16 } from '../src/audio/transcoding';
+import type { WebSocket as WSWebSocket } from 'ws';
+import type { AgentOptions } from '../src/types';
+
+/** The exact frame the pump emits (private static — re-derived here). */
+const SILENCE_FRAME_B64 = Buffer.alloc(160, 0xff).toString('base64');
+
+function makeMockWs(): WSWebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    readyState: 1,
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WSWebSocket;
+}
+
+function makeBridge(label = 'Telnyx', provider = 'telnyx'): TelephonyBridge {
+  return {
+    label,
+    telephonyProvider: provider,
+    sendAudio: vi.fn(),
+    sendMark: vi.fn(),
+    sendClear: vi.fn(),
+    transferCall: vi.fn().mockResolvedValue(undefined),
+    endCall: vi.fn().mockResolvedValue(undefined),
+    createStt: vi.fn().mockReturnValue(null),
+    queryTelephonyCost: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelephonyBridge;
+}
+
+/**
+ * Build a REAL OpenAIRealtime2Adapter (a native-audio realtime engine). Stub
+ * only ``connect`` (the OpenAI network handshake) and inject a mock WS.
+ */
+function makeRealAdapter(ws: WSWebSocket): OpenAIRealtime2Adapter {
+  const adapter = new OpenAIRealtime2Adapter(
+    'sk-test',
+    'gpt-realtime-2',
+    'alloy',
+    'You are a helpful test agent.',
+  );
+  vi.spyOn(adapter, 'connect').mockResolvedValue(undefined);
+  (adapter as unknown as { ws: WSWebSocket }).ws = ws;
+  return adapter;
+}
+
+function makeRealtimeDeps(
+  bridge: TelephonyBridge,
+  adapter: OpenAIRealtime2Adapter,
+): StreamHandlerDeps {
+  const agent: AgentOptions = {
+    systemPrompt: 'You are a helpful test agent.',
+    provider: 'openai_realtime',
+    model: 'gpt-realtime-2',
+    voice: 'alloy',
+  };
+  return makeDeps(bridge, agent, adapter);
+}
+
+function makePipelineDeps(bridge: TelephonyBridge): StreamHandlerDeps {
+  const agent: AgentOptions = {
+    systemPrompt: 'You are a helpful test agent.',
+    provider: 'pipeline',
+    // Supply a VAD so initPipeline skips the optional SileroVAD/onnxruntime
+    // import (irrelevant to the pump under test). Minimal real-shaped
+    // VADProvider — never emits, never used by these assertions.
+    vad: {
+      processFrame: async () => null,
+      close: async () => {},
+    },
+  };
+  return makeDeps(bridge, agent, undefined);
+}
+
+function makeDeps(
+  bridge: TelephonyBridge,
+  agent: AgentOptions,
+  adapter: OpenAIRealtime2Adapter | undefined,
+): StreamHandlerDeps {
+  return {
+    config: { openaiKey: 'sk-test' },
+    agent,
+    bridge,
+    metricsStore: new MetricsStore(),
+    pricing: null,
+    remoteHandler: new RemoteMessageHandler(),
+    recording: false,
+    buildAIAdapter: vi.fn().mockReturnValue(adapter),
+    sanitizeVariables: vi.fn((raw: Record<string, unknown>) => {
+      const safe: Record<string, string> = {};
+      for (const [k, v] of Object.entries(raw)) safe[k] = String(v);
+      return safe;
+    }),
+    resolveVariables: vi.fn((tpl: string) => tpl),
+  } as unknown as StreamHandlerDeps;
+}
+
+/** Capture the StreamHandler's registered onEvent callback (real subscription). */
+function captureEventCallback(
+  adapter: OpenAIRealtimeAdapter,
+): { current: ((type: string, data: unknown) => Promise<void>) | undefined } {
+  const box: { current: ((type: string, data: unknown) => Promise<void>) | undefined } = {
+    current: undefined,
+  };
+  const realOnEvent = adapter.onEvent.bind(adapter);
+  vi.spyOn(adapter, 'onEvent').mockImplementation((cb) => {
+    box.current = cb as (type: string, data: unknown) => Promise<void>;
+    realOnEvent(cb);
+  });
+  return box;
+}
+
+/** Count ``sendAudio`` calls whose payload is the silence frame. */
+function countSilenceFrames(bridge: TelephonyBridge): number {
+  const send = (bridge as unknown as { sendAudio: { mock: { calls: unknown[][] } } }).sendAudio;
+  return send.mock.calls.filter((c) => c[1] === SILENCE_FRAME_B64).length;
+}
+
+describe('[unit] comfort-noise silence frame', () => {
+  it('decodes via real mulawToPcm16 to 160 PCM16 samples of value 0 (true silence)', () => {
+    const frame = Buffer.from(SILENCE_FRAME_B64, 'base64');
+    expect(frame.length).toBe(160); // 20 ms @ 8 kHz μ-law, 1 byte/sample
+
+    const pcm = mulawToPcm16(frame);
+    // 160 μ-law bytes -> 160 PCM16 samples (2 bytes each) = 320 bytes.
+    expect(pcm.length).toBe(320);
+    const samples = pcm.length / 2;
+    expect(samples).toBe(160);
+    for (let i = 0; i < pcm.length; i += 2) {
+      expect(pcm.readInt16LE(i)).toBe(0);
+    }
+  });
+});
+
+describe('[mocked] realtime-engine comfort-noise pump over Telnyx', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    void fetchSpy;
+  });
+
+  it('emits silence frames before the first model delta, then stops once it fires', async () => {
+    const bridge = makeBridge();
+    const adapterWs = makeMockWs();
+    const adapter = makeRealAdapter(adapterWs);
+    const events = captureEventCallback(adapter);
+
+    const handler = new StreamHandler(
+      makeRealtimeDeps(bridge, adapter),
+      makeMockWs(),
+      '+15551111111',
+      '+15552222222',
+    );
+    handler.setStreamSid('telnyx-stream-1');
+    await handler.handleCallStart('telnyx-call-1');
+    expect(events.current).toBeDefined();
+
+    // Simulate the connect->first-delta gap (~300 ms). The pump runs every
+    // 20 ms, so ≥1 silence frame must reach the bridge in that window.
+    await vi.advanceTimersByTimeAsync(300);
+    const framesBeforeDelta = countSilenceFrames(bridge);
+    expect(framesBeforeDelta).toBeGreaterThanOrEqual(1);
+
+    // First real model audio arrives -> pump must stop.
+    await events.current!('audio', Buffer.alloc(480)); // real model PCM frame
+    const framesAtDelta = countSilenceFrames(bridge);
+
+    // Advance well past several pump intervals; NO further silence frames.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(countSilenceFrames(bridge)).toBe(framesAtDelta);
+  });
+
+  it('pipeline mode never arms the pump (no comfort-noise frames ever)', async () => {
+    const bridge = makeBridge();
+    const handler = new StreamHandler(
+      makePipelineDeps(bridge),
+      makeMockWs(),
+      '+15551111111',
+      '+15552222222',
+    );
+    handler.setStreamSid('telnyx-stream-pipeline');
+    await handler.handleCallStart('telnyx-call-pipeline');
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(countSilenceFrames(bridge)).toBe(0);
+  });
+
+  it('handleStop before any model audio clears the interval (no leaked timer)', async () => {
+    const bridge = makeBridge();
+    const adapterWs = makeMockWs();
+    const adapter = makeRealAdapter(adapterWs);
+
+    const handler = new StreamHandler(
+      makeRealtimeDeps(bridge, adapter),
+      makeMockWs(),
+      '+15551111111',
+      '+15552222222',
+    );
+    handler.setStreamSid('telnyx-stream-stop');
+    await handler.handleCallStart('telnyx-call-stop');
+
+    await handler.handleStop();
+    expect(
+      (handler as unknown as { comfortNoiseTimer: unknown }).comfortNoiseTimer,
+    ).toBeNull();
+
+    // No further silence frames after teardown.
+    const frames = countSilenceFrames(bridge);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(countSilenceFrames(bridge)).toBe(frames);
+  });
+
+  it('handleWsClose before any model audio clears the interval (no leaked timer)', async () => {
+    const bridge = makeBridge();
+    const adapterWs = makeMockWs();
+    const adapter = makeRealAdapter(adapterWs);
+
+    const handler = new StreamHandler(
+      makeRealtimeDeps(bridge, adapter),
+      makeMockWs(),
+      '+15551111111',
+      '+15552222222',
+    );
+    handler.setStreamSid('telnyx-stream-wsclose');
+    await handler.handleCallStart('telnyx-call-wsclose');
+
+    await handler.handleWsClose();
+    expect(
+      (handler as unknown as { comfortNoiseTimer: unknown }).comfortNoiseTimer,
+    ).toBeNull();
+  });
+});

--- a/libraries/typescript/tests/telnyx-premature-endcall.mocked.test.ts
+++ b/libraries/typescript/tests/telnyx-premature-endcall.mocked.test.ts
@@ -1,0 +1,208 @@
+/**
+ * [mocked] Premature end_call guard for native-audio realtime engines over Telnyx.
+ *
+ * BUG: a realtime engine (GeminiLive / OpenAIRealtime2) can emit ``end_call``
+ * the instant its greeting finishes — before the caller has spoken. On Telnyx
+ * the cold realtime connect→first-audio window eats the opening call budget, so
+ * the model greets and immediately bails ("no_response") ~1.5 s in, killing a
+ * live caller. Twilio and pipeline mode never hit this. The fix refuses a
+ * model-initiated hang-up that fires before ANY caller speech AND within the
+ * opening grace window, telling the model to keep listening instead.
+ *
+ * AUTHENTIC: the StreamHandler and the real OpenAIRealtime2Adapter are exercised
+ * end-to-end. The real ``handleFunctionCall`` end_call branch, the real
+ * ``onAdapterTranscriptInput`` caller-spoke path (incl. the real hallucination
+ * filter), and the real grace-window arithmetic all run. Mocked only at the
+ * external boundary — the OpenAI WebSocket transport (injected mock ``ws`` +
+ * ``connect`` stub, a network call we cannot place in CI) and the carrier
+ * ``TelephonyBridge`` (we cannot place phone calls in CI). We assert on the
+ * observable outcomes: ``bridge.endCall`` (did the call die?) and the
+ * ``sendFunctionResult`` payload the model receives back.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamHandler } from '../src/stream-handler';
+import type { TelephonyBridge, StreamHandlerDeps } from '../src/stream-handler';
+import { OpenAIRealtimeAdapter } from '../src/providers/openai-realtime';
+import { OpenAIRealtime2Adapter } from '../src/providers/openai-realtime-2';
+import { MetricsStore } from '../src/dashboard/store';
+import { RemoteMessageHandler } from '../src/remote-message';
+import type { WebSocket as WSWebSocket } from 'ws';
+import type { AgentOptions } from '../src/types';
+
+function makeMockWs(): WSWebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    readyState: 1,
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WSWebSocket;
+}
+
+function makeBridge(label = 'Telnyx', provider = 'telnyx'): TelephonyBridge {
+  return {
+    label,
+    telephonyProvider: provider,
+    sendAudio: vi.fn(),
+    sendMark: vi.fn(),
+    sendClear: vi.fn(),
+    transferCall: vi.fn().mockResolvedValue(undefined),
+    endCall: vi.fn().mockResolvedValue(undefined),
+    createStt: vi.fn().mockReturnValue(null),
+    queryTelephonyCost: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TelephonyBridge;
+}
+
+/** Build a REAL OpenAIRealtime2Adapter; stub only ``connect`` + inject mock WS. */
+function makeRealAdapter(ws: WSWebSocket): OpenAIRealtime2Adapter {
+  const adapter = new OpenAIRealtime2Adapter(
+    'sk-test',
+    'gpt-realtime-2',
+    'alloy',
+    'You are a helpful test agent.',
+  );
+  vi.spyOn(adapter, 'connect').mockResolvedValue(undefined);
+  (adapter as unknown as { ws: WSWebSocket }).ws = ws;
+  return adapter;
+}
+
+function makeRealtimeDeps(
+  bridge: TelephonyBridge,
+  adapter: OpenAIRealtime2Adapter,
+): StreamHandlerDeps {
+  const agent: AgentOptions = {
+    systemPrompt: 'You are a helpful test agent.',
+    provider: 'openai_realtime',
+    model: 'gpt-realtime-2',
+    voice: 'alloy',
+  };
+  return {
+    config: { openaiKey: 'sk-test' },
+    agent,
+    bridge,
+    metricsStore: new MetricsStore(),
+    pricing: null,
+    remoteHandler: new RemoteMessageHandler(),
+    recording: false,
+    buildAIAdapter: vi.fn().mockReturnValue(adapter),
+    sanitizeVariables: vi.fn((raw: Record<string, unknown>) => {
+      const safe: Record<string, string> = {};
+      for (const [k, v] of Object.entries(raw)) safe[k] = String(v);
+      return safe;
+    }),
+    resolveVariables: vi.fn((tpl: string) => tpl),
+  } as unknown as StreamHandlerDeps;
+}
+
+/** Capture the StreamHandler's real adapter-event callback. */
+function captureEventCallback(
+  adapter: OpenAIRealtimeAdapter,
+): { current: ((type: string, data: unknown) => Promise<void>) | undefined } {
+  const box: { current: ((type: string, data: unknown) => Promise<void>) | undefined } = {
+    current: undefined,
+  };
+  const realOnEvent = adapter.onEvent.bind(adapter);
+  vi.spyOn(adapter, 'onEvent').mockImplementation((cb) => {
+    box.current = cb as (type: string, data: unknown) => Promise<void>;
+    realOnEvent(cb);
+  });
+  return box;
+}
+
+const END_CALL_FC = { call_id: 'fc-1', name: 'end_call', arguments: JSON.stringify({ reason: 'no_response' }) };
+
+describe('[mocked] premature end_call guard over Telnyx', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => '',
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    void fetchSpy;
+  });
+
+  async function boot(bridge: TelephonyBridge) {
+    const adapter = makeRealAdapter(makeMockWs());
+    const sendResult = vi.spyOn(adapter, 'sendFunctionResult').mockResolvedValue(undefined);
+    const events = captureEventCallback(adapter);
+    const handler = new StreamHandler(
+      makeRealtimeDeps(bridge, adapter),
+      makeMockWs(),
+      '+15551111111',
+      '+15552222222',
+    );
+    handler.setStreamSid('telnyx-stream-endcall');
+    await handler.handleCallStart('telnyx-call-endcall');
+    expect(events.current).toBeDefined();
+    return { adapter, sendResult, events, handler };
+  }
+
+  it('refuses a model end_call before the caller has spoken, keeping the line open', async () => {
+    const bridge = makeBridge();
+    const { sendResult, events } = await boot(bridge);
+
+    // Model emits end_call ~1.5 s in — before any caller transcript.
+    await vi.advanceTimersByTimeAsync(1500);
+    await events.current!('function_call', END_CALL_FC);
+
+    // Call MUST NOT be torn down.
+    expect((bridge as unknown as { endCall: ReturnType<typeof vi.fn> }).endCall).not.toHaveBeenCalled();
+    // Model is told to keep listening (rejection payload, session left open).
+    expect(sendResult).toHaveBeenCalledTimes(1);
+    const [, payload] = sendResult.mock.calls[0] as [string, string];
+    expect(JSON.parse(payload)).toMatchObject({ status: 'rejected', reason: 'caller_still_connecting' });
+  });
+
+  it('honors end_call once the caller has actually spoken (within the grace window)', async () => {
+    const bridge = makeBridge();
+    const { events } = await boot(bridge);
+
+    // Real caller transcript flows through the real hallucination filter and
+    // sets the "caller has spoken" flag.
+    await events.current!('transcript_input', 'Hi, I would like to book an appointment.');
+    await events.current!('function_call', {
+      call_id: 'fc-2',
+      name: 'end_call',
+      arguments: JSON.stringify({ reason: 'conversation_complete' }),
+    });
+
+    expect((bridge as unknown as { endCall: ReturnType<typeof vi.fn> }).endCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors end_call after the grace window even if the caller never spoke', async () => {
+    const bridge = makeBridge();
+    const { events } = await boot(bridge);
+
+    // Past the 6 s opening grace window — a genuine no-answer hang-up is allowed.
+    await vi.advanceTimersByTimeAsync(6001);
+    await events.current!('function_call', END_CALL_FC);
+
+    expect((bridge as unknown as { endCall: ReturnType<typeof vi.fn> }).endCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat a Whisper hallucination as the caller speaking', async () => {
+    const bridge = makeBridge();
+    const { sendResult, events } = await boot(bridge);
+
+    // Known Whisper-on-silence hallucination — must NOT flip userHasSpoken.
+    await events.current!('transcript_input', 'Thank you for watching.');
+    await vi.advanceTimersByTimeAsync(1000);
+    await events.current!('function_call', END_CALL_FC);
+
+    expect((bridge as unknown as { endCall: ReturnType<typeof vi.fn> }).endCall).not.toHaveBeenCalled();
+    expect(sendResult).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Native-audio realtime engines (GeminiLive, OpenAI Realtime/Realtime2) dropped Telnyx calls at ~1.6 s with `normal_clearing` after exactly "1 turn." The same engines worked on Twilio; pipeline TTS worked fine on Telnyx; the engines worked in isolation.

**Root cause confirmed from source.** Outbound audio encoding was never the issue: both realtime engines already internally resample 24 kHz PCM16 → μ-law 8 kHz 160-byte/20 ms frames before handing bytes to `onAdapterAudio`, and those frames are byte-identical to what pipeline TTS sends successfully over Telnyx. The wire format, the `{event:'media',media:{payload}}` envelope, the bidirectional PCMU 8000 negotiation, and `bytesPerMs` bookkeeping are all correct.

The single behavioral difference: realtime engines emit **zero bytes to the carrier** between the carrier `start` event and the model's first audio delta. The cold path is `adapter.connect()` (TCP+TLS+`session.update` ack ~300–800 ms) + model TTFT (~300–700 ms) + resampler warmup (first delta returns 0 bytes, silently dropped). Combined, this regularly exceeds 1.5 s of dead outbound air. Pipeline never hits this gap because `playFirstMessage` puts TTS bytes on the wire within ~200 ms; Twilio has no silence timeout at that timescale; Telnyx's bidirectional RTP leg apparently clears at ~1.6 s of outbound silence.

## Fix

Pump paced μ-law 8 kHz silence frames from stream-start until the first real model frame, for realtime engines only.

**TypeScript (`stream-handler.ts`, 4 edits):**
- Added `comfortNoiseTimer`, `MULAW_SILENCE_FRAME` (160-byte `0xFF` Buffer, base64-encoded, μ-law digital zero), and `COMFORT_NOISE_INTERVAL_MS = 20` to `StreamHandler`.
- `startComfortNoise()` / `stopComfortNoise()` helpers: idempotent arm/cancel of a `setInterval` that calls `bridge.sendAudio(ws, SILENCE_FRAME, streamSid)` every 20 ms while `!responseAudioStarted`.
- Armed at the end of `initRealtimeAdapter` (realtime-only, post-connect). Cancelled as the **first line** of `onAdapterAudio` (before the first real frame goes out, so silence and speech never interleave). Also cancelled in `handleStop` and `handleWsClose` to prevent interval leaks on calls that end before any model audio.

**Python (`stream_handler.py`, parity):** Pump helpers (`_start_comfort_noise` / `_stop_comfort_noise` + `asyncio.Task` + `_MULAW_SILENCE_FRAME = b"\xff" * 160` + `_COMFORT_NOISE_INTERVAL_S = 0.02`) on the base `StreamHandler`. Wired into `OpenAIRealtimeStreamHandler` (armed after `_forward_events` task is spawned, cancelled in `_forward_events` first-frame guard and `cleanup()`) and `ElevenLabsConvAIStreamHandler` (same wiring). `PipelineStreamHandler` is untouched; the pump is never armed for pipeline.

**Audio math:** μ-law G.711 @ 8000 Hz = 8 bytes/ms → 20 ms frame = 160 bytes. μ-law digital silence = `0xFF` (linear 0 maps to inverted bits = `0xFF`). Pump cadence = one frame every 20 ms = real-time playout rate, matching all existing paced send sites. Twilio and Plivo receive the identical 160-byte μ-law silence frames, buffer-and-play them (inaudible), and are unaffected because they have no such timeout.

## What is verified

- **TypeScript build:** `tsup` CJS + DTS + CLI clean, `tsc --noEmit` zero errors.
- **TypeScript tests:** 2198 passed, 9 skipped across 137 files (full suite). New file `tests/telnyx-comfort-noise.mocked.test.ts`: 5/5 passed. Covers: silence frame decodes to true PCM16 zero via real `mulawToPcm16`; at least one silence frame reaches the bridge before the first simulated model delta; zero silence frames sent after `onAdapterAudio` fires; pipeline mode emits no comfort-noise frames; `handleStop` before any model audio leaves `comfortNoiseTimer === null`.
- **Python tests:** 2549 passed, 28 skipped, 2 xfailed (full suite, pytest `not soak`). New file `tests/test_telnyx_comfort_noise.py`: 5/5 passed.
- **Commit:** `3bad4f328bd2f2aedbac5bc32c69659e391fd6db` on `fix/telnyx-native-audio-bridge`.

## Known limitations / not yet verified

**No live Telnyx test call has been placed.** The fix is built, tested, and code-reviewed, but the original symptom (call drops at ~1.6 s on a real Telnyx number with a realtime engine) has not been reproduced and confirmed resolved with this branch. This is a prerequisite before merge.

**Python ConvAI default-mode concern (from verification review):** When `ElevenLabsConvAIStreamHandler` is constructed with default PCM16 16 kHz server formats (i.e. `_native_mulaw_8k = False`), `TelnyxAudioSender` is not in μ-law passthrough mode and will transcode the `b"\xff" * 160` comfort frame as if it were PCM16, yielding ~40 bytes of μ-law output per 20 ms tick rather than 160 bytes — roughly 4× under-feeding the RTP leg and emitting low-level noise rather than silence. The OpenAI Realtime / Realtime2 path is unaffected (sender correctly set to passthrough via `input_is_mulaw_8k=True` when Telnyx negotiates PCMU 8 kHz). The Python test uses a passthrough fake sender and does not catch this. For the current live use case (Pillar Gemini Live line, OpenAI Realtime demo line) this is not blocking, but the ConvAI claim should be reconciled before a ConvAI-on-Telnyx deployment. Suggested fix: gate `_start_comfort_noise` on `audio_sender._input_is_mulaw_8k is True`, or emit the comfort frame in the sender's expected input format.

**Telnyx silence-timeout not publicly documented.** The ~1.6 s `normal_clearing` behavior is consistent with an idle-RTP timeout but is not confirmed in Telnyx public docs. If the call still drops after this fix, the next probe is inbound audio (whether the carrier's RTP is reaching the model).

## How to test

1. Deploy this branch to a Cloud Run revision (or local `ngrok` tunnel).
2. Configure a Telnyx number with a getpatter webhook pointing at the revision.
3. Call the number with `engine=gemini_live` (or `openai_realtime_2`).
4. Verify the agent answers and speaks without dropping at ~1.6 s.
5. As a regression check, call the same number with `provider=pipeline` and confirm it still works.
6. (Optional) Call a Twilio-connected line with `engine=gemini_live` and confirm no regression.

## Files changed

| File | Change |
|---|---|
| `libraries/typescript/src/stream-handler.ts` | +74 lines: comfort-noise state, helpers, arm/cancel wiring (Edits 1–4) |
| `libraries/typescript/tests/telnyx-comfort-noise.mocked.test.ts` | +274 lines: new TS test file (5 tests) |
| `libraries/python/getpatter/stream_handler.py` | +77 lines: Python parity pump on base + both realtime subclasses |
| `libraries/python/tests/test_telnyx_comfort_noise.py` | +200 lines: new Python test file (5 tests) |
| `docs/DEVLOG.md` | +50 lines: investigation + fix notes |
