### PR TITLE
feat(providers): Fish Audio voice suite — TTS (s2.1-pro / s2-pro) + ASR in both SDKs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install base + all OSS extras
         run: |
           cd libraries/python
-          pip install -e ".[local,dev,silero,deepfilternet,ivr,anthropic,groq,cerebras,google,cartesia,soniox,assemblyai,rime,lmnt,ultravox,gemini-live,evals,tracing,scheduling,background-audio,telnyx-ai]"
+          pip install -e ".[local,dev,silero,deepfilternet,ivr,anthropic,groq,cerebras,google,cartesia,soniox,assemblyai,rime,lmnt,fish_audio,ultravox,gemini-live,evals,tracing,scheduling,background-audio,telnyx-ai]"
       - name: Run tests (provider+extras coverage)
         run: |
           cd libraries/python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ### Added
 
+- **Fish Audio voice provider suite** — TTS (S2.1-Pro / S2-Pro) and ASR land in
+  both SDKs, wired end-to-end with real pricing. One `FISH_AUDIO_API_KEY`
+  covers both directions of the call:
+  - **`FishAudioTTS`**: HTTP streaming synthesis via `POST /v1/tts`, default
+    model `s2.1-pro` (83 languages, multi-speaker via `<|speaker:N|>` markers,
+    natural-language `[bracket]` expression control). Output defaults to
+    PCM_S16LE @ 16 kHz so chunks feed the pipeline with no transcoding, and
+    `latency` defaults to `balanced` (~300 ms). Fish selects the model with a
+    **request header**, so switching generations is a constructor argument.
+    `for_twilio()` requests PCM directly at 8 kHz — the carrier wire rate — so
+    the pipeline skips the resample (Fish has no native G.711, so the μ-law
+    encode still runs); `for_telnyx()` keeps the 16 kHz pipeline rate. Every
+    unset knob is omitted from the request so Fish applies its own documented
+    default rather than one the SDK guessed.
+  - **`FishAudioWebSocketTTS`**: opt-in low-latency transport over
+    `wss://api.fish.audio/v1/tts/live`, pairing with `s2-pro`'s ~100 ms
+    time-to-first-audio and skipping the per-utterance HTTP setup. Fish serves
+    **only `s1` and `s2-pro`** on that socket, so the constructor rejects
+    `s2.1-pro` up front with a pointer back to the HTTP adapter instead of
+    failing mid-call. Frames are MessagePack (`start`→`text`→`flush`→`stop`),
+    which is the sole reason the `[fish_audio]` extra pulls in `ormsgpack`
+    (TypeScript: `@msgpack/msgpack`, an optional dependency).
+  - **`FishAudioSTT`**: batch transcription via `POST /v1/asr`. Fish exposes no
+    streaming socket, so the adapter buffers ~2 s windows and emits one final
+    transcript each — no interim partials, same shape as `WhisperSTT`. A short
+    tail is silence-padded up to Fish's documented 1-second floor rather than
+    dropped, so the last words of an utterance are never lost. Server errors
+    are logged and yield no transcript; they never raise into a live call.
+  - **Pricing** (official, docs.fish.audio): TTS $15.00 per 1M UTF-8 **bytes**
+    (`s2.1-pro-free` free), ASR $0.36 per audio hour. The adapters meter UTF-8
+    byte length rather than character count — exact for latin scripts and
+    correctly ~3× higher for CJK.
+  `libraries/python/getpatter/providers/fish_audio_{tts,ws_tts,stt}.py`,
+  `libraries/typescript/src/providers/fish-audio-{tts,ws-tts,stt}.ts`,
+  `tts/fish_audio.*`, `stt/fish_audio.*`, `pricing.*`, `telemetry/stack.*`,
+  init-wizard catalogues, and docs pages under
+  `docs/{python,typescript}-sdk/providers/fish-audio-{tts,stt}.mdx`. Beta:
+  validated against the Fish Audio API spec with real local HTTP/WebSocket
+  servers in the test suite; not yet exercised on a live call.
+
 - **xAI (Grok) voice provider suite** — all three xAI Voice APIs land in both
   SDKs, wired end-to-end with real pricing:
   - **`XaiRealtime` engine (Grok Voice Agent API)**: real-time speech-to-speech

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Patter is the **full voice stack** between your application and the phone networ
 | Layer | Choose from |
 |---|---|
 | **LLM** — text generation | OpenAI · Anthropic · Google Gemini · Groq · Cerebras |
