### PR TITLE
fix(lint): unbreak the pre-commit gate — stray trailing blank lines in xai_stt.py

### DIFF
--- a/libraries/python/getpatter/providers/xai_stt.py
+++ b/libraries/python/getpatter/providers/xai_stt.py
@@ -581,5 +581,3 @@ async def transcribe(
         duration=float(payload.get("duration", 0.0)),
         words=_parse_words(payload.get("words")),
     )
-
-


### PR DESCRIPTION
## Summary

- `main` is currently **red on the `Pre-commit (lint + hygiene)` check**, and has been since #211: `libraries/python/getpatter/providers/xai_stt.py` ends with two extra blank lines, which the `end-of-file-fixer` hook rejects.
- The CI job runs `pre-commit run --all-files`, so this fails on **every open PR** regardless of what that PR touches — it blocked #212 (Fish Audio provider), which does not go near that file.

## Implementation

- Two blank lines removed from the end of `libraries/python/getpatter/providers/xai_stt.py`. Whitespace only.
- Verified with `pre-commit run --all-files` on a clean checkout of `main` + this fix: all nine hooks pass.

## Breaking change?

No. Whitespace only — no behaviour change.

## Test plan

- [x] `pre-commit run --all-files` → all hooks pass (was: `end-of-file-fixer` failed)
- [x] No source behaviour touched, so the existing Python/TypeScript suites are unaffected

## Docs updates

N/A — whitespace-only fix, exempt from the changelog rule.
