### PR TITLE
fix(docs): remove dead Discord invite link (footer + integration guides)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,7 +30,6 @@
     "socials": {
       "x": "https://x.com/patter_dev",
       "github": "https://github.com/PatterAI/Patter",
-      "discord": "https://discord.gg/patter",
       "linkedin": "https://linkedin.com/company/patter-dev"
     }
   },

--- a/docs/integrations/hermes.mdx
+++ b/docs/integrations/hermes.mdx
@@ -622,5 +622,5 @@ the adapter forwards that to Hermes, and the answer is spoken back to the caller
 
 - Patter SDK source: [https://github.com/PatterAI/Patter](https://github.com/PatterAI/Patter)
 - Patter MCP server: [https://github.com/PatterAI/patter-mcp](https://github.com/PatterAI/patter-mcp)
-- Patter Discord: [https://discord.gg/patter](https://discord.gg/patter)
+- Patter community (GitHub Discussions): [https://github.com/PatterAI/Patter/discussions](https://github.com/PatterAI/Patter/discussions)
 - Hermes Agent docs: [https://github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)

--- a/docs/integrations/openclaw.mdx
+++ b/docs/integrations/openclaw.mdx
@@ -969,5 +969,5 @@ scoped to one least-privileged agent that never exposes the master.
 
 - Patter SDK source: [https://github.com/PatterAI/Patter](https://github.com/PatterAI/Patter)
 - Patter MCP server: [https://github.com/PatterAI/patter-mcp](https://github.com/PatterAI/patter-mcp)
-- Patter Discord: [https://discord.gg/patter](https://discord.gg/patter)
+- Patter community (GitHub Discussions): [https://github.com/PatterAI/Patter/discussions](https://github.com/PatterAI/Patter/discussions)
 - OpenClaw docs: [https://docs.openclaw.ai](https://docs.openclaw.ai)


### PR DESCRIPTION
## Summary
- Closes #193 — the Discord icon in the docs footer (and the community links in the Hermes / OpenClaw integration guides) pointed at `https://discord.gg/patter`, which is not a valid invite: the Discord API returns `{"message": "Unknown Invite", "code": 10006}`, so clicking the footer icon led nowhere.
- No Patter Discord server currently exists, so the honest fix is to remove the dead link rather than leave a broken affordance: the footer icon is removed and the two integration-guide "community" links now point at GitHub Discussions (enabled on this repo).

## Implementation
- `docs/docs.json` — removed the `discord` entry from `footer.socials` (X, GitHub, LinkedIn remain).
- `docs/integrations/hermes.mdx` / `docs/integrations/openclaw.mdx` — "Patter Discord" resource link → "Patter community (GitHub Discussions)".
- When a real Discord server (with a permanent invite) is set up, the footer entry can be restored in one line.

## Breaking change?
No — docs-site only.

## Test plan
- [x] Docs-only change; verified `docs.json` stays valid JSON and no other `discord.gg` references remain in `docs/`
- [ ] Mintlify preview renders footer without the Discord icon

## Docs updates
- `docs/docs.json`, `docs/integrations/hermes.mdx`, `docs/integrations/openclaw.mdx` (this PR is docs-only; CHANGELOG exempt)