### PR TITLE
feat(google): Gemini 3.x model catalog, 3.1 Live default, corrected pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ### Added
 
+- **Google Gemini model catalog refreshed to the 3.x generation, `GeminiLiveModel` default
+  moved to `gemini-3.1-flash-live-preview`, and pricing corrected across both SDKs**
+  (`GoogleModel` / `GoogleLLM` in `libraries/{python,typescript}/getpatter/providers/google_llm.*`,
+  `GeminiLiveModel` / `GeminiLiveAdapter` in `.../providers/gemini_live.*`, `pricing.py` /
+  `pricing.ts`):
+  - **`GoogleModel`** now lists `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`,
+    `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-3.1-pro-preview`, and
+    `gemini-3-flash-preview` alongside `gemini-2.5-flash` / `gemini-2.5-pro`. **Behaviour
+    change:** the default chat model for `GoogleLLM` moves from `gemini-2.5-flash` to
+    `gemini-3.5-flash-lite`. `gemini-2.0-flash`, `gemini-2.0-flash-lite`,
+    `gemini-2.0-flash-exp`, `gemini-1.5-flash`, and `gemini-1.5-pro` are shut down upstream
+    and **removed** from the enum in both SDKs.
+  - **`GeminiLiveModel`** gains `NATIVE_AUDIO_PREVIEW_12_2025`
+    (`gemini-2.5-flash-native-audio-preview-12-2025`). **Behaviour change:** the default
+    `GeminiLiveAdapter` model moves from the dated `gemini-2.5-flash-native-audio-preview-09-2025`
+    preview to `gemini-3.1-flash-live-preview`. `LIVE_2_0_FLASH_EXP`
+    (`gemini-2.0-flash-exp`) is **removed** — it was retired upstream in Dec 2024.
+  - **Pricing corrected**: `gemini-3.1-flash-live-preview`'s text rate was wrongly
+    `$0.30`/`$2.50` per 1M tokens (and absent from the Python table entirely) — now
+    `$0.75`/`$4.50`, matching the TS `gemini_cascade` Live-leg default. New chat-model rows
+    added for every 3.x id with `cache_read` rates; audio-modality Live API rates remain
+    unmodelled (text-only cost shape, flagged in code comments as a pre-existing gap).
+  - Docs (`docs/{python,typescript}-sdk/{llm,providers/google,providers/gemini-live}.mdx`)
+    updated with the new defaults, catalog, and pricing tables.
+
 - **xAI (Grok) voice catalog wired into both SDKs** — the 26 built-in Grok
   voices (`eve` default, `ara`, `rex`, `sal`, `leo`, `carina`, ...) are now a
   typed, immutable catalog instead of docs-only prose:

--- a/docs/python-sdk/llm.mdx
+++ b/docs/python-sdk/llm.mdx
@@ -127,7 +127,7 @@ Install: `pip install 'getpatter[cerebras]'`.
 
 ### GoogleLLM
 
-Google Gemini via the `google-genai` SDK. Supports the Gemini Developer API (API key) and Vertex AI (GCP project + location). Default model `"gemini-2.5-flash"`.
+Google Gemini via the `google-genai` SDK. Supports the Gemini Developer API (API key) and Vertex AI (GCP project + location). Default model `"gemini-3.5-flash-lite"`.
 
 ```python
 from getpatter import GoogleLLM                    # flat

--- a/docs/python-sdk/providers/gemini-live.mdx
+++ b/docs/python-sdk/providers/gemini-live.mdx
@@ -39,7 +39,7 @@ from getpatter.providers.gemini_live import (
 
 adapter = GeminiLiveAdapter(
     api_key="",                                              # reads from env if you wire it
-    model=GeminiLiveModel.NATIVE_AUDIO_PREVIEW_09_2025,      # default
+    model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,            # default
     voice=GeminiLiveVoice.PUCK,                              # Puck | Charon | Kore | Fenrir | Aoede
     instructions="You are a helpful, concise voice assistant.",
     language="en-US",
@@ -53,7 +53,7 @@ adapter = GeminiLiveAdapter(
 import { GeminiLiveAdapter } from "getpatter";
 
 const adapter = new GeminiLiveAdapter(process.env.GEMINI_API_KEY!, {
-  model: "gemini-2.5-flash-native-audio-preview-09-2025",
+  model: "gemini-3.1-flash-live-preview",                    // default
   voice: "Puck",                                             // Puck | Charon | Kore | Fenrir | Aoede
   instructions: "You are a helpful, concise voice assistant.",
   language: "en-US",
@@ -106,11 +106,12 @@ Tools work the same way as on OpenAI Realtime — pass `tools=[Tool(...)]` on `p
 
 | Model | Notes |
 |-------|-------|
-| `"gemini-2.5-flash-native-audio-preview-09-2025"` (default) | Native-audio preview, `v1alpha` only. Current production target. |
+| `"gemini-3.1-flash-live-preview"` (default) | Audio-to-audio Live model, `v1alpha` only. Released 2026-03-26 (preview). Current production target. |
+| `"gemini-2.5-flash-native-audio-preview-12-2025"` | Newer dated native-audio snapshot. |
+| `"gemini-2.5-flash-native-audio-preview-09-2025"` | Older dated native-audio snapshot, still served. |
 | `"gemini-live-2.5-flash-preview"` | Earlier preview, shut down on 2025-12-09. |
-| `"gemini-2.0-flash-exp"` | Experimental preview, retired Dec 2024. |
 
-The defaults change as Google promotes native audio to GA. The `GeminiLiveModel` enum tracks the currently shipped identifiers.
+`gemini-2.0-flash-exp` was experimental preview, retired Dec 2024, and has been removed from `GeminiLiveModel`. The defaults change as Google promotes native audio to GA. The `GeminiLiveModel` enum tracks the currently shipped identifiers.
 
 ## Voices
 

--- a/docs/python-sdk/providers/google.mdx
+++ b/docs/python-sdk/providers/google.mdx
@@ -110,14 +110,19 @@ Pricing in USD per 1M tokens.
 
 | Model | Input | Output | Notes |
 |---|---|---|---|
