### PR TITLE
fix(gemini-live): gemini-3.1-flash-live — setup dies with affectiveDialog, session wedges on BLOCKING tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+### Fixed
+
+- **`gemini-3.1-flash-live-preview` is now actually usable** (field-debugged on
+  the Pillar demo line; TS only, Python parity pending):
+  - Setup: `enableAffectiveDialog`/`proactivity` are dated-2.5-native-audio-only
+    knobs — on the flash-live family the server never sends `setupComplete`
+    ("session ready timeout"). Dropped with a warning on flash-live models.
+  - Tool calls: in the default BLOCKING function-call mode 3.1 halts audio at
+    the `toolCall` and never resumes after the response (silent stall until the
+    caller hangs up; hit on real calls where the model tools mid-conversation).
+    flash-live now opts into the async mode (`behavior: NON_BLOCKING` +
+    `scheduling: INTERRUPT`), and the tool round-trip is logged at info.
+  `libraries/typescript/src/providers/gemini-live.ts`.
+
 ## 0.7.1 (2026-07-03)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,22 @@
 ### Fixed
 
 - **`gemini-3.1-flash-live-preview` is now actually usable** (field-debugged on
-  the Pillar demo line; TS only, Python parity pending):
+  the Pillar demo line; fixed in both SDKs):
   - Setup: `enableAffectiveDialog`/`proactivity` are dated-2.5-native-audio-only
     knobs — on the flash-live family the server never sends `setupComplete`
-    ("session ready timeout"). Dropped with a warning on flash-live models.
+    ("session ready timeout"). The TypeScript adapter now drops them (with a
+    warning) on flash-live models. No-op in Python, which does not expose these
+    knobs and so never sent them.
   - Tool calls: in the default BLOCKING function-call mode 3.1 halts audio at
     the `toolCall` and never resumes after the response (silent stall until the
     caller hangs up; hit on real calls where the model tools mid-conversation).
-    flash-live now opts into the async mode (`behavior: NON_BLOCKING` +
-    `scheduling: INTERRUPT`), and the tool round-trip is logged at info.
-  `libraries/typescript/src/providers/gemini-live.ts`.
+    Both SDKs now opt flash-live into the async mode (`behavior: NON_BLOCKING`
+    on the declaration + `scheduling: INTERRUPT` on the response), and log the
+    tool round-trip at info.
+  - Adds `GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW` to the Python model enum,
+    matching the exported `GEMINI_LIVE_3_1_FLASH_PREVIEW` constant in TypeScript.
+  `libraries/typescript/src/providers/gemini-live.ts`,
+  `libraries/python/getpatter/providers/gemini_live.py`.
 
 ## 0.7.1 (2026-07-03)
 

--- a/libraries/python/getpatter/providers/gemini_live.py
+++ b/libraries/python/getpatter/providers/gemini_live.py
@@ -28,6 +28,7 @@ class GeminiLiveModel(StrEnum):
     """Known Gemini Live (v1alpha) realtime models."""
 
     NATIVE_AUDIO_PREVIEW_09_2025 = "gemini-2.5-flash-native-audio-preview-09-2025"
+    LIVE_3_1_FLASH_PREVIEW = "gemini-3.1-flash-live-preview"
     LIVE_2_5_FLASH_PREVIEW = "gemini-live-2.5-flash-preview"
     LIVE_2_0_FLASH_EXP = "gemini-2.0-flash-exp"
 
@@ -145,6 +146,17 @@ class GeminiLiveAdapter:
             f"language={self.language!r})"
         )
 
