### PR TITLE
feat(xai): wire the 26-voice Grok catalog into both SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ### Added
 
+- **xAI (Grok) voice catalog wired into both SDKs** — the 26 built-in Grok
+  voices (`eve` default, `ara`, `rex`, `sal`, `leo`, `carina`, ...) are now a
+  typed, immutable catalog instead of docs-only prose:
+  - **`XAI_VOICES` / `XAI_VOICE_IDS` / `XAI_DEFAULT_VOICE`** plus
+    `isXaiBuiltinVoice` / `normalizeXaiVoice` / `getXaiVoice` (TS) and
+    `is_xai_builtin_voice` / `normalize_xai_voice` / `get_xai_voice` (Python),
+    exported from the package root. Built-in ids are trimmed + lowercased
+    before they reach xAI; custom cloned `voice_id`s stay opaque and are
+    never rejected.
+  - **`XaiTTS` and `XaiRealtimeAdapter`** normalize the voice they send
+    (REST `voice_id`, `session.update` voice); `XAI_REALTIME_DEFAULT_VOICE`
+    stays exported as an alias.
+  - **Config helpers** `xai()` (TTS, key `xai_tts`) and `xaiAsr()` /
+    `xai_asr()` (STT, key `xai`) in `providers`, and the Python
+    `TTSConfig` / `STTConfig` factories in `telephony/common.py` now resolve
+    those keys to `XaiTTS` / `XaiSTT`.
+  - **`patter init`** lists xAI in both the STT and TTS provider tables
+    (`XAI_API_KEY`).
+  - Docs: `xai-tts.mdx` Voices section links the catalog and helpers in
+    both SDKs.
+
 - **Fish Audio voice provider suite** — TTS (S2.1-Pro / S2-Pro) and ASR land in
   both SDKs, wired end-to-end with real pricing. One `FISH_AUDIO_API_KEY`
   covers both directions of the call:

--- a/docs/python-sdk/providers/xai-tts.mdx
+++ b/docs/python-sdk/providers/xai-tts.mdx
@@ -138,6 +138,24 @@ xAI ships a roster of 26 built-in voices, each with a distinct personality. `eve
 | `zagan` | Powerful, dramatic, and unmistakable | Characters, Narration |
 | `zenith` | Sharp, focused, and driven | Sales, Advertising |
 
+### Programmatic access
+
+The table above is also available in code as `XAI_VOICES`, along with `is_xai_builtin_voice` for telling a built-in id apart from a custom cloned one (both are case-insensitive), and the `xai()` / `xai_asr()` helpers for building a pipeline-mode `TTSConfig` / `STTConfig`:
+
+```python Python
+from getpatter import XAI_VOICES, is_xai_builtin_voice
+from getpatter.providers import xai, xai_asr
+
+for voice in XAI_VOICES:
+    print(voice.id, voice.tone, voice.use_cases)
+
+is_xai_builtin_voice("EVE")           # True  — built-in ids are case-insensitive
+is_xai_builtin_voice("my-cloned-id")  # False — a custom voice, left untouched
+
+tts_config = xai(api_key="...", voice="eve")
+stt_config = xai_asr(api_key="...", language="en")
+```
+
 ### Custom voices
 
 Clone a voice from a short reference clip (WAV, ≤120 s) with the custom-voices helper. It returns a `voice_id` usable as the `voice` on both `XaiTTS` and the [xAI Realtime engine](/python-sdk/providers/xai-realtime):

--- a/docs/typescript-sdk/providers/xai-tts.mdx
+++ b/docs/typescript-sdk/providers/xai-tts.mdx
@@ -107,7 +107,7 @@ asyncio.run(phone.serve(agent))
 
 ## Voices
 
-xAI ships a roster of 26 built-in voices, each with a distinct personality. `eve` is the default; voice IDs are **case-insensitive** (`eve`, `Eve`, and `EVE` all work). Tone and suggested use cases below are from the [xAI Voice Overview](https://docs.x.ai/developers/model-capabilities/audio/voice); preview samples for each voice in the [xAI console playground](https://console.x.ai/).
+xAI ships a roster of built-in voices, each with a distinct personality — the full set ships as the `XAI_VOICES` catalog (ids alone as `XAI_VOICE_IDS`). `eve` is the default (`XAI_DEFAULT_VOICE`); voice IDs are **case-insensitive** (`eve`, `Eve`, and `EVE` all work) — Patter normalizes case for you before the request goes out. Tone and suggested use cases below are from the [xAI Voice Overview](https://docs.x.ai/developers/model-capabilities/audio/voice); preview samples for each voice in the [xAI console playground](https://console.x.ai/).
 
 | Voice | Tone | Suggested use cases |
 |---|---|---|
@@ -137,6 +137,32 @@ xAI ships a roster of 26 built-in voices, each with a distinct personality. `eve
 | `ursa` | Friendly, warm, and steadfast | Assistant, Podcast |
 | `zagan` | Powerful, dramatic, and unmistakable | Characters, Narration |
 | `zenith` | Sharp, focused, and driven | Sales, Advertising |
+
+### Looking up voices in code
+
+Import the catalog instead of hardcoding voice ids or a count — `isXaiBuiltinVoice` is case-insensitive and returns `false` (never throws) for a custom cloned voice id, so it is safe to use as a plain guard:
+
+```typescript
+import { XAI_VOICES, isXaiBuiltinVoice, XaiTTS } from "getpatter";
+
+for (const v of XAI_VOICES) {
+  console.log(v.id, v.tone, v.useCases);
+}
+
+isXaiBuiltinVoice("EVE");           // true — built-in ids are case-insensitive
+isXaiBuiltinVoice("my-cloned-id");  // false — not a preset, but still a legal voice
+
+const tts = new XaiTTS({ voice: "Leo" }); // normalized to "leo" before it is sent
+```
+
+The same catalog backs the `xai()` / `xaiAsr()` config-envelope helpers, for code that builds provider config from data rather than constructing adapters directly:
+
+```typescript
+import { xai, xaiAsr } from "getpatter";
+
+const ttsConfig = xai({ apiKey: "...", voice: "eve" });   // provider: "xai_tts"
+const sttConfig = xaiAsr({ apiKey: "...", language: "en" }); // provider: "xai"
+```
 
 ### Custom voices
 

--- a/docs/typescript-sdk/tts.mdx
+++ b/docs/typescript-sdk/tts.mdx
@@ -157,7 +157,7 @@ const tts = new LMNTTTS({ model: "blizzard", voice: "leah" });
 
 ## xAI
 
