### PR TITLE
chore(release): finalize 0.7.1 CHANGELOG (publish to npm + PyPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.7.1 (2026-07-03)
+
 ### Added
 
 - **Opt-in destination policy for the built-in `transfer_call` tool**
@@ -59,23 +61,6 @@
   worth-resuming decision is a pluggable `RedeliveryPolicy` (default: gate on a
   non-trivial un-heard remainder). New `services/redelivery.py` / `.ts`. No-op in
   realtime mode. Default off ⇒ zero behaviour change.
-
-### Changed
-
-- **Barge-in "heard prefix" is now word-accurate.** On an interruption, the
-  conversation history is truncated to what the caller actually heard down to a
-  word boundary mid-sentence, instead of rounding up to whole sentences from a
-  byte estimate. Per-sentence segments now carry their playout duration, and the
-  played position is taken from the best available source — Twilio
-  carrier-confirmed per-sentence marks, else the wall-clock pacer's emitted
-  position (when `paced_output`), else the byte estimate. An internal heard/unsaid
-  split backs the new re-delivery feature. Telnyx/Plivo (no reliable marks) use
-  the pacer/estimate tiers.
-
-## 0.7.1 (2026-06-30)
-
-### Added
-
 - **Soniox v5 real-time STT adopted (both SDKs).** `SonioxModel` gains
   `STT_RT_V5 = "stt-rt-v5"` and the default model flips `stt-rt-v4` →
   `stt-rt-v5` (the GA v5 model, released 2026-06-16); `v4`/`v3`/`v2` stay
@@ -136,6 +121,15 @@
 
 ### Changed
 
+- **Barge-in "heard prefix" is now word-accurate.** On an interruption, the
+  conversation history is truncated to what the caller actually heard down to a
+  word boundary mid-sentence, instead of rounding up to whole sentences from a
+  byte estimate. Per-sentence segments now carry their playout duration, and the
+  played position is taken from the best available source — Twilio
+  carrier-confirmed per-sentence marks, else the wall-clock pacer's emitted
+  position (when `paced_output`), else the byte estimate. An internal heard/unsaid
+  split backs the new re-delivery feature. Telnyx/Plivo (no reliable marks) use
+  the pacer/estimate tiers.
 - **`@google/genai` peerDependency bumped `^0.3.0` → `>=2.0.0`** (kept optional)
   for the 2.x unified SDK, so `npm install getpatter` alongside
   `@google/genai@^2.x` no longer needs `--legacy-peer-deps`.


### PR DESCRIPTION
## Summary
Finalizes the **0.7.1** release notes so they match what's actually on `main`, ahead of publishing to npm + PyPI.

The three version files were already bumped to `0.7.1` by #202, but the release was never tagged/published (npm + PyPI are still on `0.7.0`). Since then, #206 (transfer-destination allowlist) and #208 (low-latency voice pipeline) merged onto `main` **at version 0.7.1** while their CHANGELOG entries sat under `## Unreleased`. This PR folds those entries into the `## 0.7.1` section so the published release notes describe the code that ships.

## What's in 0.7.1
Everything currently on `main` (all opt-in, byte-identical defaults):
- **#202** — GeminiLive / GeminiCascade / InworldRealtime engine markers + Gemini Live fixes; Soniox v5 STT, Soniox TTS, Sarvam TTS providers; pricing.
- **#208** — wall-clock outbound pacing, Krisp BYO denoiser, NAMO text-based EOT, word-accurate barge-in heard-prefix + opt-in re-delivery.
- **#206** — opt-in `transfer_call` destination allowlist (toll-fraud hardening).

## Changes
- `CHANGELOG.md` only: `## Unreleased` entries moved into `## 0.7.1 (2026-07-03)`; `## Unreleased` left empty for future work. **No code change. No version change** (already `0.7.1` in all three files).

## Release steps (after merge)
1. Merge this PR.
2. Tag + push `v0.7.1` on `main` → triggers `.github/workflows/release.yml` to publish to PyPI (OIDC) and npm.
3. Create the GitHub Release for `v0.7.1`.

## Test plan
- [x] All three version files read `0.7.1` (`__init__.py`, `pyproject.toml`, `package.json`).
- [x] `## Unreleased` is empty; `## 0.7.1` now lists #202 + #206 + #208.
- [x] CHANGELOG-only; the shipping code (already merged + green on `main`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