+    @property
+    def _is_flash_live(self) -> bool:
+        """True for the ``gemini-*-flash-live*`` family (3.1+).
+
+        The two async-mode tool-call knobs key off this single predicate.
+        Kept deliberately permissive (substring, mirrors the TS adapter): the
+        retired ``*-flash-live-NNN`` ids also match but never connect, so it
+        is harmless.
+        """
+        return "flash-live" in str(self.model)
+
     async def connect(self) -> None:
         """Open a Live session with Gemini.
 
@@ -204,6 +216,16 @@ class GeminiLiveAdapter:
                             "parameters": _sanitize_gemini_schema(
                                 t.get("parameters", {})
                             ),
+                            # flash-live (3.1+) wedges in the default BLOCKING
+                            # function-call mode: the model halts audio at the
+                            # toolCall and never resumes after the response (no
+                            # error, just silence). Opt into the Live API's
+                            # async mode. Mirrors the TS adapter.
+                            **(
+                                {"behavior": "NON_BLOCKING"}
+                                if self._is_flash_live
+                                else {}
+                            ),
                         }
                         for t in self.tools
                     ],
@@ -245,15 +267,29 @@ class GeminiLiveAdapter:
         # call_id. Look it up from the map populated when the tool call was
         # emitted; fall back to ``call_id`` if we never saw this id (defensive).
         name = self._pending_tool_calls.pop(call_id, call_id)
-        await self._session.send_tool_response(
-            function_responses=[
-                {
-                    "id": call_id,
-                    "name": name,
-                    "response": {"result": result},
-                }
-            ],
-        )
+        function_response: dict[str, Any] = {
+            "id": call_id,
+            "name": name,
+            "response": {"result": result},
+        }
+        # Pair of the NON_BLOCKING declaration above: tell the model to pick
+        # the result up immediately instead of the WHEN_IDLE default, so 3.1
+        # resumes speaking after the tool round-trip. Mirrors the TS adapter.
+        if self._is_flash_live:
+            function_response["scheduling"] = "INTERRUPT"
+        try:
+            await self._session.send_tool_response(
+                function_responses=[function_response],
+            )
+            logger.info("Gemini Live toolResponse sent id=%s name=%s", call_id, name)
+        except Exception as exc:
+            logger.error(
+                "Gemini Live send_tool_response FAILED id=%s name=%s: %s",
+                call_id,
+                name,
+                exc,
+            )
+            raise
 
     async def cancel_response(self) -> None:
         """Interrupt the current model turn (barge-in)."""

--- a/libraries/python/tests/test_gemini_live.py
+++ b/libraries/python/tests/test_gemini_live.py
@@ -1,0 +1,203 @@
+"""Authentic tests for the Gemini Live adapter's async-mode tool-call fixes.
+
+The ``gemini-3.1-flash-live`` family wedges in the default BLOCKING
+function-call mode: the model halts audio at the ``toolCall`` and never
+resumes after the response (no error, just silence until the caller hangs
+up). The fix opts flash-live into the Live API's async mode —
+``behavior: NON_BLOCKING`` on the declaration and ``scheduling: INTERRUPT``
+on the response — while every other model stays byte-identical on the wire.
+
+Mock surface: only the google-genai Live session boundary (a paid external
+WebSocket). Everything else — config assembly, the flash-live predicate, the
+tool-response shaping — is the real adapter code, so swapping in a real
+session would exercise the same paths.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from getpatter.providers.gemini_live import GeminiLiveAdapter, GeminiLiveModel
+
+
+class _CapturingSession:
+    """Stand-in for the real google-genai Live session (the WebSocket boundary).
+
+    Records the tool responses it is sent. ``send_tool_response`` mirrors the
+    real coroutine's keyword-only ``function_responses`` signature.
+    """
+
+    def __init__(self) -> None:
+        self.tool_responses: list[list[dict]] = []
+
+    async def send_tool_response(self, *, function_responses: list[dict]) -> None:
+        self.tool_responses.append(function_responses)
+
+
+@pytest.mark.mocked
+async def test_flash_live_tool_response_carries_interrupt_scheduling() -> None:
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
+    )
+    session = _CapturingSession()
+    # Boundary injection: swap in the fake session so we exercise the real
+    # send_function_result shaping without opening a live socket.
+    adapter._session = session
+    adapter._pending_tool_calls["call-1"] = "qualifica_lead"
+
+    await adapter.send_function_result("call-1", '{"ok": true}')
+
+    assert len(session.tool_responses) == 1
+    fr = session.tool_responses[0][0]
+    assert fr["id"] == "call-1"
+    # Gemini needs the original function name, not the call id.
+    assert fr["name"] == "qualifica_lead"
+    assert fr["response"] == {"result": '{"ok": true}'}
+    # The fix: async pickup so 3.1 resumes speaking after the round-trip.
+    assert fr["scheduling"] == "INTERRUPT"
+
+
+@pytest.mark.mocked
+async def test_non_flash_live_tool_response_has_no_scheduling() -> None:
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.NATIVE_AUDIO_PREVIEW_09_2025,
+    )
+    session = _CapturingSession()
+    adapter._session = session
+    adapter._pending_tool_calls["call-2"] = "lookup"
+
+    await adapter.send_function_result("call-2", "result")
+
+    fr = session.tool_responses[0][0]
+    # 2.5 native-audio is byte-identical on the wire — no scheduling key.
+    assert "scheduling" not in fr
+
+
+@pytest.mark.mocked
+async def test_tool_response_logged_at_info(caplog) -> None:
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
+    )
+    adapter._session = _CapturingSession()
+    adapter._pending_tool_calls["call-3"] = "book_slot"
+
+    with caplog.at_level(logging.INFO, logger="getpatter.gemini_live"):
+        await adapter.send_function_result("call-3", "ok")
+
+    # The round-trip was invisible at default log level in prod — this stall
+    # was undiagnosable without it. It must now surface at info.
+    assert any(
+        "toolResponse sent" in r.message and "call-3" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.mocked
+async def test_tool_response_send_failure_is_logged_and_reraised(caplog) -> None:
+    class _FailingSession:
+        async def send_tool_response(self, *, function_responses):
+            raise RuntimeError("socket closed")
+
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
+    )
+    adapter._session = _FailingSession()
+    adapter._pending_tool_calls["call-4"] = "book_slot"
+
+    with caplog.at_level(logging.ERROR, logger="getpatter.gemini_live"):
+        with pytest.raises(RuntimeError, match="socket closed"):
+            await adapter.send_function_result("call-4", "ok")
+
+    assert any("FAILED" in r.message and "call-4" in r.message for r in caplog.records)
+
+
+class _FakeConnectCM:
+    """Async context manager returned by the fake ``aio.live.connect``."""
+
+    def __init__(self) -> None:
+        self.session = _CapturingSession()
+
+    async def __aenter__(self) -> _CapturingSession:
+        return self.session
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+def _install_config_capturing_client(monkeypatch, captured: dict) -> None:
+    """Patch ``google.genai.Client`` to capture the config sent to connect.
+
+    Only the genai client/session (the external WebSocket boundary) is faked;
+    the real ``genai_types`` builders and the adapter's config assembly run.
+    """
+    genai = pytest.importorskip("google.genai")
+
+    class _FakeAioLive:
+        def connect(self, *, model, config):
+            captured["model"] = model
+            captured["config"] = config
+            return _FakeConnectCM()
+
+    class _FakeAio:
+        live = _FakeAioLive()
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            self.aio = _FakeAio()
+
+    monkeypatch.setattr(genai, "Client", _FakeClient)
+
+
+@pytest.mark.mocked
+async def test_flash_live_declaration_opts_into_non_blocking(monkeypatch) -> None:
+    captured: dict = {}
+    _install_config_capturing_client(monkeypatch, captured)
+
+    tools = [
+        {
+            "name": "qualifica_lead",
+            "description": "Qualify the inbound lead.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
+        tools=tools,
+    )
+    await adapter.connect()
+
+    decls = captured["config"]["tools"][0]["function_declarations"]
+    assert decls[0]["behavior"] == "NON_BLOCKING"
+    await adapter.close()
+
+
+@pytest.mark.mocked
+async def test_non_flash_live_declaration_has_no_behavior(monkeypatch) -> None:
+    captured: dict = {}
+    _install_config_capturing_client(monkeypatch, captured)
+
+    tools = [
+        {
+            "name": "lookup",
+            "description": "Look something up.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    adapter = GeminiLiveAdapter(
+        api_key="test-key",
+        model=GeminiLiveModel.NATIVE_AUDIO_PREVIEW_09_2025,
+        tools=tools,
+    )
+    await adapter.connect()
+
+    decls = captured["config"]["tools"][0]["function_declarations"]
+    # 2.5 native-audio is byte-identical on the wire — no behavior key.
+    assert "behavior" not in decls[0]
+    await adapter.close()

--- a/libraries/typescript/src/providers/gemini-live.ts
+++ b/libraries/typescript/src/providers/gemini-live.ts
@@ -245,6 +245,17 @@ export class GeminiLiveAdapter {
   }
 
   /** Lazily import @google/genai, open a Live session, and start the receive loop. */
+  /**
+   * True for the `gemini-*-flash-live*` family (3.1+). The two async-mode
+   * tool-call knobs below key off this single predicate. Kept deliberately
+   * permissive (substring, not the stricter {@link geminiRequiresV1Alpha}
+   * regex): the retired `*-flash-live-NNN` ids also match but never connect,
+   * so it is harmless.
+   */
+  private get isFlashLive(): boolean {
+    return this.model.includes('flash-live');
+  }
+
   async connect(): Promise<void> {
     let genaiModule: { GoogleGenAI: new (args: { apiKey: string; httpOptions?: Record<string, unknown> }) => unknown };
     try {
@@ -305,15 +316,18 @@ export class GeminiLiveAdapter {
     // 2.5 previews only: on the *-flash-live-preview family the server never
     // sends setupComplete when a setup includes them (connect dies with
     // "session ready timeout"), so they are dropped there with a warning.
-    const isFlashLive = this.model.includes('flash-live');
-    if (this.affectiveDialog && isFlashLive) {
+    if (this.affectiveDialog && this.isFlashLive) {
       getLogger().warn(
         `Gemini Live: affectiveDialog is not supported on ${this.model} — ignoring (2.5 native-audio only)`,
       );
     } else if (this.affectiveDialog) {
       config.enableAffectiveDialog = true;
     }
-    if (this.proactiveAudio && !isFlashLive) {
+    if (this.proactiveAudio && this.isFlashLive) {
+      getLogger().warn(
+        `Gemini Live: proactiveAudio is not supported on ${this.model} — ignoring (2.5 native-audio only)`,
+      );
+    } else if (this.proactiveAudio) {
       config.proactivity = { proactiveAudio: true };
     }
     // Tune turn-taking: LOW start sensitivity ignores background noise/breathing
@@ -344,7 +358,7 @@ export class GeminiLiveAdapter {
             // mode: the model halts audio at the toolCall and never resumes
             // after the response (no error, just silence — seen 2/2 on the
             // first call after long idle). Opt into the Live API's async mode.
-            ...(this.model.includes('flash-live') ? { behavior: 'NON_BLOCKING' } : {}),
+            ...(this.isFlashLive ? { behavior: 'NON_BLOCKING' } : {}),
           })),
         },
       ];
@@ -551,7 +565,7 @@ export class GeminiLiveAdapter {
             response: { result },
             // Pair of the NON_BLOCKING declaration above: tell the model to
             // pick the result up immediately instead of the WHEN_IDLE default.
-            ...(this.model.includes('flash-live') ? { scheduling: 'INTERRUPT' } : {}),
+            ...(this.isFlashLive ? { scheduling: 'INTERRUPT' } : {}),
           },
         ],
       });