-Grok text-to-speech (default voice `eve`) with 26 built-in voices, inline speech tags, custom voice cloning, and telephony-native output. See [xAI TTS setup](/typescript-sdk/providers/xai-tts).
+Grok text-to-speech (default voice `eve`) with a full `XAI_VOICES` catalog of built-in voices, inline speech tags, custom voice cloning, and telephony-native output. See [xAI TTS setup](/typescript-sdk/providers/xai-tts).
 
 ```typescript
 import { XaiTTS } from "getpatter";

--- a/libraries/python/getpatter/__init__.py
+++ b/libraries/python/getpatter/__init__.py
@@ -140,6 +140,15 @@ from getpatter.tts.soniox import TTS as SonioxTTS
 from getpatter.tts.sarvam import TTS as SarvamTTS
 from getpatter.tts.xai import TTS as XaiTTS
 from getpatter.providers.xai_tts import create_custom_voice as xai_create_custom_voice
+from getpatter.providers.xai_voices import (
+    XaiVoice,
+    XAI_VOICES,
+    XAI_VOICE_IDS,
+    XAI_DEFAULT_VOICE,
+    is_xai_builtin_voice,
+    normalize_xai_voice,
+    get_xai_voice,
+)
 from getpatter.tts.fish_audio import TTS as FishAudioTTS
 from getpatter.tts.fish_audio import WebSocketTTS as FishAudioWebSocketTTS
 
@@ -552,6 +561,13 @@ __all__ = [
     "SarvamTTS",
     "XaiTTS",
     "xai_create_custom_voice",
+    "XaiVoice",
+    "XAI_VOICES",
+    "XAI_VOICE_IDS",
+    "XAI_DEFAULT_VOICE",
+    "is_xai_builtin_voice",
+    "normalize_xai_voice",
+    "get_xai_voice",
     "FishAudioTTS",
     "FishAudioWebSocketTTS",
     "OpenAILLM",

--- a/libraries/python/getpatter/init/cli.py
+++ b/libraries/python/getpatter/init/cli.py
@@ -135,6 +135,12 @@ PIPELINE_STT: dict[str, dict] = {
         "env": ("FISH_AUDIO_API_KEY",),
         "extra": "fish_audio",
     },
+    "xai": {
+        "class": "XaiSTT",
+        "label": "xAI Grok",
+        "env": ("XAI_API_KEY",),
+        "extra": "xai",
+    },
 }
 DEFAULT_STT = "deepgram"
 
@@ -216,6 +222,12 @@ PIPELINE_TTS: dict[str, dict] = {
         "label": "Fish Audio (s2.1-pro)",
         "env": ("FISH_AUDIO_API_KEY",),
         "extra": "fish_audio",
+    },
+    "xai": {
+        "class": "XaiTTS",
+        "label": "xAI Grok",
+        "env": ("XAI_API_KEY",),
+        "extra": "xai",
     },
 }
 DEFAULT_TTS = "elevenlabs"

--- a/libraries/python/getpatter/providers/__init__.py
+++ b/libraries/python/getpatter/providers/__init__.py
@@ -138,6 +138,28 @@ def fish_audio_asr(
     )
 
 
+def xai(api_key: str, voice: str = "eve") -> TTSConfig:
+    """Config helper for xAI (Grok) TTS (requires the ``xai`` optional extra).
+
+    ``voice`` is a built-in roster id (see ``getpatter.XAI_VOICES`` /
+    ``is_xai_builtin_voice``; case-insensitive) or a custom cloned
+    ``voice_id`` from ``xai_create_custom_voice``. Defaults to ``"eve"``,
+    xAI's documented default voice.
+    """
+    return TTSConfig(provider="xai_tts", api_key=api_key, voice=voice)
+
+
+def xai_asr(api_key: str, language: str = "en") -> STTConfig:
+    """Config helper for xAI (Grok) STT (requires the ``xai`` optional extra).
+
+    Named ``_asr`` rather than ``_stt`` on purpose: a helper called
+    ``xai_stt`` would be shadowed by the ``providers.xai_stt`` submodule as
+    soon as the factory imports it — the same trap ``fish_audio_asr`` (above)
+    and ``soniox_tts`` (below) already document and guard against.
+    """
+    return STTConfig(provider="xai", api_key=api_key, language=language)
+
+
 def soniox_tts(
     api_key: str,
     voice: str = "Adrian",
@@ -244,6 +266,8 @@ __all__ = [
     "inworld",
     "fish_audio",
     "fish_audio_asr",
+    "xai",
+    "xai_asr",
     "soniox_tts",
     "sarvam",
     "AnthropicLLMProvider",

--- a/libraries/python/getpatter/providers/xai_realtime.py
+++ b/libraries/python/getpatter/providers/xai_realtime.py
@@ -31,12 +31,16 @@ from __future__ import annotations
 from typing import Any, ClassVar, Mapping, Sequence
 
 from getpatter.providers.openai_realtime_2 import OpenAIRealtime2Adapter
+from getpatter.providers.xai_voices import XAI_DEFAULT_VOICE, normalize_xai_voice
 
 # Default Grok voice model. ``grok-voice-latest`` tracks the current flagship
 # (``grok-voice-think-fast-1.0`` at time of writing).
 XAI_REALTIME_URL = "wss://api.x.ai/v1/realtime"
 XAI_DEFAULT_MODEL = "grok-voice-latest"
-XAI_DEFAULT_VOICE = "eve"
+# ``XAI_DEFAULT_VOICE`` re-exported (imported above) from
+# ``getpatter.providers.xai_voices`` — see ``XAI_VOICES`` there for the full
+# built-in roster, shared with the TTS REST endpoint — so existing
+# ``from .xai_realtime import XAI_DEFAULT_VOICE`` imports keep working.
 # xAI's input-transcription model. Setting it enables the
 # ``conversation.item.input_audio_transcription.updated`` events (display-only);
 # omitting the OpenAI-only ``whisper-1`` default keeps the session xAI-valid.
@@ -75,6 +79,12 @@ class XaiRealtimeAdapter(OpenAIRealtime2Adapter):
         # explicit model/voice/transcription-model always wins.
         kwargs.setdefault("model", XAI_DEFAULT_MODEL)
         kwargs.setdefault("voice", XAI_DEFAULT_VOICE)
+        # Normalize before it is ever sent in ``session.update``: built-in ids
+        # are case-insensitive on the xAI side (trim + lowercase); a custom
+        # cloned voice_id is an opaque string and is left untouched apart from
+        # trimming. ``self.voice`` (set by the parent from this kwarg) is what
+        # ``_build_ga_session_config`` — inherited from the GA adapter — reads.
+        kwargs["voice"] = normalize_xai_voice(kwargs["voice"])
         kwargs.setdefault("input_audio_transcription_model", XAI_TRANSCRIPTION_MODEL)
         # xAI-specific session knobs (grafted in ``_build_ga_session_config``).
         # ``reasoning_effort`` and ``silence_duration_ms`` are reused from the

--- a/libraries/python/getpatter/providers/xai_tts.py
+++ b/libraries/python/getpatter/providers/xai_tts.py
@@ -26,6 +26,7 @@ import os
 from typing import Any, AsyncIterator, ClassVar, Optional
 
 from getpatter.providers.base import TTSProvider
+from getpatter.providers.xai_voices import XAI_DEFAULT_VOICE, normalize_xai_voice
 
 logger = logging.getLogger("getpatter.providers.xai_tts")
 
@@ -41,9 +42,10 @@ XAI_TTS_REST_URL = "https://api.x.ai/v1/tts"
 # Custom-voice creation endpoint (multipart upload of a reference clip).
 XAI_CUSTOM_VOICES_URL = "https://api.x.ai/v1/custom-voices"
 
-# xAI's default voice. The full 26-voice roster is shared with the Voice Agent
-# API; ``eve`` is the documented default.
-XAI_DEFAULT_VOICE = "eve"
+# ``XAI_DEFAULT_VOICE`` re-exported (imported above) from
+# ``getpatter.providers.xai_voices`` — see ``XAI_VOICES`` there for the full
+# built-in roster, shared with the Voice Agent API — so existing
+# ``from .xai_tts import XAI_DEFAULT_VOICE`` imports keep working.
 
 # Pipeline-friendly defaults when the caller leaves codec / sample_rate unset:
 # raw PCM-16-LE @ 16 kHz (NOT xAI's own mp3 default, which the pipeline can't
@@ -106,7 +108,10 @@ class XaiTTS(TTSProvider):
             )
 
         self.api_key = resolved_key
-        self.voice = voice
+        # Normalize before it is ever sent: built-in ids are case-insensitive
+        # on the xAI side (trim + lowercase); a custom cloned voice_id is an
+        # arbitrary opaque string and is left untouched apart from trimming.
+        self.voice = normalize_xai_voice(voice)
         self.language = language
         self.speed = speed
         self.optimize_streaming_latency = optimize_streaming_latency

--- a/libraries/python/getpatter/providers/xai_voices.py
+++ b/libraries/python/getpatter/providers/xai_voices.py
@@ -1,0 +1,150 @@
+"""xAI built-in voice catalog for the Patter SDK.
+
+Single source of truth for the 26 built-in xAI voice ids, shared by
+:class:`~getpatter.providers.xai_tts.XaiTTS` and
+:class:`~getpatter.providers.xai_realtime.XaiRealtimeAdapter` (the Voice Agent
+API draws on the same roster). Both modules import :data:`XAI_DEFAULT_VOICE`
+and :func:`normalize_xai_voice` from here instead of hardcoding them, so the
+roster has one place to update.
+
+Built-in ids are lowercase and case-insensitive on the xAI side (docs.x.ai).
+Custom cloned voices (see
+:func:`~getpatter.providers.xai_tts.create_custom_voice`) return an opaque
+``voice_id`` string that is NOT part of this roster — :func:`normalize_xai_voice`
+only folds case for a KNOWN built-in id and otherwise leaves the value
+untouched (besides trimming whitespace), so a custom voice id is never
+rejected or reshaped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class XaiVoice:
+    """Metadata for one built-in xAI voice (from the xAI voice catalog)."""
+
+    id: str
+    tone: str
+    use_cases: tuple[str, ...]
+
+
+# Roster order: ``eve`` (the documented default) first, then the remaining 25
+# alphabetically by id — mirrors the table in docs/*/providers/xai-tts.mdx.
+XAI_VOICES: tuple[XaiVoice, ...] = (
+    XaiVoice("eve", "Energetic and upbeat", ()),
+    XaiVoice(
+        "altair",
+        "Elegant, refined, and effortlessly premium",
+        ("Advertising", "Narration"),
+    ),
+    XaiVoice("ara", "Warm and friendly", ()),
+    XaiVoice(
+        "atlas", "Confident, commanding, and reassuring", ("Sales", "Assistant")
+    ),
+    XaiVoice("carina", "Soft, empathetic, and soothing", ("Wellness", "Support")),
+    XaiVoice(
+        "castor",
+        "Charismatic, down-to-earth, and easygoing",
+        ("Sales", "Support"),
+    ),
+    XaiVoice(
+        "celeste",
+        "Compassionate, confident, and reassuring",
+        ("Support", "Assistant"),
+    ),
+    XaiVoice("cosmo", "Bright, curious, and easy to follow", ("Education", "Podcast")),
+    XaiVoice(
+        "helios",
+        "Upbeat, energetic, and endlessly versatile",
+        ("Assistant", "Wellness"),
+    ),
+    XaiVoice(
+        "helix", "Bold, dynamic, and adrenaline-fueled", ("Commentary", "Podcast")
+    ),
+    XaiVoice(
+        "iris", "Friendly, upbeat, and naturally charming", ("Sales", "Support")
+    ),
+    XaiVoice(
+        "kepler",
+        "Inventive, forward-thinking, and charismatic",
+        ("Advertising", "Podcast"),
+    ),
+    XaiVoice("leo", "Authoritative and strong", ()),
+    XaiVoice(
+        "lumen", "Warm, articulate, and engaging", ("Education", "Advertising")
+    ),
+    XaiVoice(
+        "luna", "Gentle, patient, and deeply nurturing", ("Education", "Assistant")
+    ),
+    XaiVoice("lux", "Grounded, calm, and quietly wise", ("Wellness", "Narration")),
+    XaiVoice("naksh", "Warm, thoughtful, and wise", ("Assistant", "Support")),
+    XaiVoice("orion", "Rich, cinematic, and resonant", ("Narration", "Audiobooks")),
+    XaiVoice(
+        "perseus",
+        "Strong, confident, and trustworthy",
+        ("Advertising", "Narration"),
+    ),
+    XaiVoice("rex", "Confident and clear", ()),
+    XaiVoice(
+        "rigel",
+        "Precise, professional, and calmly confident",
+        ("Assistant", "Support"),
+    ),
+    XaiVoice("sal", "Smooth and balanced", ()),
+    XaiVoice(
+        "sirius", "Quick-witted, clever, and playful", ("Commentary", "Characters")
+    ),
+    XaiVoice("ursa", "Friendly, warm, and steadfast", ("Assistant", "Podcast")),
+    XaiVoice(
+        "zagan",
+        "Powerful, dramatic, and unmistakable",
+        ("Characters", "Narration"),
+    ),
+    XaiVoice("zenith", "Sharp, focused, and driven", ("Sales", "Advertising")),
+)
+
+XAI_VOICE_IDS: tuple[str, ...] = tuple(v.id for v in XAI_VOICES)
+
+# xAI's documented default voice. Derived from the roster (``XAI_VOICES[0]``)
+# rather than duplicated as a second literal, so the "eve first" ordering
+# invariant above is the single source of truth.
+XAI_DEFAULT_VOICE: str = XAI_VOICES[0].id
+
+# Case-insensitive lookup built once from the roster above.
+_VOICES_BY_ID: dict[str, XaiVoice] = {v.id.lower(): v for v in XAI_VOICES}
+
+
+def is_xai_builtin_voice(voice: str) -> bool:
+    """Return True if *voice* names one of the built-in roster voices.
+
+    Case-insensitive and trims surrounding whitespace, matching how xAI
+    resolves the ``voice`` / ``voice_id`` field on its API. A custom cloned
+    voice id returns False here — it is still a legal value, just not one
+    with roster metadata.
+    """
+    return voice.strip().lower() in _VOICES_BY_ID
+
+
+def normalize_xai_voice(voice: str) -> str:
+    """Prepare a ``voice`` value for the xAI wire format.
+
+    Built-in roster ids are lowercase and case-insensitive on the xAI side, so
+    a known id is trimmed and lowercased before being sent. A custom cloned
+    ``voice_id`` (see :func:`~getpatter.providers.xai_tts.create_custom_voice`)
+    is an arbitrary, case-sensitive opaque string — it must NEVER be rejected
+    or reshaped, so only surrounding whitespace is trimmed.
+    """
+    trimmed = voice.strip()
+    lowered = trimmed.lower()
+    return lowered if lowered in _VOICES_BY_ID else trimmed
+
+
+def get_xai_voice(voice_id: str) -> XaiVoice | None:
+    """Look up roster metadata for a built-in voice id, else ``None``.
+
+    Case-insensitive and trims surrounding whitespace; returns ``None`` for a
+    custom cloned voice id since it carries no roster metadata.
+    """
+    return _VOICES_BY_ID.get(voice_id.strip().lower())

--- a/libraries/python/getpatter/telephony/common.py
+++ b/libraries/python/getpatter/telephony/common.py
@@ -206,10 +206,28 @@ def _create_stt_from_config(config, for_twilio: bool = False):
         kwargs = {k: v for k, v in opts.items() if k in allowed}
         return FishAudioSTT(api_key=config.api_key, language=config.language, **kwargs)
 
+    if provider == "xai":
+        from getpatter.providers.xai_stt import XaiSTT  # type: ignore[import]
+
+        allowed = {
+            "encoding",
+            "sample_rate",
+            "interim_results",
+            "endpointing_ms",
+            "smart_turn",
+            "smart_turn_timeout_ms",
+            "keyterms",
+            "diarize",
+            "filler_words",
+            "base_url",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        return XaiSTT(api_key=config.api_key, language=config.language, **kwargs)
+
     raise ValueError(
         f"Unknown STT provider '{provider}'. "
         "Supported: deepgram, whisper, cartesia, soniox, speechmatics, "
-        "assemblyai, fish_audio."
+        "assemblyai, fish_audio, xai."
     )
 
 
@@ -376,8 +394,24 @@ def _create_tts_from_config(config):
             api_key=config.api_key, voice=config.voice or None, **kwargs
         )
 
+    if provider == "xai_tts":
+        from getpatter.providers.xai_tts import XaiTTS  # type: ignore[import]
+
+        allowed = {
+            "language",
+            "speed",
+            "optimize_streaming_latency",
+            "text_normalization",
+            "codec",
+            "sample_rate",
+            "bit_rate",
+            "base_url",
+        }
+        kwargs = {k: v for k, v in opts.items() if k in allowed}
+        return XaiTTS(api_key=config.api_key, voice=config.voice, **kwargs)
+
     raise ValueError(
         f"Unknown TTS provider '{provider}'. "
         "Supported: elevenlabs, openai, cartesia, rime, lmnt, inworld, "
-        "soniox_tts, sarvam, fish_audio."
+        "soniox_tts, sarvam, fish_audio, xai_tts."
     )

--- a/libraries/python/tests/unit/test_providers_io_unit.py
+++ b/libraries/python/tests/unit/test_providers_io_unit.py
@@ -1394,6 +1394,20 @@ class TestCreateSTTFromConfig:
         assert stt is not None
         assert stt.__class__.__name__ == "WhisperSTT"
 
+    def test_xai_via_providers_helper(self) -> None:
+        # Regression test: ``providers.xai_asr()`` builds an ``STTConfig`` with
+        # ``provider="xai"`` — this must actually be wired into the factory,
+        # not just accepted by the config helper.
+        from getpatter.telephony.common import _create_stt_from_config
+        from getpatter.providers import xai_asr
+
+        config = xai_asr(api_key="xai-key", language="es")
+        stt = _create_stt_from_config(config)
+        assert stt is not None
+        assert stt.__class__.__name__ == "XaiSTT"
+        assert stt.api_key == "xai-key"
+        assert stt.language == "es"
+
     def test_unknown_provider(self) -> None:
         from getpatter.telephony.common import _create_stt_from_config
         from getpatter.models import STTConfig
@@ -1424,6 +1438,20 @@ class TestCreateTTSFromConfig:
         tts = _create_tts_from_config(config)
         assert tts is not None
         assert tts.__class__.__name__ == "OpenAITTS"
+
+    def test_xai_via_providers_helper(self) -> None:
+        # Regression test: ``providers.xai()`` builds a ``TTSConfig`` with
+        # ``provider="xai_tts"`` — this must actually be wired into the
+        # factory, not just accepted by the config helper.
+        from getpatter.telephony.common import _create_tts_from_config
+        from getpatter.providers import xai
+
+        config = xai(api_key="xai-key", voice="leo")
+        tts = _create_tts_from_config(config)
+        assert tts is not None
+        assert tts.__class__.__name__ == "XaiTTS"
+        assert tts.api_key == "xai-key"
+        assert tts.voice == "leo"
 
     def test_unknown_provider(self) -> None:
         from getpatter.telephony.common import _create_tts_from_config

--- a/libraries/python/tests/unit/test_xai_realtime.py
+++ b/libraries/python/tests/unit/test_xai_realtime.py
@@ -50,6 +50,17 @@ def test_explicit_model_and_voice_win_over_defaults() -> None:
     assert a.voice == "ara"
 
 
+def test_builtin_voice_is_normalized_before_session_update() -> None:
+    a = _adapter(voice=" EVE ")
+    assert a.voice == "eve"
+    assert a._build_ga_session_config()["audio"]["output"]["voice"] == "eve"
+
+
+def test_custom_voice_id_is_left_untouched_besides_trim() -> None:
+    a = _adapter(voice=" CustomVoice_1 ")
+    assert a.voice == "CustomVoice_1"
+
+
 # ---------------------------------------------------------------------------
 # session.update grafting — keys PRESENT when set
 # ---------------------------------------------------------------------------

--- a/libraries/python/tests/unit/test_xai_tts.py
+++ b/libraries/python/tests/unit/test_xai_tts.py
@@ -134,6 +134,28 @@ class TestPayloadAndAuth:
         assert "optimize_streaming_latency" not in body
         assert "text_normalization" not in body
 
+    async def test_voice_is_normalized_to_lowercase_before_send(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, []))
+        tts = XaiTTS(
+            api_key="xai-test-key", session=fake, voice=" EVE "  # type: ignore[arg-type]
+        )
+        assert tts.voice == "eve"
+        async for _ in tts.synthesize("hi"):
+            pass
+        assert fake.last_json["voice_id"] == "eve"
+
+    async def test_custom_voice_id_is_sent_untouched_besides_trim(self) -> None:
+        fake = _FakeSession(_FakeResponse(200, []))
+        tts = XaiTTS(
+            api_key="xai-test-key",
+            session=fake,  # type: ignore[arg-type]
+            voice=" CustomVoice_1 ",
+        )
+        assert tts.voice == "CustomVoice_1"
+        async for _ in tts.synthesize("hi"):
+            pass
+        assert fake.last_json["voice_id"] == "CustomVoice_1"
+
     async def test_optional_fields_only_added_when_set(self) -> None:
         fake = _FakeSession(_FakeResponse(200, []))
         tts = XaiTTS(

--- a/libraries/python/tests/unit/test_xai_voices.py
+++ b/libraries/python/tests/unit/test_xai_voices.py
@@ -1,0 +1,111 @@
+"""Unit tests for the xAI built-in voice catalog (roster + normalization).
+
+Pure data + pure functions here — there is no network boundary to mock, so
+every assertion below runs against real code. See
+``.claude/rules/authentic-tests.md``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from getpatter.models import STTConfig, TTSConfig
+from getpatter.providers import xai, xai_asr
+from getpatter.providers.xai_voices import (
+    XAI_DEFAULT_VOICE,
+    XAI_VOICE_IDS,
+    XAI_VOICES,
+    XaiVoice,
+    get_xai_voice,
+    is_xai_builtin_voice,
+    normalize_xai_voice,
+)
+
+
+@pytest.mark.unit
+class TestRoster:
+    def test_roster_has_26_voices(self) -> None:
+        assert len(XAI_VOICES) == 26
+        assert len(XAI_VOICE_IDS) == 26
+
+    def test_eve_is_default_and_first(self) -> None:
+        assert XAI_DEFAULT_VOICE == "eve"
+        assert XAI_VOICES[0].id == "eve"
+        assert XAI_VOICE_IDS[0] == "eve"
+
+    def test_all_ids_are_lowercase_and_unique(self) -> None:
+        assert all(voice_id == voice_id.lower() for voice_id in XAI_VOICE_IDS)
+        assert len(set(XAI_VOICE_IDS)) == len(XAI_VOICE_IDS)
+
+    def test_voice_ids_match_roster_order(self) -> None:
+        assert XAI_VOICE_IDS == tuple(v.id for v in XAI_VOICES)
+
+    def test_voices_are_frozen(self) -> None:
+        voice = XAI_VOICES[0]
+        assert isinstance(voice, XaiVoice)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            voice.id = "someone-else"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestIsBuiltinVoice:
+    def test_true_for_builtin_id_case_insensitive(self) -> None:
+        assert is_xai_builtin_voice("EVE") is True
+        assert is_xai_builtin_voice("eve") is True
+        assert is_xai_builtin_voice(" Eve ") is True
+
+    def test_false_for_custom_voice_id(self) -> None:
+        assert is_xai_builtin_voice("my-custom-id") is False
+
+
+@pytest.mark.unit
+class TestNormalizeXaiVoice:
+    def test_builtin_id_is_trimmed_and_lowercased(self) -> None:
+        assert normalize_xai_voice(" Leo ") == "leo"
+
+    def test_custom_id_is_left_untouched(self) -> None:
+        assert normalize_xai_voice("CustomVoice_1") == "CustomVoice_1"
+
+    def test_custom_id_surrounding_whitespace_is_trimmed_only(self) -> None:
+        assert normalize_xai_voice("  CustomVoice_1  ") == "CustomVoice_1"
+
+
+@pytest.mark.unit
+class TestGetXaiVoice:
+    def test_returns_roster_metadata_for_builtin_id(self) -> None:
+        voice = get_xai_voice("carina")
+        assert voice is not None
+        assert "Wellness" in voice.use_cases
+
+    def test_is_case_insensitive_and_trims(self) -> None:
+        assert get_xai_voice("CARINA") == get_xai_voice(" carina ")
+
+    def test_returns_none_for_custom_voice_id(self) -> None:
+        assert get_xai_voice("my-custom-id") is None
+
+
+@pytest.mark.unit
+class TestConfigHelpers:
+    def test_xai_returns_tts_config_with_default_voice(self) -> None:
+        config = xai("xai-test-key")
+        assert isinstance(config, TTSConfig)
+        assert config.provider == "xai_tts"
+        assert config.api_key == "xai-test-key"
+        assert config.voice == "eve"
+
+    def test_xai_accepts_explicit_voice(self) -> None:
+        config = xai("xai-test-key", voice="ara")
+        assert config.voice == "ara"
+
+    def test_xai_asr_returns_stt_config_with_default_language(self) -> None:
+        config = xai_asr("xai-test-key")
+        assert isinstance(config, STTConfig)
+        assert config.provider == "xai"
+        assert config.api_key == "xai-test-key"
+        assert config.language == "en"
+
+    def test_xai_asr_accepts_explicit_language(self) -> None:
+        config = xai_asr("xai-test-key", language="es")
+        assert config.language == "es"

--- a/libraries/typescript/src/index.ts
+++ b/libraries/typescript/src/index.ts
@@ -70,6 +70,8 @@ export {
   sarvam,
   fishAudio,
   fishAudioAsr,
+  xai,
+  xaiAsr,
   ultravox,
   geminiLive,
 } from "./providers";
@@ -155,6 +157,17 @@ export type {
 // xAI TTS custom-voice helper + codec enum.
 export { xaiCreateCustomVoice, XaiTTSCodec } from "./providers/xai-tts";
 export type { XaiCreateCustomVoiceOptions } from "./providers/xai-tts";
+// xAI built-in voice catalog — shared by TTS, Realtime and the `xai()` /
+// `xaiAsr()` config helpers above.
+export {
+  XAI_VOICE_IDS,
+  XAI_VOICES,
+  XAI_DEFAULT_VOICE,
+  isXaiBuiltinVoice,
+  normalizeXaiVoice,
+  getXaiVoice,
+} from "./providers/xai-voices";
+export type { XaiVoiceId, XaiVoiceInfo } from "./providers/xai-voices";
 export { scheduleCron, scheduleOnce, scheduleInterval } from "./scheduler";
 export type { ScheduleHandle, JobCallback } from "./scheduler";
 // Provider adapter types (re-exported for advanced users who build custom

--- a/libraries/typescript/src/init/cli.ts
+++ b/libraries/typescript/src/init/cli.ts
@@ -125,6 +125,12 @@ const PIPELINE_STT: Record<string, ProviderEntry> = {
     env: ['FISH_AUDIO_API_KEY'],
     extra: 'fish_audio',
   },
+  xai: {
+    cls: 'XaiSTT',
+    label: 'xAI Grok (streaming)',
+    env: ['XAI_API_KEY'],
+    extra: 'xai',
+  },
 };
 const DEFAULT_STT = 'deepgram';
 
@@ -206,6 +212,12 @@ const PIPELINE_TTS: Record<string, ProviderEntry> = {
     label: 'Fish Audio (s2.1-pro)',
     env: ['FISH_AUDIO_API_KEY'],
     extra: 'fish_audio',
+  },
+  xai: {
+    cls: 'XaiTTS',
+    label: 'xAI Grok (eve default)',
+    env: ['XAI_API_KEY'],
+    extra: 'xai',
   },
 };
 const DEFAULT_TTS = 'elevenlabs';

--- a/libraries/typescript/src/providers.ts
+++ b/libraries/typescript/src/providers.ts
@@ -1,4 +1,5 @@
 import type { STTConfig, TTSConfig } from "./types";
+import { XAI_DEFAULT_VOICE, normalizeXaiVoice } from "./providers/xai-voices";
 
 /**
  * Config envelope for realtime / ConvAI pipelines — mirrors the wire-level
@@ -187,6 +188,34 @@ export function fishAudio(opts: { apiKey: string; voice?: string }): TTSConfig {
  */
 export function fishAudioAsr(opts: { apiKey: string; language?: string }): STTConfig {
   return new STTConfigImpl("fish_audio", opts.apiKey, opts.language ?? "en");
+}
+
+/**
+ * xAI (Grok) TTS config helper (parity with Python ``getpatter.providers.xai``).
+ *
+ * ``voice`` is a built-in xAI voice id (see ``XAI_VOICES`` / ``isXaiBuiltinVoice``
+ * from ``getpatter``) or a custom cloned ``voice_id``; built-in ids are
+ * case-insensitive and normalized here, defaulting to ``"eve"``. For pipeline
+ * use the documented path is the direct adapter ``new XaiTTS({...})`` from
+ * ``getpatter``. Provider key ``"xai_tts"`` matches ``XaiTTS.providerKey`` and
+ * the ``DEFAULT_PRICING`` entry it bills against.
+ */
+export function xai(opts: { apiKey: string; voice?: string }): TTSConfig {
+  return new TTSConfigImpl(
+    "xai_tts",
+    opts.apiKey,
+    normalizeXaiVoice(opts.voice ?? XAI_DEFAULT_VOICE),
+  );
+}
+
+/**
+ * xAI (Grok) streaming STT config helper (parity with Python
+ * ``getpatter.providers.xai_asr``). Shares the ``XAI_API_KEY`` credential
+ * family with xAI TTS and Realtime. Provider key ``"xai"`` matches
+ * ``XaiSTT.providerKey`` and the ``DEFAULT_PRICING`` entry it bills against.
+ */
+export function xaiAsr(opts: { apiKey: string; language?: string }): STTConfig {
+  return new STTConfigImpl("xai", opts.apiKey, opts.language ?? "en");
 }
 
 // ---------------------------------------------------------------------------

--- a/libraries/typescript/src/providers/xai-realtime.ts
+++ b/libraries/typescript/src/providers/xai-realtime.ts
@@ -35,13 +35,14 @@ import {
   type OpenAIRealtimeOptions,
 } from './openai-realtime';
 import { OpenAIRealtime2Adapter } from './openai-realtime-2';
+import { XAI_DEFAULT_VOICE, normalizeXaiVoice } from './xai-voices';
 
 /** Default xAI Voice Agent WebSocket base URL (no query string). */
 export const XAI_REALTIME_WS_URL = 'wss://api.x.ai/v1/realtime';
 /** Default model — `grok-voice-latest` always points at the newest voice model. */
 export const XAI_REALTIME_DEFAULT_MODEL = 'grok-voice-latest';
-/** Default voice — xAI's built-in `eve` (case-insensitive). */
-export const XAI_REALTIME_DEFAULT_VOICE = 'eve';
+/** Default voice — xAI's built-in `eve` (case-insensitive). Alias of {@link XAI_DEFAULT_VOICE}. */
+export const XAI_REALTIME_DEFAULT_VOICE = XAI_DEFAULT_VOICE;
 /**
  * xAI's input-transcription model. Setting it keeps the session xAI-valid —
  * the GA base defaults to OpenAI's `whisper-1`, which the xAI endpoint rejects.
@@ -190,7 +191,9 @@ export class XaiRealtimeAdapter extends OpenAIRealtime2Adapter {
     super(
       apiKey,
       opts.model ?? XAI_REALTIME_DEFAULT_MODEL,
-      opts.voice ?? XAI_REALTIME_DEFAULT_VOICE,
+      // Normalized before it reaches the base adapter so the eventual
+      // `session.update`'s `audio.output.voice` is already wire-correct.
+      normalizeXaiVoice(opts.voice ?? XAI_REALTIME_DEFAULT_VOICE),
       opts.instructions ?? '',
       opts.tools,
       opts.audioFormat ?? OpenAIRealtimeAudioFormat.G711_ULAW,

--- a/libraries/typescript/src/providers/xai-tts.ts
+++ b/libraries/typescript/src/providers/xai-tts.ts
@@ -28,6 +28,7 @@
  */
 
 import { getLogger } from '../logger';
+import { XAI_DEFAULT_VOICE, normalizeXaiVoice } from './xai-voices';
 
 /** xAI one-shot TTS REST endpoint. */
 export const XAI_TTS_REST_URL = 'https://api.x.ai/v1/tts';
@@ -36,9 +37,6 @@ export const XAI_CUSTOM_VOICES_URL = 'https://api.x.ai/v1/custom-voices';
 // WebSocket streaming endpoint (documented for reference; not used by this
 // HTTP-bytes adapter).
 export const XAI_TTS_WS_URL = 'wss://api.x.ai/v1/tts';
-
-/** xAI default voice — the built-in `eve` (case-insensitive). */
-const XAI_DEFAULT_VOICE = 'eve';
 
 /**
  * Output codecs accepted by the xAI `output_format.codec` field. `MULAW` /
@@ -119,7 +117,10 @@ export class XaiTTS {
       throw new Error('xAI TTS: apiKey is required');
     }
     this.apiKey = apiKey;
-    this.voice = opts.voice ?? XAI_DEFAULT_VOICE;
+    // Normalized here (not just at send time) so `this.voice` always reflects
+    // exactly what goes on the wire — built-in ids lowercase, custom
+    // `voice_id`s trimmed but otherwise untouched.
+    this.voice = normalizeXaiVoice(opts.voice ?? XAI_DEFAULT_VOICE);
     this.language = opts.language ?? 'auto';
     this.codec = opts.codec ?? XaiTTSCodec.PCM;
     this.sampleRate = opts.sampleRate ?? XaiTTSSampleRate.HZ_16000;

--- a/libraries/typescript/src/providers/xai-voices.ts
+++ b/libraries/typescript/src/providers/xai-voices.ts
@@ -1,0 +1,207 @@
+/**
+ * xAI (Grok) built-in voice catalog.
+ *
+ * Shared by the TTS, Realtime, and STT providers so the roster, the default
+ * voice, and the wire-normalization rule live in exactly one place instead of
+ * being duplicated (and drifting) per adapter.
+ *
+ * xAI's built-in voice ids are lowercase and case-insensitive. A caller may
+ * also pass an arbitrary custom cloned `voice_id` (see `xaiCreateCustomVoice`
+ * in `./xai-tts`) — this module must never reject those, so
+ * {@link isXaiBuiltinVoice} and {@link normalizeXaiVoice} are permissive by
+ * design: anything that isn't a recognized built-in id is left alone.
+ *
+ * Source: https://docs.x.ai/developers/model-capabilities/audio/voice
+ */
+
+/** xAI's default built-in voice. */
+export const XAI_DEFAULT_VOICE = 'eve';
+
+/** All 26 built-in xAI voice ids, alphabetical. */
+export const XAI_VOICE_IDS = [
+  'altair',
+  'ara',
+  'atlas',
+  'carina',
+  'castor',
+  'celeste',
+  'cosmo',
+  'eve',
+  'helios',
+  'helix',
+  'iris',
+  'kepler',
+  'leo',
+  'lumen',
+  'luna',
+  'lux',
+  'naksh',
+  'orion',
+  'perseus',
+  'rex',
+  'rigel',
+  'sal',
+  'sirius',
+  'ursa',
+  'zagan',
+  'zenith',
+] as const;
+
+/** One of xAI's 26 built-in voice ids (always lowercase). */
+export type XaiVoiceId = (typeof XAI_VOICE_IDS)[number];
+
+/** Tone and suggested use cases for one built-in xAI voice. */
+export interface XaiVoiceInfo {
+  readonly id: XaiVoiceId;
+  readonly tone: string;
+  readonly useCases: readonly string[];
+}
+
+/**
+ * Full built-in voice roster in xAI's documented display order — `eve` (the
+ * default) first, then the rest alphabetically. Tone and use cases are from
+ * the xAI Voice Overview (docs.x.ai/developers/model-capabilities/audio/voice).
+ */
+export const XAI_VOICES: readonly XaiVoiceInfo[] = [
+  { id: 'eve', tone: 'Energetic and upbeat', useCases: [] },
+  {
+    id: 'altair',
+    tone: 'Elegant, refined, and effortlessly premium',
+    useCases: ['Advertising', 'Narration'],
+  },
+  { id: 'ara', tone: 'Warm and friendly', useCases: [] },
+  {
+    id: 'atlas',
+    tone: 'Confident, commanding, and reassuring',
+    useCases: ['Sales', 'Assistant'],
+  },
+  {
+    id: 'carina',
+    tone: 'Soft, empathetic, and soothing',
+    useCases: ['Wellness', 'Support'],
+  },
+  {
+    id: 'castor',
+    tone: 'Charismatic, down-to-earth, and easygoing',
+    useCases: ['Sales', 'Support'],
+  },
+  {
+    id: 'celeste',
+    tone: 'Compassionate, confident, and reassuring',
+    useCases: ['Support', 'Assistant'],
+  },
+  {
+    id: 'cosmo',
+    tone: 'Bright, curious, and easy to follow',
+    useCases: ['Education', 'Podcast'],
+  },
+  {
+    id: 'helios',
+    tone: 'Upbeat, energetic, and endlessly versatile',
+    useCases: ['Assistant', 'Wellness'],
+  },
+  {
+    id: 'helix',
+    tone: 'Bold, dynamic, and adrenaline-fueled',
+    useCases: ['Commentary', 'Podcast'],
+  },
+  {
+    id: 'iris',
+    tone: 'Friendly, upbeat, and naturally charming',
+    useCases: ['Sales', 'Support'],
+  },
+  {
+    id: 'kepler',
+    tone: 'Inventive, forward-thinking, and charismatic',
+    useCases: ['Advertising', 'Podcast'],
+  },
+  { id: 'leo', tone: 'Authoritative and strong', useCases: [] },
+  {
+    id: 'lumen',
+    tone: 'Warm, articulate, and engaging',
+    useCases: ['Education', 'Advertising'],
+  },
+  {
+    id: 'luna',
+    tone: 'Gentle, patient, and deeply nurturing',
+    useCases: ['Education', 'Assistant'],
+  },
+  {
+    id: 'lux',
+    tone: 'Grounded, calm, and quietly wise',
+    useCases: ['Wellness', 'Narration'],
+  },
+  {
+    id: 'naksh',
+    tone: 'Warm, thoughtful, and wise',
+    useCases: ['Assistant', 'Support'],
+  },
+  {
+    id: 'orion',
+    tone: 'Rich, cinematic, and resonant',
+    useCases: ['Narration', 'Audiobooks'],
+  },
+  {
+    id: 'perseus',
+    tone: 'Strong, confident, and trustworthy',
+    useCases: ['Advertising', 'Narration'],
+  },
+  { id: 'rex', tone: 'Confident and clear', useCases: [] },
+  {
+    id: 'rigel',
+    tone: 'Precise, professional, and calmly confident',
+    useCases: ['Assistant', 'Support'],
+  },
+  { id: 'sal', tone: 'Smooth and balanced', useCases: [] },
+  {
+    id: 'sirius',
+    tone: 'Quick-witted, clever, and playful',
+    useCases: ['Commentary', 'Characters'],
+  },
+  {
+    id: 'ursa',
+    tone: 'Friendly, warm, and steadfast',
+    useCases: ['Assistant', 'Podcast'],
+  },
+  {
+    id: 'zagan',
+    tone: 'Powerful, dramatic, and unmistakable',
+    useCases: ['Characters', 'Narration'],
+  },
+  {
+    id: 'zenith',
+    tone: 'Sharp, focused, and driven',
+    useCases: ['Sales', 'Advertising'],
+  },
+];
+
+/** Lookup set backing {@link isXaiBuiltinVoice} / {@link normalizeXaiVoice}. */
+const BUILTIN_VOICE_SET: ReadonlySet<string> = new Set(XAI_VOICE_IDS);
+
+/**
+ * True when `voice` (trimmed, case-insensitive) names one of xAI's 26
+ * built-in voices. `false` covers everything else, INCLUDING a legitimate
+ * custom cloned `voice_id` — callers must treat `false` as "not a documented
+ * preset", never as "invalid".
+ */
+export function isXaiBuiltinVoice(voice: string): voice is XaiVoiceId {
+  return BUILTIN_VOICE_SET.has(voice.trim().toLowerCase());
+}
+
+/**
+ * Normalize a voice id for the wire: trim whitespace, then lowercase ONLY
+ * when it names a built-in voice (xAI's built-in ids are case-insensitive).
+ * A custom cloned `voice_id` is an arbitrary opaque string, so it is trimmed
+ * but never case-folded — xAI matches those ids exactly.
+ */
+export function normalizeXaiVoice(voice: string): string {
+  const trimmed = voice.trim();
+  const lowered = trimmed.toLowerCase();
+  return BUILTIN_VOICE_SET.has(lowered) ? lowered : trimmed;
+}
+
+/** Look up tone/use-case metadata for a built-in voice id (case-insensitive). */
+export function getXaiVoice(id: string): XaiVoiceInfo | undefined {
+  const normalized = id.trim().toLowerCase();
+  return XAI_VOICES.find((v) => v.id === normalized);
+}

--- a/libraries/typescript/tests/unit/xai-tts.mocked.test.ts
+++ b/libraries/typescript/tests/unit/xai-tts.mocked.test.ts
@@ -83,6 +83,16 @@ describe('[mocked] xAI TTS — request + streaming', () => {
     });
   });
 
+  it('normalizes the voice before it is sent: trims + lowercases a built-in, only trims a custom id', async () => {
+    const builtin = new XaiTTS('xai-test-key', { voice: ' LEO ' });
+    await builtin.synthesize('hi');
+    expect(lastBody).toMatchObject({ voice_id: 'leo' });
+
+    const custom = new XaiTTS('xai-test-key', { voice: '  CustomVoice_1  ' });
+    await custom.synthesize('hi');
+    expect(lastBody).toMatchObject({ voice_id: 'CustomVoice_1' });
+  });
+
   it('nests an MP3 bit_rate under output_format when set (omitted otherwise)', async () => {
     const tts = new XaiTTS('xai-test-key', {
       codec: 'mp3',

--- a/libraries/typescript/tests/unit/xai-voices.test.ts
+++ b/libraries/typescript/tests/unit/xai-voices.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  XAI_VOICE_IDS,
+  XAI_VOICES,
+  XAI_DEFAULT_VOICE,
+  isXaiBuiltinVoice,
+  normalizeXaiVoice,
+  getXaiVoice,
+} from '../../src/providers/xai-voices';
+import { xai, xaiAsr } from '../../src/providers';
+
+/**
+ * [unit] xAI built-in voice catalog — roster shape, the case-insensitive
+ * built-in predicate, wire normalization, and the `xai()` / `xaiAsr()` config
+ * helpers that consume it. Real code throughout; no external boundary.
+ */
+describe('[unit] xAI voice catalog', () => {
+  it('has exactly 26 voices, with eve as the default and listed first', () => {
+    expect(XAI_VOICES).toHaveLength(26);
+    expect(XAI_VOICE_IDS).toHaveLength(26);
+    expect(XAI_DEFAULT_VOICE).toBe('eve');
+    expect(XAI_VOICES[0].id).toBe('eve');
+  });
+
+  it('has all-lowercase, unique ids in both XAI_VOICE_IDS and XAI_VOICES', () => {
+    for (const id of XAI_VOICE_IDS) {
+      expect(id).toBe(id.toLowerCase());
+    }
+    expect(new Set(XAI_VOICE_IDS).size).toBe(XAI_VOICE_IDS.length);
+
+    const infoIds = XAI_VOICES.map((v) => v.id);
+    for (const id of infoIds) {
+      expect(id).toBe(id.toLowerCase());
+    }
+    expect(new Set(infoIds).size).toBe(infoIds.length);
+    // Both exports describe the same 26 ids.
+    expect(new Set(infoIds)).toEqual(new Set(XAI_VOICE_IDS));
+  });
+
+  it('isXaiBuiltinVoice is case-insensitive for built-ins and false for anything else', () => {
+    expect(isXaiBuiltinVoice('EVE')).toBe(true);
+    expect(isXaiBuiltinVoice('eve')).toBe(true);
+    expect(isXaiBuiltinVoice('Leo')).toBe(true);
+    // A custom cloned voice_id is NOT a built-in, but it is never "invalid" —
+    // isXaiBuiltinVoice just says "not a documented preset".
+    expect(isXaiBuiltinVoice('my-custom-id')).toBe(false);
+  });
+
+  it('normalizeXaiVoice trims + lowercases built-ins, and only trims custom ids', () => {
+    expect(normalizeXaiVoice(' Leo ')).toBe('leo');
+    expect(normalizeXaiVoice('EVE')).toBe('eve');
+    // Unrecognized id: trimmed, but case is preserved — xAI matches custom
+    // voice_ids exactly.
+    expect(normalizeXaiVoice('CustomVoice_1')).toBe('CustomVoice_1');
+    expect(normalizeXaiVoice('  CustomVoice_1  ')).toBe('CustomVoice_1');
+  });
+
+  it('getXaiVoice looks up tone/use-case metadata case-insensitively', () => {
+    expect(getXaiVoice('carina')?.useCases).toContain('Wellness');
+    expect(getXaiVoice('CARINA')?.useCases).toContain('Wellness');
+    expect(getXaiVoice('  carina  ')?.tone).toBe('Soft, empathetic, and soothing');
+    expect(getXaiVoice('not-a-voice')).toBeUndefined();
+  });
+});
+
+describe('[unit] xai() / xaiAsr() config helpers', () => {
+  it('xai() defaults to the "xai_tts" provider key and the eve voice', () => {
+    const config = xai({ apiKey: 'xai-test-key' });
+    expect(config.provider).toBe('xai_tts');
+    expect(config.apiKey).toBe('xai-test-key');
+    expect(config.voice).toBe('eve');
+  });
+
+  it('xai() normalizes a caller-supplied voice before storing it', () => {
+    const config = xai({ apiKey: 'xai-test-key', voice: ' LEO ' });
+    expect(config.voice).toBe('leo');
+  });
+
+  it('xai() leaves a custom voice_id untouched (trimmed only)', () => {
+    const config = xai({ apiKey: 'xai-test-key', voice: 'CustomVoice_1' });
+    expect(config.voice).toBe('CustomVoice_1');
+  });
+
+  it('xaiAsr() defaults to the "xai" provider key and "en" language', () => {
+    const config = xaiAsr({ apiKey: 'xai-test-key' });
+    expect(config.provider).toBe('xai');
+    expect(config.apiKey).toBe('xai-test-key');
+    expect(config.language).toBe('en');
+  });
+
+  it('xaiAsr() threads a caller-supplied language through', () => {
+    const config = xaiAsr({ apiKey: 'xai-test-key', language: 'it' });
+    expect(config.language).toBe('it');
+  });
+});


### PR DESCRIPTION
## Summary

The xAI (Grok) STT / TTS / Realtime providers shipped in #211, but the 26-voice roster lived only in docs prose. This PR wires it into both SDKs.

- **Typed immutable catalog**: `XAI_VOICES` / `XAI_VOICE_IDS` / `XAI_DEFAULT_VOICE` plus `isXaiBuiltinVoice` / `normalizeXaiVoice` / `getXaiVoice` (TS) and `is_xai_builtin_voice` / `normalize_xai_voice` / `get_xai_voice` (Python), exported from the package root.
- **Normalization at the wire**: `XaiTTS` (REST `voice_id`) and `XaiRealtimeAdapter` (`session.update` voice) trim + lowercase built-in ids; custom cloned `voice_id`s stay opaque and are never rejected. `XAI_REALTIME_DEFAULT_VOICE` remains exported as an alias.
- **Config helpers**: `providers.xai()` (TTS, key `xai_tts`) and `xaiAsr()` / `xai_asr()` (STT, key `xai`). The Python `TTSConfig` / `STTConfig` factories in `telephony/common.py` now resolve those keys to `XaiTTS` / `XaiSTT` (previously a dead end).
- **`patter init`** lists xAI in both STT and TTS provider tables (`XAI_API_KEY`).
- Docs (`xai-tts.mdx`, both SDKs) and CHANGELOG.

## Test plan

- [x] TS: `tsc --noEmit` clean; `vitest run` 166 files, 2616 passed / 9 skipped
- [x] Python: `pytest tests` 3016 passed / 33 skipped / 2 xfailed
- [x] New unit tests: `xai-voices.test.ts` (10), `test_xai_voices.py` (17), factory regression tests for `xai()` / `xai_asr()`, adapter tests asserting the normalized voice is what gets sent
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