-| `gemini-2.5-flash` (default) | $0.30 | $2.50 | Best price/perf for voice. |
-| `gemini-2.5-pro` | $1.25 | $10.00 | Highest quality. |
-| `gemini-2.0-flash` | n/a | n/a | Older fast model. |
-| `gemini-2.0-flash-lite` | n/a | n/a | Lightweight 2.0. |
-| `gemini-1.5-flash` | n/a | n/a | Legacy fast model. |
-| `gemini-1.5-pro` | n/a | n/a | Legacy pro model. |
+| `gemini-3.7-flash` | $0.75 | $3.75 | Latest, most capable Flash — GA 2026-08-13. Steps up to $1.50 / $7.50 on 2027-01-01. |
+| `gemini-3.6-flash` | $0.75 | $3.75 | Same rate card as 3.7-flash. Steps up to $1.50 / $7.50 on 2027-01-01. |
+| `gemini-3.5-flash` | $1.50 | $9.00 | |
+| `gemini-3.5-flash-lite` (default) | $0.30 | $2.50 | Best price/perf for voice. |
+| `gemini-3.1-flash-lite` | $0.25 | $1.50 | |
+| `gemini-3.1-pro-preview` | $2.00 | $12.00 | Preview. Rate for prompts ≤200k tokens. |
+| `gemini-3-flash-preview` | $0.50 | $3.00 | Preview. |
+| `gemini-2.5-flash` | $0.30 | $2.50 | |
+| `gemini-2.5-pro` | $1.25 | $10.00 | Highest quality. Rate for prompts ≤200k tokens. |
 
-For the speech-to-speech variant `gemini-live-2.5-flash-native-audio` (input $0.30 / output $2.50), see the [Engines](/python-sdk/engines) page — it is a separate Realtime adapter, not a chat-completions model.
+`gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-1.5-flash`, and `gemini-1.5-pro` are shut down and no longer supported.
+
+For the speech-to-speech variants — `gemini-3.1-flash-live-preview` (text in $0.75 / out $4.50, audio in $3.00/1M tokens = $0.005/min / out $12.00/1M tokens = $0.018/min) and `gemini-2.5-flash-native-audio-preview` (text in $0.50 / out $2.00, audio in $3.00 / out $12.00) — see the [Engines](/python-sdk/engines) page; they are separate Realtime adapters, not chat-completions models.
 
 ## Environment variables
 