--- a/libraries/typescript/src/providers/gemini-live.ts
+++ b/libraries/typescript/src/providers/gemini-live.ts
@@ -301,11 +301,19 @@ export class GeminiLiveAdapter {
     };
     // Native-audio humanization knobs (opt-in). enableAffectiveDialog makes the
     // model adapt prosody to the caller's emotion; proactivity lets it choose
-    // when to speak. Both are v1alpha native-audio features.
-    if (this.affectiveDialog) {
+    // when to speak. Both are v1alpha native-audio features — of the DATED
+    // 2.5 previews only: on the *-flash-live-preview family the server never
+    // sends setupComplete when a setup includes them (connect dies with
+    // "session ready timeout"), so they are dropped there with a warning.
+    const isFlashLive = this.model.includes('flash-live');
+    if (this.affectiveDialog && isFlashLive) {
+      getLogger().warn(
+        `Gemini Live: affectiveDialog is not supported on ${this.model} — ignoring (2.5 native-audio only)`,
+      );
+    } else if (this.affectiveDialog) {
       config.enableAffectiveDialog = true;
     }
-    if (this.proactiveAudio) {
+    if (this.proactiveAudio && !isFlashLive) {
       config.proactivity = { proactiveAudio: true };
     }
     // Tune turn-taking: LOW start sensitivity ignores background noise/breathing
@@ -332,6 +340,11 @@ export class GeminiLiveAdapter {
             // ($schema, additionalProperties — strict-mode and zod-derived
             // MCP tools): one such tool 400'd the whole session.
             parameters: sanitizeGeminiSchema(t.parameters),
+            // flash-live (3.1+) wedges in the default BLOCKING function-call
+            // mode: the model halts audio at the toolCall and never resumes
+            // after the response (no error, just silence — seen 2/2 on the
+            // first call after long idle). Opt into the Live API's async mode.
+            ...(this.model.includes('flash-live') ? { behavior: 'NON_BLOCKING' } : {}),
           })),
         },
       ];