-| **STT** — speech-to-text | Deepgram · AssemblyAI · Cartesia · Soniox · Speechmatics · Whisper |
-| **TTS** — text-to-speech | ElevenLabs · OpenAI · Cartesia · LMNT · Rime · Telnyx |
+| **STT** — speech-to-text | Deepgram · AssemblyAI · Cartesia · Soniox · Speechmatics · Whisper · Fish Audio |
+| **TTS** — text-to-speech | ElevenLabs · OpenAI · Cartesia · LMNT · Rime · Telnyx · Fish Audio |
 | **Realtime** — all-in-one voice | OpenAI Realtime · Gemini Live · Ultravox · ElevenLabs ConvAI |
 | **Telephony** — phone carriers | Twilio · Telnyx · Plivo |
 | **Audio** — VAD & suppression | Silero VAD · Krisp · DeepFilterNet |

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -101,9 +101,9 @@ Want fully custom LLM logic (multi-model routing, local models, an internal gate
 
 Three independent stages — swap any of them for a different vendor or local model:
 
-- **STT (Speech-to-Text)** — transcribes caller audio in real time. Providers: `DeepgramSTT`, `WhisperSTT`, `CartesiaSTT`, `SonioxSTT`, `SpeechmaticsSTT` (Python-only), `AssemblyAISTT`, `XaiSTT`. See [STT](/python-sdk/stt).
+- **STT (Speech-to-Text)** — transcribes caller audio in real time. Providers: `DeepgramSTT`, `WhisperSTT`, `CartesiaSTT`, `SonioxSTT`, `SpeechmaticsSTT` (Python-only), `AssemblyAISTT`, `XaiSTT`, `FishAudioSTT`. See [STT](/python-sdk/stt).
 - **LLM (Large Language Model)** — generates the reply. Pass a class instance via `llm=`: `OpenAILLM`, `AnthropicLLM`, `GroqLLM`, `CerebrasLLM`, `GoogleLLM`. Tool calling works across all five. For anything else, use `on_message`. See [LLM](/python-sdk/llm).
-- **TTS (Text-to-Speech)** — synthesizes the reply audio. Providers: `ElevenLabsTTS`, `OpenAITTS`, `CartesiaTTS`, `RimeTTS`, `LMNTTTS`, `XaiTTS`. See [TTS](/python-sdk/tts).
+- **TTS (Text-to-Speech)** — synthesizes the reply audio. Providers: `ElevenLabsTTS`, `OpenAITTS`, `CartesiaTTS`, `RimeTTS`, `LMNTTTS`, `XaiTTS`, `FishAudioTTS`. See [TTS](/python-sdk/tts).
 
 Pick engine mode when you want minimum code. Pick pipeline mode when you need a specific LLM, a custom voice, or fine-grained control over latency / costs.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -128,7 +128,8 @@
                       "python-sdk/providers/soniox",
                       "python-sdk/providers/speechmatics",
                       "python-sdk/providers/telnyx-stt",
-                      "python-sdk/providers/xai-stt"
+                      "python-sdk/providers/xai-stt",
+                      "python-sdk/providers/fish-audio-stt"
                     ]
                   },
                   {
@@ -155,7 +156,8 @@
                       "python-sdk/providers/cartesia-tts",
                       "python-sdk/providers/inworld",
                       "python-sdk/providers/telnyx-tts",
-                      "python-sdk/providers/xai-tts"
+                      "python-sdk/providers/xai-tts",
+                      "python-sdk/providers/fish-audio-tts"
                     ]
                   },
                   {
@@ -266,7 +268,8 @@
                       "typescript-sdk/providers/soniox",
                       "typescript-sdk/providers/speechmatics",
                       "typescript-sdk/providers/telnyx-stt",
-                      "typescript-sdk/providers/xai-stt"
+                      "typescript-sdk/providers/xai-stt",
+                      "typescript-sdk/providers/fish-audio-stt"
                     ]
                   },
                   {
@@ -293,7 +296,8 @@
                       "typescript-sdk/providers/cartesia-tts",
                       "typescript-sdk/providers/inworld",
                       "typescript-sdk/providers/telnyx-tts",
-                      "typescript-sdk/providers/xai-tts"
+                      "typescript-sdk/providers/xai-tts",
+                      "typescript-sdk/providers/fish-audio-tts"
                     ]
                   },
                   {

--- a/docs/python-sdk/metrics.mdx
+++ b/docs/python-sdk/metrics.mdx
@@ -246,10 +246,12 @@ Provider-level defaults are listed below. Per-model rates live under `DEFAULT_PR
 | Soniox | per minute | $0.002 |
 | Speechmatics (Pro) | per minute | $0.004 |
 | xAI STT (streaming) | per minute | $0.003333 ($0.20/hr) |
+| Fish Audio ASR (`transcribe-1`) | per minute | $0.006 ($0.36/hr) |
 | ElevenLabs (`eleven_flash_v2_5`) | per 1k chars | $0.06 |
 | OpenAI TTS (`tts-1`) | per 1k chars | $0.015 |
 | Cartesia TTS (`sonic-2`) | per 1k chars | $0.030 |
 | Rime (`mistv2`) | per 1k chars | $0.030 |
+| Fish Audio (`s2.1-pro` / `s2-pro`) | per 1k chars | $0.015 (per 1k UTF-8 **bytes**) |
 | LMNT (`aurora`) | per 1k chars | $0.050 |
 | Inworld (`inworld-tts-2`) | per 1k chars | $0.020 |
 | xAI TTS | per 1k chars | $0.015 |

--- a/docs/python-sdk/providers/fish-audio-stt.mdx
+++ b/docs/python-sdk/providers/fish-audio-stt.mdx
@@ -1,0 +1,204 @@
+---
+title: "Fish Audio STT"
+description: "Batch transcription via Fish Audio's ASR endpoint — one vendor for both directions of the call, at $0.36 per audio hour."
+icon: "fish"
+---
+
+# Fish Audio STT
+
+`FishAudioSTT` targets the [Fish Audio ASR endpoint](https://docs.fish.audio/api-reference/endpoint/openapi-v1/speech-to-text) (`POST https://api.fish.audio/v1/asr`). It buffers incoming PCM, uploads it as a WAV once the window fills, and emits the returned text as a final transcript.
+
+<Warning>
+**Fish transcription is batch-only** — there is no streaming socket. This
+adapter therefore emits one final transcript per ~2 s window and **no interim
+partials**, exactly like [`WhisperSTT`](/python-sdk/providers/whisper). If turn
+latency is what you are optimising, use a genuinely streaming provider:
+[Deepgram](/python-sdk/providers/deepgram), [Soniox](/python-sdk/providers/soniox),
+[AssemblyAI](/python-sdk/providers/assemblyai) or
+[Speechmatics](/python-sdk/providers/speechmatics).
+
+Reach for Fish ASR when you want a single vendor (and a single key) for both
+directions of the call, or for its language coverage.
+</Warning>
+
+## Install
+
+<CodeGroup>
+
+```bash Python
+pip install "getpatter[fish_audio]"
+```
+
+```bash TypeScript
+npm install getpatter
+```
+
+</CodeGroup>
+
+## Authentication
+
+```bash
+export FISH_AUDIO_API_KEY="<your-fish-audio-api-key>"
+```
+
+The same key covers ASR and [Fish Audio TTS](/python-sdk/providers/fish-audio-tts).
+
+## Usage
+
+<CodeGroup>
+
+```python Python
+# Namespaced import (pipeline mode)
+from getpatter.stt import fish_audio
+
+stt = fish_audio.STT()                                   # reads FISH_AUDIO_API_KEY
+stt = fish_audio.STT(api_key="...", language="it")
+
+# Flat alias (equivalent)
+from getpatter import FishAudioSTT
+
+stt = FishAudioSTT()
+```
+
+```typescript TypeScript
+// Namespaced import (pipeline mode)
+import * as fishAudio from "getpatter/stt/fish-audio";
+
+const stt = new fishAudio.STT();                         // reads FISH_AUDIO_API_KEY
+const stt2 = new fishAudio.STT({ apiKey: "...", language: "it" });
+
+// Flat alias (equivalent)
+import { FishAudioSTT } from "getpatter";
+
+const stt3 = new FishAudioSTT();
+```
+
+</CodeGroup>
+
+Plug it into an agent:
+
+<CodeGroup>
+
+```python Python
+import asyncio
+from getpatter import Patter, Twilio, FishAudioSTT, FishAudioTTS
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+agent = phone.agent(
+    stt=FishAudioSTT(language="it"),                      # FISH_AUDIO_API_KEY from env
+    tts=FishAudioTTS.for_twilio(),                        # same key
+    system_prompt="Sei l'assistente di Acme. Rispondi in italiano.",
+)
+
+asyncio.run(phone.serve(agent))
+```
+
+```typescript TypeScript
+// npx tsx example.ts
+import { Patter, Twilio, FishAudioSTT, FishAudioTTS } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  stt: new FishAudioSTT({ language: "it" }),              // FISH_AUDIO_API_KEY from env
+  tts: FishAudioTTS.forTwilio({}),                        // same key
+  systemPrompt: "Sei l'assistente di Acme. Rispondi in italiano.",
+});
+
+await phone.serve({ agent });
+```
+
+</CodeGroup>
+
+## Language detection
+
+Leave `language` unset (`None` / `undefined`) and Fish auto-detects. Pass an ISO code to pin it — pinning is usually more accurate and slightly faster on short windows.
+
+<CodeGroup>
+
+```python Python
+stt = FishAudioSTT(language=None)                         # auto-detect
+stt = FishAudioSTT(language="it")                         # pinned
+```
+
+```typescript TypeScript
+const auto = new FishAudioSTT({ language: undefined });   // auto-detect
+const pinned = new FishAudioSTT({ language: "it" });      // pinned
+```
+
+</CodeGroup>
+
+## Timestamps
+
+`ignore_timestamps` defaults to `True`, which Fish documents as the lower-latency path for clips under 30 s. Set it to `False` to receive per-segment timings.
+
+<CodeGroup>
+
+```python Python
+stt = FishAudioSTT(ignore_timestamps=False)
+
+# Segments arrive on Transcript.words — Fish returns {text, start, end} per segment.
+# transcript.words[0] -> {"text": "ciao", "start": 0.0, "end": 0.4}
+```
+
+```typescript TypeScript
+const stt = new FishAudioSTT({ ignoreTimestamps: false });
+
+// Segments arrive on Transcript.segments — {text, start, end} per segment.
+// transcript.segments?.[0] -> { text: "ciao", start: 0, end: 0.4 }
+```
+
+</CodeGroup>
+
+<Note>
+Python surfaces segments on `Transcript.words` (the shared frozen dataclass's
+provider-specific field); TypeScript exposes a dedicated `segments` array. Same
+data, same order — the field name differs because the Python `Transcript` shape
+is shared across every STT provider.
+</Note>
+
+## Buffering and the 1-second floor
+
+Fish rejects clips shorter than **1 second** and longer than 60 minutes / 20 MB. The adapter handles both ends:
+
+- The steady-state window is **~2 s** (64,000 bytes of 16 kHz PCM16), comfortably clear of the floor and half the request count of a 1 s window.
+- On `close()` a **short tail is padded with digital silence** up to the 1 s minimum rather than dropped — otherwise the last words of an utterance would vanish, which is the exact bug that was fixed on the Whisper adapter.
+- An oversized buffer is truncated to the most recent 20 MB with a warning.
+
+Tune the window with `buffer_size_bytes` / `bufferSize` if you want lower latency at the cost of more requests:
+
+<CodeGroup>
+
+```python Python
+stt = FishAudioSTT(buffer_size_bytes=32000)               # ~1 s windows
+```
+
+```typescript TypeScript
+const stt = new FishAudioSTT({ bufferSize: 32000 });      // ~1 s windows
+```
+
+</CodeGroup>
+
+## Failure behaviour
+
+A non-2xx response or an unreachable host is logged at ERROR and yields **no transcript** — it never raises into the call. A live call degrades to silence on that window rather than dropping.
+
+## Options
+
+| Python | TypeScript | Default | Notes |
+|---|---|---|---|
+| `api_key` | `apiKey` | — | Reads `FISH_AUDIO_API_KEY` when omitted. |
+| `language` | `language` | `"en"` | ISO code. Pass `None` / `undefined` to auto-detect. |
+| `ignore_timestamps` | `ignoreTimestamps` | `True` | `False` returns per-segment `start` / `end`. |
+| `buffer_size_bytes` | `bufferSize` | `64000` | Bytes of 16 kHz PCM16 per upload (~2 s). |
+| `base_url` | `baseUrl` | Fish `/v1/asr` | Override for proxying or tests. |
+
+## Pricing
+
+Fish bills ASR at **$0.36 per audio hour**, rounded up to the nearest second — Patter records `$0.006 / minute`. See [Fish Audio pricing and rate limits](https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits) for the authoritative numbers and the concurrency tiers.
+
+<Note>
+**Beta.** This provider is validated against the Fish Audio API specification
+but has not yet been exercised on a live phone call end to end.
+</Note>

--- a/docs/python-sdk/providers/fish-audio-tts.mdx
+++ b/docs/python-sdk/providers/fish-audio-tts.mdx
@@ -1,0 +1,297 @@
+---
+title: "Fish Audio TTS"
+description: "S2.1-Pro (83 languages, bracket expression control, multi-speaker) and S2-Pro (~100 ms time-to-first-audio) over Fish Audio's HTTP streaming and WebSocket endpoints."
+icon: "fish"
+---
+
+# Fish Audio TTS
+
+`FishAudioTTS` targets the [Fish Audio TTS endpoint](https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech) (`POST https://api.fish.audio/v1/tts`), which streams synthesised audio back with chunked transfer encoding.
+
+The default model is **`s2.1-pro`** — Fish's recommended production model: 83 languages, multi-speaker synthesis, and natural-language expression control via `[bracket]` tags. The default audio output is **PCM_S16LE @ 16 kHz** so chunks drop straight into the Patter pipeline without transcoding.
+
+<Note>
+Fish selects the model with a **request header**, not a body field. One API key
+therefore serves every model without reconnecting — switching between
+`s2.1-pro` and `s2-pro` is a constructor argument, nothing more.
+</Note>
+
+## Install
+
+<CodeGroup>
+
+```bash Python
+pip install "getpatter[fish_audio]"
+```
+
+```bash TypeScript
+npm install getpatter
+```
+
+</CodeGroup>
+
+The `getpatter[fish_audio]` extra adds `aiohttp>=3.10` for HTTP streaming plus `ormsgpack>=1.5`, which is used **only** by the WebSocket transport (see [WebSocket streaming](#websocket-streaming-s2-pro)). On TypeScript the HTTP and ASR adapters need nothing beyond the base install; the WebSocket transport uses `@msgpack/msgpack`, shipped as an optional dependency.
+
+## Authentication
+
+```bash
+export FISH_AUDIO_API_KEY="<your-fish-audio-api-key>"
+```
+
+The same key covers TTS and [Fish Audio ASR](/python-sdk/providers/fish-audio-stt).
+
+## Usage
+
+<CodeGroup>
+
+```python Python
+# Namespaced import (pipeline mode)
+from getpatter.tts import fish_audio
+
+tts = fish_audio.TTS()                                   # reads FISH_AUDIO_API_KEY
+tts = fish_audio.TTS(api_key="...", voice="<reference-id>", latency="low")
+
+# Flat alias (equivalent)
+from getpatter import FishAudioTTS
+
+tts = FishAudioTTS()
+```
+
+```typescript TypeScript
+// Namespaced import (pipeline mode)
+import * as fishAudio from "getpatter/tts/fish-audio";
+
+const tts = new fishAudio.TTS();                         // reads FISH_AUDIO_API_KEY
+const tts2 = new fishAudio.TTS({ apiKey: "...", voice: "<reference-id>", latency: "low" });
+
+// Flat alias (equivalent)
+import { FishAudioTTS } from "getpatter";
+
+const tts3 = new FishAudioTTS();
+```
+
+</CodeGroup>
+
+Plug it into an agent:
+
+<CodeGroup>
+
+```python Python
+import asyncio
+from getpatter import Patter, Twilio, DeepgramSTT, FishAudioTTS
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+agent = phone.agent(
+    stt=DeepgramSTT(),                                   # DEEPGRAM_API_KEY from env
+    tts=FishAudioTTS.for_twilio(),                       # FISH_AUDIO_API_KEY from env
+    system_prompt="You are a helpful assistant.",
+)
+
+asyncio.run(phone.serve(agent))
+```
+
+```typescript TypeScript
+// npx tsx example.ts
+import { Patter, Twilio, DeepgramSTT, FishAudioTTS } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  stt: new DeepgramSTT(),                                // DEEPGRAM_API_KEY from env
+  tts: FishAudioTTS.forTwilio({}),                       // FISH_AUDIO_API_KEY from env
+  systemPrompt: "You are a helpful assistant.",
+});
+
+await phone.serve({ agent });
+```
+
+</CodeGroup>
+
+## Choosing a voice
+
+`voice` maps to Fish's `reference_id` — the id of a voice model from the Fish voice library or one you cloned yourself. Omit it entirely to use the model's built-in voice.
+
+<CodeGroup>
+
+```python Python
+tts = FishAudioTTS(voice="9a9cf47702da476aa4629e2506d4a857")
+```
+
+```typescript TypeScript
+const tts = new FishAudioTTS({ voice: "9a9cf47702da476aa4629e2506d4a857" });
+```
+
+</CodeGroup>
+
+### Multi-speaker (S2 models)
+
+Pass a sequence of reference ids and mark the speakers inline in the text:
+
+<CodeGroup>
+
+```python Python
+tts = FishAudioTTS(voice=["speaker-a-id", "speaker-b-id"])
+
+async for pcm in tts.synthesize("<|speaker:0|>Buongiorno!<|speaker:1|>Salve, come posso aiutarla?"):
+    ...
+```
+
+```typescript TypeScript
+const tts = new FishAudioTTS({ voice: ["speaker-a-id", "speaker-b-id"] });
+
+for await (const pcm of tts.synthesizeStream(
+  "<|speaker:0|>Buongiorno!<|speaker:1|>Salve, come posso aiutarla?",
+)) {
+  // ...
+}
+```
+
+</CodeGroup>
+
+## Expression control
+
+S2 models steer delivery from natural-language tags written inline in `[brackets]`. The tags are consumed by the model, not spoken:
+
+```text
+[whispers sweetly] Non dirlo a nessuno. [excited] Abbiamo vinto!
+```
+
+<Warning>
+The legacy `s1` model uses `(parentheses)` for its 64+ named emotions instead
+of bracket syntax. Bracket tags sent to `s1` are read aloud verbatim.
+</Warning>
+
+## Latency
+
+`latency` trades quality against time-to-first-audio. Patter defaults to `balanced`, the interactive sweet spot.
+
+| Mode | Fish's stated latency | When to use |
+|---|---|---|
+| `low` | fastest first chunk | Barge-in-heavy agents where responsiveness beats fidelity |
+| `balanced` | ~300 ms | **Default.** Live phone calls |
+| `normal` | ~500 ms | Voicemail drops, IVR prompts, anything pre-rendered |
+
+## Telephony
+
+Fish emits linear PCM only — it has no native G.711 output — so the pipeline always runs the μ-law encode. The carrier factories still save work:
+
+| Factory | Output | Effect |
+|---|---|---|
+| `for_twilio()` / `forTwilio()` | PCM @ 8 kHz | Requests the carrier wire rate directly, so the pipeline skips the 16 kHz → 8 kHz resample |
+| `for_telnyx()` / `forTelnyx()` | PCM @ 16 kHz | Matches the Telnyx PCM16 pipeline; one resample downstream |
+
+<CodeGroup>
+
+```python Python
+tts = FishAudioTTS.for_twilio(voice="<reference-id>", latency="low")
+```
+
+```typescript TypeScript
+const tts = FishAudioTTS.forTwilio({ voice: "<reference-id>", latency: "low" });
+```
+
+</CodeGroup>
+
+## WebSocket streaming (`s2-pro`)
+
+`FishAudioWebSocketTTS` targets [`wss://api.fish.audio/v1/tts/live`](https://docs.fish.audio/api-reference/endpoint/websocket/tts-live) instead of the HTTP endpoint. It skips the per-utterance HTTP request setup (~50 ms) and pairs with `s2-pro`'s ~100 ms time-to-first-audio.
+
+<Warning>
+Fish serves **only `s1` and `s2-pro`** on the streaming socket — `s2.1-pro` is
+HTTP-only. The constructor raises immediately (with a pointer back to
+`FishAudioTTS`) rather than letting the socket fail mid-call.
+</Warning>
+
+<CodeGroup>
+
+```python Python
+from getpatter import FishAudioWebSocketTTS
+
+tts = FishAudioWebSocketTTS()                            # s2-pro by default
+```
+
+```typescript TypeScript
+import { FishAudioWebSocketTTS } from "getpatter";
+
+const tts = new FishAudioWebSocketTTS();                 // s2-pro by default
+```
+
+</CodeGroup>
+
+The socket protocol is MessagePack-framed (`start` → `text` → `flush` → `stop`, with `audio` frames coming back). That is why the codec dependency exists — the server returns raw audio bytes inline, which JSON cannot carry without base64. The HTTP adapter has no such requirement.
+
+## Models
+
+| Model id | Languages | Notes |
+|---|---|---|
+| `s2.1-pro` | 83 | **Default.** Recommended production model. Multi-speaker, bracket expression control. |
+| `s2.1-pro-free` | 83 | Same model, free tier under fair-use limits. **No time-to-first-audio guarantee** — not suitable for live calls. |
+| `s2-pro` | 80+ | ~100 ms time-to-first-audio. The only S2 model on the WebSocket transport. |
+| `s1` | 13 | Legacy. Emotion control uses `(parentheses)`. |
+
+## Options
+
+| Python | TypeScript | Default | Notes |
+|---|---|---|---|
+| `api_key` | `apiKey` | — | Reads `FISH_AUDIO_API_KEY` when omitted. |
+| `model` | `model` | `"s2.1-pro"` | Sent as the `model:` request header. |
+| `voice` | `voice` | — | Fish `reference_id`; a sequence enables multi-speaker. |
+| `format` | `format` | `"pcm"` | `pcm` / `wav` / `mp3` / `opus`. Only `pcm` is pipeline-compatible. |
+| `sample_rate` | `sampleRate` | `16000` | Hz. Sent for `pcm` / `wav` only. |
+| `latency` | `latency` | `"balanced"` | `low` / `balanced` / `normal`. |
+| `speed` | `speed` | — | Prosody speed multiplier, `[0.5, 2.0]`. |
+| `volume` | `volume` | — | Prosody volume in dB, `[-20, +20]`. |
+| `normalize_loudness` | `normalizeLoudness` | — | Loudness normalisation (S2-Pro only). |
+| `temperature` | `temperature` | — | `[0, 1]`. Fish default `0.7`. |
+| `top_p` | `topP` | — | `[0, 1]`. Fish default `0.7`. |
+| `chunk_length` | `chunkLength` | — | `[100, 300]`. Fish default `300`. |
+| `min_chunk_length` | `minChunkLength` | — | `[0, 100]` characters. Fish default `50`. |
+| `normalize` | `normalize` | — | Text normalisation. Fish default `true`. |
+| `max_new_tokens` | `maxNewTokens` | — | Fish default `1024`. |
+| `repetition_penalty` | `repetitionPenalty` | — | Fish default `1.2`. |
+| `condition_on_previous_chunks` | `conditionOnPreviousChunks` | — | Fish default `true`. |
+| `early_stop_threshold` | `earlyStopThreshold` | — | `[0, 1]`. Fish default `1`. |
+| `mp3_bitrate` | `mp3Bitrate` | — | `64` / `128` / `192` kbps. |
+| `opus_bitrate` | `opusBitrate` | — | `-1000` (auto) / `24000` / `32000` / `48000` / `64000` bps. |
+| `base_url` | `baseUrl` | Fish `/v1/tts` | Override for proxying or tests. |
+
+Every option left unset is **omitted from the request** so Fish applies its own documented default rather than a value the SDK guessed.
+
+## Low-level usage
+
+<CodeGroup>
+
+```python Python
+from getpatter.providers.fish_audio_tts import FishAudioTTS as _LowLevelTTS
+
+tts = _LowLevelTTS(api_key="...", model="s2-pro", sample_rate=16000)
+
+async for pcm_chunk in tts.synthesize("Hello from the Patter pipeline."):
+    ...                                                  # raw PCM_S16LE @ 16 kHz
+
+await tts.close()
+```
+
+```typescript TypeScript
+import { FishAudioTTS } from "getpatter/providers/fish-audio-tts";
+
+const tts = new FishAudioTTS("...", { model: "s2-pro", sampleRate: 16000 });
+
+for await (const pcmChunk of tts.synthesizeStream("Hello from the Patter pipeline.")) {
+  // raw PCM_S16LE @ 16 kHz
+}
+```
+
+</CodeGroup>
+
+## Pricing
+
+Fish bills **$15.00 per 1M UTF-8 bytes** for `s2.1-pro`, `s2-pro` and `s1`; `s2.1-pro-free` bills nothing. Patter records `$0.015 / 1k` and meters **UTF-8 byte length**, not character count — exact for latin scripts and correctly ~3× higher for CJK, where one character is three bytes.
+
+Override per project via `Patter(pricing={...})`. See [Fish Audio pricing and rate limits](https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits) for the authoritative numbers and the concurrency tiers.
+
+<Note>
+**Beta.** This provider is validated against the Fish Audio API specification
+but has not yet been exercised on a live phone call end to end.
+</Note>

--- a/docs/python-sdk/stt.mdx
+++ b/docs/python-sdk/stt.mdx
@@ -56,6 +56,7 @@ agent = phone.agent(
 | `SonioxSTT` | `getpatter.stt.soniox.STT` | `SONIOX_API_KEY` | `getpatter[soniox]` |
 | `SpeechmaticsSTT` | `getpatter.stt.speechmatics.STT` | `SPEECHMATICS_API_KEY` | `getpatter[speechmatics]` |
 | `XaiSTT` | `getpatter.stt.xai.STT` | `XAI_API_KEY` | `getpatter[xai]` |
+| `FishAudioSTT` | `getpatter.stt.fish_audio.STT` | `FISH_AUDIO_API_KEY` | `getpatter[fish_audio]` |
 
 ### Model enums
 
@@ -185,6 +186,17 @@ from getpatter import XaiSTT
 
 stt = XaiSTT()                               # reads XAI_API_KEY
 stt = XaiSTT(smart_turn=0.7, language="en")
+```
+
+## Fish Audio
+
+Batch transcription via Fish Audio's ASR endpoint — one vendor and one key for both directions of the call. Emits one final transcript per ~2 s window and **no interim partials**, so prefer a streaming provider when turn latency dominates. See [Fish Audio STT setup](/python-sdk/providers/fish-audio-stt).
+
+```python
+from getpatter import FishAudioSTT
+
+stt = FishAudioSTT()                         # reads FISH_AUDIO_API_KEY
+stt = FishAudioSTT(language="it", ignore_timestamps=False)
 ```
 
 ## Missing credentials

--- a/docs/python-sdk/tts.mdx
+++ b/docs/python-sdk/tts.mdx
@@ -54,6 +54,8 @@ agent = phone.agent(
 | `RimeTTS` | `getpatter.tts.rime.TTS` | `RIME_API_KEY` | `getpatter[rime]` |
 | `LMNTTTS` | `getpatter.tts.lmnt.TTS` | `LMNT_API_KEY` | `getpatter[lmnt]` |
 | `XaiTTS` | `getpatter.tts.xai.TTS` | `XAI_API_KEY` | `getpatter[xai]` |
+| `FishAudioTTS` | `getpatter.tts.fish_audio.TTS` | `FISH_AUDIO_API_KEY` | `getpatter[fish_audio]` |
+| `FishAudioWebSocketTTS` | `getpatter.tts.fish_audio.WebSocketTTS` | `FISH_AUDIO_API_KEY` | `getpatter[fish_audio]` |
 
 ### Model / voice / format enums
 
@@ -191,6 +193,19 @@ from getpatter import XaiTTS
 tts = XaiTTS()                              # reads XAI_API_KEY
 tts = XaiTTS(voice="leo", language="en")
 tts = XaiTTS.for_twilio(voice="eve")        # μ-law @ 8 kHz native
+```
+
+## Fish Audio
+
+S2.1-Pro (83 languages, `[bracket]` expression control, multi-speaker) over HTTP streaming, plus an opt-in WebSocket transport for S2-Pro's ~100 ms time-to-first-audio. See [Fish Audio TTS setup](/python-sdk/providers/fish-audio-tts).
+
+```python
+from getpatter import FishAudioTTS, FishAudioWebSocketTTS
+
+tts = FishAudioTTS()                        # reads FISH_AUDIO_API_KEY, model s2.1-pro
+tts = FishAudioTTS(voice="<reference-id>", latency="low")
+tts = FishAudioTTS.for_twilio()             # PCM @ 8 kHz — skips the resample
+tts = FishAudioWebSocketTTS()               # s2-pro over wss:// (HTTP-only models rejected)
 ```
 
 ## Missing credentials

--- a/docs/typescript-sdk/metrics.mdx
+++ b/docs/typescript-sdk/metrics.mdx
@@ -257,10 +257,12 @@ Provider-level defaults are listed below. Per-model rates live under `DEFAULT_PR
 | Soniox | per minute | $0.002 |
 | Speechmatics (Pro) | per minute | $0.004 |
 | xAI STT (streaming) | per minute | $0.003333 ($0.20/hr) |
+| Fish Audio ASR (`transcribe-1`) | per minute | $0.006 ($0.36/hr) |
 | ElevenLabs (`eleven_flash_v2_5`) | per 1k chars | $0.06 |
 | OpenAI TTS (`tts-1`) | per 1k chars | $0.015 |
 | Cartesia TTS (`sonic-2`) | per 1k chars | $0.030 |
 | Rime (`mistv2`) | per 1k chars | $0.030 |
+| Fish Audio (`s2.1-pro` / `s2-pro`) | per 1k chars | $0.015 (per 1k UTF-8 **bytes**) |
 | LMNT (`aurora`) | per 1k chars | $0.050 |
 | Inworld (`inworld-tts-2`) | per 1k chars | $0.020 |
 | xAI TTS | per 1k chars | $0.015 |

--- a/docs/typescript-sdk/providers/fish-audio-stt.mdx
+++ b/docs/typescript-sdk/providers/fish-audio-stt.mdx
@@ -1,0 +1,204 @@
+---
+title: "Fish Audio STT"
+description: "Batch transcription via Fish Audio's ASR endpoint — one vendor for both directions of the call, at $0.36 per audio hour."
+icon: "fish"
+---
+
+# Fish Audio STT
+
+`FishAudioSTT` targets the [Fish Audio ASR endpoint](https://docs.fish.audio/api-reference/endpoint/openapi-v1/speech-to-text) (`POST https://api.fish.audio/v1/asr`). It buffers incoming PCM, uploads it as a WAV once the window fills, and emits the returned text as a final transcript.
+
+<Warning>
+**Fish transcription is batch-only** — there is no streaming socket. This
+adapter therefore emits one final transcript per ~2 s window and **no interim
+partials**, exactly like [`WhisperSTT`](/typescript-sdk/providers/whisper). If turn
+latency is what you are optimising, use a genuinely streaming provider:
+[Deepgram](/typescript-sdk/providers/deepgram), [Soniox](/typescript-sdk/providers/soniox),
+[AssemblyAI](/typescript-sdk/providers/assemblyai) or
+[Speechmatics](/typescript-sdk/providers/speechmatics).
+
+Reach for Fish ASR when you want a single vendor (and a single key) for both
+directions of the call, or for its language coverage.
+</Warning>
+
+## Install
+
+<CodeGroup>
+
+```bash TypeScript
+npm install getpatter
+```
+
+```bash Python
+pip install "getpatter[fish_audio]"
+```
+
+</CodeGroup>
+
+## Authentication
+
+```bash
+export FISH_AUDIO_API_KEY="<your-fish-audio-api-key>"
+```
+
+The same key covers ASR and [Fish Audio TTS](/typescript-sdk/providers/fish-audio-tts).
+
+## Usage
+
+<CodeGroup>
+
+```typescript TypeScript
+// Namespaced import (pipeline mode)
+import * as fishAudio from "getpatter/stt/fish-audio";
+
+const stt = new fishAudio.STT();                         // reads FISH_AUDIO_API_KEY
+const stt2 = new fishAudio.STT({ apiKey: "...", language: "it" });
+
+// Flat alias (equivalent)
+import { FishAudioSTT } from "getpatter";
+
+const stt3 = new FishAudioSTT();
+```
+
+```python Python
+# Namespaced import (pipeline mode)
+from getpatter.stt import fish_audio
+
+stt = fish_audio.STT()                                   # reads FISH_AUDIO_API_KEY
+stt = fish_audio.STT(api_key="...", language="it")
+
+# Flat alias (equivalent)
+from getpatter import FishAudioSTT
+
+stt = FishAudioSTT()
+```
+
+</CodeGroup>
+
+Plug it into an agent:
+
+<CodeGroup>
+
+```typescript TypeScript
+// npx tsx example.ts
+import { Patter, Twilio, FishAudioSTT, FishAudioTTS } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  stt: new FishAudioSTT({ language: "it" }),              // FISH_AUDIO_API_KEY from env
+  tts: FishAudioTTS.forTwilio({}),                        // same key
+  systemPrompt: "Sei l'assistente di Acme. Rispondi in italiano.",
+});
+
+await phone.serve({ agent });
+```
+
+```python Python
+import asyncio
+from getpatter import Patter, Twilio, FishAudioSTT, FishAudioTTS
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+agent = phone.agent(
+    stt=FishAudioSTT(language="it"),                      # FISH_AUDIO_API_KEY from env
+    tts=FishAudioTTS.for_twilio(),                        # same key
+    system_prompt="Sei l'assistente di Acme. Rispondi in italiano.",
+)
+
+asyncio.run(phone.serve(agent))
+```
+
+</CodeGroup>
+
+## Language detection
+
+Leave `language` unset (`None` / `undefined`) and Fish auto-detects. Pass an ISO code to pin it — pinning is usually more accurate and slightly faster on short windows.
+
+<CodeGroup>
+
+```typescript TypeScript
+const auto = new FishAudioSTT({ language: undefined });   // auto-detect
+const pinned = new FishAudioSTT({ language: "it" });      // pinned
+```
+
+```python Python
+stt = FishAudioSTT(language=None)                         # auto-detect
+stt = FishAudioSTT(language="it")                         # pinned
+```
+
+</CodeGroup>
+
+## Timestamps
+
+`ignore_timestamps` defaults to `True`, which Fish documents as the lower-latency path for clips under 30 s. Set it to `False` to receive per-segment timings.
+
+<CodeGroup>
+
+```typescript TypeScript
+const stt = new FishAudioSTT({ ignoreTimestamps: false });
+
+// Segments arrive on Transcript.segments — {text, start, end} per segment.
+// transcript.segments?.[0] -> { text: "ciao", start: 0, end: 0.4 }
+```
+
+```python Python
+stt = FishAudioSTT(ignore_timestamps=False)
+
+# Segments arrive on Transcript.words — Fish returns {text, start, end} per segment.
+# transcript.words[0] -> {"text": "ciao", "start": 0.0, "end": 0.4}
+```
+
+</CodeGroup>
+
+<Note>
+Python surfaces segments on `Transcript.words` (the shared frozen dataclass's
+provider-specific field); TypeScript exposes a dedicated `segments` array. Same
+data, same order — the field name differs because the Python `Transcript` shape
+is shared across every STT provider.
+</Note>
+
+## Buffering and the 1-second floor
+
+Fish rejects clips shorter than **1 second** and longer than 60 minutes / 20 MB. The adapter handles both ends:
+
+- The steady-state window is **~2 s** (64,000 bytes of 16 kHz PCM16), comfortably clear of the floor and half the request count of a 1 s window.
+- On `close()` a **short tail is padded with digital silence** up to the 1 s minimum rather than dropped — otherwise the last words of an utterance would vanish, which is the exact bug that was fixed on the Whisper adapter.
+- An oversized buffer is truncated to the most recent 20 MB with a warning.
+
+Tune the window with `buffer_size_bytes` / `bufferSize` if you want lower latency at the cost of more requests:
+
+<CodeGroup>
+
+```typescript TypeScript
+const stt = new FishAudioSTT({ bufferSize: 32000 });      // ~1 s windows
+```
+
+```python Python
+stt = FishAudioSTT(buffer_size_bytes=32000)               # ~1 s windows
+```
+
+</CodeGroup>
+
+## Failure behaviour
+
+A non-2xx response or an unreachable host is logged at ERROR and yields **no transcript** — it never raises into the call. A live call degrades to silence on that window rather than dropping.
+
+## Options
+
+| Python | TypeScript | Default | Notes |
+|---|---|---|---|
+| `api_key` | `apiKey` | — | Reads `FISH_AUDIO_API_KEY` when omitted. |
+| `language` | `language` | `"en"` | ISO code. Pass `None` / `undefined` to auto-detect. |
+| `ignore_timestamps` | `ignoreTimestamps` | `True` | `False` returns per-segment `start` / `end`. |
+| `buffer_size_bytes` | `bufferSize` | `64000` | Bytes of 16 kHz PCM16 per upload (~2 s). |
+| `base_url` | `baseUrl` | Fish `/v1/asr` | Override for proxying or tests. |
+
+## Pricing
+
+Fish bills ASR at **$0.36 per audio hour**, rounded up to the nearest second — Patter records `$0.006 / minute`. See [Fish Audio pricing and rate limits](https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits) for the authoritative numbers and the concurrency tiers.
+
+<Note>
+**Beta.** This provider is validated against the Fish Audio API specification
+but has not yet been exercised on a live phone call end to end.
+</Note>

--- a/docs/typescript-sdk/providers/fish-audio-tts.mdx
+++ b/docs/typescript-sdk/providers/fish-audio-tts.mdx
@@ -1,0 +1,297 @@
+---
+title: "Fish Audio TTS"
+description: "S2.1-Pro (83 languages, bracket expression control, multi-speaker) and S2-Pro (~100 ms time-to-first-audio) over Fish Audio's HTTP streaming and WebSocket endpoints."
+icon: "fish"
+---
+
+# Fish Audio TTS
+
+`FishAudioTTS` targets the [Fish Audio TTS endpoint](https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech) (`POST https://api.fish.audio/v1/tts`), which streams synthesised audio back with chunked transfer encoding.
+
+The default model is **`s2.1-pro`** — Fish's recommended production model: 83 languages, multi-speaker synthesis, and natural-language expression control via `[bracket]` tags. The default audio output is **PCM_S16LE @ 16 kHz** so chunks drop straight into the Patter pipeline without transcoding.
+
+<Note>
+Fish selects the model with a **request header**, not a body field. One API key
+therefore serves every model without reconnecting — switching between
+`s2.1-pro` and `s2-pro` is a constructor argument, nothing more.
+</Note>
+
+## Install
+
+<CodeGroup>
+
+```bash TypeScript
+npm install getpatter
+```
+
+```bash Python
+pip install "getpatter[fish_audio]"
+```
+
+</CodeGroup>
+
+The `getpatter[fish_audio]` extra adds `aiohttp>=3.10` for HTTP streaming plus `ormsgpack>=1.5`, which is used **only** by the WebSocket transport (see [WebSocket streaming](#websocket-streaming-s2-pro)). On TypeScript the HTTP and ASR adapters need nothing beyond the base install; the WebSocket transport uses `@msgpack/msgpack`, shipped as an optional dependency.
+
+## Authentication
+
+```bash
+export FISH_AUDIO_API_KEY="<your-fish-audio-api-key>"
+```
+
+The same key covers TTS and [Fish Audio ASR](/typescript-sdk/providers/fish-audio-stt).
+
+## Usage
+
+<CodeGroup>
+
+```typescript TypeScript
+// Namespaced import (pipeline mode)
+import * as fishAudio from "getpatter/tts/fish-audio";
+
+const tts = new fishAudio.TTS();                         // reads FISH_AUDIO_API_KEY
+const tts2 = new fishAudio.TTS({ apiKey: "...", voice: "<reference-id>", latency: "low" });
+
+// Flat alias (equivalent)
+import { FishAudioTTS } from "getpatter";
+
+const tts3 = new FishAudioTTS();
+```
+
+```python Python
+# Namespaced import (pipeline mode)
+from getpatter.tts import fish_audio
+
+tts = fish_audio.TTS()                                   # reads FISH_AUDIO_API_KEY
+tts = fish_audio.TTS(api_key="...", voice="<reference-id>", latency="low")
+
+# Flat alias (equivalent)
+from getpatter import FishAudioTTS
+
+tts = FishAudioTTS()
+```
+
+</CodeGroup>
+
+Plug it into an agent:
+
+<CodeGroup>
+
+```typescript TypeScript
+// npx tsx example.ts
+import { Patter, Twilio, DeepgramSTT, FishAudioTTS } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+
+const agent = phone.agent({
+  stt: new DeepgramSTT(),                                // DEEPGRAM_API_KEY from env
+  tts: FishAudioTTS.forTwilio({}),                       // FISH_AUDIO_API_KEY from env
+  systemPrompt: "You are a helpful assistant.",
+});
+
+await phone.serve({ agent });
+```
+
+```python Python
+import asyncio
+from getpatter import Patter, Twilio, DeepgramSTT, FishAudioTTS
+
+phone = Patter(carrier=Twilio(), phone_number="+15550001234")
+
+agent = phone.agent(
+    stt=DeepgramSTT(),                                   # DEEPGRAM_API_KEY from env
+    tts=FishAudioTTS.for_twilio(),                       # FISH_AUDIO_API_KEY from env
+    system_prompt="You are a helpful assistant.",
+)
+
+asyncio.run(phone.serve(agent))
+```
+
+</CodeGroup>
+
+## Choosing a voice
+
+`voice` maps to Fish's `reference_id` — the id of a voice model from the Fish voice library or one you cloned yourself. Omit it entirely to use the model's built-in voice.
+
+<CodeGroup>
+
+```typescript TypeScript
+const tts = new FishAudioTTS({ voice: "9a9cf47702da476aa4629e2506d4a857" });
+```
+
+```python Python
+tts = FishAudioTTS(voice="9a9cf47702da476aa4629e2506d4a857")
+```
+
+</CodeGroup>
+
+### Multi-speaker (S2 models)
+
+Pass a sequence of reference ids and mark the speakers inline in the text:
+
+<CodeGroup>
+
+```typescript TypeScript
+const tts = new FishAudioTTS({ voice: ["speaker-a-id", "speaker-b-id"] });
+
+for await (const pcm of tts.synthesizeStream(
+  "<|speaker:0|>Buongiorno!<|speaker:1|>Salve, come posso aiutarla?",
+)) {
+  // ...
+}
+```
+
+```python Python
+tts = FishAudioTTS(voice=["speaker-a-id", "speaker-b-id"])
+
+async for pcm in tts.synthesize("<|speaker:0|>Buongiorno!<|speaker:1|>Salve, come posso aiutarla?"):
+    ...
+```
+
+</CodeGroup>
+
+## Expression control
+
+S2 models steer delivery from natural-language tags written inline in `[brackets]`. The tags are consumed by the model, not spoken:
+
+```text
+[whispers sweetly] Non dirlo a nessuno. [excited] Abbiamo vinto!
+```
+
+<Warning>
+The legacy `s1` model uses `(parentheses)` for its 64+ named emotions instead
+of bracket syntax. Bracket tags sent to `s1` are read aloud verbatim.
+</Warning>
+
+## Latency
+
+`latency` trades quality against time-to-first-audio. Patter defaults to `balanced`, the interactive sweet spot.
+
+| Mode | Fish's stated latency | When to use |
+|---|---|---|
+| `low` | fastest first chunk | Barge-in-heavy agents where responsiveness beats fidelity |
+| `balanced` | ~300 ms | **Default.** Live phone calls |
+| `normal` | ~500 ms | Voicemail drops, IVR prompts, anything pre-rendered |
+
+## Telephony
+
+Fish emits linear PCM only — it has no native G.711 output — so the pipeline always runs the μ-law encode. The carrier factories still save work:
+
+| Factory | Output | Effect |
+|---|---|---|
+| `for_twilio()` / `forTwilio()` | PCM @ 8 kHz | Requests the carrier wire rate directly, so the pipeline skips the 16 kHz → 8 kHz resample |
+| `for_telnyx()` / `forTelnyx()` | PCM @ 16 kHz | Matches the Telnyx PCM16 pipeline; one resample downstream |
+
+<CodeGroup>
+
+```typescript TypeScript
+const tts = FishAudioTTS.forTwilio({ voice: "<reference-id>", latency: "low" });
+```
+
+```python Python
+tts = FishAudioTTS.for_twilio(voice="<reference-id>", latency="low")
+```
+
+</CodeGroup>
+
+## WebSocket streaming (`s2-pro`)
+
+`FishAudioWebSocketTTS` targets [`wss://api.fish.audio/v1/tts/live`](https://docs.fish.audio/api-reference/endpoint/websocket/tts-live) instead of the HTTP endpoint. It skips the per-utterance HTTP request setup (~50 ms) and pairs with `s2-pro`'s ~100 ms time-to-first-audio.
+
+<Warning>
+Fish serves **only `s1` and `s2-pro`** on the streaming socket — `s2.1-pro` is
+HTTP-only. The constructor raises immediately (with a pointer back to
+`FishAudioTTS`) rather than letting the socket fail mid-call.
+</Warning>
+
+<CodeGroup>
+
+```typescript TypeScript
+import { FishAudioWebSocketTTS } from "getpatter";
+
+const tts = new FishAudioWebSocketTTS();                 // s2-pro by default
+```
+
+```python Python
+from getpatter import FishAudioWebSocketTTS
+
+tts = FishAudioWebSocketTTS()                            # s2-pro by default
+```
+
+</CodeGroup>
+
+The socket protocol is MessagePack-framed (`start` → `text` → `flush` → `stop`, with `audio` frames coming back). That is why the codec dependency exists — the server returns raw audio bytes inline, which JSON cannot carry without base64. The HTTP adapter has no such requirement.
+
+## Models
+
+| Model id | Languages | Notes |
+|---|---|---|
+| `s2.1-pro` | 83 | **Default.** Recommended production model. Multi-speaker, bracket expression control. |
+| `s2.1-pro-free` | 83 | Same model, free tier under fair-use limits. **No time-to-first-audio guarantee** — not suitable for live calls. |
+| `s2-pro` | 80+ | ~100 ms time-to-first-audio. The only S2 model on the WebSocket transport. |
+| `s1` | 13 | Legacy. Emotion control uses `(parentheses)`. |
+
+## Options
+
+| Python | TypeScript | Default | Notes |
+|---|---|---|---|
+| `api_key` | `apiKey` | — | Reads `FISH_AUDIO_API_KEY` when omitted. |
+| `model` | `model` | `"s2.1-pro"` | Sent as the `model:` request header. |
+| `voice` | `voice` | — | Fish `reference_id`; a sequence enables multi-speaker. |
+| `format` | `format` | `"pcm"` | `pcm` / `wav` / `mp3` / `opus`. Only `pcm` is pipeline-compatible. |
+| `sample_rate` | `sampleRate` | `16000` | Hz. Sent for `pcm` / `wav` only. |
+| `latency` | `latency` | `"balanced"` | `low` / `balanced` / `normal`. |
+| `speed` | `speed` | — | Prosody speed multiplier, `[0.5, 2.0]`. |
+| `volume` | `volume` | — | Prosody volume in dB, `[-20, +20]`. |
+| `normalize_loudness` | `normalizeLoudness` | — | Loudness normalisation (S2-Pro only). |
+| `temperature` | `temperature` | — | `[0, 1]`. Fish default `0.7`. |
+| `top_p` | `topP` | — | `[0, 1]`. Fish default `0.7`. |
+| `chunk_length` | `chunkLength` | — | `[100, 300]`. Fish default `300`. |
+| `min_chunk_length` | `minChunkLength` | — | `[0, 100]` characters. Fish default `50`. |
+| `normalize` | `normalize` | — | Text normalisation. Fish default `true`. |
+| `max_new_tokens` | `maxNewTokens` | — | Fish default `1024`. |
+| `repetition_penalty` | `repetitionPenalty` | — | Fish default `1.2`. |
+| `condition_on_previous_chunks` | `conditionOnPreviousChunks` | — | Fish default `true`. |
+| `early_stop_threshold` | `earlyStopThreshold` | — | `[0, 1]`. Fish default `1`. |
+| `mp3_bitrate` | `mp3Bitrate` | — | `64` / `128` / `192` kbps. |
+| `opus_bitrate` | `opusBitrate` | — | `-1000` (auto) / `24000` / `32000` / `48000` / `64000` bps. |
+| `base_url` | `baseUrl` | Fish `/v1/tts` | Override for proxying or tests. |
+
+Every option left unset is **omitted from the request** so Fish applies its own documented default rather than a value the SDK guessed.
+
+## Low-level usage
+
+<CodeGroup>
+
+```typescript TypeScript
+import { FishAudioTTS } from "getpatter/providers/fish-audio-tts";
+
+const tts = new FishAudioTTS("...", { model: "s2-pro", sampleRate: 16000 });
+
+for await (const pcmChunk of tts.synthesizeStream("Hello from the Patter pipeline.")) {
+  // raw PCM_S16LE @ 16 kHz
+}
+```
+
+```python Python
+from getpatter.providers.fish_audio_tts import FishAudioTTS as _LowLevelTTS
+
+tts = _LowLevelTTS(api_key="...", model="s2-pro", sample_rate=16000)
+
+async for pcm_chunk in tts.synthesize("Hello from the Patter pipeline."):
+    ...                                                  # raw PCM_S16LE @ 16 kHz
+
+await tts.close()
+```
+
+</CodeGroup>
+
+## Pricing
+
+Fish bills **$15.00 per 1M UTF-8 bytes** for `s2.1-pro`, `s2-pro` and `s1`; `s2.1-pro-free` bills nothing. Patter records `$0.015 / 1k` and meters **UTF-8 byte length**, not character count — exact for latin scripts and correctly ~3× higher for CJK, where one character is three bytes.
+
+Override per project via `Patter(pricing={...})`. See [Fish Audio pricing and rate limits](https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits) for the authoritative numbers and the concurrency tiers.
+
+<Note>
+**Beta.** This provider is validated against the Fish Audio API specification
+but has not yet been exercised on a live phone call end to end.
+</Note>

--- a/docs/typescript-sdk/stt.mdx
+++ b/docs/typescript-sdk/stt.mdx
@@ -40,6 +40,7 @@ await phone.serve({ agent });
 | `SonioxSTT` | `getpatter/stt/soniox` | `SONIOX_API_KEY` |
 | `SpeechmaticsSTT` | `getpatter/stt/speechmatics` | `SPEECHMATICS_API_KEY` |
 | `XaiSTT` | `getpatter/stt/xai` | `XAI_API_KEY` |
+| `FishAudioSTT` | `getpatter/stt/fish-audio` | `FISH_AUDIO_API_KEY` |
 
 <Note>
 `SpeechmaticsSTT` is being ported to TypeScript in the upcoming release — see the `## Unreleased` section in `CHANGELOG.md`. Use Python or wait for the next minor version.
@@ -159,6 +160,17 @@ import { XaiSTT } from "getpatter";
 
 const stt = new XaiSTT();                                         // reads XAI_API_KEY
 const stt2 = new XaiSTT({ smartTurn: 0.7, language: "en" });
+```
+
+## Fish Audio
+
+Batch transcription via Fish Audio's ASR endpoint — one vendor and one key for both directions of the call. Emits one final transcript per ~2 s window and **no interim partials**, so prefer a streaming provider when turn latency dominates. See [Fish Audio STT setup](/typescript-sdk/providers/fish-audio-stt).
+
+```typescript
+import { FishAudioSTT } from "getpatter";
+
+const stt = new FishAudioSTT();                                   // reads FISH_AUDIO_API_KEY
+const stt2 = new FishAudioSTT({ language: "it", ignoreTimestamps: false });
 ```
 
 ## Missing credentials

--- a/docs/typescript-sdk/tts.mdx
+++ b/docs/typescript-sdk/tts.mdx
@@ -38,6 +38,8 @@ await phone.serve({ agent });
 | `RimeTTS` | `RIME_API_KEY` |
 | `LMNTTTS` | `LMNT_API_KEY` |
 | `XaiTTS` | `XAI_API_KEY` |
+| `FishAudioTTS` | `FISH_AUDIO_API_KEY` |
+| `FishAudioWebSocketTTS` | `FISH_AUDIO_API_KEY` |
 
 ### Model / voice / format enums
 
@@ -163,6 +165,19 @@ import { XaiTTS } from "getpatter";
 const tts = new XaiTTS();                                         // reads XAI_API_KEY
 const tts2 = new XaiTTS({ voice: "leo", language: "en" });
 const tts3 = XaiTTS.forTwilio({ voice: "eve" });                 // μ-law @ 8 kHz native
+```
+
+## Fish Audio
+
+S2.1-Pro (83 languages, `[bracket]` expression control, multi-speaker) over HTTP streaming, plus an opt-in WebSocket transport for S2-Pro's ~100 ms time-to-first-audio. See [Fish Audio TTS setup](/typescript-sdk/providers/fish-audio-tts).
+
+```typescript
+import { FishAudioTTS, FishAudioWebSocketTTS } from "getpatter";
+
+const tts = new FishAudioTTS();                                   // reads FISH_AUDIO_API_KEY, model s2.1-pro
+const tts2 = new FishAudioTTS({ voice: "<reference-id>", latency: "low" });
+const tts3 = FishAudioTTS.forTwilio({});                          // PCM @ 8 kHz — skips the resample
+const tts4 = new FishAudioWebSocketTTS();                         // s2-pro over wss:// (HTTP-only models rejected)
 ```
 
 ## Missing credentials

--- a/libraries/python/.env.example
+++ b/libraries/python/.env.example
@@ -60,6 +60,8 @@
 # ELEVENLABS_AGENT_ID=
 # LMNT_API_KEY=
 # RIME_API_KEY=
+# Fish Audio — one key covers both TTS (s2.1-pro / s2-pro) and ASR.
+# FISH_AUDIO_API_KEY=
 
 # ------------------------------------------------------------
 # Patter runtime tunables

--- a/libraries/python/README.md
+++ b/libraries/python/README.md
@@ -81,6 +81,7 @@ Every provider reads its credentials from the environment by default. Pass `api_
 | `CARTESIA_API_KEY` | `getpatter.stt.cartesia.STT`, `getpatter.tts.cartesia.TTS` |
 | `RIME_API_KEY` | `getpatter.tts.rime.TTS` |
 | `LMNT_API_KEY` | `getpatter.tts.lmnt.TTS` |
+| `FISH_AUDIO_API_KEY` | `getpatter.tts.fish_audio.TTS`, `getpatter.stt.fish_audio.STT` |
 | `SONIOX_API_KEY` | `getpatter.stt.soniox.STT` |
 | `SPEECHMATICS_API_KEY` | `getpatter.stt.speechmatics.STT` |
 | `ASSEMBLYAI_API_KEY` | `getpatter.stt.assemblyai.STT` |

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -12,7 +12,7 @@ Installation extras:
   small).
 * Optional provider extras (``anthropic``, ``groq``, ``cerebras``, ``google``,
   ``gemini-live``, ``ultravox``, ``speechmatics``, ``assemblyai``, ``cartesia``,
-  ``soniox``, ``rime``, ``lmnt``, ``telnyx-ai``, ``silero``,
+  ``soniox``, ``rime``, ``lmnt``, ``fish_audio``, ``telnyx-ai``, ``silero``,
   ``turn-detector``, ``krisp``, ``deepfilternet``, ``ivr``,
   ``background-audio``, ``evals``, ``tracing``) —
   install only the ones matching the provider your agent uses.
@@ -116,6 +116,7 @@ from getpatter.stt.soniox import STT as SonioxSTT
 from getpatter.stt.speechmatics import STT as SpeechmaticsSTT
 from getpatter.stt.assemblyai import STT as AssemblyAISTT
 from getpatter.stt.xai import STT as XaiSTT
+from getpatter.stt.fish_audio import STT as FishAudioSTT
 from getpatter.providers.xai_stt import (
     XaiTranscription,
     XaiWord,
@@ -139,6 +140,8 @@ from getpatter.tts.soniox import TTS as SonioxTTS
 from getpatter.tts.sarvam import TTS as SarvamTTS
 from getpatter.tts.xai import TTS as XaiTTS
 from getpatter.providers.xai_tts import create_custom_voice as xai_create_custom_voice
+from getpatter.tts.fish_audio import TTS as FishAudioTTS
+from getpatter.tts.fish_audio import WebSocketTTS as FishAudioWebSocketTTS
 
 # LLM flat aliases — parity with libraries/typescript/src/index.ts and mirror of STT/TTS layout.
 from getpatter.llm.openai import LLM as OpenAILLM
@@ -536,6 +539,7 @@ __all__ = [
     "XaiTranscription",
     "XaiWord",
     "xai_transcribe",
+    "FishAudioSTT",
     "ElevenLabsTTS",
     "ElevenLabsWebSocketTTS",
     "ElevenLabsRestTTS",
@@ -548,6 +552,8 @@ __all__ = [
     "SarvamTTS",
     "XaiTTS",
     "xai_create_custom_voice",
+    "FishAudioTTS",
+    "FishAudioWebSocketTTS",
     "OpenAILLM",
     "AnthropicLLM",
     "GroqLLM",

--- a/libraries/python/getpatter/init/cli.py
+++ b/libraries/python/getpatter/init/cli.py
@@ -129,6 +129,12 @@ PIPELINE_STT: dict[str, dict] = {
         "env": ("OPENAI_API_KEY",),
         "extra": "",
     },
+    "fish_audio": {
+        "class": "FishAudioSTT",
+        "label": "Fish Audio (batch — higher latency)",
+        "env": ("FISH_AUDIO_API_KEY",),
+        "extra": "fish_audio",
+    },
 }
 DEFAULT_STT = "deepgram"
 
@@ -204,6 +210,12 @@ PIPELINE_TTS: dict[str, dict] = {
         "label": "Inworld",
         "env": ("INWORLD_API_KEY",),
         "extra": "inworld",
+    },
+    "fish_audio": {
+        "class": "FishAudioTTS",
+        "label": "Fish Audio (s2.1-pro)",
+        "env": ("FISH_AUDIO_API_KEY",),
+        "extra": "fish_audio",
     },
 }
 DEFAULT_TTS = "elevenlabs"

--- a/libraries/python/getpatter/local_config.py
+++ b/libraries/python/getpatter/local_config.py
@@ -21,6 +21,7 @@ class LocalConfig:
     speechmatics_key: str = ""
     assemblyai_key: str = ""
     xai_key: str = ""
+    fish_audio_key: str = ""
     phone_number: str = ""
     webhook_url: str = ""
     # SECURITY: require valid webhook signatures on Twilio, Telnyx and Plivo

--- a/libraries/python/getpatter/pricing.py
+++ b/libraries/python/getpatter/pricing.py
@@ -244,6 +244,26 @@ DEFAULT_PRICING: dict[str, dict] = {
     "soniox_tts": {"unit": PricingUnit.THOUSAND_CHARS, "price": 0.013},
     # xAI TTS: $15.00 / 1M chars = $0.015 / 1k chars.
     "xai_tts": {"unit": PricingUnit.THOUSAND_CHARS, "price": 0.015},
+    # Fish Audio TTS: $15.00 / 1M UTF-8 BYTES = $0.015 / 1k bytes. Fish meters
+    # bytes, not characters, so the adapter reports UTF-8 byte length as the
+    # "chars" figure — exact for latin scripts, and correctly ~3x higher for
+    # CJK where one character is three bytes. ``s2.1-pro-free`` is the free
+    # tier and bills nothing. Source:
+    # https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits
+    "fish_audio": {
+        "unit": PricingUnit.THOUSAND_CHARS,
+        # Default = s2.1-pro.
+        "price": 0.015,
+        "models": {
+            "s2.1-pro": {"price": 0.015},
+            "s2.1-pro-free": {"price": 0.0},
+            "s2-pro": {"price": 0.015},
+            "s1": {"price": 0.015},
+        },
+    },
+    # Fish Audio ASR (transcribe-1): $0.36 / audio hour = $0.006 / minute,
+    # rounded up to the nearest second by Fish.
+    "fish_audio_stt": {"unit": PricingUnit.MINUTE, "price": 0.006},
     # Sarvam AI Bulbul TTS — per 1,000 characters. INR is authoritative; USD is
     # an indicative FX conversion (~Rs 83-84/USD). Bulbul v3 (default): Rs 30 /
     # 10k chars ≈ $0.036/1k; Bulbul v2: Rs 15 / 10k ≈ $0.018/1k. Billed per

--- a/libraries/python/getpatter/providers/__init__.py
+++ b/libraries/python/getpatter/providers/__init__.py
@@ -90,6 +90,54 @@ def inworld(
     )
 
 
+def fish_audio(
+    api_key: str,
+    voice: str = "",
+    *,
+    model: str = "s2.1-pro",
+    latency: str = "balanced",
+) -> TTSConfig:
+    """Config helper for Fish Audio TTS (requires the ``fish_audio`` extra).
+
+    ``voice`` is a Fish ``reference_id`` — a voice-model id from the Fish voice
+    library or one you cloned. Leave it empty to use the model's built-in
+    voice. ``model`` defaults to ``s2.1-pro`` (the recommended production
+    model); pass ``s2-pro`` for the ~100 ms time-to-first-audio generation or
+    ``s2.1-pro-free`` for the free tier (no latency guarantee).
+    """
+    return TTSConfig(
+        provider="fish_audio",
+        api_key=api_key,
+        voice=voice,
+        options={"model": model, "latency": latency},
+    )
+
+
+def fish_audio_asr(
+    api_key: str,
+    language: str = "en",
+    *,
+    ignore_timestamps: bool = True,
+) -> STTConfig:
+    """Config helper for Fish Audio ASR (requires the ``fish_audio`` extra).
+
+    Fish transcription is a batch endpoint, so this adapter uploads short
+    windows instead of streaming — see ``FishAudioSTT`` for the latency
+    trade-off against Deepgram / Soniox / AssemblyAI.
+
+    Named ``_asr`` (Fish's own term for the endpoint) rather than ``_stt`` on
+    purpose: a helper called ``fish_audio_stt`` would be shadowed by the
+    ``providers.fish_audio_stt`` submodule as soon as the factory imports it —
+    the same trap that ``soniox_tts`` needs an explicit re-bind to survive.
+    """
+    return STTConfig(
+        provider="fish_audio",
+        api_key=api_key,
+        language=language,
+        options={"ignore_timestamps": ignore_timestamps},
+    )
+
+
 def soniox_tts(
     api_key: str,
     voice: str = "Adrian",
@@ -194,6 +242,8 @@ __all__ = [
     "rime",
     "lmnt",
     "inworld",
+    "fish_audio",
+    "fish_audio_asr",
     "soniox_tts",
     "sarvam",
     "AnthropicLLMProvider",

--- a/libraries/python/getpatter/providers/fish_audio_stt.py
+++ b/libraries/python/getpatter/providers/fish_audio_stt.py
@@ -1,0 +1,317 @@
+"""Fish Audio Speech-to-Text for the Patter SDK — buffered batch adapter.
+
+Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+exercised against a live phone call.
+
+Fish exposes transcription as a **batch** endpoint only
+(``POST https://api.fish.audio/v1/asr``) — there is no streaming socket. This
+adapter therefore follows the same buffer-and-POST shape as
+:class:`~getpatter.providers.whisper_stt.WhisperSTT`: incoming PCM is
+accumulated, uploaded as a WAV once the buffer fills, and the resulting text is
+emitted as a final :class:`~getpatter.providers.base.Transcript`.
+
+Latency consequence: transcripts arrive in ~2 s windows rather than as interim
+partials. For latency-sensitive agents prefer a genuinely streaming STT
+(Deepgram, Soniox, AssemblyAI, Speechmatics). Use this adapter when you want a
+single vendor for both directions of the call, or for Fish's language coverage.
+
+Credential: ``FISH_AUDIO_API_KEY`` env var / ``api_key`` argument. Auth is an
+``Authorization: Bearer <key>`` header.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+import wave
+from typing import Any, AsyncIterator, ClassVar, Optional
+
+from getpatter.providers.base import STTProvider, Transcript
+from getpatter.providers.fish_audio_tts import FISH_AUDIO_API_ORIGIN
+
+logger = logging.getLogger("getpatter.providers.fish_audio_stt")
+
+# Lazy import: aiohttp is declared as an optional dep for this provider
+# (shared ``[fish_audio]`` extra with the Fish TTS adapters).
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+FISH_AUDIO_ASR_URL = f"{FISH_AUDIO_API_ORIGIN}/v1/asr"
+
+# The adapter always uploads 16 kHz / 16-bit / mono WAV.
+STT_SAMPLE_RATE = 16000
+_BYTES_PER_SECOND = STT_SAMPLE_RATE * 2
+
+# ~2 s of audio per upload. Fish rejects clips under 1 second, so a 1 s window
+# (what WhisperSTT uses) would sit exactly on the boundary; 2 s keeps every
+# steady-state upload comfortably inside the accepted range and halves the
+# request count.
+BUFFER_SIZE_BYTES = _BYTES_PER_SECOND * 2
+
+# Fish's documented minimum clip length. Tails shorter than this are padded
+# with digital silence rather than dropped — see :meth:`close`.
+MIN_AUDIO_BYTES = _BYTES_PER_SECOND
+
+# Fish's documented per-request ceiling (20 MB). A 2 s window is ~64 KB, so this
+# only ever guards against a pathological buffer.
+MAX_UPLOAD_BYTES = 20 * 1024 * 1024
+
+
+class FishAudioSTT(STTProvider):
+    """Fish Audio ASR adapter — buffers PCM audio and transcribes in windows.
+
+    Compatible with the :class:`~getpatter.providers.base.STTProvider` interface
+    so it can be swapped into pipeline mode without changing calling code.
+
+    Args:
+        api_key: Fish Audio API key. Falls back to ``FISH_AUDIO_API_KEY``.
+        language: ISO language code (e.g. ``"en"``). Pass ``None`` to let Fish
+            auto-detect — Fish's own default.
+        ignore_timestamps: ``True`` (default) skips segment timing, which Fish
+            documents as the lower-latency path for clips under 30 s. Set
+            ``False`` to receive per-segment ``start`` / ``end`` on
+            :attr:`Transcript.words`.
+        buffer_size_bytes: Bytes of 16 kHz PCM16 to accumulate before each
+            upload. Default ~2 s.
+    """
+
+    #: Stable pricing/dashboard key — read by stream-handler/metrics.
+    provider_key: ClassVar[str] = "fish_audio_stt"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        language: Optional[str] = "en",
+        *,
+        ignore_timestamps: bool = True,
+        buffer_size_bytes: int = BUFFER_SIZE_BYTES,
+        base_url: str = FISH_AUDIO_ASR_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for FishAudioSTT. "
+                "Install with: pip install getpatter[fish_audio]"
+            )
+
+        resolved_key = api_key or os.environ.get("FISH_AUDIO_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Fish Audio STT requires an api_key. Pass api_key='...' or "
+                "set FISH_AUDIO_API_KEY in the environment."
+            )
+
+        self.api_key = resolved_key
+        self.language = language
+        self.ignore_timestamps = ignore_timestamps
+        self.buffer_size_bytes = buffer_size_bytes
+        self.base_url = base_url
+        # Declared so the observability layer can compute audio seconds.
+        self.sample_rate = STT_SAMPLE_RATE
+        self.encoding = "linear16"
+
+        self._buffer = bytearray()
+        self._audio_bytes_sent: int = 0
+        # Queue holds Transcript items; None is a sentinel that signals the
+        # generator to stop after draining all real transcripts.
+        self._transcript_queue: asyncio.Queue[Transcript | None] = asyncio.Queue()
+        self._running = False
+        self._pending: set[asyncio.Task] = set()
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        # Never leak the API key in repr / logs.
+        return (
+            f"FishAudioSTT(language={self.language!r}, "
+            f"ignore_timestamps={self.ignore_timestamps})"
+        )
+
+    @classmethod
+    def for_twilio(
+        cls,
+        api_key: Optional[str] = None,
+        language: Optional[str] = "en",
+        **kwargs: Any,
+    ) -> "FishAudioSTT":
+        """Factory mirroring the TS ``forTwilio`` helper.
+
+        Twilio delivers mu-law @ 8 kHz which the upstream transcoder converts to
+        PCM16 @ 16 kHz before it reaches this adapter, so no extra config is
+        needed — the factory exists for API parity.
+        """
+        return cls(api_key=api_key, language=language, **kwargs)
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _record_transcript_cost(self) -> None:
+        """Emit ``patter.cost.stt_seconds`` for the transcribed audio."""
+        try:
+            from getpatter.observability.attributes import record_patter_attrs
+
+            seconds = self._audio_bytes_sent / float(_BYTES_PER_SECOND)
+            record_patter_attrs(
+                {
+                    "patter.cost.stt_seconds": seconds,
+                    "patter.stt.provider": "fish_audio",
+                }
+            )
+            self._audio_bytes_sent = 0
+        except Exception:  # pragma: no cover — defense in depth
+            logger.debug("_record_transcript_cost failed", exc_info=True)
+
+    async def connect(self) -> None:
+        """Initialise the adapter (Fish ASR needs no persistent connection)."""
+        self._running = True
+        self._buffer = bytearray()
+
+    async def send_audio(self, audio_chunk: bytes) -> None:
+        """Buffer incoming PCM audio and transcribe when the window fills."""
+        self._audio_bytes_sent += len(audio_chunk)
+        self._buffer.extend(audio_chunk)
+        if len(self._buffer) >= self.buffer_size_bytes:
+            buf = bytes(self._buffer)
+            self._buffer.clear()
+            task = asyncio.create_task(self._transcribe_and_enqueue(buf))
+            self._pending.add(task)
+            task.add_done_callback(self._pending.discard)
+
+    async def _transcribe_and_enqueue(self, pcm_data: bytes) -> None:
+        transcript = await self._transcribe_buffer(pcm_data)
+        if transcript:
+            await self._transcript_queue.put(transcript)
+
+    async def _transcribe_buffer(self, pcm_data: bytes) -> Transcript | None:
+        """Upload one PCM window to ``/v1/asr`` and return the transcript."""
+        if len(pcm_data) > MAX_UPLOAD_BYTES:
+            logger.warning(
+                "Fish Audio STT buffer is %d bytes, over the %d-byte per-request "
+                "limit; truncating to the most recent audio.",
+                len(pcm_data),
+                MAX_UPLOAD_BYTES,
+            )
+            pcm_data = pcm_data[-MAX_UPLOAD_BYTES:]
+
+        wav_bytes = _pcm_to_wav(pcm_data, STT_SAMPLE_RATE)
+        form = aiohttp.FormData()
+        form.add_field(
+            "audio", wav_bytes, filename="audio.wav", content_type="audio/wav"
+        )
+        if self.language:
+            form.add_field("language", self.language)
+        form.add_field(
+            "ignore_timestamps", "true" if self.ignore_timestamps else "false"
+        )
+
+        try:
+            session = self._ensure_session()
+            async with session.post(
+                self.base_url,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                data=form,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    logger.error("Fish Audio STT error %d: %s", resp.status, body[:500])
+                    return None
+                payload = await resp.json()
+        except Exception as exc:  # noqa: BLE001 - never kill the call on STT
+            logger.exception("Fish Audio STT transcription error: %s", exc)
+            return None
+
+        return _parse_asr_response(payload)
+
+    async def receive_transcripts(self) -> AsyncIterator[Transcript]:
+        """Yield transcripts as they arrive.
+
+        Keeps draining after ``_running`` goes False so transcripts flushed by
+        :meth:`close` (trailing buffer + in-flight uploads) are not dropped;
+        :meth:`close` enqueues a ``None`` sentinel once flushing is complete,
+        which ends this generator.
+        """
+        while True:
+            try:
+                transcript = await asyncio.wait_for(
+                    self._transcript_queue.get(), timeout=0.1
+                )
+            except asyncio.TimeoutError:
+                if not self._running and self._transcript_queue.empty():
+                    # close() was never called (e.g. unit-test tear-down) —
+                    # give up gracefully instead of looping forever.
+                    break
+                continue
+            if transcript is None:
+                break
+            if transcript.is_final:
+                self._record_transcript_cost()
+            yield transcript
+
+    async def close(self) -> None:
+        """Flush the remaining buffer and release the HTTP session.
+
+        Fish rejects clips shorter than 1 second, so a short tail is padded with
+        digital silence up to the minimum rather than dropped — the alternative
+        would silently lose the last words of an utterance, the exact bug that
+        was fixed on the Whisper adapter.
+        """
+        if len(self._buffer) > 0:
+            tail = bytes(self._buffer)
+            if len(tail) < MIN_AUDIO_BYTES:
+                tail = tail + b"\x00" * (MIN_AUDIO_BYTES - len(tail))
+            transcript = await self._transcribe_buffer(tail)
+            if transcript:
+                await self._transcript_queue.put(transcript)
+        self._buffer.clear()
+        # Wait for in-flight uploads so their results land before the sentinel.
+        if self._pending:
+            await asyncio.gather(*self._pending, return_exceptions=True)
+        self._running = False
+        await self._transcript_queue.put(None)
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None
+
+
+def _pcm_to_wav(pcm_data: bytes, sample_rate: int) -> bytes:
+    """Wrap raw PCM16 mono samples in a WAV container."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+    return buf.getvalue()
+
+
+def _parse_asr_response(payload: Any) -> Transcript | None:
+    """Map a ``/v1/asr`` response onto a :class:`Transcript`.
+
+    Fish returns ``{"text": str, "duration": float, "segments": [...]}``.
+    Segments are surfaced on :attr:`Transcript.words` when the caller asked for
+    timestamps; Fish reports no confidence score, so ``confidence`` is 1.0.
+    """
+    if not isinstance(payload, dict):
+        return None
+    text = (payload.get("text") or "").strip()
+    if not text:
+        return None
+    segments = payload.get("segments")
+    words: tuple[dict[str, Any], ...] = ()
+    if isinstance(segments, list):
+        words = tuple(seg for seg in segments if isinstance(seg, dict))
+    return Transcript(
+        text=text,
+        is_final=True,
+        confidence=1.0,
+        speech_final=True,
+        words=words,
+    )

--- a/libraries/python/getpatter/providers/fish_audio_tts.py
+++ b/libraries/python/getpatter/providers/fish_audio_tts.py
@@ -1,0 +1,385 @@
+"""Fish Audio Text-to-Speech for the Patter SDK — HTTP streaming endpoint.
+
+Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+exercised against a live phone call.
+
+Targets ``POST https://api.fish.audio/v1/tts``, which streams the synthesised
+audio back with chunked transfer encoding. The model is selected with a
+``model:`` request header (NOT a body field) — the same key can therefore serve
+``s2.1-pro``, ``s2-pro``, ``s1`` and the free tier without reconnecting.
+
+Default output is raw PCM-16-LE @ 16 kHz (``format="pcm"``) so chunks drop
+straight into the Patter pipeline with no transcoding — the same choice made
+for LMNT (``raw``) and Inworld (``PCM``).
+
+Model families (see :class:`FishAudioModel`):
+
+* ``s2.1-pro``      — recommended production model. 83 languages, multi-speaker,
+                      natural-language expression control via ``[brackets]``.
+* ``s2.1-pro-free`` — same model on the free tier. No time-to-first-audio
+                      guarantee, so it is NOT the default here: a voice agent
+                      that stalls mid-call is worse than one that costs money.
+* ``s2-pro``        — previous generation, ~100 ms time-to-first-audio. Also the
+                      only S2 model reachable over the WebSocket transport
+                      (see :class:`~getpatter.providers.fish_audio_ws_tts.FishAudioWebSocketTTS`).
+* ``s1``            — legacy. Emotion control uses ``(parentheses)`` instead of
+                      brackets.
+
+Credential: ``FISH_AUDIO_API_KEY`` env var / ``api_key`` argument. Auth is an
+``Authorization: Bearer <key>`` header.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import StrEnum
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    ClassVar,
+    Optional,
+    Sequence,
+    Union,
+)
+
+from getpatter.providers.base import TTSProvider
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from getpatter.audio.format import AudioFormat
+
+logger = logging.getLogger("getpatter.providers.fish_audio_tts")
+
+# Lazy import: aiohttp is declared as an optional dep for this provider
+# (shared ``[fish_audio]`` extra with the WebSocket TTS and ASR adapters).
+try:  # pragma: no cover - trivial import guard
+    import aiohttp
+except ImportError:  # pragma: no cover
+    aiohttp = None  # type: ignore
+
+# API origin — shared by the TTS, ASR and model-listing endpoints.
+FISH_AUDIO_API_ORIGIN = "https://api.fish.audio"
+# HTTP streaming text-to-speech endpoint.
+FISH_AUDIO_TTS_URL = f"{FISH_AUDIO_API_ORIGIN}/v1/tts"
+# Voice-model listing — a free metadata read used as the warmup target.
+FISH_AUDIO_MODELS_URL = f"{FISH_AUDIO_API_ORIGIN}/model"
+
+# Pipeline-friendly defaults: raw PCM-16-LE @ 16 kHz (NOT Fish's own mp3
+# default, which the pipeline cannot decode).
+FISH_AUDIO_DEFAULT_FORMAT = "pcm"
+FISH_AUDIO_DEFAULT_SAMPLE_RATE = 16000
+
+
+class FishAudioModel(StrEnum):
+    """Fish Audio TTS model ids, passed via the ``model:`` request header."""
+
+    S2_1_PRO = "s2.1-pro"
+    S2_1_PRO_FREE = "s2.1-pro-free"
+    S2_PRO = "s2-pro"
+    S1 = "s1"
+
+
+class FishAudioFormat(StrEnum):
+    """Output container/codec. Only ``PCM`` is pipeline-compatible."""
+
+    PCM = "pcm"
+    WAV = "wav"
+    MP3 = "mp3"
+    OPUS = "opus"
+
+
+class FishAudioLatency(StrEnum):
+    """Latency/quality trade-off.
+
+    ``NORMAL`` favours quality (~500 ms), ``BALANCED`` is the interactive
+    sweet spot (~300 ms) and is Patter's default, ``LOW`` trades quality for
+    the fastest possible first chunk.
+    """
+
+    LOW = "low"
+    BALANCED = "balanced"
+    NORMAL = "normal"
+
+
+class FishAudioTTS(TTSProvider):
+    """Fish Audio TTS over the HTTP ``/v1/tts`` streaming endpoint (Beta).
+
+    Default output is raw PCM-16-LE @ 16 kHz with ``model="s2.1-pro"`` and
+    ``latency="balanced"``.
+
+    Voice selection
+    ---------------
+    ``voice`` maps to Fish's ``reference_id`` — the id of a voice model from the
+    Fish voice library or one you cloned yourself. Leave it unset to use the
+    model's built-in default voice. Pass a sequence of ids for multi-speaker
+    synthesis, and mark the speakers inline in the text with
+    ``<|speaker:0|>`` / ``<|speaker:1|>``.
+
+    Telephony
+    ---------
+    Fish emits linear PCM only (no native G.711), so the pipeline always runs
+    the mu-law encode. :meth:`for_twilio` requests PCM directly at 8 kHz so the
+    resample step is skipped; :meth:`for_telnyx` keeps the 16 kHz pipeline rate.
+    """
+
+    #: Stable pricing/dashboard key — read by stream-handler/metrics.
+    provider_key: ClassVar[str] = "fish_audio"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: Union[FishAudioModel, str] = FishAudioModel.S2_1_PRO,
+        voice: Optional[Union[str, Sequence[str]]] = None,
+        format: Union[FishAudioFormat, str] = FISH_AUDIO_DEFAULT_FORMAT,
+        sample_rate: int = FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+        latency: Union[FishAudioLatency, str] = FishAudioLatency.BALANCED,
+        speed: Optional[float] = None,
+        volume: Optional[float] = None,
+        normalize_loudness: Optional[bool] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        chunk_length: Optional[int] = None,
+        min_chunk_length: Optional[int] = None,
+        normalize: Optional[bool] = None,
+        max_new_tokens: Optional[int] = None,
+        repetition_penalty: Optional[float] = None,
+        condition_on_previous_chunks: Optional[bool] = None,
+        early_stop_threshold: Optional[float] = None,
+        mp3_bitrate: Optional[int] = None,
+        opus_bitrate: Optional[int] = None,
+        base_url: str = FISH_AUDIO_TTS_URL,
+        session: Optional["aiohttp.ClientSession"] = None,
+    ) -> None:
+        if aiohttp is None:
+            raise ImportError(
+                "aiohttp is required for FishAudioTTS. "
+                "Install with: pip install getpatter[fish_audio]"
+            )
+
+        resolved_key = api_key or os.environ.get("FISH_AUDIO_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Fish Audio TTS requires an api_key. Pass api_key='...' or "
+                "set FISH_AUDIO_API_KEY in the environment."
+            )
+
+        self.api_key = resolved_key
+        self.model = model
+        self.voice = voice
+        self.format = format
+        self.sample_rate = int(sample_rate)
+        self.latency = latency
+        self.speed = speed
+        self.volume = volume
+        self.normalize_loudness = normalize_loudness
+        self.temperature = temperature
+        self.top_p = top_p
+        self.chunk_length = chunk_length
+        self.min_chunk_length = min_chunk_length
+        self.normalize = normalize
+        self.max_new_tokens = max_new_tokens
+        self.repetition_penalty = repetition_penalty
+        self.condition_on_previous_chunks = condition_on_previous_chunks
+        self.early_stop_threshold = early_stop_threshold
+        self.mp3_bitrate = mp3_bitrate
+        self.opus_bitrate = opus_bitrate
+        self.base_url = base_url
+        self._owns_session = session is None
+        self._session = session
+
+    def __repr__(self) -> str:
+        # Never leak the API key in repr / logs.
+        return (
+            f"FishAudioTTS(model={self.model!r}, voice={self.voice!r}, "
+            f"format={self.format!r}, sample_rate={self.sample_rate}, "
+            f"latency={self.latency!r})"
+        )
+
+    # ------------------------------------------------------------------
+    # Telephony factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def for_twilio(cls, api_key: Optional[str] = None, **kwargs: Any) -> "FishAudioTTS":
+        """Build an instance pre-configured for Twilio Media Streams.
+
+        Requests PCM directly at 8 kHz — the carrier wire rate — so the pipeline
+        skips the 16 kHz -> 8 kHz resample and only runs the mu-law encode. Fish
+        has no native G.711 output, so a fully bit-clean passthrough is not
+        available on this provider.
+        """
+        kwargs.pop("format", None)
+        kwargs.pop("sample_rate", None)
+        return cls(
+            api_key=api_key, format=FishAudioFormat.PCM, sample_rate=8000, **kwargs
+        )
+
+    @classmethod
+    def for_telnyx(cls, api_key: Optional[str] = None, **kwargs: Any) -> "FishAudioTTS":
+        """Build an instance pre-configured for Telnyx bidirectional media.
+
+        Emits PCM @ 16 kHz to match the Telnyx PCM16 pipeline; the SDK resamples
+        to the 8 kHz PCMU wire once, downstream.
+        """
+        kwargs.pop("format", None)
+        kwargs.pop("sample_rate", None)
+        return cls(
+            api_key=api_key,
+            format=FishAudioFormat.PCM,
+            sample_rate=FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+            **kwargs,
+        )
+
+    def source_audio_format(self) -> "AudioFormat":
+        """Declare the audio format this adapter emits so the pipeline sender
+        derives the correct resample ratio instead of assuming 16 kHz. See
+        ``getpatter.audio.format``.
+
+        Only ``format="pcm"`` produces pipeline-consumable bytes; ``wav`` /
+        ``mp3`` / ``opus`` are container formats intended for offline use and
+        are reported here as their underlying PCM rate.
+        """
+        from getpatter.audio.format import AudioFormat
+
+        return AudioFormat(encoding="pcm_s16le", sample_rate=self.sample_rate)
+
+    def _ensure_session(self) -> "aiohttp.ClientSession":
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self._session
+
+    def _build_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            # Fish selects the model with a header, not a body field.
+            "model": str(self.model),
+        }
+
+    def _build_payload(self, text: str) -> dict[str, Any]:
+        """Build the ``TTSRequest`` body.
+
+        Every optional knob is omitted when unset so Fish applies its own
+        documented default rather than a value we guessed.
+        """
+        payload: dict[str, Any] = {
+            "text": text,
+            "format": str(self.format),
+            "latency": str(self.latency),
+        }
+        # ``sample_rate`` is only meaningful for the raw/uncompressed formats;
+        # mp3 and opus derive it from the bitrate instead.
+        if str(self.format) in (FishAudioFormat.PCM, FishAudioFormat.WAV):
+            payload["sample_rate"] = self.sample_rate
+        if self.voice:
+            # str -> single speaker; sequence -> multi-speaker (s2 models).
+            payload["reference_id"] = (
+                self.voice if isinstance(self.voice, str) else list(self.voice)
+            )
+
+        prosody = self._build_prosody()
+        if prosody:
+            payload["prosody"] = prosody
+
+        optional: dict[str, Any] = {
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "chunk_length": self.chunk_length,
+            "min_chunk_length": self.min_chunk_length,
+            "normalize": self.normalize,
+            "max_new_tokens": self.max_new_tokens,
+            "repetition_penalty": self.repetition_penalty,
+            "condition_on_previous_chunks": self.condition_on_previous_chunks,
+            "early_stop_threshold": self.early_stop_threshold,
+            "mp3_bitrate": self.mp3_bitrate,
+            "opus_bitrate": self.opus_bitrate,
+        }
+        payload.update({k: v for k, v in optional.items() if v is not None})
+        return payload
+
+    def _build_prosody(self) -> dict[str, Any]:
+        """Collapse the flat speed/volume/loudness args into Fish's nested
+        ``prosody`` object. Returns ``{}`` when none of them is set."""
+        prosody: dict[str, Any] = {}
+        if self.speed is not None:
+            prosody["speed"] = self.speed
+        if self.volume is not None:
+            prosody["volume"] = self.volume
+        if self.normalize_loudness is not None:
+            prosody["normalize_loudness"] = self.normalize_loudness
+        return prosody
+
+    def _record_synthesis_cost(self, text: str) -> None:
+        """Emit ``patter.cost.tts_chars`` for the synthesised text.
+
+        Fish bills UTF-8 *bytes*, so we report the byte length rather than the
+        character count — they diverge by ~3x on CJK text.
+        """
+        try:
+            from getpatter.observability.attributes import record_patter_attrs
+
+            record_patter_attrs(
+                {
+                    "patter.cost.tts_chars": len(text.encode("utf-8")),
+                    "patter.tts.provider": "fish_audio",
+                }
+            )
+        except Exception:  # pragma: no cover — defense in depth
+            logger.debug("_record_synthesis_cost failed", exc_info=True)
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream audio bytes for ``text``.
+
+        With the default ``format="pcm"`` these are raw PCM-16-LE chunks at the
+        configured ``sample_rate``.
+        """
+        self._record_synthesis_cost(text)
+        session = self._ensure_session()
+
+        async with session.post(
+            self.base_url,
+            headers=self._build_headers(),
+            json=self._build_payload(text),
+            timeout=aiohttp.ClientTimeout(total=60),
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RuntimeError(f"Fish Audio TTS error {resp.status}: {body[:500]}")
+            async for chunk in resp.content.iter_chunked(4096):
+                if chunk:
+                    yield chunk
+
+    async def warmup(self) -> None:
+        """Best-effort pre-call HTTP warmup.
+
+        Issues ``GET /model?page_size=1`` — the voice-model listing — so DNS,
+        TLS and the HTTP connection are already established when the first
+        :meth:`synthesize` POST lands. Billing safety: listing voice models is a
+        free metadata read; synthesis is billed only by ``POST /v1/tts``.
+
+        A ``HEAD`` against ``/v1/tts`` would be cheaper still but that endpoint
+        is POST-only and answers 405 — the same trap already documented on the
+        Inworld adapter. Best-effort throughout: 5 s timeout, every exception
+        swallowed at DEBUG.
+        """
+        try:
+            session = self._ensure_session()
+            async with session.get(
+                FISH_AUDIO_MODELS_URL,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                params={"page_size": "1"},
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                # Drain so the connection returns cleanly to the pool.
+                await resp.read()
+        except Exception as exc:  # noqa: BLE001 - best-effort
+            logger.debug("Fish Audio TTS warmup failed (best-effort): %s", exc)
+
+    async def close(self) -> None:
+        """Close the underlying session (idempotent)."""
+        if self._session is not None and self._owns_session:
+            await self._session.close()
+            self._session = None

--- a/libraries/python/getpatter/providers/fish_audio_ws_tts.py
+++ b/libraries/python/getpatter/providers/fish_audio_ws_tts.py
@@ -1,0 +1,283 @@
+"""WebSocket-based Fish Audio TTS provider — opt-in low-latency variant.
+
+Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+exercised against a live phone call.
+
+This adapter targets the streaming endpoint ``wss://api.fish.audio/v1/tts/live``
+instead of the HTTP ``/v1/tts`` endpoint used by :class:`FishAudioTTS`. The
+WebSocket path skips the per-utterance HTTP request setup (~50 ms) and pairs
+with ``s2-pro``'s ~100 ms time-to-first-audio.
+
+Usage matches :class:`FishAudioTTS` exactly::
+
+    from getpatter.providers.fish_audio_ws_tts import FishAudioWebSocketTTS
+
+    tts = FishAudioWebSocketTTS.for_twilio(api_key=...)
+    async for audio in tts.synthesize("Hello world"):
+        ...
+
+Behaviour notes
+---------------
+* **Model support is narrower than HTTP.** Fish restricts the ``model:`` header
+  on this endpoint to ``s1`` and ``s2-pro``; ``s2.1-pro`` is HTTP-only. The
+  constructor rejects unsupported models with a message pointing at
+  :class:`FishAudioTTS` rather than letting the socket fail at call time.
+* Frames are **MessagePack**, not JSON — the server returns raw audio bytes
+  inline, which JSON cannot carry without base64. This is the only reason the
+  ``[fish_audio]`` extra pulls in a msgpack codec; the HTTP and ASR adapters
+  work without it.
+* The socket is opened **per-utterance**, matching the HTTP semantics and the
+  ElevenLabs WebSocket adapter.
+* Protocol: ``start`` (config) -> ``text`` (payload) -> ``flush`` -> ``stop``,
+  with the server replying ``audio`` frames followed by ``finish``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, AsyncIterator, Callable, ClassVar, Optional, Sequence, Union
+
+try:
+    import websockets
+except ImportError as e:  # pragma: no cover - websockets is in main deps
+    raise ImportError(
+        "websockets is required for FishAudioWebSocketTTS — it is already "
+        "a runtime dependency of getpatter, so this should never happen."
+    ) from e
+
+from getpatter.providers.fish_audio_tts import (
+    FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+    FishAudioFormat,
+    FishAudioLatency,
+    FishAudioModel,
+    FishAudioTTS,
+)
+
+logger = logging.getLogger("getpatter.providers.fish_audio_ws_tts")
+
+FISH_AUDIO_WS_URL = "wss://api.fish.audio/v1/tts/live"
+
+# Models Fish accepts on the ``/v1/tts/live`` socket. ``s2.1-pro`` and
+# ``s2.1-pro-free`` are HTTP-only.
+WS_SUPPORTED_MODELS: frozenset[str] = frozenset(
+    {FishAudioModel.S1.value, FishAudioModel.S2_PRO.value}
+)
+
+# Connect timeout — 5 s keeps the carrier WebSocket from sitting in dead air
+# while a stuck DNS / TLS handshake is retried.
+DEFAULT_OPEN_TIMEOUT = 5.0
+
+# Per-frame receive timeout. If the server stalls (no audio, no finish, no
+# close) the generator would otherwise hang until carrier hangup.
+DEFAULT_FRAME_TIMEOUT = 30.0
+
+# Maximum size of a single audio frame from the server. Real frames are far
+# smaller; anything beyond 1 MB is almost certainly malformed or hostile.
+MAX_AUDIO_FRAME_SIZE = 1024 * 1024
+
+
+class FishAudioWSError(Exception):
+    """Raised when the Fish Audio WebSocket reports a server-side error."""
+
+
+def _load_msgpack() -> tuple[Callable[[Any], bytes], Callable[[bytes], Any]]:
+    """Resolve a MessagePack codec, preferring ``ormsgpack``.
+
+    Returns a ``(packb, unpackb)`` pair. ``ormsgpack`` is what Fish's own
+    Python SDK uses; plain ``msgpack`` is accepted as a fallback so users who
+    already have it installed don't need a second codec.
+    """
+    try:  # pragma: no cover - import-path branch
+        import ormsgpack
+
+        return ormsgpack.packb, ormsgpack.unpackb
+    except ImportError:
+        pass
+    try:  # pragma: no cover - import-path branch
+        import msgpack
+
+        return (
+            lambda obj: msgpack.packb(obj, use_bin_type=True),
+            lambda data: msgpack.unpackb(data, raw=False),
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "FishAudioWebSocketTTS needs a MessagePack codec — the Fish "
+            "streaming socket frames are msgpack, not JSON. Install with: "
+            "pip install getpatter[fish_audio]  (or: pip install ormsgpack). "
+            "The HTTP FishAudioTTS adapter has no such requirement."
+        ) from exc
+
+
+class FishAudioWebSocketTTS(FishAudioTTS):
+    """Fish Audio TTS over the ``/v1/tts/live`` WebSocket (Beta).
+
+    Same constructor surface as :class:`FishAudioTTS`, except the default model
+    is ``s2-pro`` (the fastest model this endpoint serves) and ``s2.1-pro`` is
+    rejected up-front because Fish does not route it here.
+    """
+
+    #: Stable pricing/dashboard key — read by stream-handler/metrics. Shares the
+    #: HTTP adapter's key: same models, same per-byte rate.
+    provider_key: ClassVar[str] = "fish_audio"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        model: Union[FishAudioModel, str] = FishAudioModel.S2_PRO,
+        voice: Optional[Union[str, Sequence[str]]] = None,
+        format: Union[FishAudioFormat, str] = FishAudioFormat.PCM,
+        sample_rate: int = FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+        latency: Union[FishAudioLatency, str] = FishAudioLatency.BALANCED,
+        ws_url: str = FISH_AUDIO_WS_URL,
+        open_timeout: float = DEFAULT_OPEN_TIMEOUT,
+        frame_timeout: float = DEFAULT_FRAME_TIMEOUT,
+        **kwargs: Any,
+    ) -> None:
+        if str(model) not in WS_SUPPORTED_MODELS:
+            raise ValueError(
+                f"FishAudioWebSocketTTS: model {str(model)!r} is not available on "
+                f"the /v1/tts/live socket (Fish accepts only "
+                f"{sorted(WS_SUPPORTED_MODELS)} there). Use the HTTP adapter "
+                f"instead: FishAudioTTS(model={str(model)!r})."
+            )
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            voice=voice,
+            format=format,
+            sample_rate=sample_rate,
+            latency=latency,
+            **kwargs,
+        )
+        self.ws_url = ws_url
+        self.open_timeout = open_timeout
+        self.frame_timeout = frame_timeout
+        # Resolved lazily on first synthesise so importing the module (and
+        # constructing the adapter) never requires the msgpack extra.
+        self._packb: Optional[Callable[[Any], bytes]] = None
+        self._unpackb: Optional[Callable[[bytes], Any]] = None
+
+    def __repr__(self) -> str:
+        return (
+            f"FishAudioWebSocketTTS(model={self.model!r}, voice={self.voice!r}, "
+            f"format={self.format!r}, sample_rate={self.sample_rate})"
+        )
+
+    def _codec(self) -> tuple[Callable[[Any], bytes], Callable[[bytes], Any]]:
+        if self._packb is None or self._unpackb is None:
+            self._packb, self._unpackb = _load_msgpack()
+        return self._packb, self._unpackb
+
+    def _build_start_event(self) -> dict[str, Any]:
+        """Build the ``start`` frame.
+
+        The ``request`` object takes the same fields as the HTTP TTS body with
+        an empty ``text`` — the actual text arrives in later ``text`` frames.
+        """
+        request = self._build_payload("")
+        return {"event": "start", "request": request}
+
+    async def synthesize(self, text: str) -> AsyncIterator[bytes]:
+        """Stream audio bytes for ``text`` over a per-utterance WebSocket.
+
+        With the default ``format="pcm"`` these are raw PCM-16-LE chunks at the
+        configured ``sample_rate``.
+        """
+        packb, unpackb = self._codec()
+        self._record_synthesis_cost(text)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "model": str(self.model),
+        }
+
+        ws = await asyncio.wait_for(
+            websockets.connect(self.ws_url, additional_headers=headers),
+            timeout=self.open_timeout,
+        )
+        try:
+            await ws.send(packb(self._build_start_event()))
+            await ws.send(packb({"event": "text", "text": text}))
+            await ws.send(packb({"event": "flush"}))
+            await ws.send(packb({"event": "stop"}))
+
+            while True:
+                try:
+                    frame = await asyncio.wait_for(
+                        ws.recv(), timeout=self.frame_timeout
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise FishAudioWSError(
+                        f"Fish Audio WS stalled: no frame within {self.frame_timeout}s"
+                    ) from exc
+                except websockets.exceptions.ConnectionClosedOK:
+                    break
+                except websockets.exceptions.ConnectionClosed as exc:
+                    raise FishAudioWSError(
+                        f"Fish Audio WS closed unexpectedly: {exc}"
+                    ) from exc
+
+                audio, done = _decode_server_frame(frame, unpackb)
+                if audio:
+                    yield audio
+                if done:
+                    break
+        finally:
+            await ws.close()
+
+    async def close(self) -> None:
+        """Release the warmup HTTP session (the synthesis socket is
+        per-utterance and closed by :meth:`synthesize`)."""
+        await super().close()
+
+
+def _decode_server_frame(
+    frame: Union[bytes, str], unpackb: Callable[[bytes], Any]
+) -> tuple[Optional[bytes], bool]:
+    """Decode one server frame into ``(audio_bytes, is_final)``.
+
+    Returns ``(None, False)`` for frames that carry neither audio nor a
+    terminal signal (``log`` frames, unknown future event types) so the caller
+    can keep reading. Raises :class:`FishAudioWSError` when the server reports
+    ``finish`` with ``reason="error"``.
+    """
+    if isinstance(frame, str):
+        # The protocol is msgpack-binary; a text frame is only ever an
+        # out-of-band server message. Log it and keep going.
+        logger.debug("Fish Audio WS text frame ignored: %s", frame[:200])
+        return None, False
+
+    try:
+        parsed = unpackb(frame)
+    except Exception as exc:  # noqa: BLE001 - malformed frame from the server
+        raise FishAudioWSError(
+            f"Fish Audio WS sent an undecodable frame: {exc}"
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        return None, False
+
+    event = parsed.get("event")
+    if event == "audio":
+        audio = parsed.get("audio")
+        if not isinstance(audio, (bytes, bytearray)):
+            return None, False
+        if len(audio) > MAX_AUDIO_FRAME_SIZE:
+            raise FishAudioWSError(
+                f"Fish Audio WS audio frame is {len(audio)} bytes, over the "
+                f"{MAX_AUDIO_FRAME_SIZE}-byte sanity limit"
+            )
+        return bytes(audio), False
+    if event == "finish":
+        reason = parsed.get("reason")
+        if reason == "error":
+            raise FishAudioWSError(
+                f"Fish Audio WS finished with an error: {parsed.get('message') or reason}"
+            )
+        return None, True
+    if event == "log":
+        logger.debug("Fish Audio WS log: %s", str(parsed.get("message"))[:200])
+    return None, False

--- a/libraries/python/getpatter/providers/xai_stt.py
+++ b/libraries/python/getpatter/providers/xai_stt.py
@@ -581,5 +581,3 @@ async def transcribe(
         duration=float(payload.get("duration", 0.0)),
         words=_parse_words(payload.get("words")),
     )
-
-

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -1244,16 +1244,20 @@ class StreamHandler(ABC):
         cls_name = type(tts).__name__.lower()
         # Heuristic: provider classes are named like ``ElevenLabsTTS``,
         # ``OpenAITTS``, ``CartesiaTTS`` etc.
-        for known in (
-            "elevenlabs",
-            "openai",
-            "cartesia",
-            "rime",
-            "lmnt",
-            "inworld",
-            "telnyx",
+        # Pairs are ``(class-name needle, canonical provider key)`` — they only
+        # differ when the class name drops a separator, e.g. ``FishAudioTTS``
+        # -> ``fish_audio``.
+        for needle, known in (
+            ("elevenlabs", "elevenlabs"),
+            ("openai", "openai"),
+            ("cartesia", "cartesia"),
+            ("rime", "rime"),
+            ("lmnt", "lmnt"),
+            ("inworld", "inworld"),
+            ("fishaudio", "fish_audio"),
+            ("telnyx", "telnyx"),
         ):
-            if known in cls_name:
+            if needle in cls_name:
                 return known
         return cls_name.replace("tts", "") or None
 
@@ -3961,7 +3965,9 @@ class PipelineStreamHandler(StreamHandler):
             from getpatter.providers.denoiser import resolve_denoiser
 
             self._resolved_denoiser = resolve_denoiser(denoiser_id)
-            logger.info("denoiser '%s' resolved for pipeline inbound chain", denoiser_id)
+            logger.info(
+                "denoiser '%s' resolved for pipeline inbound chain", denoiser_id
+            )
 
         # Prewarm-handoff: try to adopt pre-opened provider WebSockets
         # that the prewarm pipeline (see
@@ -7989,9 +7995,7 @@ class PipelineStreamHandler(StreamHandler):
             else:  # in flight — proportional word-boundary split
                 span = end_s - start_s
                 frac = (heard_s - start_s) / span if span > 1e-9 else 0.0
-                heard_words, unsaid_words = self._split_sentence_at_fraction(
-                    text, frac
-                )
+                heard_words, unsaid_words = self._split_sentence_at_fraction(text, frac)
                 if heard_words:
                     heard_parts.append(heard_words)
                 if unsaid_words:
@@ -8100,9 +8104,7 @@ class PipelineStreamHandler(StreamHandler):
         if not should:
             return
         self._pending_redelivery = (heard, unsaid)
-        logger.debug(
-            "Re-delivery armed: %d word(s) un-heard", len(unsaid.split())
-        )
+        logger.debug("Re-delivery armed: %d word(s) un-heard", len(unsaid.split()))
 
     def _arm_pending_redelivery_nudge(self) -> None:
         """Inject any armed re-delivery as a one-shot LLM system nudge.

--- a/libraries/python/getpatter/stt/__init__.py
+++ b/libraries/python/getpatter/stt/__init__.py
@@ -23,4 +23,5 @@ __all__ = [
     "assemblyai",
     "openai_transcribe",
     "xai",
+    "fish_audio",
 ]

--- a/libraries/python/getpatter/stt/fish_audio.py
+++ b/libraries/python/getpatter/stt/fish_audio.py
@@ -1,0 +1,52 @@
+"""Fish Audio batch STT for Patter pipeline mode (Beta)."""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar
+
+from getpatter.providers.fish_audio_stt import (
+    BUFFER_SIZE_BYTES,
+    FishAudioSTT as _FishAudioSTT,
+)
+
+__all__ = ["STT"]
+
+
+class STT(_FishAudioSTT):
+    """Fish Audio ASR — buffered batch transcription (Beta).
+
+    Example::
+
+        from getpatter.stt import fish_audio
+
+        stt = fish_audio.STT()                       # reads FISH_AUDIO_API_KEY
+        stt = fish_audio.STT(api_key="...", language="it")
+
+    Fish has no streaming transcription socket, so this adapter uploads ~2 s
+    windows and emits one final transcript per window — no interim partials.
+    Prefer Deepgram / Soniox / AssemblyAI when turn latency matters most.
+    """
+
+    provider_key: ClassVar[str] = "fish_audio_stt"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        language: str | None = "en",
+        *,
+        ignore_timestamps: bool = True,
+        buffer_size_bytes: int = BUFFER_SIZE_BYTES,
+    ) -> None:
+        key = api_key or os.environ.get("FISH_AUDIO_API_KEY")
+        if not key:
+            raise ValueError(
+                "Fish Audio STT requires an api_key. Pass api_key='...' or "
+                "set FISH_AUDIO_API_KEY in the environment."
+            )
+        super().__init__(
+            key,
+            language,
+            ignore_timestamps=ignore_timestamps,
+            buffer_size_bytes=buffer_size_bytes,
+        )

--- a/libraries/python/getpatter/telemetry/stack.py
+++ b/libraries/python/getpatter/telemetry/stack.py
@@ -44,6 +44,7 @@ STACK_VENDORS: frozenset[str] = frozenset(
         "inworld",
         "sarvam",
         "xai",
+        "fish_audio",
         "telnyx",
         "other",
     }
@@ -59,6 +60,7 @@ _VENDOR_ALIASES: dict[str, str] = {
     "soniox_tts": "soniox",
     "xai_tts": "xai",
     "xai_realtime": "xai",
+    "fish_audio_stt": "fish_audio",
     "telnyx_stt": "telnyx",
     "telnyx_tts": "telnyx",
 }

--- a/libraries/python/getpatter/telephony/common.py
+++ b/libraries/python/getpatter/telephony/common.py
@@ -199,9 +199,17 @@ def _create_stt_from_config(config, for_twilio: bool = False):
             )
         return AssemblyAISTT(api_key=config.api_key, language=config.language, **kwargs)
 
+    if provider == "fish_audio":
+        from getpatter.providers.fish_audio_stt import FishAudioSTT  # type: ignore[import]
+
+        allowed = {"ignore_timestamps", "buffer_size_bytes", "base_url"}
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        return FishAudioSTT(api_key=config.api_key, language=config.language, **kwargs)
+
     raise ValueError(
         f"Unknown STT provider '{provider}'. "
-        "Supported: deepgram, whisper, cartesia, soniox, speechmatics, assemblyai."
+        "Supported: deepgram, whisper, cartesia, soniox, speechmatics, "
+        "assemblyai, fish_audio."
     )
 
 
@@ -324,8 +332,52 @@ def _create_tts_from_config(config):
         # The Sarvam adapter calls the user-facing ``voice`` a ``speaker``.
         return SarvamTTS(api_key=config.api_key, speaker=config.voice, **kwargs)
 
+    if provider == "fish_audio":
+        allowed = {
+            "model",
+            "format",
+            "sample_rate",
+            "latency",
+            "speed",
+            "volume",
+            "normalize_loudness",
+            "temperature",
+            "top_p",
+            "chunk_length",
+            "min_chunk_length",
+            "normalize",
+            "max_new_tokens",
+            "repetition_penalty",
+            "condition_on_previous_chunks",
+            "early_stop_threshold",
+            "mp3_bitrate",
+            "opus_bitrate",
+            "base_url",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        # ``transport="websocket"`` selects the /v1/tts/live socket (s1 /
+        # s2-pro only); anything else uses the HTTP streaming endpoint, which
+        # is the only transport that serves s2.1-pro.
+        if opts.get("transport") == "websocket":
+            from getpatter.providers.fish_audio_ws_tts import (  # type: ignore[import]
+                FishAudioWebSocketTTS,
+            )
+
+            kwargs.setdefault("model", "s2-pro")
+            return FishAudioWebSocketTTS(
+                api_key=config.api_key, voice=config.voice or None, **kwargs
+            )
+
+        from getpatter.providers.fish_audio_tts import FishAudioTTS  # type: ignore[import]
+
+        # Fish's ``voice`` is a reference_id; an empty string means "use the
+        # model's built-in voice", which the adapter expresses as None.
+        return FishAudioTTS(
+            api_key=config.api_key, voice=config.voice or None, **kwargs
+        )
+
     raise ValueError(
         f"Unknown TTS provider '{provider}'. "
         "Supported: elevenlabs, openai, cartesia, rime, lmnt, inworld, "
-        "soniox_tts, sarvam."
+        "soniox_tts, sarvam, fish_audio."
     )

--- a/libraries/python/getpatter/tts/__init__.py
+++ b/libraries/python/getpatter/tts/__init__.py
@@ -22,4 +22,5 @@ __all__ = [
     "soniox",
     "sarvam",
     "xai",
+    "fish_audio",
 ]

--- a/libraries/python/getpatter/tts/fish_audio.py
+++ b/libraries/python/getpatter/tts/fish_audio.py
@@ -1,0 +1,105 @@
+"""Fish Audio TTS for Patter pipeline mode (Beta)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, ClassVar, Optional, Sequence, Union
+
+from getpatter.providers.fish_audio_tts import (
+    FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+    FishAudioTTS as _FishAudioTTS,
+)
+from getpatter.providers.fish_audio_ws_tts import (
+    FishAudioWebSocketTTS as _FishAudioWebSocketTTS,
+)
+
+__all__ = ["TTS", "WebSocketTTS"]
+
+
+def _resolve_api_key(api_key: str | None) -> str:
+    key = api_key or os.environ.get("FISH_AUDIO_API_KEY")
+    if not key:
+        raise ValueError(
+            "Fish Audio TTS requires an api_key. Pass api_key='...' or "
+            "set FISH_AUDIO_API_KEY in the environment."
+        )
+    return key
+
+
+class TTS(_FishAudioTTS):
+    """Fish Audio HTTP TTS — defaults to the ``s2.1-pro`` model (Beta).
+
+    Example::
+
+        from getpatter.tts import fish_audio
+
+        tts = fish_audio.TTS()                                  # reads FISH_AUDIO_API_KEY
+        tts = fish_audio.TTS(api_key="...", voice="<reference-id>", latency="low")
+
+    ``voice`` is a Fish ``reference_id`` — a voice-model id from the Fish voice
+    library or one you cloned. Omit it to use the model's built-in voice; pass a
+    sequence of ids for multi-speaker synthesis with ``<|speaker:0|>`` markers.
+
+    Telephony: use :meth:`for_twilio` / :meth:`for_telnyx` on phone calls so the
+    PCM is requested at the carrier's rate and the pipeline skips a resample.
+    """
+
+    provider_key: ClassVar[str] = "fish_audio"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "s2.1-pro",
+        voice: Optional[Union[str, Sequence[str]]] = None,
+        format: str = "pcm",
+        sample_rate: int = FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+        latency: str = "balanced",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            api_key=_resolve_api_key(api_key),
+            model=model,
+            voice=voice,
+            format=format,
+            sample_rate=sample_rate,
+            latency=latency,
+            **kwargs,
+        )
+
+
+class WebSocketTTS(_FishAudioWebSocketTTS):
+    """Fish Audio WebSocket TTS — opt-in low-latency path, ``s2-pro`` (Beta).
+
+    Example::
+
+        from getpatter.tts import fish_audio
+
+        tts = fish_audio.WebSocketTTS()                         # reads FISH_AUDIO_API_KEY
+
+    Fish serves only ``s1`` and ``s2-pro`` on the streaming socket — for
+    ``s2.1-pro`` use :class:`TTS` (HTTP) instead.
+    """
+
+    provider_key: ClassVar[str] = "fish_audio"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "s2-pro",
+        voice: Optional[Union[str, Sequence[str]]] = None,
+        format: str = "pcm",
+        sample_rate: int = FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+        latency: str = "balanced",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            api_key=_resolve_api_key(api_key),
+            model=model,
+            voice=voice,
+            format=format,
+            sample_rate=sample_rate,
+            latency=latency,
+            **kwargs,
+        )

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -59,6 +59,14 @@ soniox = [
 xai = [
     "aiohttp>=3.10",
 ]
+# Fish Audio TTS (s2.1-pro / s2-pro) + ASR. The HTTP TTS and ASR adapters need
+# only aiohttp; ``ormsgpack`` is required exclusively by the WebSocket TTS
+# transport, whose frames are MessagePack (they carry raw audio bytes inline,
+# which JSON cannot express without base64).
+fish_audio = [
+    "aiohttp>=3.10",
+    "ormsgpack>=1.5",
+]
 speechmatics = [
     "speechmatics-voice[smart]>=0.2.8",
 ]

--- a/libraries/python/tests/unit/test_fish_audio_stt.py
+++ b/libraries/python/tests/unit/test_fish_audio_stt.py
@@ -1,0 +1,327 @@
+"""Tests for the Fish Audio batch STT (ASR) provider.
+
+These run against a **real in-process aiohttp server** on 127.0.0.1 that parses
+the real multipart body the adapter uploads — only Fish's transcription is
+simulated. Buffering, WAV framing, multipart field names, tail padding,
+transcript mapping, the queue/sentinel drain and the error path all execute for
+real. See ``.claude/rules/authentic-tests.md``.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+from typing import Any, AsyncIterator
+
+import pytest
+from aiohttp import web
+
+from getpatter.providers.base import Transcript
+from getpatter.providers.fish_audio_stt import (
+    BUFFER_SIZE_BYTES,
+    MIN_AUDIO_BYTES,
+    FishAudioSTT,
+    _parse_asr_response,
+)
+
+pytestmark = pytest.mark.mocked
+
+
+class _ASRRecorder:
+    def __init__(self) -> None:
+        self.uploads: list[dict[str, Any]] = []
+        self.status = 200
+        self.payload: dict[str, Any] = {"text": "ciao mondo", "duration": 2.0}
+        self.error_body = ""
+
+
+@pytest.fixture
+async def fish_asr_server() -> AsyncIterator[tuple[str, _ASRRecorder]]:
+    rec = _ASRRecorder()
+
+    async def asr_handler(request: web.Request) -> web.Response:
+        data = await request.post()
+        audio_field = data.get("audio")
+        raw = audio_field.file.read() if hasattr(audio_field, "file") else b""
+        rec.uploads.append(
+            {
+                "authorization": request.headers.get("Authorization"),
+                "language": data.get("language"),
+                "ignore_timestamps": data.get("ignore_timestamps"),
+                "filename": getattr(audio_field, "filename", None),
+                "content_type": getattr(audio_field, "content_type", None),
+                "wav": raw,
+            }
+        )
+        if rec.status != 200:
+            return web.Response(status=rec.status, text=rec.error_body)
+        return web.json_response(rec.payload)
+
+    app = web.Application()
+    app.router.add_post("/v1/asr", asr_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    try:
+        yield f"http://{host}:{port}/v1/asr", rec
+    finally:
+        await runner.cleanup()
+
+
+def _stt(url: str, **kwargs: Any) -> FishAudioSTT:
+    return FishAudioSTT(api_key="fish-test-key", base_url=url, **kwargs)
+
+
+async def _drain(stt: FishAudioSTT) -> list[Transcript]:
+    return [t async for t in stt.receive_transcripts()]
+
+
+def _silence(num_bytes: int) -> bytes:
+    return b"\x00" * num_bytes
+
+
+# ---------------------------------------------------------------------------
+# Upload shape
+# ---------------------------------------------------------------------------
+
+
+async def test_a_full_window_is_uploaded_and_yields_a_final_transcript(
+    fish_asr_server,
+) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+
+    transcripts = await _drain(stt)
+    assert [t.text for t in transcripts] == ["ciao mondo"]
+    assert transcripts[0].is_final is True
+    assert transcripts[0].speech_final is True
+    assert len(rec.uploads) == 1
+
+
+async def test_audio_is_uploaded_as_a_valid_16k_mono_pcm16_wav(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    await _drain(stt)
+
+    with wave.open(io.BytesIO(rec.uploads[0]["wav"]), "rb") as wf:
+        assert wf.getnchannels() == 1
+        assert wf.getsampwidth() == 2
+        assert wf.getframerate() == 16000
+        # Every PCM byte we buffered made it into the upload.
+        assert wf.getnframes() == BUFFER_SIZE_BYTES // 2
+
+
+async def test_multipart_uses_fishs_documented_field_names(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url, language="it")
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    await _drain(stt)
+
+    upload = rec.uploads[0]
+    assert upload["authorization"] == "Bearer fish-test-key"
+    assert upload["language"] == "it"
+    assert upload["ignore_timestamps"] == "true"
+    assert upload["filename"] == "audio.wav"
+    assert upload["content_type"] == "audio/wav"
+
+
+async def test_ignore_timestamps_false_is_forwarded(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url, ignore_timestamps=False)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    await _drain(stt)
+    assert rec.uploads[0]["ignore_timestamps"] == "false"
+
+
+async def test_language_is_omitted_when_none_so_fish_auto_detects(
+    fish_asr_server,
+) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url, language=None)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    await _drain(stt)
+    assert rec.uploads[0]["language"] is None
+
+
+# ---------------------------------------------------------------------------
+# Buffering / flush semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_a_partial_window_is_not_uploaded_until_the_threshold(
+    fish_asr_server,
+) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES // 4))
+    assert rec.uploads == []
+    await stt.close()
+    await _drain(stt)
+
+
+async def test_a_short_tail_is_silence_padded_to_fishs_one_second_minimum(
+    fish_asr_server,
+) -> None:
+    """Fish rejects clips under 1 s; dropping the tail would lose the last
+    words of an utterance, so it is padded instead."""
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(1600))  # 50 ms — far under the 1 s minimum
+    await stt.close()
+    await _drain(stt)
+
+    assert len(rec.uploads) == 1
+    with wave.open(io.BytesIO(rec.uploads[0]["wav"]), "rb") as wf:
+        assert wf.getnframes() == MIN_AUDIO_BYTES // 2
+
+
+async def test_a_tail_already_over_the_minimum_is_not_padded(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    tail = MIN_AUDIO_BYTES + 4000
+    await stt.send_audio(_silence(tail))
+    await stt.close()
+    await _drain(stt)
+    with wave.open(io.BytesIO(rec.uploads[0]["wav"]), "rb") as wf:
+        assert wf.getnframes() == tail // 2
+
+
+async def test_multiple_windows_produce_multiple_transcripts(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    transcripts = await _drain(stt)
+    assert len(transcripts) == 2
+    assert len(rec.uploads) == 2
+
+
+async def test_a_custom_buffer_size_changes_the_upload_cadence(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    stt = _stt(url, buffer_size_bytes=MIN_AUDIO_BYTES)
+    await stt.connect()
+    await stt.send_audio(_silence(MIN_AUDIO_BYTES * 2))
+    await stt.close()
+    await _drain(stt)
+    assert len(rec.uploads) == 1  # one full window, nothing left over
+
+
+# ---------------------------------------------------------------------------
+# Failure handling — STT must never kill the call
+# ---------------------------------------------------------------------------
+
+
+async def test_a_server_error_is_logged_and_yields_no_transcript(
+    fish_asr_server,
+) -> None:
+    url, rec = fish_asr_server
+    rec.status = 402
+    rec.error_body = "insufficient credit"
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    assert await _drain(stt) == []
+
+
+async def test_an_unreachable_host_does_not_raise() -> None:
+    stt = _stt("http://127.0.0.1:1/v1/asr")
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    assert await _drain(stt) == []
+
+
+async def test_an_empty_transcript_is_dropped(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    rec.payload = {"text": "   ", "duration": 2.0}
+    stt = _stt(url)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    assert await _drain(stt) == []
+
+
+# ---------------------------------------------------------------------------
+# Response mapping
+# ---------------------------------------------------------------------------
+
+
+async def test_segments_are_surfaced_on_the_transcript(fish_asr_server) -> None:
+    url, rec = fish_asr_server
+    rec.payload = {
+        "text": "ciao mondo",
+        "duration": 2.0,
+        "segments": [
+            {"text": "ciao", "start": 0.0, "end": 0.4},
+            {"text": "mondo", "start": 0.4, "end": 1.1},
+        ],
+    }
+    stt = _stt(url, ignore_timestamps=False)
+    await stt.connect()
+    await stt.send_audio(_silence(BUFFER_SIZE_BYTES))
+    await stt.close()
+    transcripts = await _drain(stt)
+    assert len(transcripts[0].words) == 2
+    assert transcripts[0].words[0]["text"] == "ciao"
+
+
+def test_parse_maps_text_and_defaults_confidence_to_one() -> None:
+    t = _parse_asr_response({"text": " hello ", "duration": 1.0})
+    assert t is not None
+    assert (t.text, t.is_final, t.confidence, t.words) == ("hello", True, 1.0, ())
+
+
+def test_parse_returns_none_for_empty_or_malformed_payloads() -> None:
+    assert _parse_asr_response({"text": ""}) is None
+    assert _parse_asr_response({}) is None
+    assert _parse_asr_response("not a dict") is None
+    assert _parse_asr_response(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_falls_back_to_the_environment(monkeypatch) -> None:
+    monkeypatch.setenv("FISH_AUDIO_API_KEY", "env-key")
+    assert FishAudioSTT().api_key == "env-key"
+
+
+def test_missing_api_key_raises_a_pointed_error(monkeypatch) -> None:
+    monkeypatch.delenv("FISH_AUDIO_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="FISH_AUDIO_API_KEY"):
+        FishAudioSTT()
+
+
+def test_repr_never_leaks_the_api_key() -> None:
+    assert "super-secret" not in repr(FishAudioSTT(api_key="super-secret"))
+
+
+def test_for_twilio_matches_the_default_construction() -> None:
+    stt = FishAudioSTT.for_twilio(api_key="k", language="fr")
+    assert (stt.language, stt.sample_rate, stt.encoding) == ("fr", 16000, "linear16")
+
+
+def test_default_window_is_two_seconds_clear_of_fishs_one_second_floor() -> None:
+    assert BUFFER_SIZE_BYTES == MIN_AUDIO_BYTES * 2

--- a/libraries/python/tests/unit/test_fish_audio_tts.py
+++ b/libraries/python/tests/unit/test_fish_audio_tts.py
@@ -1,0 +1,319 @@
+"""Tests for the Fish Audio HTTP TTS provider.
+
+These run against a **real in-process aiohttp server** bound to 127.0.0.1 —
+only the Fish endpoint itself is simulated. Everything from the adapter inward
+(header assembly, JSON payload construction, prosody nesting, chunked response
+streaming, error surfacing, warmup, cost accounting) executes for real over a
+real socket. See ``.claude/rules/authentic-tests.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+from aiohttp import web
+
+from getpatter.audio.format import AudioFormat
+from getpatter.providers.fish_audio_tts import (
+    FishAudioFormat,
+    FishAudioLatency,
+    FishAudioModel,
+    FishAudioTTS,
+)
+
+pytestmark = pytest.mark.mocked
+
+
+class _Recorder:
+    """Captures what the adapter actually put on the wire."""
+
+    def __init__(self) -> None:
+        self.tts_headers: dict[str, str] = {}
+        self.tts_body: dict[str, Any] = {}
+        self.model_query: dict[str, str] = {}
+        self.model_hits = 0
+        self.status = 200
+        self.chunks: list[bytes] = [b"\x01\x02", b"\x03\x04", b"\x05\x06"]
+        self.error_body = ""
+
+
+@pytest.fixture
+async def fish_server() -> AsyncIterator[tuple[str, _Recorder]]:
+    rec = _Recorder()
+
+    async def tts_handler(request: web.Request) -> web.StreamResponse:
+        rec.tts_headers = dict(request.headers)
+        rec.tts_body = await request.json()
+        if rec.status != 200:
+            return web.Response(status=rec.status, text=rec.error_body)
+        resp = web.StreamResponse(status=200)
+        resp.content_type = "application/octet-stream"
+        await resp.prepare(request)
+        for chunk in rec.chunks:
+            await resp.write(chunk)
+        await resp.write_eof()
+        return resp
+
+    async def model_handler(request: web.Request) -> web.Response:
+        rec.model_hits += 1
+        rec.model_query = dict(request.query)
+        return web.json_response({"items": [], "total": 0})
+
+    app = web.Application()
+    app.router.add_post("/v1/tts", tts_handler)
+    app.router.add_get("/model", model_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    try:
+        yield f"http://{host}:{port}", rec
+    finally:
+        await runner.cleanup()
+
+
+def _tts(base: str, **kwargs: Any) -> FishAudioTTS:
+    return FishAudioTTS(api_key="fish-test-key", base_url=f"{base}/v1/tts", **kwargs)
+
+
+async def _collect(tts: FishAudioTTS, text: str) -> bytes:
+    out = bytearray()
+    async for chunk in tts.synthesize(text):
+        out.extend(chunk)
+    return bytes(out)
+
+
+async def test_streams_every_chunk_the_server_emits(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base)
+    try:
+        assert await _collect(tts, "ciao") == b"\x01\x02\x03\x04\x05\x06"
+    finally:
+        await tts.close()
+
+
+async def test_model_travels_in_a_header_not_the_body(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base, model=FishAudioModel.S2_PRO)
+    try:
+        await _collect(tts, "ciao")
+    finally:
+        await tts.close()
+    assert rec.tts_headers["model"] == "s2-pro"
+    assert rec.tts_headers["Authorization"] == "Bearer fish-test-key"
+    assert rec.tts_headers["Content-Type"] == "application/json"
+    assert "model" not in rec.tts_body
+
+
+async def test_defaults_are_s21pro_pcm_16k_balanced(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base)
+    try:
+        await _collect(tts, "hello")
+    finally:
+        await tts.close()
+    assert rec.tts_headers["model"] == "s2.1-pro"
+    assert rec.tts_body == {
+        "text": "hello",
+        "format": "pcm",
+        "latency": "balanced",
+        "sample_rate": 16000,
+    }
+
+
+async def test_unset_knobs_are_omitted_so_fish_applies_its_own_defaults(
+    fish_server,
+) -> None:
+    base, rec = fish_server
+    tts = _tts(base)
+    try:
+        await _collect(tts, "hello")
+    finally:
+        await tts.close()
+    for absent in (
+        "temperature",
+        "top_p",
+        "chunk_length",
+        "normalize",
+        "prosody",
+        "reference_id",
+        "max_new_tokens",
+    ):
+        assert absent not in rec.tts_body, f"{absent} should not be sent when unset"
+
+
+async def test_voice_string_maps_to_reference_id(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base, voice="ref-abc123")
+    try:
+        await _collect(tts, "hello")
+    finally:
+        await tts.close()
+    assert rec.tts_body["reference_id"] == "ref-abc123"
+
+
+async def test_voice_sequence_maps_to_multi_speaker_reference_ids(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base, voice=("spk-a", "spk-b"))
+    try:
+        await _collect(tts, "<|speaker:0|>Hi<|speaker:1|>Yo")
+    finally:
+        await tts.close()
+    assert rec.tts_body["reference_id"] == ["spk-a", "spk-b"]
+
+
+async def test_flat_speed_volume_loudness_collapse_into_nested_prosody(
+    fish_server,
+) -> None:
+    base, rec = fish_server
+    tts = _tts(base, speed=1.2, volume=-3.0, normalize_loudness=False)
+    try:
+        await _collect(tts, "hello")
+    finally:
+        await tts.close()
+    assert rec.tts_body["prosody"] == {
+        "speed": 1.2,
+        "volume": -3.0,
+        "normalize_loudness": False,
+    }
+
+
+async def test_sample_rate_is_sent_for_pcm_and_wav_but_not_mp3(fish_server) -> None:
+    base, rec = fish_server
+    for fmt, expected in (
+        (FishAudioFormat.PCM, True),
+        (FishAudioFormat.WAV, True),
+        (FishAudioFormat.MP3, False),
+        (FishAudioFormat.OPUS, False),
+    ):
+        tts = _tts(base, format=fmt, sample_rate=24000)
+        try:
+            await _collect(tts, "hello")
+        finally:
+            await tts.close()
+        assert ("sample_rate" in rec.tts_body) is expected, f"format={fmt}"
+
+
+async def test_latency_mode_is_forwarded(fish_server) -> None:
+    base, rec = fish_server
+    tts = _tts(base, latency=FishAudioLatency.LOW)
+    try:
+        await _collect(tts, "hello")
+    finally:
+        await tts.close()
+    assert rec.tts_body["latency"] == "low"
+
+
+async def test_non_200_raises_with_status_and_body(fish_server) -> None:
+    base, rec = fish_server
+    rec.status = 402
+    rec.error_body = json.dumps({"detail": "insufficient credit"})
+    tts = _tts(base)
+    try:
+        with pytest.raises(RuntimeError, match="Fish Audio TTS error 402"):
+            await _collect(tts, "hello")
+    finally:
+        await tts.close()
+
+
+async def test_warmup_hits_the_free_model_listing_not_the_billed_endpoint(
+    fish_server,
+) -> None:
+    base, rec = fish_server
+    tts = FishAudioTTS(api_key="fish-test-key", base_url=f"{base}/v1/tts")
+    # Point the module-level warmup URL at the local server for this test.
+    import getpatter.providers.fish_audio_tts as mod
+
+    original = mod.FISH_AUDIO_MODELS_URL
+    mod.FISH_AUDIO_MODELS_URL = f"{base}/model"
+    try:
+        await tts.warmup()
+    finally:
+        mod.FISH_AUDIO_MODELS_URL = original
+        await tts.close()
+    assert rec.model_hits == 1
+    assert rec.model_query == {"page_size": "1"}
+    # The billed synthesis endpoint was never touched.
+    assert rec.tts_body == {}
+
+
+async def test_warmup_never_raises_when_the_host_is_unreachable() -> None:
+    tts = FishAudioTTS(api_key="fish-test-key", base_url="http://127.0.0.1:1/v1/tts")
+    import getpatter.providers.fish_audio_tts as mod
+
+    original = mod.FISH_AUDIO_MODELS_URL
+    mod.FISH_AUDIO_MODELS_URL = "http://127.0.0.1:1/model"
+    try:
+        await tts.warmup()  # must not raise
+    finally:
+        mod.FISH_AUDIO_MODELS_URL = original
+        await tts.close()
+
+
+def test_source_audio_format_tracks_the_configured_sample_rate() -> None:
+    assert FishAudioTTS(api_key="k").source_audio_format() == AudioFormat(
+        encoding="pcm_s16le", sample_rate=16000
+    )
+    assert FishAudioTTS(api_key="k", sample_rate=24000).source_audio_format() == (
+        AudioFormat(encoding="pcm_s16le", sample_rate=24000)
+    )
+
+
+def test_for_twilio_requests_8k_pcm_so_the_pipeline_skips_the_resample() -> None:
+    tts = FishAudioTTS.for_twilio(api_key="k")
+    assert tts.format == FishAudioFormat.PCM
+    assert tts.source_audio_format() == AudioFormat(
+        encoding="pcm_s16le", sample_rate=8000
+    )
+
+
+def test_for_telnyx_keeps_the_16k_pipeline_rate() -> None:
+    tts = FishAudioTTS.for_telnyx(api_key="k")
+    assert tts.source_audio_format() == AudioFormat(
+        encoding="pcm_s16le", sample_rate=16000
+    )
+
+
+def test_carrier_factories_preserve_other_options() -> None:
+    tts = FishAudioTTS.for_twilio(api_key="k", model="s2-pro", voice="ref-1", speed=1.1)
+    assert (tts.model, tts.voice, tts.speed) == ("s2-pro", "ref-1", 1.1)
+
+
+def test_api_key_falls_back_to_the_environment(monkeypatch) -> None:
+    monkeypatch.setenv("FISH_AUDIO_API_KEY", "env-key")
+    assert FishAudioTTS().api_key == "env-key"
+
+
+def test_missing_api_key_raises_a_pointed_error(monkeypatch) -> None:
+    monkeypatch.delenv("FISH_AUDIO_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="FISH_AUDIO_API_KEY"):
+        FishAudioTTS()
+
+
+def test_repr_never_leaks_the_api_key() -> None:
+    assert "super-secret" not in repr(FishAudioTTS(api_key="super-secret"))
+
+
+async def test_cost_is_metered_in_utf8_bytes_not_characters(fish_server) -> None:
+    """Fish bills UTF-8 bytes; a CJK string costs ~3x its character count."""
+    base, _rec = fish_server
+    captured: list[dict] = []
+
+    import getpatter.observability.attributes as attrs
+
+    original = attrs.record_patter_attrs
+    attrs.record_patter_attrs = lambda payload: captured.append(payload)  # type: ignore[assignment]
+    tts = _tts(base)
+    try:
+        await _collect(tts, "你好世界")  # 4 chars, 12 UTF-8 bytes
+    finally:
+        attrs.record_patter_attrs = original  # type: ignore[assignment]
+        await tts.close()
+
+    assert captured, "synthesis should record a cost attribute"
+    assert captured[0]["patter.cost.tts_chars"] == 12
+    assert captured[0]["patter.tts.provider"] == "fish_audio"

--- a/libraries/python/tests/unit/test_fish_audio_ws_tts.py
+++ b/libraries/python/tests/unit/test_fish_audio_ws_tts.py
@@ -1,0 +1,241 @@
+"""Tests for the Fish Audio WebSocket TTS provider.
+
+These run against a **real in-process ``websockets`` server** on 127.0.0.1 that
+speaks the real MessagePack framing — only Fish's synthesis is simulated. The
+handshake headers, frame encode/decode, protocol ordering, audio reassembly,
+error surfacing and stall timeout all execute for real over a real socket.
+See ``.claude/rules/authentic-tests.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+import websockets
+
+from getpatter.providers.fish_audio_ws_tts import (
+    FishAudioWebSocketTTS,
+    FishAudioWSError,
+    _decode_server_frame,
+)
+
+ormsgpack = pytest.importorskip(
+    "ormsgpack", reason="the [fish_audio] extra provides the msgpack codec"
+)
+
+pytestmark = pytest.mark.mocked
+
+
+class _WSRecorder:
+    def __init__(self) -> None:
+        # The raw ``websockets`` Headers object (case-insensitive lookup).
+        self.headers: Any = {}
+        self.events: list[dict[str, Any]] = []
+        self.audio_frames: list[bytes] = [b"\xaa\xbb", b"\xcc\xdd"]
+        self.finish_reason: str = "stop"
+        self.finish_message: str | None = None
+        self.stall: bool = False
+
+
+@pytest.fixture
+async def fish_ws_server() -> AsyncIterator[tuple[str, _WSRecorder]]:
+    rec = _WSRecorder()
+
+    async def handler(ws: Any) -> None:
+        rec.headers = ws.request.headers
+        try:
+            async for raw in ws:
+                event = ormsgpack.unpackb(raw)
+                rec.events.append(event)
+                if event.get("event") != "stop":
+                    continue
+                if rec.stall:
+                    await asyncio.sleep(5)
+                    return
+                for frame in rec.audio_frames:
+                    await ws.send(ormsgpack.packb({"event": "audio", "audio": frame}))
+                finish: dict[str, Any] = {
+                    "event": "finish",
+                    "reason": rec.finish_reason,
+                }
+                if rec.finish_message is not None:
+                    finish["message"] = rec.finish_message
+                await ws.send(ormsgpack.packb(finish))
+                return
+        except websockets.exceptions.ConnectionClosed:  # pragma: no cover - teardown
+            return
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        yield f"ws://127.0.0.1:{port}", rec
+
+
+def _ws_tts(url: str, **kwargs: Any) -> FishAudioWebSocketTTS:
+    return FishAudioWebSocketTTS(api_key="fish-test-key", ws_url=url, **kwargs)
+
+
+async def _collect(tts: FishAudioWebSocketTTS, text: str) -> bytes:
+    out = bytearray()
+    async for chunk in tts.synthesize(text):
+        out.extend(chunk)
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# Model guard — the reason this class exists as a separate adapter.
+# ---------------------------------------------------------------------------
+
+
+def test_s21_pro_is_rejected_up_front_with_a_pointer_to_the_http_adapter() -> None:
+    with pytest.raises(ValueError) as exc:
+        FishAudioWebSocketTTS(api_key="k", model="s2.1-pro")
+    assert "FishAudioTTS" in str(exc.value)
+    assert "/v1/tts/live" in str(exc.value)
+
+
+def test_s21_pro_free_is_rejected_too() -> None:
+    with pytest.raises(ValueError):
+        FishAudioWebSocketTTS(api_key="k", model="s2.1-pro-free")
+
+
+@pytest.mark.parametrize("model", ["s1", "s2-pro"])
+def test_socket_supported_models_are_accepted(model: str) -> None:
+    assert FishAudioWebSocketTTS(api_key="k", model=model).model == model
+
+
+def test_default_model_is_s2_pro_the_fastest_socket_model() -> None:
+    assert FishAudioWebSocketTTS(api_key="k").model == "s2-pro"
+
+
+# ---------------------------------------------------------------------------
+# Live protocol against a real socket.
+# ---------------------------------------------------------------------------
+
+
+async def test_audio_frames_are_reassembled_in_order(fish_ws_server) -> None:
+    url, rec = fish_ws_server
+    tts = _ws_tts(url)
+    try:
+        assert await _collect(tts, "ciao") == b"\xaa\xbb\xcc\xdd"
+    finally:
+        await tts.close()
+
+
+async def test_protocol_is_start_text_flush_stop(fish_ws_server) -> None:
+    url, rec = fish_ws_server
+    tts = _ws_tts(url)
+    try:
+        await _collect(tts, "ciao mondo")
+    finally:
+        await tts.close()
+    assert [e["event"] for e in rec.events] == ["start", "text", "flush", "stop"]
+    assert rec.events[1]["text"] == "ciao mondo"
+
+
+async def test_start_frame_carries_the_config_with_empty_text(fish_ws_server) -> None:
+    url, rec = fish_ws_server
+    tts = _ws_tts(url, voice="ref-1", sample_rate=8000)
+    try:
+        await _collect(tts, "ciao")
+    finally:
+        await tts.close()
+    request = rec.events[0]["request"]
+    assert request["text"] == ""
+    assert request["format"] == "pcm"
+    assert request["sample_rate"] == 8000
+    assert request["reference_id"] == "ref-1"
+
+
+async def test_handshake_sends_bearer_auth_and_the_model_header(fish_ws_server) -> None:
+    url, rec = fish_ws_server
+    tts = _ws_tts(url, model="s1")
+    try:
+        await _collect(tts, "ciao")
+    finally:
+        await tts.close()
+    assert rec.headers["Authorization"] == "Bearer fish-test-key"
+    assert rec.headers["model"] == "s1"
+
+
+async def test_finish_with_reason_error_raises(fish_ws_server) -> None:
+    url, rec = fish_ws_server
+    rec.finish_reason = "error"
+    rec.finish_message = "voice model not found"
+    tts = _ws_tts(url)
+    try:
+        with pytest.raises(FishAudioWSError, match="voice model not found"):
+            await _collect(tts, "ciao")
+    finally:
+        await tts.close()
+
+
+async def test_a_stalled_server_raises_instead_of_hanging_the_call(
+    fish_ws_server,
+) -> None:
+    url, rec = fish_ws_server
+    rec.stall = True
+    tts = _ws_tts(url, frame_timeout=0.2)
+    try:
+        with pytest.raises(FishAudioWSError, match="stalled"):
+            await _collect(tts, "ciao")
+    finally:
+        await tts.close()
+
+
+async def test_a_server_that_closes_without_finish_ends_the_stream_cleanly(
+    fish_ws_server,
+) -> None:
+    url, rec = fish_ws_server
+    rec.audio_frames = [b"\x01"]
+    rec.finish_reason = "stop"
+    tts = _ws_tts(url)
+    try:
+        assert await _collect(tts, "ciao") == b"\x01"
+    finally:
+        await tts.close()
+
+
+# ---------------------------------------------------------------------------
+# Frame decoding edge cases.
+# ---------------------------------------------------------------------------
+
+
+def test_log_and_unknown_frames_are_skipped_without_ending_the_stream() -> None:
+    unpackb = ormsgpack.unpackb
+    for frame in (
+        ormsgpack.packb({"event": "log", "message": "warming up"}),
+        ormsgpack.packb({"event": "some-future-event"}),
+        ormsgpack.packb([1, 2, 3]),
+    ):
+        assert _decode_server_frame(frame, unpackb) == (None, False)
+
+
+def test_text_frames_are_ignored_rather_than_crashing_the_stream() -> None:
+    assert _decode_server_frame("unexpected text", ormsgpack.unpackb) == (None, False)
+
+
+def test_an_undecodable_frame_raises_a_typed_error() -> None:
+    with pytest.raises(FishAudioWSError, match="undecodable"):
+        # 0x81 announces a 1-pair map and then ends — a truncated frame.
+        _decode_server_frame(b"\x81", ormsgpack.unpackb)
+
+
+def test_an_oversized_audio_frame_is_rejected() -> None:
+    from getpatter.providers.fish_audio_ws_tts import MAX_AUDIO_FRAME_SIZE
+
+    huge = ormsgpack.packb(
+        {"event": "audio", "audio": b"\x00" * (MAX_AUDIO_FRAME_SIZE + 1)}
+    )
+    with pytest.raises(FishAudioWSError, match="sanity limit"):
+        _decode_server_frame(huge, ormsgpack.unpackb)
+
+
+def test_an_audio_frame_without_bytes_is_skipped() -> None:
+    frame = ormsgpack.packb({"event": "audio", "audio": None})
+    assert _decode_server_frame(frame, ormsgpack.unpackb) == (None, False)
+
+
+def test_repr_never_leaks_the_api_key() -> None:
+    assert "super-secret" not in repr(FishAudioWebSocketTTS(api_key="super-secret"))

--- a/libraries/typescript/.env.example
+++ b/libraries/typescript/.env.example
@@ -55,6 +55,8 @@
 # ELEVENLABS_AGENT_ID=
 # LMNT_API_KEY=
 # RIME_API_KEY=
+# Fish Audio — one key covers both TTS (s2.1-pro / s2-pro) and ASR.
+# FISH_AUDIO_API_KEY=
 
 # ------------------------------------------------------------
 # Tracing (OpenTelemetry)

--- a/libraries/typescript/README.md
+++ b/libraries/typescript/README.md
@@ -81,6 +81,7 @@ Every provider reads its credentials from the environment by default. Pass `apiK
 | `CARTESIA_API_KEY` | `CartesiaSTT`, `CartesiaTTS` |
 | `RIME_API_KEY` | `RimeTTS` |
 | `LMNT_API_KEY` | `LMNTTTS` |
+| `FISH_AUDIO_API_KEY` | `FishAudioTTS`, `FishAudioSTT` |
 | `SONIOX_API_KEY` | `SonioxSTT` |
 | `ASSEMBLYAI_API_KEY` | `AssemblyAISTT` |
 | `ANTHROPIC_API_KEY` | `AnthropicLLM` |

--- a/libraries/typescript/package-lock.json
+++ b/libraries/typescript/package-lock.json
@@ -31,6 +31,7 @@
       "optionalDependencies": {
         "@huggingface/transformers": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@msgpack/msgpack": "^3.0.0",
         "cloudflared": "^0.7.1",
         "node-cron": "^4.0.0",
         "onnxruntime-node": "~1.18.0"
@@ -1289,6 +1290,16 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -73,6 +73,7 @@
   "optionalDependencies": {
     "@huggingface/transformers": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@msgpack/msgpack": "^3.0.0",
     "cloudflared": "^0.7.1",
     "node-cron": "^4.0.0",
     "onnxruntime-node": "~1.18.0"

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -68,6 +68,8 @@ export {
   inworld,
   sonioxTts,
   sarvam,
+  fishAudio,
+  fishAudioAsr,
   ultravox,
   geminiLive,
 } from "./providers";
@@ -193,6 +195,9 @@ export type { CartesiaSTTOptions } from "./stt/cartesia";
 export { STT as SonioxSTT } from "./stt/soniox";
 export { STT as XaiSTT } from "./stt/xai";
 export type { XaiSTTOptions } from "./stt/xai";
+export { STT as FishAudioSTT } from "./stt/fish-audio";
+export type { FishAudioSTTOptions } from "./stt/fish-audio";
+export type { FishAudioSegment } from "./providers/fish-audio-stt";
 export { STT as AssemblyAISTT } from "./stt/assemblyai";
 export type { AssemblyAISTTOptions } from "./stt/assemblyai";
 export { STT as SpeechmaticsSTT } from "./stt/speechmatics";
@@ -234,6 +239,13 @@ export { TTS as SarvamTTS } from "./tts/sarvam";
 export type { SarvamTTSOptions, SarvamCarrierOptions } from "./tts/sarvam";
 export { TTS as XaiTTS } from "./tts/xai";
 export type { XaiTTSOptions, XaiCarrierOptions } from "./tts/xai";
+export { TTS as FishAudioTTS, WebSocketTTS as FishAudioWebSocketTTS } from "./tts/fish-audio";
+export type {
+  FishAudioTTSOptions,
+  FishAudioWebSocketTTSOptions,
+  FishAudioCarrierOptions,
+} from "./tts/fish-audio";
+export { FishAudioModel, FishAudioFormat, FishAudioLatency } from "./providers/fish-audio-tts";
 
 // New namespaced LLM classes (Phase 2 of the v0.5.x API refactor).
 export { LLM as OpenAILLM } from "./llm/openai";

--- a/libraries/typescript/src/init/cli.ts
+++ b/libraries/typescript/src/init/cli.ts
@@ -119,6 +119,12 @@ const PIPELINE_STT: Record<string, ProviderEntry> = {
     env: ['OPENAI_API_KEY'],
     extra: '',
   },
+  fish_audio: {
+    cls: 'FishAudioSTT',
+    label: 'Fish Audio (batch — higher latency)',
+    env: ['FISH_AUDIO_API_KEY'],
+    extra: 'fish_audio',
+  },
 };
 const DEFAULT_STT = 'deepgram';
 
@@ -194,6 +200,12 @@ const PIPELINE_TTS: Record<string, ProviderEntry> = {
     label: 'Inworld',
     env: ['INWORLD_API_KEY'],
     extra: 'inworld',
+  },
+  fish_audio: {
+    cls: 'FishAudioTTS',
+    label: 'Fish Audio (s2.1-pro)',
+    env: ['FISH_AUDIO_API_KEY'],
+    extra: 'fish_audio',
   },
 };
 const DEFAULT_TTS = 'elevenlabs';

--- a/libraries/typescript/src/pricing.ts
+++ b/libraries/typescript/src/pricing.ts
@@ -292,6 +292,26 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
   // xAI TTS — $15.00 / 1M chars = $0.000015/char = $0.015 / 1k chars.
   // Source: docs.x.ai/developers/pricing.
   xai_tts: { unit: PricingUnit.THOUSAND_CHARS, price: 0.015 },
+  // Fish Audio TTS — $15.00 / 1M UTF-8 BYTES = $0.015 / 1k bytes. Fish meters
+  // bytes, not characters, so the adapter reports UTF-8 byte length as the
+  // "chars" figure — exact for latin scripts, and correctly ~3x higher for CJK
+  // where one character is three bytes. `s2.1-pro-free` is the free tier and
+  // bills nothing. Source:
+  // https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits
+  fish_audio: {
+    unit: PricingUnit.THOUSAND_CHARS,
+    // Default = s2.1-pro.
+    price: 0.015,
+    models: {
+      's2.1-pro': { price: 0.015 },
+      's2.1-pro-free': { price: 0.0 },
+      's2-pro': { price: 0.015 },
+      s1: { price: 0.015 },
+    },
+  },
+  // Fish Audio ASR (transcribe-1) — $0.36 / audio hour = $0.006 / minute,
+  // rounded up to the nearest second by Fish.
+  fish_audio_stt: { unit: PricingUnit.MINUTE, price: 0.006 },
   // Sarvam AI Bulbul TTS — per 1,000 characters. INR is authoritative; USD is an
   // indicative FX conversion (~Rs 83-84/USD). Bulbul v3 (default): Rs 30 / 10k
   // chars ≈ $0.036/1k; Bulbul v2: Rs 15 / 10k ≈ $0.018/1k. Billed per character,

--- a/libraries/typescript/src/providers.ts
+++ b/libraries/typescript/src/providers.ts
@@ -167,6 +167,28 @@ export function sarvam(opts: { apiKey: string; voice?: string }): TTSConfig {
   return new TTSConfigImpl("sarvam", opts.apiKey, opts.voice ?? "shubh");
 }
 
+/**
+ * Fish Audio TTS config helper (parity with Python ``getpatter.providers.fish_audio``).
+ *
+ * ``voice`` is a Fish ``reference_id`` — a voice-model id from the Fish voice
+ * library or one you cloned. Leave it empty to use the model's built-in voice.
+ * For pipeline use the documented path is the direct adapter
+ * ``new FishAudioTTS({...})`` from ``getpatter``.
+ */
+export function fishAudio(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl("fish_audio", opts.apiKey, opts.voice ?? "");
+}
+
+/**
+ * Fish Audio ASR config helper (parity with Python
+ * ``getpatter.providers.fish_audio_asr``). Fish transcription is a batch
+ * endpoint, so the adapter uploads short windows instead of streaming — see
+ * ``FishAudioSTT`` for the latency trade-off against Deepgram / Soniox.
+ */
+export function fishAudioAsr(opts: { apiKey: string; language?: string }): STTConfig {
+  return new STTConfigImpl("fish_audio", opts.apiKey, opts.language ?? "en");
+}
+
 // ---------------------------------------------------------------------------
 // Realtime / ConvAI helpers
 // ---------------------------------------------------------------------------

--- a/libraries/typescript/src/providers/fish-audio-stt.ts
+++ b/libraries/typescript/src/providers/fish-audio-stt.ts
@@ -1,0 +1,300 @@
+/**
+ * Fish Audio Speech-to-Text adapter for the Patter SDK pipeline mode.
+ *
+ * **Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+ * exercised against a live phone call.**
+ *
+ * Fish exposes transcription as a **batch** endpoint only
+ * (`POST https://api.fish.audio/v1/asr`) — there is no streaming socket. This
+ * adapter therefore follows the same buffer-and-POST shape as
+ * {@link WhisperSTT}: incoming PCM is accumulated, uploaded as a WAV once the
+ * window fills, and the resulting text is emitted as a final transcript.
+ *
+ * Latency consequence: transcripts arrive in ~2 s windows rather than as
+ * interim partials. For latency-sensitive agents prefer a genuinely streaming
+ * STT (Deepgram, Soniox, AssemblyAI, Speechmatics). Use this adapter when you
+ * want a single vendor for both directions of the call, or for Fish's language
+ * coverage.
+ *
+ * Credential: `FISH_AUDIO_API_KEY`. Auth is an `Authorization: Bearer <key>` header.
+ */
+
+import { getLogger } from '../logger';
+import { FISH_AUDIO_API_ORIGIN } from './fish-audio-tts';
+
+/** Fish Audio batch transcription endpoint. */
+export const FISH_AUDIO_ASR_URL = `${FISH_AUDIO_API_ORIGIN}/v1/asr`;
+
+/** The adapter always uploads 16 kHz / 16-bit / mono WAV. */
+const STT_SAMPLE_RATE = 16000;
+const BYTES_PER_SECOND = STT_SAMPLE_RATE * 2;
+
+/**
+ * ~2 s of audio per upload. Fish rejects clips under 1 second, so a 1 s window
+ * (what {@link WhisperSTT} uses) would sit exactly on the boundary; 2 s keeps
+ * every steady-state upload comfortably inside the accepted range and halves
+ * the request count.
+ */
+export const DEFAULT_BUFFER_SIZE = BYTES_PER_SECOND * 2;
+
+/** Fish's documented minimum clip length — shorter tails are silence-padded. */
+const MIN_AUDIO_BYTES = BYTES_PER_SECOND;
+
+/** Fish's documented per-request ceiling (20 MB). */
+const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
+
+/** One timed segment from a Fish transcription (only when timestamps are requested). */
+export interface FishAudioSegment {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Patter-normalised transcript event emitted by {@link FishAudioSTT}. */
+export interface Transcript {
+  readonly text: string;
+  readonly isFinal: boolean;
+  readonly confidence: number;
+  /** Per-segment timings, populated only when `ignoreTimestamps` is false. */
+  readonly segments?: readonly FishAudioSegment[];
+}
+
+type TranscriptCallback = (transcript: Transcript) => void;
+
+/** Constructor options for {@link FishAudioSTT}. */
+export interface FishAudioSTTOptions {
+  /**
+   * `true` (default) skips segment timing, which Fish documents as the
+   * lower-latency path for clips under 30 s. Set `false` to receive
+   * per-segment `start` / `end` on the transcript.
+   */
+  ignoreTimestamps?: boolean;
+  /** Bytes of 16 kHz PCM16 to accumulate before each upload. Default ~2 s. */
+  bufferSize?: number;
+  /** Override the REST endpoint (e.g. for tests). */
+  baseUrl?: string;
+}
+
+/**
+ * Wrap raw PCM16 data in a minimal WAV container (RIFF header + data).
+ *
+ * Kept local to the provider, matching `whisper-stt.ts` / `telnyx-stt.ts` /
+ * `gemini-stt.ts`, which each carry their own copy.
+ */
+function wrapPcmInWav(pcm: Buffer, sampleRate: number = STT_SAMPLE_RATE): Buffer {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const dataSize = pcm.length;
+  const header = Buffer.alloc(44);
+
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write('WAVE', 8);
+
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * channels * (bitsPerSample / 8), 28);
+  header.writeUInt16LE(channels * (bitsPerSample / 8), 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+
+  header.write('data', 36);
+  header.writeUInt32LE(dataSize, 40);
+
+  return Buffer.concat([header, pcm]);
+}
+
+/** Buffered STT adapter for Fish Audio's batch transcription HTTP API. */
+export class FishAudioSTT {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey: string = 'fish_audio_stt';
+
+  private readonly apiKey: string;
+  private readonly language: string | undefined;
+  private readonly ignoreTimestamps: boolean;
+  private readonly bufferSize: number;
+  private readonly baseUrl: string;
+  // Accumulate chunks in an array and concat once on flush — avoids the
+  // per-`sendAudio` O(n) concat that dominates CPU on 20 ms carrier frames.
+  private chunks: Buffer[] = [];
+  private bufferedBytes = 0;
+  private callbacks: Set<TranscriptCallback> = new Set();
+  private running = false;
+  private pendingTranscriptions: Promise<void>[] = [];
+  /** Construction args replayed by clone(). */
+  private readonly patterCtorArgs: unknown[];
+
+  /**
+   * @param apiKey Fish Audio API key.
+   * @param language ISO language code (e.g. `"en"`). Omit to let Fish auto-detect.
+   * @param opts Optional tuning — see {@link FishAudioSTTOptions}.
+   *
+   * Argument order matches the Python SDK's
+   * `FishAudioSTT(api_key, language, *, ignore_timestamps=...)`.
+   */
+  constructor(apiKey: string, language?: string, opts: FishAudioSTTOptions = {}) {
+    if (!apiKey) {
+      throw new Error('Fish Audio STT: apiKey is required');
+    }
+    this.patterCtorArgs = [apiKey, language, opts];
+    this.apiKey = apiKey;
+    this.language = language;
+    this.ignoreTimestamps = opts.ignoreTimestamps ?? true;
+    this.bufferSize = opts.bufferSize ?? DEFAULT_BUFFER_SIZE;
+    this.baseUrl = opts.baseUrl ?? FISH_AUDIO_ASR_URL;
+  }
+
+  /** Factory for Twilio calls — μ-law 8 kHz is transcoded upstream to PCM16 16 kHz. */
+  static forTwilio(
+    apiKey: string,
+    language: string = 'en',
+    opts: FishAudioSTTOptions = {},
+  ): FishAudioSTT {
+    return new FishAudioSTT(apiKey, language, opts);
+  }
+
+  /**
+   * Fresh adapter built with this instance's construction arguments — called
+   * per call by the stream handler so concurrent calls never share buffer state.
+   */
+  clone(): this {
+    const ctor = this.constructor as new (...args: unknown[]) => this;
+    return new ctor(...this.patterCtorArgs);
+  }
+
+  /** Reset the audio buffer and arm the adapter for incoming chunks. */
+  async connect(): Promise<void> {
+    this.running = true;
+    this.chunks = [];
+    this.bufferedBytes = 0;
+  }
+
+  /** Buffer a PCM16 chunk; uploads to Fish once `bufferSize` bytes are reached. */
+  sendAudio(audio: Buffer): void {
+    if (!this.running) return;
+
+    this.chunks.push(audio);
+    this.bufferedBytes += audio.length;
+
+    if (this.bufferedBytes >= this.bufferSize) {
+      const pcm = this.flushChunks();
+      this.trackTranscription(this.transcribeBuffer(pcm));
+    }
+  }
+
+  /** Register a transcript listener. */
+  onTranscript(callback: TranscriptCallback): void {
+    this.callbacks.add(callback);
+  }
+
+  /** Remove a previously registered transcript listener. */
+  offTranscript(callback: TranscriptCallback): void {
+    this.callbacks.delete(callback);
+  }
+
+  /**
+   * Flush buffered audio, await pending uploads, and clear listeners.
+   *
+   * Fish rejects clips shorter than 1 second, so a short tail is padded with
+   * digital silence up to the minimum rather than dropped — the alternative
+   * would silently lose the last words of an utterance, the exact bug that was
+   * fixed on the Whisper adapter.
+   */
+  async close(): Promise<void> {
+    this.running = false;
+
+    if (this.bufferedBytes > 0) {
+      let pcm = this.flushChunks();
+      if (pcm.length < MIN_AUDIO_BYTES) {
+        pcm = Buffer.concat([pcm, Buffer.alloc(MIN_AUDIO_BYTES - pcm.length)]);
+      }
+      this.trackTranscription(this.transcribeBuffer(pcm));
+    }
+
+    await Promise.allSettled(this.pendingTranscriptions);
+    this.callbacks.clear();
+  }
+
+  // ------------------------------------------------------------------
+  // Private
+  // ------------------------------------------------------------------
+
+  private flushChunks(): Buffer {
+    const pcm =
+      this.chunks.length === 1
+        ? this.chunks[0]
+        : Buffer.concat(this.chunks, this.bufferedBytes);
+    this.chunks = [];
+    this.bufferedBytes = 0;
+    return pcm;
+  }
+
+  private trackTranscription(promise: Promise<void>): void {
+    const wrapped = promise.finally(() => {
+      const idx = this.pendingTranscriptions.indexOf(wrapped);
+      if (idx !== -1) this.pendingTranscriptions.splice(idx, 1);
+    });
+    this.pendingTranscriptions.push(wrapped);
+  }
+
+  private async transcribeBuffer(pcmInput: Buffer): Promise<void> {
+    let pcm = pcmInput;
+    if (pcm.length > MAX_UPLOAD_BYTES) {
+      getLogger().warn(
+        `Fish Audio STT buffer is ${pcm.length} bytes, over the ` +
+          `${MAX_UPLOAD_BYTES}-byte per-request limit; truncating to the most recent audio.`,
+      );
+      pcm = pcm.subarray(pcm.length - MAX_UPLOAD_BYTES);
+    }
+
+    const wav = wrapPcmInWav(pcm);
+    const bytes = wav.buffer.slice(
+      wav.byteOffset,
+      wav.byteOffset + wav.byteLength,
+    ) as BlobPart;
+
+    const formData = new FormData();
+    formData.append('audio', new Blob([bytes], { type: 'audio/wav' }), 'audio.wav');
+    if (this.language) formData.append('language', this.language);
+    formData.append('ignore_timestamps', this.ignoreTimestamps ? 'true' : 'false');
+
+    try {
+      const resp = await fetch(this.baseUrl, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        body: formData,
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!resp.ok) {
+        const body = await resp.text();
+        getLogger().error(`Fish Audio STT error: ${resp.status} ${body}`);
+        return;
+      }
+
+      const json = (await resp.json()) as {
+        text?: string;
+        duration?: number;
+        segments?: FishAudioSegment[];
+      };
+      const text = (json.text ?? '').trim();
+      if (!text) return;
+
+      // Fish reports no confidence score, so it is fixed at 1.0.
+      const transcript: Transcript = {
+        text,
+        isFinal: true,
+        confidence: 1.0,
+        ...(Array.isArray(json.segments) ? { segments: json.segments } : {}),
+      };
+
+      for (const cb of this.callbacks) {
+        cb(transcript);
+      }
+    } catch (err) {
+      getLogger().error(`Fish Audio STT transcription error: ${String(err)}`);
+    }
+  }
+}

--- a/libraries/typescript/src/providers/fish-audio-tts.ts
+++ b/libraries/typescript/src/providers/fish-audio-tts.ts
@@ -1,0 +1,347 @@
+/**
+ * Fish Audio Text-to-Speech provider — HTTP streaming `/v1/tts` endpoint.
+ *
+ * **Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+ * exercised against a live phone call.**
+ *
+ * Calls `POST https://api.fish.audio/v1/tts`, which streams the synthesised
+ * audio back with chunked transfer encoding. The model is selected with a
+ * `model:` request HEADER (not a body field), so one key serves `s2.1-pro`,
+ * `s2-pro`, `s1` and the free tier without reconnecting.
+ *
+ * Default output is raw PCM16-LE @ 16 kHz (`format: "pcm"`) so chunks drop
+ * straight into the Patter pipeline with no transcoding — the same choice made
+ * for LMNT (`raw`) and Inworld (`PCM`).
+ *
+ * Model families (see {@link FishAudioModel}):
+ * - `s2.1-pro`      — recommended production model. 83 languages, multi-speaker,
+ *                     natural-language expression control via `[brackets]`.
+ * - `s2.1-pro-free` — same model on the free tier. No time-to-first-audio
+ *                     guarantee, so it is NOT the default here: a voice agent
+ *                     that stalls mid-call is worse than one that costs money.
+ * - `s2-pro`        — previous generation, ~100 ms time-to-first-audio. Also the
+ *                     only S2 model reachable over the WebSocket transport
+ *                     (see {@link FishAudioWebSocketTTS}).
+ * - `s1`            — legacy. Emotion control uses `(parentheses)`.
+ *
+ * Credential: `FISH_AUDIO_API_KEY`. Auth is an `Authorization: Bearer <key>` header.
+ *
+ * **Telephony** — Fish emits linear PCM only (no native G.711), so the pipeline
+ * always runs the μ-law encode. {@link FishAudioTTS.forTwilio} requests PCM
+ * directly at 8 kHz so the resample step is skipped;
+ * {@link FishAudioTTS.forTelnyx} keeps the 16 kHz pipeline rate.
+ */
+
+/** Fish Audio API origin — shared by the TTS, ASR and model-listing endpoints. */
+export const FISH_AUDIO_API_ORIGIN = 'https://api.fish.audio';
+/** HTTP streaming text-to-speech endpoint. */
+export const FISH_AUDIO_TTS_URL = `${FISH_AUDIO_API_ORIGIN}/v1/tts`;
+/** Voice-model listing — a free metadata read, used as the warmup target. */
+export const FISH_AUDIO_MODELS_URL = `${FISH_AUDIO_API_ORIGIN}/model`;
+
+/** Pipeline-friendly default sample rate (Hz). */
+export const FISH_AUDIO_DEFAULT_SAMPLE_RATE = 16000;
+
+/** Fish Audio TTS model ids, passed via the `model:` request header. */
+export const FishAudioModel = {
+  S2_1_PRO: 's2.1-pro',
+  S2_1_PRO_FREE: 's2.1-pro-free',
+  S2_PRO: 's2-pro',
+  S1: 's1',
+} as const;
+export type FishAudioModel = (typeof FishAudioModel)[keyof typeof FishAudioModel];
+
+/** Output container/codec. Only `PCM` is pipeline-compatible. */
+export const FishAudioFormat = {
+  PCM: 'pcm',
+  WAV: 'wav',
+  MP3: 'mp3',
+  OPUS: 'opus',
+} as const;
+export type FishAudioFormat = (typeof FishAudioFormat)[keyof typeof FishAudioFormat];
+
+/**
+ * Latency/quality trade-off. `NORMAL` favours quality (~500 ms), `BALANCED` is
+ * the interactive sweet spot (~300 ms) and is Patter's default, `LOW` trades
+ * quality for the fastest possible first chunk.
+ */
+export const FishAudioLatency = {
+  LOW: 'low',
+  BALANCED: 'balanced',
+  NORMAL: 'normal',
+} as const;
+export type FishAudioLatency = (typeof FishAudioLatency)[keyof typeof FishAudioLatency];
+
+/** Constructor options for {@link FishAudioTTS}. */
+export interface FishAudioTTSOptions {
+  /** Model id. Defaults to `"s2.1-pro"`. */
+  model?: FishAudioModel | string;
+  /**
+   * Fish `reference_id` — a voice-model id from the Fish voice library or one
+   * you cloned. Omit to use the model's built-in voice. Pass an array for
+   * multi-speaker synthesis and mark speakers inline with `<|speaker:0|>`.
+   */
+  voice?: string | readonly string[];
+  /** Output format. Defaults to `"pcm"` (the only pipeline-compatible one). */
+  format?: FishAudioFormat | string;
+  /** Output sample rate in Hz (pcm/wav only). Defaults to 16000. */
+  sampleRate?: number;
+  /** Latency mode. Defaults to `"balanced"`. */
+  latency?: FishAudioLatency | string;
+  /** Speaking-rate multiplier in `[0.5, 2.0]`. */
+  speed?: number;
+  /** Volume adjustment in dB, `[-20, +20]`. */
+  volume?: number;
+  /** Loudness normalisation (S2-Pro only). */
+  normalizeLoudness?: boolean;
+  /** Expressiveness sampling temperature in `[0, 1]` (Fish default 0.7). */
+  temperature?: number;
+  /** Nucleus sampling in `[0, 1]` (Fish default 0.7). */
+  topP?: number;
+  /** Text segment size in `[100, 300]` (Fish default 300). */
+  chunkLength?: number;
+  /** Minimum chunk size in `[0, 100]` characters (Fish default 50). */
+  minChunkLength?: number;
+  /** Normalise English/Chinese text before synthesis (Fish default true). */
+  normalize?: boolean;
+  /** Max tokens generated per chunk (Fish default 1024). */
+  maxNewTokens?: number;
+  /** Repetition penalty (Fish default 1.2). */
+  repetitionPenalty?: number;
+  /** Condition each chunk on the previously generated audio (Fish default true). */
+  conditionOnPreviousChunks?: boolean;
+  /** Batch early-stop threshold in `[0, 1]` (Fish default 1). */
+  earlyStopThreshold?: number;
+  /** MP3 bitrate in kbps: 64 | 128 | 192. */
+  mp3Bitrate?: number;
+  /** Opus bitrate in bps: -1000 (auto) | 24000 | 32000 | 48000 | 64000. */
+  opusBitrate?: number;
+  /** Override the REST endpoint (e.g. for tests or an on-prem proxy). */
+  baseUrl?: string;
+}
+
+/** Options for the carrier-specific factories — same minus `format`/`sampleRate`. */
+export type FishAudioCarrierOptions = Omit<FishAudioTTSOptions, 'format' | 'sampleRate'>;
+
+/** Fish Audio TTS adapter backed by the HTTP `/v1/tts` streaming endpoint. */
+export class FishAudioTTS {
+  /** Stable pricing/dashboard key — read by stream-handler/metrics. */
+  static readonly providerKey = 'fish_audio';
+
+  protected readonly apiKey: string;
+  readonly model: string;
+  readonly voice?: string | readonly string[];
+  readonly format: string;
+  readonly sampleRate: number;
+  readonly latency: string;
+  private readonly speed?: number;
+  private readonly volume?: number;
+  private readonly normalizeLoudness?: boolean;
+  private readonly temperature?: number;
+  private readonly topP?: number;
+  private readonly chunkLength?: number;
+  private readonly minChunkLength?: number;
+  private readonly normalize?: boolean;
+  private readonly maxNewTokens?: number;
+  private readonly repetitionPenalty?: number;
+  private readonly conditionOnPreviousChunks?: boolean;
+  private readonly earlyStopThreshold?: number;
+  private readonly mp3Bitrate?: number;
+  private readonly opusBitrate?: number;
+  protected readonly baseUrl: string;
+
+  constructor(apiKey: string, opts: FishAudioTTSOptions = {}) {
+    if (!apiKey) {
+      throw new Error('Fish Audio TTS: apiKey is required');
+    }
+    this.apiKey = apiKey;
+    this.model = opts.model ?? FishAudioModel.S2_1_PRO;
+    this.voice = opts.voice;
+    this.format = opts.format ?? FishAudioFormat.PCM;
+    this.sampleRate = opts.sampleRate ?? FISH_AUDIO_DEFAULT_SAMPLE_RATE;
+    this.latency = opts.latency ?? FishAudioLatency.BALANCED;
+    this.speed = opts.speed;
+    this.volume = opts.volume;
+    this.normalizeLoudness = opts.normalizeLoudness;
+    this.temperature = opts.temperature;
+    this.topP = opts.topP;
+    this.chunkLength = opts.chunkLength;
+    this.minChunkLength = opts.minChunkLength;
+    this.normalize = opts.normalize;
+    this.maxNewTokens = opts.maxNewTokens;
+    this.repetitionPenalty = opts.repetitionPenalty;
+    this.conditionOnPreviousChunks = opts.conditionOnPreviousChunks;
+    this.earlyStopThreshold = opts.earlyStopThreshold;
+    this.mp3Bitrate = opts.mp3Bitrate;
+    this.opusBitrate = opts.opusBitrate;
+    this.baseUrl = opts.baseUrl ?? FISH_AUDIO_TTS_URL;
+  }
+
+  /**
+   * Declare the audio format this adapter emits so the pipeline sender derives
+   * the correct resample ratio instead of assuming 16 kHz.
+   *
+   * Only `format: "pcm"` produces pipeline-consumable bytes; `wav` / `mp3` /
+   * `opus` are container formats for offline use and are reported here as their
+   * underlying PCM rate.
+   */
+  sourceAudioFormat(): { encoding: 'pcm_s16le' | 'mulaw' | 'alaw'; sampleRate: number } {
+    return { encoding: 'pcm_s16le', sampleRate: this.sampleRate };
+  }
+
+  /**
+   * Construct an instance pre-configured for Twilio Media Streams.
+   *
+   * Requests PCM directly at 8 kHz — the carrier wire rate — so the pipeline
+   * skips the 16 kHz → 8 kHz resample and only runs the μ-law encode. Fish has
+   * no native G.711 output, so a fully bit-clean passthrough is not available.
+   */
+  static forTwilio(apiKey: string, options: FishAudioCarrierOptions = {}): FishAudioTTS {
+    return new FishAudioTTS(apiKey, {
+      ...options,
+      format: FishAudioFormat.PCM,
+      sampleRate: 8000,
+    });
+  }
+
+  /**
+   * Construct an instance pre-configured for Telnyx bidirectional media.
+   *
+   * Emits PCM @ 16 kHz to match the Telnyx PCM16 pipeline; the SDK resamples to
+   * the 8 kHz PCMU wire once, downstream.
+   */
+  static forTelnyx(apiKey: string, options: FishAudioCarrierOptions = {}): FishAudioTTS {
+    return new FishAudioTTS(apiKey, {
+      ...options,
+      format: FishAudioFormat.PCM,
+      sampleRate: FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+    });
+  }
+
+  /** Request headers. Fish selects the model with a header, not a body field. */
+  protected buildHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+      model: this.model,
+    };
+  }
+
+  /**
+   * Build the `TTSRequest` body. Every optional knob is omitted when unset so
+   * Fish applies its own documented default rather than a value we guessed.
+   */
+  protected buildPayload(text: string): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      text,
+      format: this.format,
+      latency: this.latency,
+    };
+    // `sample_rate` is only meaningful for the raw/uncompressed formats; mp3
+    // and opus derive it from the bitrate instead.
+    if (this.format === FishAudioFormat.PCM || this.format === FishAudioFormat.WAV) {
+      payload.sample_rate = this.sampleRate;
+    }
+    if (this.voice !== undefined && this.voice.length > 0) {
+      // string → single speaker; array → multi-speaker (s2 models).
+      payload.reference_id = typeof this.voice === 'string' ? this.voice : [...this.voice];
+    }
+
+    const prosody: Record<string, unknown> = {};
+    if (this.speed !== undefined) prosody.speed = this.speed;
+    if (this.volume !== undefined) prosody.volume = this.volume;
+    if (this.normalizeLoudness !== undefined) {
+      prosody.normalize_loudness = this.normalizeLoudness;
+    }
+    if (Object.keys(prosody).length > 0) payload.prosody = prosody;
+
+    const optional: Record<string, unknown> = {
+      temperature: this.temperature,
+      top_p: this.topP,
+      chunk_length: this.chunkLength,
+      min_chunk_length: this.minChunkLength,
+      normalize: this.normalize,
+      max_new_tokens: this.maxNewTokens,
+      repetition_penalty: this.repetitionPenalty,
+      condition_on_previous_chunks: this.conditionOnPreviousChunks,
+      early_stop_threshold: this.earlyStopThreshold,
+      mp3_bitrate: this.mp3Bitrate,
+      opus_bitrate: this.opusBitrate,
+    };
+    for (const [key, value] of Object.entries(optional)) {
+      if (value !== undefined) payload[key] = value;
+    }
+    return payload;
+  }
+
+  /**
+   * Best-effort pre-call HTTP warmup.
+   *
+   * Issues `GET /model?page_size=1` — the voice-model listing — so DNS, TLS and
+   * the HTTP connection are already established when the first synthesis POST
+   * lands. Billing safety: listing voice models is a free metadata read;
+   * synthesis is billed only by `POST /v1/tts`. A `HEAD` against `/v1/tts`
+   * would be cheaper still, but that endpoint is POST-only and answers 405 —
+   * the trap already documented on the Inworld adapter.
+   */
+  async warmup(): Promise<void> {
+    try {
+      await fetch(`${new URL(this.baseUrl).origin}/model?page_size=1`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+    } catch {
+      // Best-effort: a failed warmup must never affect the call.
+    }
+  }
+
+  /** Synthesize text and return the concatenated audio buffer. */
+  async synthesize(text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of this.synthesizeStream(text)) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  /**
+   * Yield audio chunks as they arrive. With the default `format: "pcm"` these
+   * are raw PCM16-LE bytes at the configured `sampleRate`.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify(this.buildPayload(text)),
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Fish Audio TTS error ${response.status}: ${body}`);
+    }
+    if (!response.body) {
+      throw new Error('Fish Audio TTS: no response body');
+    }
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          yield Buffer.from(value);
+        }
+      }
+    } finally {
+      if (typeof reader.cancel === 'function') await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+
+  /** No persistent resources to release — present for interface parity. */
+  async close(): Promise<void> {
+    // fetch() owns its own connection pool; nothing to tear down.
+  }
+}

--- a/libraries/typescript/src/providers/fish-audio-ws-tts.ts
+++ b/libraries/typescript/src/providers/fish-audio-ws-tts.ts
@@ -1,0 +1,320 @@
+/**
+ * WebSocket-based Fish Audio TTS provider — opt-in low-latency variant.
+ *
+ * **Beta: validated against the Fish Audio API spec (docs.fish.audio); not yet
+ * exercised against a live phone call.**
+ *
+ * Targets `wss://api.fish.audio/v1/tts/live` instead of the HTTP `/v1/tts`
+ * endpoint used by {@link FishAudioTTS}. The WebSocket path skips the
+ * per-utterance HTTP request setup (~50 ms) and pairs with `s2-pro`'s ~100 ms
+ * time-to-first-audio.
+ *
+ * Behaviour notes:
+ * - **Model support is narrower than HTTP.** Fish restricts the `model:` header
+ *   on this endpoint to `s1` and `s2-pro`; `s2.1-pro` is HTTP-only. The
+ *   constructor rejects unsupported models with a message pointing at
+ *   {@link FishAudioTTS} rather than letting the socket fail at call time.
+ * - Frames are **MessagePack**, not JSON — the server returns raw audio bytes
+ *   inline, which JSON cannot carry without base64. `@msgpack/msgpack` is
+ *   therefore required for this transport only; the HTTP and ASR adapters have
+ *   no such dependency.
+ * - The socket is opened **per-utterance**, matching the HTTP semantics and the
+ *   ElevenLabs WebSocket adapter.
+ * - Protocol: `start` (config) → `text` (payload) → `flush` → `stop`, with the
+ *   server replying `audio` frames followed by `finish`.
+ */
+
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import WebSocket from 'ws';
+import { getLogger } from '../logger';
+import {
+  FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+  FishAudioFormat,
+  FishAudioLatency,
+  FishAudioModel,
+  FishAudioTTS,
+  type FishAudioTTSOptions,
+} from './fish-audio-tts';
+
+/** Fish Audio streaming TTS endpoint. */
+export const FISH_AUDIO_WS_URL = 'wss://api.fish.audio/v1/tts/live';
+
+/**
+ * Models Fish accepts on the `/v1/tts/live` socket. `s2.1-pro` and
+ * `s2.1-pro-free` are HTTP-only.
+ */
+export const WS_SUPPORTED_MODELS: readonly string[] = [
+  FishAudioModel.S1,
+  FishAudioModel.S2_PRO,
+];
+
+/** Connect timeout — keeps the carrier WebSocket out of dead air on a stuck handshake. */
+const DEFAULT_OPEN_TIMEOUT_MS = 5_000;
+/** Per-frame receive timeout — a stalled server must not hang until carrier hangup. */
+const DEFAULT_FRAME_TIMEOUT_MS = 30_000;
+/** Sanity bound on a single audio frame; real frames are far smaller. */
+const MAX_AUDIO_FRAME_SIZE = 1024 * 1024;
+
+/** A parked reader waiting for the next inbound frame (or the frame timeout). */
+interface FrameWaiter {
+  resolve: () => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Minimal `@msgpack/msgpack` surface used by this adapter. */
+export interface MsgpackCodec {
+  encode(value: unknown): Uint8Array;
+  decode(buffer: Uint8Array): unknown;
+}
+
+let cachedCodec: MsgpackCodec | null = null;
+
+/** Load `@msgpack/msgpack` lazily, with a remedy-shaped error when it is absent. */
+async function loadMsgpack(): Promise<MsgpackCodec> {
+  if (cachedCodec) return cachedCodec;
+  try {
+    cachedCodec = (await import('@msgpack/msgpack')) as unknown as MsgpackCodec;
+    return cachedCodec;
+  } catch (firstErr) {
+    // Fallback: resolve from the user's project root. Catches file:-linked
+    // workspaces where the SDK's own node_modules is elsewhere.
+    try {
+      const req = createRequire(path.join(process.cwd(), 'package.json'));
+      cachedCodec = req('@msgpack/msgpack') as MsgpackCodec;
+      return cachedCodec;
+    } catch {
+      throw new Error(
+        'FishAudioWebSocketTTS requires the "@msgpack/msgpack" package — the Fish ' +
+          'streaming socket frames are MessagePack, not JSON. Install it with ' +
+          '`npm install @msgpack/msgpack`, or use the HTTP adapter (FishAudioTTS), ' +
+          `which has no such requirement. Original error: ${
+            (firstErr as Error)?.message ?? String(firstErr)
+          }`,
+      );
+    }
+  }
+}
+
+/** Constructor options for {@link FishAudioWebSocketTTS}. */
+export interface FishAudioWebSocketTTSOptions extends FishAudioTTSOptions {
+  /** Override the WebSocket endpoint (e.g. for tests). */
+  wsUrl?: string;
+  /** Connect timeout in ms. Defaults to 5000. */
+  openTimeoutMs?: number;
+  /** Per-frame receive timeout in ms. Defaults to 30000. */
+  frameTimeoutMs?: number;
+}
+
+/**
+ * Fish Audio TTS over the `/v1/tts/live` WebSocket (Beta).
+ *
+ * Same option surface as {@link FishAudioTTS}, except the default model is
+ * `s2-pro` (the fastest model this endpoint serves) and `s2.1-pro` is rejected
+ * up-front because Fish does not route it here.
+ */
+export class FishAudioWebSocketTTS extends FishAudioTTS {
+  /**
+   * Stable pricing/dashboard key. Shares the HTTP adapter's key: same models,
+   * same per-byte rate.
+   */
+  static readonly providerKey = 'fish_audio';
+
+  private readonly wsUrl: string;
+  private readonly openTimeoutMs: number;
+  private readonly frameTimeoutMs: number;
+
+  constructor(apiKey: string, opts: FishAudioWebSocketTTSOptions = {}) {
+    const model = opts.model ?? FishAudioModel.S2_PRO;
+    if (!WS_SUPPORTED_MODELS.includes(model)) {
+      throw new Error(
+        `FishAudioWebSocketTTS: model "${model}" is not available on the ` +
+          `/v1/tts/live socket (Fish accepts only ${WS_SUPPORTED_MODELS.join(', ')} ` +
+          `there). Use the HTTP adapter instead: new FishAudioTTS(apiKey, ` +
+          `{ model: "${model}" }).`,
+      );
+    }
+    super(apiKey, {
+      ...opts,
+      model,
+      format: opts.format ?? FishAudioFormat.PCM,
+      sampleRate: opts.sampleRate ?? FISH_AUDIO_DEFAULT_SAMPLE_RATE,
+      latency: opts.latency ?? FishAudioLatency.BALANCED,
+    });
+    this.wsUrl = opts.wsUrl ?? FISH_AUDIO_WS_URL;
+    this.openTimeoutMs = opts.openTimeoutMs ?? DEFAULT_OPEN_TIMEOUT_MS;
+    this.frameTimeoutMs = opts.frameTimeoutMs ?? DEFAULT_FRAME_TIMEOUT_MS;
+  }
+
+  /**
+   * Build the `start` frame. The `request` object takes the same fields as the
+   * HTTP TTS body with an empty `text` — the real text arrives in `text` frames.
+   */
+  private buildStartEvent(): Record<string, unknown> {
+    return { event: 'start', request: this.buildPayload('') };
+  }
+
+  /**
+   * Yield audio chunks as they arrive over a per-utterance WebSocket. With the
+   * default `format: "pcm"` these are raw PCM16-LE bytes at `sampleRate`.
+   */
+  async *synthesizeStream(text: string): AsyncGenerator<Buffer> {
+    const codec = await loadMsgpack();
+    const ws = await this.openSocket();
+
+    // Frames can arrive while the consumer is between `await`s, so they are
+    // queued rather than handled inline; `waiter` parks the loop until the next
+    // frame (or the frame timeout) fires.
+    const inbound: Array<Buffer | string> = [];
+    const state: { closed: boolean; error: Error | null } = { closed: false, error: null };
+    // Held in a ref cell rather than a plain `let` so TypeScript does not narrow
+    // it to `null` across the callbacks that assign it.
+    const waiter: { current: FrameWaiter | null } = { current: null };
+
+    const wake = (): void => {
+      const pending = waiter.current;
+      if (!pending) return;
+      waiter.current = null;
+      clearTimeout(pending.timer);
+      pending.resolve();
+    };
+
+    ws.on('message', (data: WebSocket.RawData, isBinary: boolean) => {
+      const buf = toBuffer(data);
+      inbound.push(isBinary ? buf : buf.toString('utf8'));
+      wake();
+    });
+    ws.on('error', (err: Error) => {
+      state.error = err;
+      state.closed = true;
+      wake();
+    });
+    ws.on('close', () => {
+      state.closed = true;
+      wake();
+    });
+
+    const waitForFrame = (): Promise<void> =>
+      new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          waiter.current = null;
+          reject(
+            new Error(`Fish Audio WS stalled: no frame within ${this.frameTimeoutMs}ms`),
+          );
+        }, this.frameTimeoutMs);
+        waiter.current = { resolve, timer };
+      });
+
+    try {
+      ws.send(codec.encode(this.buildStartEvent()));
+      ws.send(codec.encode({ event: 'text', text }));
+      ws.send(codec.encode({ event: 'flush' }));
+      ws.send(codec.encode({ event: 'stop' }));
+
+      for (;;) {
+        while (inbound.length > 0) {
+          const { audio, done } = decodeServerFrame(inbound.shift()!, codec);
+          if (audio) yield audio;
+          if (done) return;
+        }
+        if (state.error) throw state.error;
+        if (state.closed) return;
+        await waitForFrame();
+      }
+    } finally {
+      if (waiter.current) clearTimeout(waiter.current.timer);
+      ws.removeAllListeners();
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+    }
+  }
+
+  /** Open the synthesis socket with the auth + model headers, bounded by a timeout. */
+  private openSocket(): Promise<WebSocket> {
+    return new Promise<WebSocket>((resolve, reject) => {
+      const ws = new WebSocket(this.wsUrl, {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          model: this.model,
+        },
+        handshakeTimeout: this.openTimeoutMs,
+      });
+      const onOpen = (): void => {
+        ws.off('error', onError);
+        resolve(ws);
+      };
+      const onError = (err: Error): void => {
+        ws.off('open', onOpen);
+        reject(err);
+      };
+      ws.once('open', onOpen);
+      ws.once('error', onError);
+    });
+  }
+}
+
+/** Normalise a `ws` RawData payload into a single Buffer. */
+function toBuffer(data: WebSocket.RawData): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return Buffer.from(data as ArrayBuffer);
+}
+
+/**
+ * Decode one server frame into `{ audio, done }`.
+ *
+ * Returns `{ done: false }` with no audio for frames carrying neither audio nor
+ * a terminal signal (`log` frames, unknown future event types) so the caller
+ * keeps reading. Throws when the server reports `finish` with `reason: "error"`.
+ */
+export function decodeServerFrame(
+  frame: Buffer | string,
+  codec: MsgpackCodec,
+): { audio: Buffer | null; done: boolean } {
+  if (typeof frame === 'string') {
+    // The protocol is msgpack-binary; a text frame is only ever an
+    // out-of-band server message. Log it and keep going.
+    getLogger().debug(`Fish Audio WS text frame ignored: ${frame.slice(0, 200)}`);
+    return { audio: null, done: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = codec.decode(new Uint8Array(frame));
+  } catch (err) {
+    throw new Error(`Fish Audio WS sent an undecodable frame: ${String(err)}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { audio: null, done: false };
+  }
+
+  const evt = parsed as { event?: string; audio?: unknown; reason?: string; message?: string };
+  if (evt.event === 'audio') {
+    const audio = evt.audio;
+    if (!(audio instanceof Uint8Array) && !Buffer.isBuffer(audio)) {
+      return { audio: null, done: false };
+    }
+    if (audio.length > MAX_AUDIO_FRAME_SIZE) {
+      throw new Error(
+        `Fish Audio WS audio frame is ${audio.length} bytes, over the ` +
+          `${MAX_AUDIO_FRAME_SIZE}-byte sanity limit`,
+      );
+    }
+    return { audio: Buffer.from(audio), done: false };
+  }
+  if (evt.event === 'finish') {
+    if (evt.reason === 'error') {
+      throw new Error(
+        `Fish Audio WS finished with an error: ${evt.message ?? evt.reason}`,
+      );
+    }
+    return { audio: null, done: true };
+  }
+  if (evt.event === 'log') {
+    getLogger().debug(`Fish Audio WS log: ${String(evt.message ?? '').slice(0, 200)}`);
+  }
+  return { audio: null, done: false };
+}

--- a/libraries/typescript/src/stt/fish-audio.ts
+++ b/libraries/typescript/src/stt/fish-audio.ts
@@ -1,0 +1,44 @@
+/** Fish Audio batch STT for Patter pipeline mode (Beta). */
+import {
+  FishAudioSTT as _FishAudioSTT,
+  type FishAudioSTTOptions as _FishAudioSTTOptions,
+} from "../providers/fish-audio-stt";
+
+/** Constructor options for the Fish Audio `STT` adapter. */
+export interface FishAudioSTTOptions extends _FishAudioSTTOptions {
+  /** API key. Falls back to the FISH_AUDIO_API_KEY env var when omitted. */
+  apiKey?: string;
+  /** ISO language code (e.g. `"en"`). Omit to let Fish auto-detect. */
+  language?: string;
+}
+
+/**
+ * Fish Audio ASR — buffered batch transcription (Beta).
+ *
+ * @example
+ * ```ts
+ * import * as fishAudio from "getpatter/stt/fish-audio";
+ * const stt = new fishAudio.STT();                    // reads FISH_AUDIO_API_KEY
+ * const stt2 = new fishAudio.STT({ apiKey: "...", language: "it" });
+ * ```
+ *
+ * Fish has no streaming transcription socket, so this adapter uploads ~2 s
+ * windows and emits one final transcript per window — no interim partials.
+ * Prefer Deepgram / Soniox / AssemblyAI when turn latency matters most.
+ */
+export class STT extends _FishAudioSTT {
+  static override readonly providerKey = "fish_audio_stt";
+
+  constructor(opts: FishAudioSTTOptions = {}) {
+    const key = opts.apiKey ?? process.env.FISH_AUDIO_API_KEY;
+    if (!key) {
+      throw new Error(
+        "Fish Audio STT requires an apiKey. Pass { apiKey: '...' } or " +
+          "set FISH_AUDIO_API_KEY in the environment.",
+      );
+    }
+    const { apiKey: _ignored, language, ...rest } = opts;
+    void _ignored;
+    super(key, language ?? "en", rest);
+  }
+}

--- a/libraries/typescript/src/telemetry/stack.ts
+++ b/libraries/typescript/src/telemetry/stack.ts
@@ -36,6 +36,7 @@ export const STACK_VENDORS: ReadonlySet<string> = new Set([
   'inworld',
   'sarvam',
   'xai',
+  'fish_audio',
   'telnyx',
   'other',
 ]);
@@ -49,6 +50,7 @@ const VENDOR_ALIASES: Record<string, string> = {
   elevenlabs_ws: 'elevenlabs',
   soniox_tts: 'soniox',
   xai_tts: 'xai',
+  fish_audio_stt: 'fish_audio',
   xai_realtime: 'xai',
   telnyx_stt: 'telnyx',
   telnyx_tts: 'telnyx',

--- a/libraries/typescript/src/tts/fish-audio.ts
+++ b/libraries/typescript/src/tts/fish-audio.ts
@@ -1,0 +1,114 @@
+/** Fish Audio TTS for Patter pipeline mode (Beta). */
+import {
+  FishAudioTTS as _FishAudioTTS,
+  type FishAudioTTSOptions as _FishAudioTTSOptions,
+} from "../providers/fish-audio-tts";
+import {
+  FishAudioWebSocketTTS as _FishAudioWebSocketTTS,
+  type FishAudioWebSocketTTSOptions as _FishAudioWebSocketTTSOptions,
+} from "../providers/fish-audio-ws-tts";
+
+/** Constructor options for the Fish Audio `TTS` adapter. */
+export interface FishAudioTTSOptions extends _FishAudioTTSOptions {
+  /** API key. Falls back to the FISH_AUDIO_API_KEY env var when omitted. */
+  apiKey?: string;
+}
+
+/** Constructor options for the Fish Audio `WebSocketTTS` adapter. */
+export interface FishAudioWebSocketTTSOptions extends _FishAudioWebSocketTTSOptions {
+  /** API key. Falls back to the FISH_AUDIO_API_KEY env var when omitted. */
+  apiKey?: string;
+}
+
+/** Options for the carrier-specific factories — same minus `format`/`sampleRate`. */
+export type FishAudioCarrierOptions = Omit<
+  FishAudioTTSOptions,
+  "format" | "sampleRate"
+>;
+
+function resolveApiKey(apiKey: string | undefined): string {
+  const key = apiKey ?? process.env.FISH_AUDIO_API_KEY;
+  if (!key) {
+    throw new Error(
+      "Fish Audio TTS requires an apiKey. Pass { apiKey: '...' } or " +
+        "set FISH_AUDIO_API_KEY in the environment.",
+    );
+  }
+  return key;
+}
+
+/**
+ * Fish Audio HTTP TTS — defaults to the `s2.1-pro` model (Beta).
+ *
+ * @example
+ * ```ts
+ * import * as fishAudio from "getpatter/tts/fish-audio";
+ * const tts = new fishAudio.TTS();                                 // reads FISH_AUDIO_API_KEY
+ * const tts2 = new fishAudio.TTS({ apiKey: "...", voice: "<reference-id>", latency: "low" });
+ * ```
+ *
+ * `voice` is a Fish `reference_id` — a voice-model id from the Fish voice
+ * library or one you cloned. Omit it to use the model's built-in voice; pass an
+ * array of ids for multi-speaker synthesis with `<|speaker:0|>` markers.
+ *
+ * **Telephony** — use {@link TTS.forTwilio} (pcm @ 8 kHz, no resample) or
+ * {@link TTS.forTelnyx} (pcm @ 16 kHz) on phone calls.
+ */
+export class TTS extends _FishAudioTTS {
+  static readonly providerKey = "fish_audio";
+
+  constructor(opts: FishAudioTTSOptions = {}) {
+    const key = resolveApiKey(opts.apiKey);
+    const { apiKey: _ignored, ...rest } = opts;
+    void _ignored;
+    super(key, rest);
+  }
+
+  /** Pipeline TTS pre-configured for Twilio Media Streams (pcm @ 8 kHz — no resample). */
+  static override forTwilio(opts?: FishAudioCarrierOptions): TTS;
+  // Parent-compatible overload — accepts the legacy positional form too.
+  static override forTwilio(apiKey: string, options?: FishAudioCarrierOptions): TTS;
+  static override forTwilio(
+    arg1?: string | FishAudioCarrierOptions,
+    arg2?: FishAudioCarrierOptions,
+  ): TTS {
+    const opts: FishAudioCarrierOptions =
+      typeof arg1 === "string" ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({ ...opts, format: "pcm", sampleRate: 8000 });
+  }
+
+  /** Pipeline TTS pre-configured for Telnyx bidirectional media (pcm @ 16 kHz). */
+  static override forTelnyx(opts?: FishAudioCarrierOptions): TTS;
+  static override forTelnyx(apiKey: string, options?: FishAudioCarrierOptions): TTS;
+  static override forTelnyx(
+    arg1?: string | FishAudioCarrierOptions,
+    arg2?: FishAudioCarrierOptions,
+  ): TTS {
+    const opts: FishAudioCarrierOptions =
+      typeof arg1 === "string" ? { apiKey: arg1, ...(arg2 ?? {}) } : (arg1 ?? {});
+    return new TTS({ ...opts, format: "pcm", sampleRate: 16000 });
+  }
+}
+
+/**
+ * Fish Audio WebSocket TTS — opt-in low-latency path, `s2-pro` (Beta).
+ *
+ * @example
+ * ```ts
+ * import * as fishAudio from "getpatter/tts/fish-audio";
+ * const tts = new fishAudio.WebSocketTTS();                        // reads FISH_AUDIO_API_KEY
+ * ```
+ *
+ * Fish serves only `s1` and `s2-pro` on the streaming socket — for `s2.1-pro`
+ * use {@link TTS} (HTTP) instead. Requires the `@msgpack/msgpack` package.
+ */
+export class WebSocketTTS extends _FishAudioWebSocketTTS {
+  static readonly providerKey = "fish_audio";
+
+  constructor(opts: FishAudioWebSocketTTSOptions = {}) {
+    const key = resolveApiKey(opts.apiKey);
+    const { apiKey: _ignored, ...rest } = opts;
+    void _ignored;
+    super(key, rest);
+  }
+}

--- a/libraries/typescript/tests/unit/fish-audio-stt.mocked.test.ts
+++ b/libraries/typescript/tests/unit/fish-audio-stt.mocked.test.ts
@@ -1,0 +1,277 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  DEFAULT_BUFFER_SIZE,
+  FishAudioSTT,
+  type Transcript,
+} from '../../src/providers/fish-audio-stt';
+import { STT as FishAudioPipelineSTT } from '../../src/stt/fish-audio';
+
+/**
+ * [mocked] Fish Audio batch STT (ASR).
+ *
+ * Runs against a **real in-process HTTP server** on 127.0.0.1 that receives the
+ * real multipart body the adapter uploads — only Fish's transcription is
+ * simulated. Buffering, WAV framing, multipart field names, tail padding,
+ * transcript mapping and the error path all execute for real over a real socket.
+ */
+
+/** One second of 16 kHz PCM16 = 32000 bytes. */
+const BYTES_PER_SECOND = 16000 * 2;
+
+interface Upload {
+  authorization: string | undefined;
+  raw: Buffer;
+}
+
+/** Locate the embedded WAV and parse the fields we care about. */
+function parseWav(raw: Buffer): {
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+  dataBytes: number;
+} {
+  const start = raw.indexOf(Buffer.from('RIFF'));
+  if (start < 0) throw new Error('no RIFF header in the uploaded body');
+  return {
+    channels: raw.readUInt16LE(start + 22),
+    sampleRate: raw.readUInt32LE(start + 24),
+    bitsPerSample: raw.readUInt16LE(start + 34),
+    dataBytes: raw.readUInt32LE(start + 40),
+  };
+}
+
+function fieldValue(raw: Buffer, name: string): string | null {
+  const body = raw.toString('latin1');
+  const marker = `name="${name}"`;
+  const at = body.indexOf(marker);
+  if (at < 0) return null;
+  const valueStart = body.indexOf('\r\n\r\n', at);
+  if (valueStart < 0) return null;
+  const valueEnd = body.indexOf('\r\n', valueStart + 4);
+  return body.slice(valueStart + 4, valueEnd < 0 ? undefined : valueEnd);
+}
+
+describe('[mocked] Fish Audio STT — upload shape + buffering', () => {
+  let server: http.Server;
+  let base: string;
+
+  const recorder = {
+    uploads: [] as Upload[],
+    status: 200,
+    payload: {} as Record<string, unknown>,
+    errorBody: '',
+  };
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      const body: Buffer[] = [];
+      req.on('data', (c: Buffer) => body.push(c));
+      req.on('end', () => {
+        recorder.uploads.push({
+          authorization: req.headers.authorization,
+          raw: Buffer.concat(body),
+        });
+        if (recorder.status !== 200) {
+          res.writeHead(recorder.status);
+          res.end(recorder.errorBody);
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(recorder.payload));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1/asr`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    recorder.uploads = [];
+    recorder.status = 200;
+    recorder.errorBody = '';
+    recorder.payload = { text: 'ciao mondo', duration: 2.0 };
+  });
+
+  const stt = (language?: string, opts = {}): FishAudioSTT =>
+    new FishAudioSTT('fish-test-key', language, { baseUrl: base, ...opts });
+
+  async function run(
+    adapter: FishAudioSTT,
+    audio: Buffer,
+  ): Promise<Transcript[]> {
+    const received: Transcript[] = [];
+    adapter.onTranscript((t) => received.push(t));
+    await adapter.connect();
+    adapter.sendAudio(audio);
+    await adapter.close();
+    return received;
+  }
+
+  it('uploads a full window and emits a final transcript', async () => {
+    const got = await run(stt('en'), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    expect(got.map((t) => t.text)).toEqual(['ciao mondo']);
+    expect(got[0].isFinal).toBe(true);
+    expect(recorder.uploads).toHaveLength(1);
+  });
+
+  it('uploads valid 16 kHz mono PCM16 WAV', async () => {
+    await run(stt('en'), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    expect(parseWav(recorder.uploads[0].raw)).toEqual({
+      channels: 1,
+      sampleRate: 16000,
+      bitsPerSample: 16,
+      dataBytes: DEFAULT_BUFFER_SIZE,
+    });
+  });
+
+  it("uses Fish's documented multipart field names", async () => {
+    await run(stt('it'), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    const { raw, authorization } = recorder.uploads[0];
+    expect(authorization).toBe('Bearer fish-test-key');
+    expect(raw.toString('latin1')).toContain('name="audio"');
+    expect(raw.toString('latin1')).toContain('filename="audio.wav"');
+    expect(fieldValue(raw, 'language')).toBe('it');
+    expect(fieldValue(raw, 'ignore_timestamps')).toBe('true');
+  });
+
+  it('forwards ignoreTimestamps: false', async () => {
+    await run(stt('en', { ignoreTimestamps: false }), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    expect(fieldValue(recorder.uploads[0].raw, 'ignore_timestamps')).toBe('false');
+  });
+
+  it('omits language entirely when unset so Fish auto-detects', async () => {
+    await run(stt(undefined), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    expect(fieldValue(recorder.uploads[0].raw, 'language')).toBeNull();
+  });
+
+  it('does not upload a partial window before the threshold', async () => {
+    const adapter = stt('en');
+    await adapter.connect();
+    adapter.sendAudio(Buffer.alloc(DEFAULT_BUFFER_SIZE / 4));
+    expect(recorder.uploads).toHaveLength(0);
+    await adapter.close();
+  });
+
+  it("pads a short tail with silence up to Fish's 1 s minimum", async () => {
+    // 50 ms of audio — far below the documented floor. Dropping it would lose
+    // the last words of an utterance, so it is padded instead.
+    await run(stt('en'), Buffer.alloc(1600));
+    expect(recorder.uploads).toHaveLength(1);
+    expect(parseWav(recorder.uploads[0].raw).dataBytes).toBe(BYTES_PER_SECOND);
+  });
+
+  it('does not pad a tail already over the minimum', async () => {
+    const tail = BYTES_PER_SECOND + 4000;
+    await run(stt('en'), Buffer.alloc(tail));
+    expect(parseWav(recorder.uploads[0].raw).dataBytes).toBe(tail);
+  });
+
+  it('emits one transcript per window', async () => {
+    const adapter = stt('en');
+    const received: Transcript[] = [];
+    adapter.onTranscript((t) => received.push(t));
+    await adapter.connect();
+    adapter.sendAudio(Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    adapter.sendAudio(Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    await adapter.close();
+    expect(received).toHaveLength(2);
+    expect(recorder.uploads).toHaveLength(2);
+  });
+
+  it('honours a custom buffer size', async () => {
+    await run(
+      stt('en', { bufferSize: BYTES_PER_SECOND }),
+      Buffer.alloc(BYTES_PER_SECOND * 2),
+    );
+    expect(recorder.uploads).toHaveLength(1);
+  });
+
+  it('surfaces segments when the caller asked for timestamps', async () => {
+    recorder.payload = {
+      text: 'ciao mondo',
+      duration: 2.0,
+      segments: [
+        { text: 'ciao', start: 0, end: 0.4 },
+        { text: 'mondo', start: 0.4, end: 1.1 },
+      ],
+    };
+    const got = await run(
+      stt('it', { ignoreTimestamps: false }),
+      Buffer.alloc(DEFAULT_BUFFER_SIZE),
+    );
+    expect(got[0].segments).toHaveLength(2);
+    expect(got[0].segments?.[0].text).toBe('ciao');
+  });
+
+  it('omits segments when Fish returns none', async () => {
+    const got = await run(stt('en'), Buffer.alloc(DEFAULT_BUFFER_SIZE));
+    expect(got[0].segments).toBeUndefined();
+  });
+
+  it('logs a server error and emits nothing — the call must survive', async () => {
+    recorder.status = 402;
+    recorder.errorBody = 'insufficient credit';
+    expect(await run(stt('en'), Buffer.alloc(DEFAULT_BUFFER_SIZE))).toEqual([]);
+  });
+
+  it('drops an empty transcript', async () => {
+    recorder.payload = { text: '   ', duration: 2.0 };
+    expect(await run(stt('en'), Buffer.alloc(DEFAULT_BUFFER_SIZE))).toEqual([]);
+  });
+
+  it('does not throw when the host is unreachable', async () => {
+    const adapter = new FishAudioSTT('k', 'en', { baseUrl: 'http://127.0.0.1:1/v1/asr' });
+    expect(await run(adapter, Buffer.alloc(DEFAULT_BUFFER_SIZE))).toEqual([]);
+  });
+});
+
+describe('[unit] Fish Audio STT — construction', () => {
+  it('requires an apiKey', () => {
+    expect(() => new FishAudioSTT('')).toThrow(/apiKey is required/);
+  });
+
+  it('exposes the stable pricing key', () => {
+    expect(FishAudioSTT.providerKey).toBe('fish_audio_stt');
+  });
+
+  it('clones without sharing buffer state', () => {
+    const original = new FishAudioSTT('k', 'en');
+    const copy = original.clone();
+    expect(copy).not.toBe(original);
+    expect(copy).toBeInstanceOf(FishAudioSTT);
+  });
+
+  it('forTwilio matches the default construction', () => {
+    expect(FishAudioSTT.forTwilio('k', 'fr')).toBeInstanceOf(FishAudioSTT);
+  });
+
+  it('defaults the window to two seconds, clear of the 1 s floor', () => {
+    expect(DEFAULT_BUFFER_SIZE).toBe(BYTES_PER_SECOND * 2);
+  });
+
+  it('falls back to FISH_AUDIO_API_KEY on the pipeline subclass', () => {
+    const prev = process.env.FISH_AUDIO_API_KEY;
+    process.env.FISH_AUDIO_API_KEY = 'env-key';
+    try {
+      expect(() => new FishAudioPipelineSTT()).not.toThrow();
+    } finally {
+      if (prev === undefined) delete process.env.FISH_AUDIO_API_KEY;
+      else process.env.FISH_AUDIO_API_KEY = prev;
+    }
+  });
+
+  it('raises a pointed error when no key is available', () => {
+    const prev = process.env.FISH_AUDIO_API_KEY;
+    delete process.env.FISH_AUDIO_API_KEY;
+    try {
+      expect(() => new FishAudioPipelineSTT()).toThrow(/FISH_AUDIO_API_KEY/);
+    } finally {
+      if (prev !== undefined) process.env.FISH_AUDIO_API_KEY = prev;
+    }
+  });
+});

--- a/libraries/typescript/tests/unit/fish-audio-tts.mocked.test.ts
+++ b/libraries/typescript/tests/unit/fish-audio-tts.mocked.test.ts
@@ -1,0 +1,278 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  FishAudioFormat,
+  FishAudioLatency,
+  FishAudioModel,
+  FishAudioTTS,
+} from '../../src/providers/fish-audio-tts';
+import { TTS as FishAudioPipelineTTS } from '../../src/tts/fish-audio';
+
+/**
+ * [mocked] Fish Audio HTTP TTS.
+ *
+ * Runs against a **real in-process HTTP server** on 127.0.0.1 — only Fish's
+ * synthesis is simulated. Header assembly, JSON payload construction, prosody
+ * nesting, chunked response streaming, error surfacing, the warmup request and
+ * the env-var fallback all execute for real over a real socket.
+ */
+describe('[mocked] Fish Audio TTS — request + streaming', () => {
+  let server: http.Server;
+  let base: string;
+
+  const recorder = {
+    ttsHeaders: {} as http.IncomingHttpHeaders,
+    ttsBody: {} as Record<string, unknown>,
+    modelHits: 0,
+    modelUrl: '',
+    status: 200,
+    errorBody: '',
+    chunks: [] as number[][],
+  };
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.method === 'GET' && req.url?.startsWith('/model')) {
+        recorder.modelHits += 1;
+        recorder.modelUrl = req.url;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ items: [], total: 0 }));
+        return;
+      }
+      const body: Buffer[] = [];
+      req.on('data', (c: Buffer) => body.push(c));
+      req.on('end', () => {
+        recorder.ttsHeaders = req.headers;
+        recorder.ttsBody = JSON.parse(Buffer.concat(body).toString('utf8'));
+        if (recorder.status !== 200) {
+          res.writeHead(recorder.status);
+          res.end(recorder.errorBody);
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/octet-stream',
+          'Transfer-Encoding': 'chunked',
+        });
+        for (const chunk of recorder.chunks) res.write(Buffer.from(chunk));
+        res.end();
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    recorder.ttsHeaders = {};
+    recorder.ttsBody = {};
+    recorder.modelHits = 0;
+    recorder.modelUrl = '';
+    recorder.status = 200;
+    recorder.errorBody = '';
+    recorder.chunks = [
+      [1, 2],
+      [3, 4],
+    ];
+  });
+
+  const tts = (opts = {}): FishAudioTTS =>
+    new FishAudioTTS('fish-test-key', { baseUrl: `${base}/v1/tts`, ...opts });
+
+  it('streams every chunk the server emits', async () => {
+    const audio = await tts().synthesize('ciao');
+    expect(Array.from(audio)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('sends the model in a header, never in the body', async () => {
+    await tts({ model: FishAudioModel.S2_PRO }).synthesize('ciao');
+    expect(recorder.ttsHeaders.model).toBe('s2-pro');
+    expect(recorder.ttsHeaders.authorization).toBe('Bearer fish-test-key');
+    expect(recorder.ttsHeaders['content-type']).toBe('application/json');
+    expect(recorder.ttsBody).not.toHaveProperty('model');
+  });
+
+  it('defaults to s2.1-pro / pcm @ 16 kHz / balanced latency', async () => {
+    await tts().synthesize('hello');
+    expect(recorder.ttsHeaders.model).toBe('s2.1-pro');
+    expect(recorder.ttsBody).toEqual({
+      text: 'hello',
+      format: 'pcm',
+      latency: 'balanced',
+      sample_rate: 16000,
+    });
+  });
+
+  it('omits unset knobs so Fish applies its own documented defaults', async () => {
+    await tts().synthesize('hello');
+    for (const absent of [
+      'temperature',
+      'top_p',
+      'chunk_length',
+      'normalize',
+      'prosody',
+      'reference_id',
+      'max_new_tokens',
+    ]) {
+      expect(recorder.ttsBody).not.toHaveProperty(absent);
+    }
+  });
+
+  it('maps a string voice to reference_id', async () => {
+    await tts({ voice: 'ref-abc123' }).synthesize('hello');
+    expect(recorder.ttsBody.reference_id).toBe('ref-abc123');
+  });
+
+  it('maps an array voice to multi-speaker reference_ids', async () => {
+    await tts({ voice: ['spk-a', 'spk-b'] }).synthesize('<|speaker:0|>Hi<|speaker:1|>Yo');
+    expect(recorder.ttsBody.reference_id).toEqual(['spk-a', 'spk-b']);
+  });
+
+  it('collapses flat speed/volume/loudness into a nested prosody object', async () => {
+    await tts({ speed: 1.2, volume: -3, normalizeLoudness: false }).synthesize('hi');
+    expect(recorder.ttsBody.prosody).toEqual({
+      speed: 1.2,
+      volume: -3,
+      normalize_loudness: false,
+    });
+  });
+
+  it('sends sample_rate for pcm/wav but not for mp3/opus', async () => {
+    for (const [format, expected] of [
+      [FishAudioFormat.PCM, true],
+      [FishAudioFormat.WAV, true],
+      [FishAudioFormat.MP3, false],
+      [FishAudioFormat.OPUS, false],
+    ] as const) {
+      await tts({ format, sampleRate: 24000 }).synthesize('hi');
+      expect(Object.hasOwn(recorder.ttsBody, 'sample_rate'), `format=${format}`).toBe(
+        expected,
+      );
+    }
+  });
+
+  it('forwards the latency mode', async () => {
+    await tts({ latency: FishAudioLatency.LOW }).synthesize('hi');
+    expect(recorder.ttsBody.latency).toBe('low');
+  });
+
+  it('forwards the advanced sampling knobs under their snake_case names', async () => {
+    await tts({
+      temperature: 0.4,
+      topP: 0.9,
+      chunkLength: 200,
+      minChunkLength: 20,
+      normalize: false,
+      maxNewTokens: 512,
+      repetitionPenalty: 1.1,
+      conditionOnPreviousChunks: false,
+      earlyStopThreshold: 0.5,
+    }).synthesize('hi');
+    expect(recorder.ttsBody).toMatchObject({
+      temperature: 0.4,
+      top_p: 0.9,
+      chunk_length: 200,
+      min_chunk_length: 20,
+      normalize: false,
+      max_new_tokens: 512,
+      repetition_penalty: 1.1,
+      condition_on_previous_chunks: false,
+      early_stop_threshold: 0.5,
+    });
+  });
+
+  it('throws with the status and body on a non-200', async () => {
+    recorder.status = 402;
+    recorder.errorBody = '{"detail":"insufficient credit"}';
+    await expect(tts().synthesize('hi')).rejects.toThrow(/Fish Audio TTS error 402/);
+  });
+
+  it('warms up against the free model listing, never the billed endpoint', async () => {
+    await tts().warmup();
+    expect(recorder.modelHits).toBe(1);
+    expect(recorder.modelUrl).toBe('/model?page_size=1');
+    expect(recorder.ttsBody).toEqual({});
+  });
+
+  it('never throws from warmup when the host is unreachable', async () => {
+    const unreachable = new FishAudioTTS('k', { baseUrl: 'http://127.0.0.1:1/v1/tts' });
+    await expect(unreachable.warmup()).resolves.toBeUndefined();
+  });
+});
+
+describe('[unit] Fish Audio TTS — construction + format declaration', () => {
+  it('declares the configured sample rate as its source format', () => {
+    expect(new FishAudioTTS('k').sourceAudioFormat()).toEqual({
+      encoding: 'pcm_s16le',
+      sampleRate: 16000,
+    });
+    expect(new FishAudioTTS('k', { sampleRate: 24000 }).sourceAudioFormat()).toEqual({
+      encoding: 'pcm_s16le',
+      sampleRate: 24000,
+    });
+  });
+
+  it('forTwilio requests 8 kHz PCM so the pipeline skips the resample', () => {
+    const t = FishAudioTTS.forTwilio('k');
+    expect(t.format).toBe('pcm');
+    expect(t.sourceAudioFormat()).toEqual({ encoding: 'pcm_s16le', sampleRate: 8000 });
+  });
+
+  it('forTelnyx keeps the 16 kHz pipeline rate', () => {
+    expect(FishAudioTTS.forTelnyx('k').sourceAudioFormat()).toEqual({
+      encoding: 'pcm_s16le',
+      sampleRate: 16000,
+    });
+  });
+
+  it('carrier factories preserve the other options', () => {
+    const t = FishAudioTTS.forTwilio('k', { model: 's2-pro', voice: 'ref-1' });
+    expect(t.model).toBe('s2-pro');
+    expect(t.voice).toBe('ref-1');
+  });
+
+  it('requires an apiKey', () => {
+    expect(() => new FishAudioTTS('')).toThrow(/apiKey is required/);
+  });
+
+  it('exposes the stable pricing key', () => {
+    expect(FishAudioTTS.providerKey).toBe('fish_audio');
+  });
+});
+
+describe('[unit] Fish Audio pipeline TTS — env fallback', () => {
+  it('falls back to FISH_AUDIO_API_KEY', () => {
+    const prev = process.env.FISH_AUDIO_API_KEY;
+    process.env.FISH_AUDIO_API_KEY = 'env-key';
+    try {
+      expect(() => new FishAudioPipelineTTS()).not.toThrow();
+    } finally {
+      if (prev === undefined) delete process.env.FISH_AUDIO_API_KEY;
+      else process.env.FISH_AUDIO_API_KEY = prev;
+    }
+  });
+
+  it('raises a pointed error when no key is available', () => {
+    const prev = process.env.FISH_AUDIO_API_KEY;
+    delete process.env.FISH_AUDIO_API_KEY;
+    try {
+      expect(() => new FishAudioPipelineTTS()).toThrow(/FISH_AUDIO_API_KEY/);
+    } finally {
+      if (prev !== undefined) process.env.FISH_AUDIO_API_KEY = prev;
+    }
+  });
+
+  it('keeps the carrier factories on the pipeline subclass', () => {
+    expect(FishAudioPipelineTTS.forTwilio({ apiKey: 'k' }).sourceAudioFormat()).toEqual({
+      encoding: 'pcm_s16le',
+      sampleRate: 8000,
+    });
+    expect(FishAudioPipelineTTS.forTelnyx({ apiKey: 'k' }).sourceAudioFormat()).toEqual({
+      encoding: 'pcm_s16le',
+      sampleRate: 16000,
+    });
+  });
+});

--- a/libraries/typescript/tests/unit/fish-audio-ws-tts.mocked.test.ts
+++ b/libraries/typescript/tests/unit/fish-audio-ws-tts.mocked.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { decode, encode } from '@msgpack/msgpack';
+import { WebSocketServer, type WebSocket as WSSocket } from 'ws';
+import type { AddressInfo } from 'node:net';
+import {
+  FishAudioWebSocketTTS,
+  WS_SUPPORTED_MODELS,
+  decodeServerFrame,
+  type MsgpackCodec,
+} from '../../src/providers/fish-audio-ws-tts';
+import { WebSocketTTS as FishAudioPipelineWSTTS } from '../../src/tts/fish-audio';
+
+/**
+ * [mocked] Fish Audio WebSocket TTS.
+ *
+ * Runs against a **real in-process `ws` server** on 127.0.0.1 speaking the real
+ * MessagePack framing — only Fish's synthesis is simulated. Handshake headers,
+ * frame encode/decode, protocol ordering, audio reassembly, error surfacing and
+ * the stall timeout all execute for real over a real socket.
+ */
+
+const codec: MsgpackCodec = { encode, decode };
+
+describe('[mocked] Fish Audio WebSocket TTS — live protocol', () => {
+  let wss: WebSocketServer;
+  let url: string;
+
+  const recorder = {
+    headers: {} as Record<string, string | string[] | undefined>,
+    events: [] as Array<Record<string, unknown>>,
+    audioFrames: [] as number[][],
+    finishReason: 'stop',
+    finishMessage: undefined as string | undefined,
+    stall: false,
+  };
+
+  beforeAll(async () => {
+    wss = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    wss.on('connection', (socket: WSSocket, req) => {
+      recorder.headers = req.headers;
+      socket.on('message', (raw: Buffer) => {
+        const event = decode(new Uint8Array(raw)) as Record<string, unknown>;
+        recorder.events.push(event);
+        if (event.event !== 'stop') return;
+        if (recorder.stall) return; // never answer — exercises the frame timeout
+        for (const frame of recorder.audioFrames) {
+          socket.send(encode({ event: 'audio', audio: Uint8Array.from(frame) }));
+        }
+        const finish: Record<string, unknown> = {
+          event: 'finish',
+          reason: recorder.finishReason,
+        };
+        if (recorder.finishMessage !== undefined) finish.message = recorder.finishMessage;
+        socket.send(encode(finish));
+      });
+    });
+    await new Promise<void>((resolve) => wss.on('listening', () => resolve()));
+    url = `ws://127.0.0.1:${(wss.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    recorder.headers = {};
+    recorder.events = [];
+    recorder.audioFrames = [
+      [170, 187],
+      [204, 221],
+    ];
+    recorder.finishReason = 'stop';
+    recorder.finishMessage = undefined;
+    recorder.stall = false;
+  });
+
+  const ws = (opts = {}): FishAudioWebSocketTTS =>
+    new FishAudioWebSocketTTS('fish-test-key', { wsUrl: url, ...opts });
+
+  async function collect(tts: FishAudioWebSocketTTS, text: string): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of tts.synthesizeStream(text)) chunks.push(chunk);
+    return Buffer.concat(chunks);
+  }
+
+  it('reassembles audio frames in order', async () => {
+    expect(Array.from(await collect(ws(), 'ciao'))).toEqual([170, 187, 204, 221]);
+  });
+
+  it('sends start → text → flush → stop', async () => {
+    await collect(ws(), 'ciao mondo');
+    expect(recorder.events.map((e) => e.event)).toEqual(['start', 'text', 'flush', 'stop']);
+    expect(recorder.events[1].text).toBe('ciao mondo');
+  });
+
+  it('carries the config on the start frame with an empty text', async () => {
+    await collect(ws({ voice: 'ref-1', sampleRate: 8000 }), 'ciao');
+    const request = recorder.events[0].request as Record<string, unknown>;
+    expect(request).toMatchObject({
+      text: '',
+      format: 'pcm',
+      sample_rate: 8000,
+      reference_id: 'ref-1',
+    });
+  });
+
+  it('sends Bearer auth and the model header on the handshake', async () => {
+    await collect(ws({ model: 's1' }), 'ciao');
+    expect(recorder.headers.authorization).toBe('Bearer fish-test-key');
+    expect(recorder.headers.model).toBe('s1');
+  });
+
+  it('throws when the server finishes with reason=error', async () => {
+    recorder.finishReason = 'error';
+    recorder.finishMessage = 'voice model not found';
+    await expect(collect(ws(), 'ciao')).rejects.toThrow(/voice model not found/);
+  });
+
+  it('throws instead of hanging when the server stalls', async () => {
+    recorder.stall = true;
+    await expect(collect(ws({ frameTimeoutMs: 200 }), 'ciao')).rejects.toThrow(/stalled/);
+  });
+});
+
+describe('[unit] Fish Audio WebSocket TTS — model guard', () => {
+  it('rejects s2.1-pro up front and points at the HTTP adapter', () => {
+    expect(() => new FishAudioWebSocketTTS('k', { model: 's2.1-pro' })).toThrow(
+      /FishAudioTTS/,
+    );
+    expect(() => new FishAudioWebSocketTTS('k', { model: 's2.1-pro' })).toThrow(
+      /\/v1\/tts\/live/,
+    );
+  });
+
+  it('rejects s2.1-pro-free too', () => {
+    expect(() => new FishAudioWebSocketTTS('k', { model: 's2.1-pro-free' })).toThrow();
+  });
+
+  it.each(WS_SUPPORTED_MODELS)('accepts the socket-supported model %s', (model) => {
+    expect(new FishAudioWebSocketTTS('k', { model }).model).toBe(model);
+  });
+
+  it('defaults to s2-pro, the fastest socket model', () => {
+    expect(new FishAudioWebSocketTTS('k').model).toBe('s2-pro');
+  });
+
+  it('shares the HTTP adapter pricing key', () => {
+    expect(FishAudioWebSocketTTS.providerKey).toBe('fish_audio');
+  });
+
+  it('falls back to FISH_AUDIO_API_KEY on the pipeline subclass', () => {
+    const prev = process.env.FISH_AUDIO_API_KEY;
+    process.env.FISH_AUDIO_API_KEY = 'env-key';
+    try {
+      expect(new FishAudioPipelineWSTTS().model).toBe('s2-pro');
+    } finally {
+      if (prev === undefined) delete process.env.FISH_AUDIO_API_KEY;
+      else process.env.FISH_AUDIO_API_KEY = prev;
+    }
+  });
+});
+
+describe('[unit] Fish Audio WebSocket TTS — frame decoding', () => {
+  it('skips log and unknown frames without ending the stream', () => {
+    for (const frame of [
+      Buffer.from(encode({ event: 'log', message: 'warming up' })),
+      Buffer.from(encode({ event: 'some-future-event' })),
+      Buffer.from(encode([1, 2, 3])),
+    ]) {
+      expect(decodeServerFrame(frame, codec)).toEqual({ audio: null, done: false });
+    }
+  });
+
+  it('ignores text frames rather than crashing the stream', () => {
+    expect(decodeServerFrame('unexpected text', codec)).toEqual({
+      audio: null,
+      done: false,
+    });
+  });
+
+  it('throws on an undecodable frame', () => {
+    // 0x81 announces a 1-pair map and then ends — a truncated frame.
+    expect(() => decodeServerFrame(Buffer.from([0x81]), codec)).toThrow(/undecodable/);
+  });
+
+  it('rejects an oversized audio frame', () => {
+    const huge = Buffer.from(
+      encode({ event: 'audio', audio: new Uint8Array(1024 * 1024 + 1) }),
+    );
+    expect(() => decodeServerFrame(huge, codec)).toThrow(/sanity limit/);
+  });
+
+  it('skips an audio frame that carries no bytes', () => {
+    const frame = Buffer.from(encode({ event: 'audio', audio: null }));
+    expect(decodeServerFrame(frame, codec)).toEqual({ audio: null, done: false });
+  });
+
+  it('reports finish as terminal', () => {
+    const frame = Buffer.from(encode({ event: 'finish', reason: 'stop' }));
+    expect(decodeServerFrame(frame, codec)).toEqual({ audio: null, done: true });
+  });
+});

--- a/scripts/pr-validate.sh
+++ b/scripts/pr-validate.sh
@@ -142,7 +142,7 @@ if [ "$SKIP_PY" = "0" ] && [ "$MODE" != "quick" ]; then
         bash -c "cd libraries/python && pytest tests/security/ -q -m security"
     if [ "$MODE" = "full" ]; then
         run_check "python: all-extras tests (slow)" pytest \
-            bash -c "cd libraries/python && pip install -e '.[dev,silero,deepfilternet,ivr,anthropic,groq,cerebras,google,cartesia,soniox,assemblyai,rime,lmnt,ultravox,gemini-live,evals,tracing,scheduling,background-audio,telnyx-ai]' --quiet && pytest tests/ -q --tb=line"
+            bash -c "cd libraries/python && pip install -e '.[dev,silero,deepfilternet,ivr,anthropic,groq,cerebras,google,cartesia,soniox,assemblyai,rime,lmnt,fish_audio,ultravox,gemini-live,evals,tracing,scheduling,background-audio,telnyx-ai]' --quiet && pytest tests/ -q --tb=line"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds **Fish Audio** as a first-class Patter provider in **both SDKs**: TTS over HTTP streaming (`s2.1-pro`, the recommended production model) and over WebSocket (`s2-pro`, ~100 ms time-to-first-audio), plus batch ASR. One `FISH_AUDIO_API_KEY` covers both directions of the call.
- Wired exactly like every existing provider — low-level adapter → namespaced wrapper → flat export → config helper → `TTSConfig`/`STTConfig` factory → pricing → telemetry vendor map → init wizard → docs → tests.
- Purely additive and opt-in: no existing default changes and no public signature changes.

## Implementation

**Adapters** (Python `libraries/python/getpatter/providers/fish_audio_{tts,ws_tts,stt}.py`, TypeScript `libraries/typescript/src/providers/fish-audio-{tts,ws-tts,stt}.ts`):

- **`FishAudioTTS`** — `POST /v1/tts`, chunked audio response. Defaults: `model=s2.1-pro`, `format=pcm`, `sample_rate=16000`, `latency=balanced`. Fish selects the model with a **request header**, not a body field, so switching generations is a constructor argument. `voice` maps to Fish's `reference_id`; a sequence enables multi-speaker with `<|speaker:N|>` markers. Every unset knob is **omitted from the request** so Fish applies its own documented default instead of one the SDK guessed. `warmup()` pings `GET /model` — a free metadata read — rather than `HEAD /v1/tts`, which is POST-only and answers 405 (the trap already documented on the Inworld adapter).
- **`FishAudioWebSocketTTS`** — `wss://api.fish.audio/v1/tts/live`, per-utterance socket (the ElevenLabs WS pattern). Fish serves **only `s1` and `s2-pro`** there, so `s2.1-pro` is rejected at construction with a pointer back to the HTTP adapter rather than failing mid-call. Frames are MessagePack (`start` → `text` → `flush` → `stop`), which is the sole reason for the codec dependency — the server returns raw audio bytes inline, which JSON cannot carry without base64.
- **`FishAudioSTT`** — `POST /v1/asr` on the `WhisperSTT` pattern. Fish exposes no streaming socket, so this buffers ~2 s windows and emits one final transcript each, with no interim partials. A short tail is **silence-padded to Fish's documented 1 s floor** rather than dropped, so the last words of an utterance are never lost. Server errors are logged and yield no transcript; they never raise into a live call.

**Design decisions worth reviewing:**

1. **Default is `s2.1-pro`, not Fish's own `s2.1-pro-free` API default.** The free tier ships with no time-to-first-audio guarantee, which is unusable for live telephony. `s2.1-pro-free` is one argument away and is priced at `0.0`.
2. **HTTP is the default transport, WebSocket is opt-in.** The socket cannot serve `s2.1-pro`, so defaulting to it would silently downgrade the headline model. Same split as `ElevenLabsTTS` vs `ElevenLabsWebSocketTTS`.
3. **Telephony.** Fish emits linear PCM only — no native G.711 — so the μ-law encode always runs. `for_twilio()` requests PCM directly at 8 kHz so the pipeline at least skips the resample; `for_telnyx()` keeps 16 kHz. Both declare their rate via `source_audio_format()`.
4. **Pricing is metered in UTF-8 bytes.** Fish bills $15 / 1M UTF-8 **bytes** (ASR $0.36 / audio hour). The adapters report byte length rather than character count — exact for latin scripts and correctly ~3× higher for CJK. Documented inline in `pricing.py` / `pricing.ts` and on the docs pages.
5. **The ASR config helper is named `fish_audio_asr`, not `fish_audio_stt`.** A helper named after the `providers.fish_audio_stt` submodule would be shadowed the moment the factory imports it — the same trap that `soniox_tts` needs an explicit re-bind to survive. Avoided at the source instead of replicating the workaround.

**Dependencies added:** Python extra `getpatter[fish_audio]` = `aiohttp>=3.10` + `ormsgpack>=1.5`; TypeScript `@msgpack/msgpack` as an **optional** dependency (lazily imported). The msgpack codec is required by the WebSocket transport only — the HTTP and ASR adapters work without it and raise a remedy-shaped error naming the extra if it is missing.

**Also touched:** `pricing.*`, `telemetry/stack.*` (vendor allowlist + alias), `stream_handler.py` (`_infer_tts_provider` needle→key pairs — behaviour-identical for existing providers), `telephony/common.py` (both `TTSConfig` and `STTConfig` factories), `local_config.py`, init-wizard catalogues in both SDKs, `.env.example` × 2, and the extras lists in `.github/workflows/test.yml` / `scripts/pr-validate.sh` so the WebSocket path is actually covered in CI rather than skipped.

## Breaking change?

No. Everything is additive and opt-in — no existing default changes, no public signature changes, no version bump (that belongs to the release PR).

## Test plan

- [x] Python: `pytest tests/ -m "not soak"` → **3183 passed**, 8 skipped, 2 xfailed
- [x] TypeScript: `npm test` → **2605 passed**, 9 skipped (165 files)
- [x] TypeScript: `npm run lint` (tsc --noEmit) clean + `npm run build` succeeds
- [x] Parity verified by comparing both SDKs' resolved defaults side by side — model / format / sample rate / latency / buffer size / carrier rates / pricing tables / provider keys match byte-for-byte
- [x] 59 new Python tests + 63 new TypeScript tests

Tests run against **real in-process servers** (`aiohttp.web`, `websockets.serve`, `node:http`, `ws.WebSocketServer`) on 127.0.0.1 rather than faking the HTTP client, so header assembly, JSON payload construction, MessagePack framing, WAV framing, multipart field names, chunked streaming, the stall timeout and every failure path execute for real over a real socket. Only Fish's synthesis/transcription itself is simulated.

Not yet exercised against a live Fish Audio key on a real phone call — the provider is marked **Beta** in every docstring and on both docs pages until that happens.

## Docs updates

- `docs/python-sdk/providers/fish-audio-tts.mdx`, `docs/python-sdk/providers/fish-audio-stt.mdx` (new)
- `docs/typescript-sdk/providers/fish-audio-tts.mdx`, `docs/typescript-sdk/providers/fish-audio-stt.mdx` (new)
- `docs/docs.json` — added to the STT and TTS navigation groups for both SDKs
- `docs/{python,typescript}-sdk/tts.mdx`, `docs/{python,typescript}-sdk/stt.mdx` — provider tables + sections
- `docs/{python,typescript}-sdk/metrics.mdx` — pricing table rows
- `docs/concepts.mdx`, root `README.md`, `libraries/{python,typescript}/README.md` — provider inventories
- `CHANGELOG.md` — entry under `## Unreleased` → `### Added`
