### PR TITLE
docs: add optional hosted web search MCP examples

### DIFF
--- a/docs/python-sdk/mcp.mdx
+++ b/docs/python-sdk/mcp.mdx
@@ -172,6 +172,30 @@ asyncio.run(main())
 This is a tool-call integration for caller-provided media URLs. It does not
 inspect live caller audio or replace application-specific escalation policy.
 
+## Optional hosted MCP example - Parallel web search
+
+Opt in to Parallel's hosted Search MCP when a caller needs current web research
+or wants the agent to look up a specific URL during a voice call. This gives the
+caller useful, sourced web context without a custom search wrapper and does not
+require an API key. Learn more in the [Parallel Search MCP
+documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
+
+```python
+agent = phone.agent(
+    engine=OpenAIRealtime(),
+    system_prompt=(
+        "When the caller asks for current web information, use the Parallel "
+        "search tools. When they provide a URL, use the URL lookup tool."
+    ),
+    mcp_servers=["https://search.parallel.ai/mcp"],
+)
+```
+
+This optional configuration does not change Patter's provider, default, or
+runtime behavior. Only after you explicitly opt in and the agent uses these
+tools, submitted search objectives, search queries, and requested URLs are sent
+to third-party Parallel.
+
 ## Real-world example — Postgres MCP server
 
 Connect a phone agent to a Postgres MCP server so the caller can query an orders table by phone number.

--- a/docs/typescript-sdk/mcp.mdx
+++ b/docs/typescript-sdk/mcp.mdx
@@ -162,6 +162,29 @@ This is a tool-call integration for caller-provided media URLs and text. It
 does not inspect live caller audio or replace application-specific escalation
 policy.
 
+## Optional hosted MCP example - Parallel web search
+
+Opt in to Parallel's hosted Search MCP when a caller needs current web research
+or wants the agent to look up a specific URL during a voice call. This gives the
+caller useful, sourced web context without a custom search wrapper and does not
+require an API key. Learn more in the [Parallel Search MCP
+documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
+
+```typescript
+const agent = phone.agent({
+  engine: new OpenAIRealtime(),
+  systemPrompt:
+    "When the caller asks for current web information, use the Parallel " +
+    "search tools. When they provide a URL, use the URL lookup tool.",
+  mcpServers: ["https://search.parallel.ai/mcp"],
+});
+```
+
+This optional configuration does not change Patter's provider, default, or
+runtime behavior. Only after you explicitly opt in and the agent uses these
+tools, submitted search objectives, search queries, and requested URLs are sent
+to third-party Parallel.
+
 ## Real-world example — Postgres MCP server
 
 Connect a phone agent to a Postgres MCP server so the caller can query an orders table by phone number.


### PR DESCRIPTION
## Summary

Adds matching, optional hosted Parallel Search MCP examples to the Python and TypeScript MCP guides so voice-agent builders can opt in to current web search and caller-requested URL lookup without writing a custom wrapper or supplying an API key.

Only after you explicitly opt in and the agent uses these tools, submitted search objectives, search queries, and requested URLs are sent to third-party Parallel.

## Changes

- Add the native `mcp_servers=["https://search.parallel.ai/mcp"]` Python example.
- Add the equivalent `mcpServers: ["https://search.parallel.ai/mcp"]` TypeScript example.
- Document the caller-facing web research and URL lookup benefit, no-key setup, opt-in data boundary, and [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
- Preserve every existing provider, default, and runtime behavior.

## Pre-merge checklist

- [ ] **Local validation is green**: `bash scripts/pr-validate.sh` (not run; this is a two-file docs-only change).
- [x] **Both SDKs** updated when the change is user-visible — matching Python and TypeScript documentation examples are included.
- [x] **`CHANGELOG.md` updated** — docs-only diffs are exempt, so no changelog entry is needed.
- [ ] **Tests** added for new behaviour — no runtime behavior changed; validated the exact two-file scope, required copy, and `git diff --check` only.
- [x] **No secrets, credentials, or real phone numbers / PII** in the diff.
- [x] **No external license headers or "ported from <repo>" provenance comments** in source files.

## Breaking change?

No. The examples are optional and do not change providers, defaults, or runtime behavior.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.