@@ -529,11 +542,24 @@ export class GeminiLiveAdapter {
     // emitted; fall back to callId if we never saw this id (defensive).
     const name = this.pendingToolCalls.get(callId) ?? callId;
     this.pendingToolCalls.delete(callId);
-    await sess.sendToolResponse?.({
-      functionResponses: [
-        { id: callId, name, response: { result } },
-      ],
-    });
+    try {
+      await sess.sendToolResponse?.({
+        functionResponses: [
+          {
+            id: callId,
+            name,
+            response: { result },
+            // Pair of the NON_BLOCKING declaration above: tell the model to
+            // pick the result up immediately instead of the WHEN_IDLE default.
+            ...(this.model.includes('flash-live') ? { scheduling: 'INTERRUPT' } : {}),
+          },
+        ],
+      });
+      getLogger().info(`Gemini Live toolResponse sent id=${callId} name=${name}`);
+    } catch (err) {
+      getLogger().error(`Gemini Live sendToolResponse FAILED id=${callId} name=${name}: ${String(err)}`);
+      throw err;
+    }
   }
 
   /** No-op — Gemini Live barge-in is VAD-driven, not client-cancelled. */

--- a/libraries/typescript/tests/gemini-live-tools.mocked.test.ts
+++ b/libraries/typescript/tests/gemini-live-tools.mocked.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GeminiLiveAdapter, GEMINI_LIVE_3_1_FLASH_PREVIEW } from '../src/providers/gemini-live';
+
+// [mocked] GeminiLiveAdapter — async-mode tool-call fixes for the
+// gemini-3.1-flash-live family. In the default BLOCKING function-call mode 3.1
+// halts audio at the toolCall and never resumes after the response (silent
+// stall until the caller hangs up). The fix opts flash-live into the async
+// mode: `behavior: NON_BLOCKING` on the declaration + `scheduling: INTERRUPT`
+// on the response. Every other model stays byte-identical on the wire.
+//
+// Mocks the @google/genai boundary only — the config assembly and the
+// tool-response shaping under test are the real adapter code.
+
+const NATIVE_AUDIO_2_5 = 'gemini-2.5-flash-native-audio-preview-09-2025';
+
+interface LiveCbs {
+  onopen?: () => void;
+  onmessage?: (e: unknown) => void;
+}
+
+interface ConnectCapture {
+  configs: Array<Record<string, unknown>>;
+}
+
+function makeFakeSession() {
+  return {
+    sendRealtimeInput: vi.fn(),
+    sendClientContent: vi.fn(),
+    sendToolResponse: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+/** Mock of @google/genai — mirrors the real handshake (open, then setupComplete). */
+function makeGenAIMock(session: unknown, capture: ConnectCapture) {
+  return {
+    GoogleGenAI: vi.fn().mockImplementation(() => ({
+      live: {
+        connect: vi.fn(async (args: { config?: Record<string, unknown>; callbacks?: LiveCbs }) => {
+          if (args.config) capture.configs.push(args.config);
+          args.callbacks?.onopen?.();
+          args.callbacks?.onmessage?.({ setupComplete: {} });
+          return session;
+        }),
+      },
+    })),
+  };
+}
+
+const TOOLS = [
+  { name: 'qualifica_lead', description: 'Qualify the inbound lead.', parameters: { type: 'object', properties: {} } },
+];
+
+type FnDecl = { behavior?: string };
+type ToolCfg = { functionDeclarations: FnDecl[] };
+
+describe('[mocked] GeminiLiveAdapter — async tool-call mode (3.1 flash-live wedge fix)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('opts flash-live function declarations into NON_BLOCKING behavior', async () => {
+    const capture: ConnectCapture = { configs: [] };
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      tools: TOOLS,
+    });
+    await adapter.connect();
+
+    const cfg = capture.configs[0] as { tools?: ToolCfg[] };
+    expect(cfg.tools?.[0].functionDeclarations[0].behavior).toBe('NON_BLOCKING');
+    await adapter.close();
+  });
+
+  it('leaves non-flash-live declarations byte-identical (no behavior key)', async () => {
+    const capture: ConnectCapture = { configs: [] };
+    vi.doMock('@google/genai', () => makeGenAIMock(makeFakeSession(), capture));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: NATIVE_AUDIO_2_5, tools: TOOLS });
+    await adapter.connect();
+
+    const cfg = capture.configs[0] as { tools?: ToolCfg[] };
+    expect(cfg.tools?.[0].functionDeclarations[0]).not.toHaveProperty('behavior');
+    await adapter.close();
+  });
+
+  it('sends INTERRUPT scheduling on the flash-live tool response', async () => {
+    const session = makeFakeSession();
+    vi.doMock('@google/genai', () => makeGenAIMock(session, { configs: [] }));
+
+    const adapter = new GeminiLiveAdapter('test-key', {
+      model: GEMINI_LIVE_3_1_FLASH_PREVIEW,
+      tools: TOOLS,
+    });
+    await adapter.connect();
+    await adapter.sendFunctionResult('call-1', '{"ok":true}');
+
+    expect(session.sendToolResponse).toHaveBeenCalledTimes(1);
+    const arg = session.sendToolResponse.mock.calls[0][0] as {
+      functionResponses: Array<Record<string, unknown>>;
+    };
+    const fr = arg.functionResponses[0];
+    expect(fr.id).toBe('call-1');
+    expect(fr.response).toEqual({ result: '{"ok":true}' });
+    expect(fr.scheduling).toBe('INTERRUPT');
+    await adapter.close();
+  });
+
+  it('omits scheduling on non-flash-live tool responses', async () => {
+    const session = makeFakeSession();
+    vi.doMock('@google/genai', () => makeGenAIMock(session, { configs: [] }));
+
+    const adapter = new GeminiLiveAdapter('test-key', { model: NATIVE_AUDIO_2_5, tools: TOOLS });
+    await adapter.connect();
+    await adapter.sendFunctionResult('call-2', 'result');
+
+    const arg = session.sendToolResponse.mock.calls[0][0] as {
+      functionResponses: Array<Record<string, unknown>>;
+    };
+    expect(arg.functionResponses[0]).not.toHaveProperty('scheduling');
+    await adapter.close();
+  });
+});


