### PR TITLE
fix(readme): restore the star history chart and stop it from breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ cd python && pip install -r requirements.txt && python main.py
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=PatterAI%2FPatter&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#PatterAI/Patter&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=PatterAI/Patter&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=PatterAI/Patter&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=PatterAI/Patter&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=PatterAI/Patter&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=PatterAI/Patter&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=PatterAI/Patter&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart is broken: GitHub stargazer API restrictions break the embeds, so the chart in the README does not render correctly. This fixes it by pointing the star history images to a working alternative domain. No other content in the README is affected.