@@ -134,7 +139,7 @@ For the speech-to-speech variant `gemini-live-2.5-flash-native-audio` (input $0.
 | Option | Default | Notes |
 |---|---|---|
 | `api_key` / `apiKey` | `None` | Reads `GEMINI_API_KEY`, then `GOOGLE_API_KEY`. Ignored when `vertexai=True`. |
-| `model` | `"gemini-2.5-flash"` | Any Gemini chat model id. |
+| `model` | `"gemini-3.5-flash-lite"` | Any Gemini chat model id. |
 | `vertexai` | `False` | Use Vertex AI instead of the Developer API. |
 | `project` | `None` | GCP project (Vertex AI). |
 | `location` | `"us-central1"` | GCP region (Vertex AI). |

--- a/docs/typescript-sdk/llm.mdx
+++ b/docs/typescript-sdk/llm.mdx
@@ -113,7 +113,7 @@ const llm2 = new CerebrasLLM({
 
 ### GoogleLLM
 
-Google Gemini via the Developer API (streaming SSE). Default model `"gemini-2.5-flash"`.
+Google Gemini via the Developer API (streaming SSE). Default model `"gemini-3.5-flash-lite"`.
 
 ```typescript
 import { GoogleLLM } from "getpatter";

--- a/docs/typescript-sdk/providers/gemini-live.mdx
+++ b/docs/typescript-sdk/providers/gemini-live.mdx
@@ -33,7 +33,7 @@ Set `GEMINI_API_KEY` in your environment.
 import { GeminiLiveAdapter } from "getpatter";
 
 const adapter = new GeminiLiveAdapter(process.env.GEMINI_API_KEY!, {
-  model: "gemini-2.5-flash-native-audio-preview-09-2025",    // default
+  model: "gemini-3.1-flash-live-preview",                    // default
   voice: "Puck",                                             // Puck | Charon | Kore | Fenrir | Aoede
   instructions: "You are a helpful, concise voice assistant.",
   language: "en-US",
@@ -52,7 +52,7 @@ from getpatter.providers.gemini_live import (
 
 adapter = GeminiLiveAdapter(
     api_key="",
-    model=GeminiLiveModel.NATIVE_AUDIO_PREVIEW_09_2025,
+    model=GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
     voice=GeminiLiveVoice.PUCK,
     instructions="You are a helpful, concise voice assistant.",
     language="en-US",
@@ -105,11 +105,12 @@ Tools work the same way as on OpenAI Realtime — pass `tools: [...]` on `phone.
 
 | Model | Notes |
 |-------|-------|
-| `"gemini-2.5-flash-native-audio-preview-09-2025"` (default) | Native-audio preview, `v1alpha` only. Current production target. |
+| `"gemini-3.1-flash-live-preview"` (default) | Audio-to-audio Live model, `v1alpha` only. Released 2026-03-26 (preview). Current production target. |
+| `"gemini-2.5-flash-native-audio-preview-12-2025"` | Newer dated native-audio snapshot. |
+| `"gemini-2.5-flash-native-audio-preview-09-2025"` | Older dated native-audio snapshot, still served. |
 | `"gemini-live-2.5-flash-preview"` | Earlier preview, shut down on 2025-12-09. |
-| `"gemini-2.0-flash-exp"` | Experimental preview, retired Dec 2024. |
 
-The defaults change as Google promotes native audio to GA.
+`gemini-2.0-flash-exp` was experimental preview, retired Dec 2024, and is no longer supported. The defaults change as Google promotes native audio to GA.
 
 ## Voices
 

--- a/docs/typescript-sdk/providers/google.mdx
+++ b/docs/typescript-sdk/providers/google.mdx
@@ -110,14 +110,19 @@ Pricing in USD per 1M tokens.
 
 | Model | Input | Output | Notes |
 |---|---|---|---|
-| `gemini-2.5-flash` (default) | $0.30 | $2.50 | Best price/perf for voice. |
-| `gemini-2.5-pro` | $1.25 | $10.00 | Highest quality. |
-| `gemini-2.0-flash` | n/a | n/a | Older fast model. |
-| `gemini-2.0-flash-lite` | n/a | n/a | Lightweight 2.0. |
-| `gemini-1.5-flash` | n/a | n/a | Legacy fast model. |
-| `gemini-1.5-pro` | n/a | n/a | Legacy pro model. |
+| `gemini-3.7-flash` | $0.75 | $3.75 | Latest, most capable Flash — GA 2026-08-13. Steps up to $1.50 / $7.50 on 2027-01-01. |
+| `gemini-3.6-flash` | $0.75 | $3.75 | Same rate card as 3.7-flash. Steps up to $1.50 / $7.50 on 2027-01-01. |
+| `gemini-3.5-flash` | $1.50 | $9.00 | |
+| `gemini-3.5-flash-lite` (default) | $0.30 | $2.50 | Best price/perf for voice. |
+| `gemini-3.1-flash-lite` | $0.25 | $1.50 | |
+| `gemini-3.1-pro-preview` | $2.00 | $12.00 | Preview. Rate for prompts ≤200k tokens. |
+| `gemini-3-flash-preview` | $0.50 | $3.00 | Preview. |
+| `gemini-2.5-flash` | $0.30 | $2.50 | |
+| `gemini-2.5-pro` | $1.25 | $10.00 | Highest quality. Rate for prompts ≤200k tokens. |
 
-For the speech-to-speech variant `gemini-live-2.5-flash-native-audio` (input $0.30 / output $2.50), see the [Engines](/typescript-sdk/engines) page — it is a separate Realtime adapter, not a chat-completions model.
+`gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-1.5-flash`, and `gemini-1.5-pro` are shut down and no longer supported.
+
+For the speech-to-speech variants — `gemini-3.1-flash-live-preview` (text in $0.75 / out $4.50, audio in $3.00/1M tokens = $0.005/min / out $12.00/1M tokens = $0.018/min) and `gemini-2.5-flash-native-audio-preview` (text in $0.50 / out $2.00, audio in $3.00 / out $12.00) — see the [Engines](/typescript-sdk/engines) page; they are separate Realtime adapters, not chat-completions models.
 
 ## Environment variables
 
@@ -131,7 +136,7 @@ For the speech-to-speech variant `gemini-live-2.5-flash-native-audio` (input $0.
 | Option | Default | Notes |
 |---|---|---|
 | `apiKey` / `api_key` | `undefined` | Reads `GEMINI_API_KEY`, then `GOOGLE_API_KEY`. |
-| `model` | `"gemini-2.5-flash"` | Any Gemini chat model id. |
+| `model` | `"gemini-3.5-flash-lite"` | Any Gemini chat model id. |
 | `baseUrl` / `base_url` | unset | Override the Generative Language API endpoint (rarely needed). |
 | `temperature` | unset | Optional sampling temperature. |
 | `maxOutputTokens` / `max_output_tokens` | unset | Output token cap. |

--- a/libraries/python/getpatter/llm/google.py
+++ b/libraries/python/getpatter/llm/google.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import ClassVar
 
+from getpatter.providers.google_llm import _DEFAULT_MODEL
 from getpatter.providers.google_llm import GoogleLLMProvider as _GoogleLLM
 
 __all__ = ["LLM"]
@@ -27,7 +28,7 @@ class LLM(_GoogleLLM):
         self,
         api_key: str | None = None,
         *,
-        model: str = "gemini-2.5-flash",
+        model: str = _DEFAULT_MODEL,
         **kwargs,
     ) -> None:
         # Prefer ``GEMINI_API_KEY`` (more specific), fall back to

--- a/libraries/python/getpatter/pricing.py
+++ b/libraries/python/getpatter/pricing.py
@@ -24,6 +24,11 @@ provider entry with a merged ``models`` dict, e.g.::
     overrides via ``Patter(pricing={...})``.
 """
 
+# TODO(pricing-split): module is 824 lines, over core.md's 800-line file cap
+# (778 lines pre-catalog-refresh). Split by provider group before the next
+# pricing addition -- deferred here because a real split touches many import
+# sites, out of scope for a catalog refresh.
+
 from __future__ import annotations
 
 from enum import StrEnum
@@ -668,10 +673,56 @@ LLM_PRICING: dict[str, dict[str, dict[str, float]]] = {
             "cache_write": 1.25,
         },
     },
+    # Google Gemini — chat/completion LLM per-1M-token rates (input / output /
+    # cache_read = context-caching read rate). Source:
+    # https://ai.google.dev/gemini-api/docs/pricing (verified 2026-08-24).
+    # gemini-2.0-flash, gemini-2.0-flash-lite, gemini-2.0-flash-exp,
+    # gemini-1.5-flash, and gemini-1.5-pro are shut down and intentionally
+    # absent — see https://ai.google.dev/gemini-api/docs/models.
     "google": {
-        "gemini-2.5-pro": {"input": 1.25, "output": 10.0},
-        "gemini-2.5-flash": {"input": 0.30, "output": 2.50},
+        # 3.7-flash and 3.6-flash list a two-tier rate: current tier below,
+        # stepping up to input 1.50 / output 7.50 / cache_read 0.15 on
+        # 2027-01-01.
+        "gemini-3.7-flash": {"input": 0.75, "output": 3.75, "cache_read": 0.075},
+        "gemini-3.6-flash": {"input": 0.75, "output": 3.75, "cache_read": 0.075},
+        "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cache_read": 0.15},
+        "gemini-3.5-flash-lite": {
+            "input": 0.30,
+            "output": 2.50,
+            "cache_read": 0.03,
+        },
+        "gemini-3.1-flash-lite": {
+            "input": 0.25,
+            "output": 1.50,
+            "cache_read": 0.025,
+        },
+        # <=200k-token prompts; >200k steps up to 4.00 / 18.00 / 0.40. Prompt
+        # length isn't threaded into calculate_llm_cost, so only the <=200k
+        # tier is modelled.
+        "gemini-3.1-pro-preview": {
+            "input": 2.00,
+            "output": 12.00,
+            "cache_read": 0.20,
+        },
+        "gemini-3-flash-preview": {"input": 0.50, "output": 3.00, "cache_read": 0.05},
+        "gemini-2.5-pro": {"input": 1.25, "output": 10.0, "cache_read": 0.125},
+        "gemini-2.5-flash": {"input": 0.30, "output": 2.50, "cache_read": 0.03},
+        # Pre-existing entry — no known model id matches or prefix-matches
+        # this key; left untouched (dead/unreachable via calculate_llm_cost,
+        # out of this refresh's scope).
         "gemini-live-2.5-flash-native-audio": {"input": 0.30, "output": 2.50},
+        # Live API TEXT rate for the audio-to-audio model (used if chat-style
+        # usage is ever metered against this model id). AUDIO-modality rates
+        # ($3.00/1M in = $0.005/min, $12.00/1M out = $0.018/min) have no slot
+        # here — the rate shape is input/output-only, and
+        # CallMetricsAccumulator has no gemini_live cost branch
+        # (GeminiLiveAdapter never surfaces usage either) — gap, not plumbed
+        # by this refresh. Was missing entirely before (TS/PY parity gap).
+        "gemini-3.1-flash-live-preview": {"input": 0.75, "output": 4.50},
+        # Native-audio Live model (both dated snapshots resolve here via
+        # longest-prefix match). TEXT rate only — same audio-modality gap as
+        # above (audio in 3.00 / audio out 12.00 per 1M tokens unmodelled).
+        "gemini-2.5-flash-native-audio-preview": {"input": 0.50, "output": 2.00},
     },
     "groq": {
         # Rates as of 2026-05-08; verify against groq.com/pricing.

--- a/libraries/python/getpatter/providers/gemini_live.py
+++ b/libraries/python/getpatter/providers/gemini_live.py
@@ -25,12 +25,20 @@ logger = logging.getLogger("getpatter.gemini_live")
 
 
 class GeminiLiveModel(StrEnum):
-    """Known Gemini Live (v1alpha) realtime models."""
+    """Known Gemini Live (v1alpha) realtime models.
+
+    Catalog verified against https://ai.google.dev/gemini-api/docs/models and
+    https://ai.google.dev/gemini-api/docs/changelog as of 2026-08-24.
+    ``gemini-2.0-flash-exp`` was experimental preview, retired Dec 2024, and
+    has been removed. ``gemini-live-2.5-flash-preview`` was shut down
+    2025-12-09 but is kept for reference/back-compat — it is still a valid
+    string for any existing caller code that already pins it.
+    """
 
     NATIVE_AUDIO_PREVIEW_09_2025 = "gemini-2.5-flash-native-audio-preview-09-2025"
+    NATIVE_AUDIO_PREVIEW_12_2025 = "gemini-2.5-flash-native-audio-preview-12-2025"
     LIVE_3_1_FLASH_PREVIEW = "gemini-3.1-flash-live-preview"
     LIVE_2_5_FLASH_PREVIEW = "gemini-live-2.5-flash-preview"
-    LIVE_2_0_FLASH_EXP = "gemini-2.0-flash-exp"
 
 
 class GeminiLiveVoice(StrEnum):
@@ -104,12 +112,13 @@ class GeminiLiveAdapter:
         api_key: str,
         # gemini-2.0-flash-exp was experimental preview retired Dec 2024.
         # gemini-live-2.5-flash-preview was shut down Dec 9, 2025.
-        # Current native-audio live model (v1alpha only) is the dated preview.
+        # Current audio-to-audio Live model (v1alpha only) is
+        # gemini-3.1-flash-live-preview, released 2026-03-26 (preview) — verified against
+        # https://ai.google.dev/gemini-api/docs/changelog as of 2026-08-24.
         # Override via GeminiLive(model=...) if needed.
-        # TODO verify against Google docs: https://ai.google.dev/gemini-api/docs/live
         model: Union[
             GeminiLiveModel, str
-        ] = GeminiLiveModel.NATIVE_AUDIO_PREVIEW_09_2025,
+        ] = GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW,
         voice: Union[GeminiLiveVoice, str] = GeminiLiveVoice.PUCK,
         instructions: str = "",
         language: str = "en-US",

--- a/libraries/python/getpatter/providers/google_llm.py
+++ b/libraries/python/getpatter/providers/google_llm.py
@@ -25,14 +25,23 @@ __all__ = ["GoogleLLMProvider", "GoogleModel", "GoogleVertexLocation"]
 
 
 class GoogleModel(StrEnum):
-    """Known Google Gemini chat models."""
+    """Known Google Gemini chat models.
 
+    Catalog verified against https://ai.google.dev/gemini-api/docs/models as
+    of 2026-08-24. ``gemini-2.0-flash``, ``gemini-2.0-flash-lite``,
+    ``gemini-2.0-flash-exp``, ``gemini-1.5-flash``, and ``gemini-1.5-pro`` are
+    shut down and intentionally not listed.
+    """
+
+    GEMINI_3_7_FLASH = "gemini-3.7-flash"
+    GEMINI_3_6_FLASH = "gemini-3.6-flash"
+    GEMINI_3_5_FLASH = "gemini-3.5-flash"
+    GEMINI_3_5_FLASH_LITE = "gemini-3.5-flash-lite"
+    GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite"
+    GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
+    GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
     GEMINI_2_5_FLASH = "gemini-2.5-flash"
     GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_2_0_FLASH = "gemini-2.0-flash"
-    GEMINI_2_0_FLASH_LITE = "gemini-2.0-flash-lite"
-    GEMINI_1_5_FLASH = "gemini-1.5-flash"
-    GEMINI_1_5_PRO = "gemini-1.5-pro"
 
 
 class GoogleVertexLocation(StrEnum):
@@ -48,7 +57,7 @@ class GoogleVertexLocation(StrEnum):
     ASIA_SOUTHEAST1 = "asia-southeast1"
 
 
-_DEFAULT_MODEL = GoogleModel.GEMINI_2_5_FLASH.value
+_DEFAULT_MODEL = GoogleModel.GEMINI_3_5_FLASH_LITE.value
 _DEFAULT_VERTEX_LOCATION = GoogleVertexLocation.US_CENTRAL1.value
 
 
@@ -63,7 +72,7 @@ class GoogleLLMProvider:
         api_key: Google API key for the Gemini Developer API. If
             omitted, ``GOOGLE_API_KEY`` is read from the environment.
             Ignored when ``vertexai=True``.
-        model: Gemini model ID. Defaults to ``gemini-2.5-flash``.
+        model: Gemini model ID. Defaults to ``gemini-3.5-flash-lite``.
         vertexai: If True, use Vertex AI instead of the Developer API.
         project: GCP project (Vertex AI only).
         location: GCP location (Vertex AI only). Defaults to

--- a/libraries/python/tests/test_gemini_live.py
+++ b/libraries/python/tests/test_gemini_live.py
@@ -201,3 +201,12 @@ async def test_non_flash_live_declaration_has_no_behavior(monkeypatch) -> None:
     # 2.5 native-audio is byte-identical on the wire — no behavior key.
     assert "behavior" not in decls[0]
     await adapter.close()
+
+
+@pytest.mark.unit
+def test_default_model_is_gemini_3_1_flash_live_preview() -> None:
+    """3.x catalog refresh (2026-08-24): no explicit model resolves to the
+    current audio-to-audio Live model, not the retired 2.5 dated preview."""
+    adapter = GeminiLiveAdapter(api_key="test-key")
+    assert adapter.model == GeminiLiveModel.LIVE_3_1_FLASH_PREVIEW
+    assert adapter.model == "gemini-3.1-flash-live-preview"

--- a/libraries/python/tests/test_pricing.py
+++ b/libraries/python/tests/test_pricing.py
@@ -13,6 +13,7 @@ from getpatter.pricing import (
     calculate_tts_cost,
     merge_pricing,
 )
+from getpatter.providers.google_llm import GoogleLLMProvider, GoogleModel
 
 
 class TestMergePricing:
@@ -501,3 +502,56 @@ class TestLLMCostBilling:
         assert spec_cost == pytest.approx(0.99)
         assert ver_cost == pytest.approx(0.79)
         assert spec_cost > ver_cost
+
+
+class TestGoogleGeminiPricingCatalogRefresh:
+    """Gemini 3.x catalog refresh (2026-08-24).
+
+    Rates verified against https://ai.google.dev/gemini-api/docs/pricing;
+    model catalog verified against
+    https://ai.google.dev/gemini-api/docs/models. 3.7/3.6/3.5/3.5-lite/
+    3.1-lite/3.1-pro-preview/3-flash-preview replace the retired 2.0/1.5
+    family in ``GoogleModel``.
+    """
+
+    def test_every_google_model_enum_value_has_a_pricing_entry(self):
+        """Every model in the GoogleModel enum has a pricing entry (no $0 holes)."""
+        for model in GoogleModel:
+            cost = calculate_llm_cost("google", model.value, 10_000, 10_000)
+            assert cost > 0.0, f"google model {model.value!r} silently billed $0"
+            assert model.value in LLM_PRICING["google"], f"missing rate for {model.value!r}"
+
+    def test_default_model_is_gemini_3_5_flash_lite(self):
+        assert GoogleModel.GEMINI_3_5_FLASH_LITE.value == "gemini-3.5-flash-lite"
+
+    def test_google_llm_provider_resolves_to_default_when_no_model_passed(self):
+        provider = GoogleLLMProvider(api_key="test-key")
+        assert provider._model == GoogleModel.GEMINI_3_5_FLASH_LITE
+
+    def test_removed_models_are_no_longer_enum_values(self):
+        """2.0/1.5 family and the shut-down 3-pro-preview must not resurface."""
+        values = {m.value for m in GoogleModel}
+        assert "gemini-2.0-flash" not in values
+        assert "gemini-2.0-flash-lite" not in values
+        assert "gemini-2.0-flash-exp" not in values
+        assert "gemini-1.5-flash" not in values
+        assert "gemini-1.5-pro" not in values
+        assert "gemini-3-pro-preview" not in values
+
+    def test_gemini_3_1_flash_live_preview_text_rate_corrected(self):
+        """Was wrongly 0.30/2.50 (and absent from Python entirely); now 0.75/4.50."""
+        cost = calculate_llm_cost(
+            "google", "gemini-3.1-flash-live-preview", 1_000_000, 1_000_000
+        )
+        assert cost == pytest.approx(0.75 + 4.50)
+
+    def test_gemini_2_5_flash_native_audio_preview_dated_snapshots_resolve(self):
+        """Both dated Live-API snapshots resolve via longest-prefix match."""
+        cost_09 = calculate_llm_cost(
+            "google", "gemini-2.5-flash-native-audio-preview-09-2025", 1_000_000, 0
+        )
+        cost_12 = calculate_llm_cost(
+            "google", "gemini-2.5-flash-native-audio-preview-12-2025", 1_000_000, 0
+        )
+        assert cost_09 == pytest.approx(0.50)
+        assert cost_12 == pytest.approx(0.50)

--- a/libraries/python/tests/test_pricing.py
+++ b/libraries/python/tests/test_pricing.py
@@ -525,6 +525,9 @@ class TestGoogleGeminiPricingCatalogRefresh:
         assert GoogleModel.GEMINI_3_5_FLASH_LITE.value == "gemini-3.5-flash-lite"
 
     def test_google_llm_provider_resolves_to_default_when_no_model_passed(self):
+        # Constructing the provider imports google-genai, which is an optional
+        # extra; the base CI matrix runs without it.
+        pytest.importorskip("google.genai")
         provider = GoogleLLMProvider(api_key="test-key")
         assert provider._model == GoogleModel.GEMINI_3_5_FLASH_LITE
 

--- a/libraries/python/tests/unit/test_llm_api.py
+++ b/libraries/python/tests/unit/test_llm_api.py
@@ -151,6 +151,14 @@ class TestProviderWrappers:
         with pytest.raises(ValueError, match="GEMINI_API_KEY"):
             GoogleLLM()
 
+    @_skip_if_no_google
+    def test_google_default_model_is_gemini_3_5_flash_lite(self, monkeypatch) -> None:
+        """3.x catalog refresh (2026-08-24): no explicit model resolves to
+        the new default, not the retired gemini-2.5-flash."""
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-default-check")
+        llm = GoogleLLM()
+        assert llm._model == "gemini-3.5-flash-lite"
+
 
 # ---------------------------------------------------------------------------
 # phone.agent(llm=...)

--- a/libraries/typescript/src/pricing.ts
+++ b/libraries/typescript/src/pricing.ts
@@ -15,6 +15,10 @@
  *
  *     new Patter({ pricing: { elevenlabs: { models: { my_custom: { price: 0.075 } } } } })
  */
+// TODO(pricing-split): module is 887 lines, already over the 800-line file
+// cap (856 lines pre-catalog-refresh). Split by provider group before the
+// next pricing addition -- deferred here because a real split touches many
+// import sites, out of scope for a catalog refresh.
 
 /** Pricing table version identifier, updated in lockstep with the Python SDK. */
 export const PRICING_VERSION = '2026.3';
@@ -407,20 +411,20 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
   },
   // Gemini Cascade — two-leg architecture: Live leg (text in/out per token)
   // and TTS leg (text-in / audio-out per token). Rates per 1M tokens (USD).
-  // Sources: Google AI Studio pricing page (verified 2026-06-18).
-  //   gemini-3.1-flash-live-preview: $0.30/M text input, $2.50/M text output.
+  // Sources: https://ai.google.dev/gemini-api/docs/pricing (verified 2026-08-24).
+  //   gemini-3.1-flash-live-preview: $0.75/M text input, $4.50/M text output.
   //   gemini-3.1-flash-tts-preview:  $1.00/M text input, $20.00/M audio output.
   // Provider defaults represent the Live leg; TTS leg rates are per-model.
   gemini_cascade: {
     unit: PricingUnit.TOKEN,
     // Live leg defaults (gemini-3.1-flash-live-preview): text in/out only.
-    text_input_per_token: 0.00000030,   // $0.30 per 1M text input tokens
-    text_output_per_token: 0.0000025,   // $2.50 per 1M text output tokens
+    text_input_per_token: 0.00000075,   // $0.75 per 1M text input tokens
+    text_output_per_token: 0.0000045,   // $4.50 per 1M text output tokens
     models: {
       // Live STT+brain leg (TEXT modality — no audio output from this leg).
       'gemini-3.1-flash-live-preview': {
-        text_input_per_token: 0.00000030,
-        text_output_per_token: 0.0000025,
+        text_input_per_token: 0.00000075,
+        text_output_per_token: 0.0000045,
       },
       // TTS voice-synthesis leg: text in → audio out.
       'gemini-3.1-flash-tts-preview': {
@@ -748,11 +752,42 @@ export const llmPricing: Record<string, Record<string, LlmModelPricing>> = {
       cache_write: 1.25,
     },
   },
+  // Google Gemini — chat/completion LLM per-1M-token rates (input / output /
+  // cache_read = context-caching read rate). Source:
+  // https://ai.google.dev/gemini-api/docs/pricing (verified 2026-08-24).
+  // gemini-2.0-flash, gemini-2.0-flash-lite, gemini-2.0-flash-exp,
+  // gemini-1.5-flash, and gemini-1.5-pro are shut down and intentionally
+  // absent — see https://ai.google.dev/gemini-api/docs/models.
   google: {
-    'gemini-2.5-pro': { input: 1.25, output: 10.0 },
-    'gemini-2.5-flash': { input: 0.30, output: 2.50 },
+    // 3.7-flash and 3.6-flash list a two-tier rate: current tier below,
+    // stepping up to input 1.50 / output 7.50 / cache_read 0.15 on 2027-01-01.
+    'gemini-3.7-flash': { input: 0.75, output: 3.75, cache_read: 0.075 },
+    'gemini-3.6-flash': { input: 0.75, output: 3.75, cache_read: 0.075 },
+    'gemini-3.5-flash': { input: 1.50, output: 9.00, cache_read: 0.15 },
+    'gemini-3.5-flash-lite': { input: 0.30, output: 2.50, cache_read: 0.03 },
+    'gemini-3.1-flash-lite': { input: 0.25, output: 1.50, cache_read: 0.025 },
+    // <=200k-token prompts; >200k steps up to 4.00 / 18.00 / 0.40. Prompt
+    // length isn't threaded into calculateLlmCost, so only the <=200k tier
+    // is modelled.
+    'gemini-3.1-pro-preview': { input: 2.00, output: 12.00, cache_read: 0.20 },
+    'gemini-3-flash-preview': { input: 0.50, output: 3.00, cache_read: 0.05 },
+    'gemini-2.5-pro': { input: 1.25, output: 10.0, cache_read: 0.125 },
+    'gemini-2.5-flash': { input: 0.30, output: 2.50, cache_read: 0.03 },
+    // Pre-existing entry — no known model id matches or prefix-matches this
+    // key; left untouched (dead/unreachable via calculateLlmCost, out of
+    // this refresh's scope).
     'gemini-live-2.5-flash-native-audio': { input: 0.30, output: 2.50 },
-    'gemini-3.1-flash-live-preview': { input: 0.30, output: 2.50 },
+    // Live API TEXT rate for the audio-to-audio model (used if chat-style
+    // usage is ever metered against this model id). AUDIO-modality rates
+    // ($3.00/1M in = $0.005/min, $12.00/1M out = $0.018/min) have no slot
+    // here: LlmModelPricing is text-only, and metrics.ts _computeCost has no
+    // gemini_live cost branch (GeminiLiveAdapter never surfaces usage either)
+    // — gap, not plumbed by this refresh. Was wrongly 0.30/2.50 before.
+    'gemini-3.1-flash-live-preview': { input: 0.75, output: 4.50 },
+    // Native-audio Live model (both dated snapshots resolve here via
+    // longest-prefix match). TEXT rate only — same audio-modality gap as
+    // above (audio in 3.00 / audio out 12.00 per 1M tokens unmodelled).
+    'gemini-2.5-flash-native-audio-preview': { input: 0.50, output: 2.00 },
   },
   groq: {
     // Rates as of 2026-05-08; verify against groq.com/pricing.

--- a/libraries/typescript/src/providers/gemini-live.ts
+++ b/libraries/typescript/src/providers/gemini-live.ts
@@ -52,6 +52,10 @@ const INBOUND_GAIN = 2;
 /** Model ID for Gemini 3.1 Flash Live (audio-in → audio-out, emotion-aware). */
 export const GEMINI_LIVE_3_1_FLASH_PREVIEW = 'gemini-3.1-flash-live-preview';
 
+/** Model ID for the newer dated native-audio Live snapshot (released 2025-12-12). */
+export const GEMINI_LIVE_NATIVE_AUDIO_PREVIEW_12_2025 =
+  'gemini-2.5-flash-native-audio-preview-12-2025';
+
 /**
  * Whether a Gemini Live model must be addressed on the `v1alpha` channel.
  *
@@ -206,10 +210,11 @@ export class GeminiLiveAdapter {
     this.options = options;
     // gemini-2.0-flash-exp was experimental preview retired Dec 2024.
     // gemini-live-2.5-flash-preview was shut down Dec 9, 2025.
-    // Current native-audio live model (v1alpha-only) is the dated preview.
+    // Current audio-to-audio Live model (v1alpha-only) is gemini-3.1-flash-
+    // live-preview, released 2026-03-26 (preview) — verified against
+    // https://ai.google.dev/gemini-api/docs/changelog as of 2026-08-24.
     // Callers can override via GeminiLive({ model: ... }).
-    // Default model — see https://ai.google.dev/gemini-api/docs/live
-    this.model = options.model ?? 'gemini-2.5-flash-native-audio-preview-09-2025';
+    this.model = options.model ?? GEMINI_LIVE_3_1_FLASH_PREVIEW;
     this.voice = options.voice ?? 'Puck';
     this.instructions = options.instructions ?? '';
     this.language = options.language ?? 'en-US';

--- a/libraries/typescript/src/providers/google-llm.ts
+++ b/libraries/typescript/src/providers/google-llm.ts
@@ -25,19 +25,29 @@ import {
 import { getLogger } from '../logger';
 import { PatterConnectionError } from '../errors';
 
-/** Known Google Gemini chat models. */
+/**
+ * Known Google Gemini chat models.
+ *
+ * Catalog verified against https://ai.google.dev/gemini-api/docs/models as of
+ * 2026-08-24. `gemini-2.0-flash`, `gemini-2.0-flash-lite`,
+ * `gemini-2.0-flash-exp`, `gemini-1.5-flash`, and `gemini-1.5-pro` are shut
+ * down and intentionally not listed.
+ */
 export const GoogleModel = {
+  GEMINI_3_7_FLASH: 'gemini-3.7-flash',
+  GEMINI_3_6_FLASH: 'gemini-3.6-flash',
+  GEMINI_3_5_FLASH: 'gemini-3.5-flash',
+  GEMINI_3_5_FLASH_LITE: 'gemini-3.5-flash-lite',
+  GEMINI_3_1_FLASH_LITE: 'gemini-3.1-flash-lite',
+  GEMINI_3_1_PRO_PREVIEW: 'gemini-3.1-pro-preview',
+  GEMINI_3_FLASH_PREVIEW: 'gemini-3-flash-preview',
   GEMINI_2_5_FLASH: 'gemini-2.5-flash',
   GEMINI_2_5_PRO: 'gemini-2.5-pro',
-  GEMINI_2_0_FLASH: 'gemini-2.0-flash',
-  GEMINI_2_0_FLASH_LITE: 'gemini-2.0-flash-lite',
-  GEMINI_1_5_FLASH: 'gemini-1.5-flash',
-  GEMINI_1_5_PRO: 'gemini-1.5-pro',
 } as const;
 /** Union of {@link GoogleModel} string values. */
 export type GoogleModel = (typeof GoogleModel)[keyof typeof GoogleModel];
 
-const DEFAULT_MODEL: string = GoogleModel.GEMINI_2_5_FLASH;
+const DEFAULT_MODEL: string = GoogleModel.GEMINI_3_5_FLASH_LITE;
 const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
 
 /** Constructor options for {@link GoogleLLMProvider}. */

--- a/libraries/typescript/tests/gemini-live-tools.mocked.test.ts
+++ b/libraries/typescript/tests/gemini-live-tools.mocked.test.ts
@@ -123,3 +123,13 @@ describe('[mocked] GeminiLiveAdapter — async tool-call mode (3.1 flash-live we
     await adapter.close();
   });
 });
+
+describe('[unit] GeminiLiveAdapter — default model (3.x catalog refresh)', () => {
+  it('defaults to gemini-3.1-flash-live-preview when no model is passed', () => {
+    // Construction only — no connect(), so no @google/genai mock is needed.
+    const adapter = new GeminiLiveAdapter('test-key');
+    const a = adapter as unknown as Record<string, unknown>;
+    expect(a['model']).toBe(GEMINI_LIVE_3_1_FLASH_PREVIEW);
+    expect(a['model']).toBe('gemini-3.1-flash-live-preview');
+  });
+});

--- a/libraries/typescript/tests/pricing.test.ts
+++ b/libraries/typescript/tests/pricing.test.ts
@@ -10,6 +10,7 @@ import {
   calculateLlmCost,
   llmPricing,
 } from '../src/pricing';
+import { GoogleModel, GoogleLLMProvider } from '../src/providers/google-llm';
 
 describe('DEFAULT_PRICING', () => {
   it('includes all expected providers', () => {
@@ -446,5 +447,76 @@ describe('LLM cost billing — Cerebras + Groq silent under-billing regression',
     expect(specCost).toBeCloseTo(0.99, 6);
     expect(verCost).toBeCloseTo(0.79, 6);
     expect(specCost).toBeGreaterThan(verCost);
+  });
+});
+
+describe('Google Gemini LLM pricing — 3.x catalog refresh', () => {
+  // 2026-08-24: Gemini 3.x GA wave (3.7/3.6/3.5/3.5-lite/3.1-lite/3.1-pro-
+  // preview/3-flash-preview) replaces the retired 2.0/1.5 family in
+  // GoogleModel. Rates verified against
+  // https://ai.google.dev/gemini-api/docs/pricing (2026-08-24).
+
+  it('every GoogleModel enum value has a pricing entry (no $0 holes)', () => {
+    // Mirrors libraries/typescript/src/providers/google-llm.ts GoogleModel.
+    const googleModels = Object.values(GoogleModel);
+    for (const model of googleModels) {
+      const cost = calculateLlmCost('google', model, 10_000, 10_000);
+      expect(cost, `google model ${model} silently billed $0`).toBeGreaterThan(0);
+      expect(llmPricing.google[model], `missing rate for ${model}`).toBeDefined();
+    }
+  });
+
+  it('default model is gemini-3.5-flash-lite', () => {
+    expect(GoogleModel.GEMINI_3_5_FLASH_LITE).toBe('gemini-3.5-flash-lite');
+  });
+
+  it('GoogleLLMProvider resolves to gemini-3.5-flash-lite when no model is passed', () => {
+    const provider = new GoogleLLMProvider({ apiKey: 'test-key' });
+    expect(provider.model).toBe(GoogleModel.GEMINI_3_5_FLASH_LITE);
+  });
+
+  it('removed models (2.0/1.5 family) are no longer GoogleModel enum values', () => {
+    const values: readonly string[] = Object.values(GoogleModel);
+    expect(values).not.toContain('gemini-2.0-flash');
+    expect(values).not.toContain('gemini-2.0-flash-lite');
+    expect(values).not.toContain('gemini-2.0-flash-exp');
+    expect(values).not.toContain('gemini-1.5-flash');
+    expect(values).not.toContain('gemini-1.5-pro');
+  });
+
+  it('gemini-3.1-flash-live-preview text rate is corrected to 0.75/4.50 (was wrongly 0.30/2.50)', () => {
+    const cost = calculateLlmCost(
+      'google',
+      'gemini-3.1-flash-live-preview',
+      1_000_000,
+      1_000_000,
+    );
+    expect(cost).toBeCloseTo(0.75 + 4.5, 6);
+  });
+
+  it('gemini-2.5-flash-native-audio-preview dated snapshots resolve via longest-prefix match', () => {
+    const cost09 = calculateLlmCost(
+      'google',
+      'gemini-2.5-flash-native-audio-preview-09-2025',
+      1_000_000,
+      0,
+    );
+    const cost12 = calculateLlmCost(
+      'google',
+      'gemini-2.5-flash-native-audio-preview-12-2025',
+      1_000_000,
+      0,
+    );
+    expect(cost09).toBeCloseTo(0.5, 6);
+    expect(cost12).toBeCloseTo(0.5, 6);
+  });
+
+  it('gemini_cascade Live-leg rate is corrected to 0.75/4.50 (was wrongly 0.30/2.50)', () => {
+    const cascade = DEFAULT_PRICING.gemini_cascade;
+    expect(cascade.text_input_per_token).toBeCloseTo(0.00000075, 12);
+    expect(cascade.text_output_per_token).toBeCloseTo(0.0000045, 12);
+    const liveLeg = cascade.models?.['gemini-3.1-flash-live-preview'];
+    expect(liveLeg?.text_input_per_token).toBeCloseTo(0.00000075, 12);
+    expect(liveLeg?.text_output_per_token).toBeCloseTo(0.0000045, 12);
   });
 });

--- a/libraries/typescript/tests/unit/llm-api.test.ts
+++ b/libraries/typescript/tests/unit/llm-api.test.ts
@@ -163,6 +163,11 @@ describe("llm/google", () => {
     expect(() => new googleLlm.LLM()).toThrow(/GEMINI_API_KEY/);
     expect(() => new googleLlm.LLM()).toThrow(/GOOGLE_API_KEY/);
   });
+
+  it("LLM defaults to gemini-3.5-flash-lite when no model is passed (3.x catalog refresh)", () => {
+    const llm = new googleLlm.LLM({ apiKey: "AIza-explicit" });
+    expect(llm.model).toBe("gemini-3.5-flash-lite");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Refreshes the Google Gemini model catalog to the 3.x generation in both SDKs, verified
  against `https://ai.google.dev/gemini-api/docs/models` and
  `https://ai.google.dev/gemini-api/docs/pricing` as of 2026-08-24.
- **`GoogleModel`** (chat/completions) adds `gemini-3.7-flash`, `gemini-3.6-flash`,
  `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`,
  `gemini-3.1-pro-preview`, `gemini-3-flash-preview`; keeps `gemini-2.5-flash` /
  `gemini-2.5-pro`; **removes** `gemini-2.0-flash`, `gemini-2.0-flash-lite`,
  `gemini-2.0-flash-exp`, `gemini-1.5-flash`, `gemini-1.5-pro` (all shut down upstream).
- **`GeminiLiveModel`** adds `NATIVE_AUDIO_PREVIEW_12_2025`
  (`gemini-2.5-flash-native-audio-preview-12-2025`); **removes**
  `LIVE_2_0_FLASH_EXP` (`gemini-2.0-flash-exp`, retired Dec 2024).
- **Defaults changed (behaviour change):**
  - `GoogleLLM` / `GoogleLLMProvider` default model: `gemini-2.5-flash` → `gemini-3.5-flash-lite`.
  - `GeminiLiveAdapter` default model: `gemini-2.5-flash-native-audio-preview-09-2025` →
    `gemini-3.1-flash-live-preview`.
- **Pricing corrected:** `gemini-3.1-flash-live-preview` text rate was wrongly
  `$0.30`/`$2.50` per 1M tokens in both SDKs' chat-pricing tables (and missing from the
  Python table entirely) — now `$0.75`/`$4.50`, matching the TS `gemini_cascade` Live-leg
  default it was already meant to mirror. Every new/kept `GoogleModel` id now has a pricing
  row with `input`/`output`/`cache_read`, so no enum value silently bills `$0`.
- Docs (`docs/{python,typescript}-sdk/{llm,providers/google,providers/gemini-live}.mdx`)
  updated with the new defaults, catalog tables, and rate cards.
- Why: Google's 3.x wave superseded 2.0/1.5, several of the old ids are already shut down
  (silent breakage for anyone pinning them), and the Live-preview pricing bug was
  under-billing every gemini-3.1-flash-live-preview call by ~2.5x on input / ~1.8x on output.

## Verification

- Python: 8 new tests — `test_gemini_live.py::test_default_model_is_gemini_3_1_flash_live_preview`;
  `test_pricing.py::TestGoogleGeminiPricingCatalogRefresh` (6 tests: every enum value has a
  pricing row, default model id, `GoogleLLMProvider` resolves to the new default, removed
  models stay removed, corrected `gemini-3.1-flash-live-preview` rate, both dated
  native-audio snapshots resolve via longest-prefix match); `test_llm_api.py::test_google_default_model_is_gemini_3_5_flash_lite`.
- TypeScript: 9 new tests — `gemini-live-tools.mocked.test.ts` default-model test;
  `pricing.test.ts` (7 tests, mirroring the Python `TestGoogleGeminiPricingCatalogRefresh`
  suite plus a `gemini_cascade` Live-leg rate check); `llm-api.test.ts` default-model test.
- CI: see checks.

## Notes / follow-ups

- `libraries/python/getpatter/pricing.py` is now 824 lines and `libraries/typescript/src/pricing.ts`
  is now 887 lines — both already over the repo's 800-line file cap before this change
  (778 / 856 lines pre-refresh) and grow further here. A `TODO(pricing-split)` comment is
  left in both files; splitting by provider group is deferred because it touches many
  import sites and is out of scope for a catalog/pricing refresh.
- Audio-modality Live API rates (`gemini-3.1-flash-live-preview` audio in $3.00/1M =
  $0.005/min, audio out $12.00/1M = $0.018/min; `gemini-2.5-flash-native-audio-preview`
  audio in $3.00, audio out $12.00) are **not modelled** — `LlmModelPricing` /
  the Python pricing dict shape is text-only, `CallMetricsAccumulator` (Python) and
  `metrics.ts` `_computeCost` (TS) have no `gemini_live` cost branch, and `GeminiLiveAdapter`
  never surfaces usage in either SDK. This gap predates this PR and isn't plumbed here.
  Only the TEXT-rate rows are corrected/added.
  Same gap for `gemini-2.5-flash-native-audio-preview` was already true and is unchanged.
- The pre-existing `gemini-live-2.5-flash-native-audio` pricing entry (both SDKs) has no
  known model id that matches or prefix-matches it — left untouched as dead/unreachable via
  `calculate_llm_cost` / `calculateLlmCost`, out of this refresh's scope.
- `gemini-3.1-pro-preview` and `gemini-2.5-pro` pricing rows reflect the ≤200k-token-prompt
  tier only; prompt length isn't threaded into `calculate_llm_cost` / `calculateLlmCost`, so
  the >200k tier (steps up to $4.00/$18.00 input/output for `gemini-3.1-pro-preview`) isn't
  modelled.
- `gemini-3.7-flash` and `gemini-3.6-flash` list a two-tier rate card upstream; only the
  current tier is modelled, with a comment noting the 2027-01-01 step-up to
  $1.50/$7.50/$0.15.
- `gemini-live-2.5-flash-preview` (shut down 2025-12-09) is kept in `GeminiLiveModel` for
  back-compat with callers that already pin it, per existing code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