### PR DESCRIPTION
## What

Two field-debugged fixes that make `gemini-3.1-flash-live-preview` actually usable, found while moving the Pillar demo line to 3.1:

1. **Setup**: `enableAffectiveDialog`/`proactivity` are dated-2.5-native-audio-only knobs. On the flash-live family the server **never sends `setupComplete`** if the setup includes them → `Gemini Live connect: session ready timeout`. Now dropped with a warning on flash-live models. (Empirically isolated with a config-ablation matrix: minimal/voice/it-IT/VAD/instructions all connect in ~300ms; adding affectiveDialog → timeout, 100% reproducible. 2.5 with the same config connects fine.)

2. **Tool calls**: in the default **BLOCKING** function-call mode, 3.1 halts audio generation when it emits the `toolCall` and **never resumes speech** after receiving our `toolResponse` — no error event, no socket close, just silence until the caller gives up. Hit 2/2 on real calls (first call after long idle, where the model emits the tool call mid-conversation; warm sessions batch it at end-of-call, which is why local repros never triggered it). Fix: opt flash-live into the documented async mode — `behavior: 'NON_BLOCKING'` on the declarations + `scheduling: 'INTERRUPT'` on the response. Also logs the tool round-trip at info (it was invisible at default log level, which made this stall undiagnosable in prod).

Both changes are gated on `model.includes('flash-live')` — 2.5 native-audio and every other model are byte-identical on the wire.

## Testing

- TS suite: 158 files, 2493 passing.
- Live-verified on the Pillar demo line (Telnyx, it-IT, Cloud Run): 3.1 connects in ~300-450ms, ~1.35s median first-audio per turn, and a NON_BLOCKING `qualifica_lead` round-trip observed completing with the conversation continuing (`toolCall received` → `toolResponse sent` → native lead write → clean goodbye).

## Notes

- Python parity pending: `gemini_live.py` sends the same BLOCKING-shape `FunctionResponse`; the same two changes apply.
- Note for reviewers: the mocked gemini-live test only asserts `function_call` event emission — the post-toolResponse resume path (where 3.1 wedges) has no coverage yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DYHvQ7uFxXVLoEEmduKso