### PR TITLE
feat(openai): GPT-5.6 catalog, gpt-realtime-2.1, gpt-transcribe, gpt-5.6-luna default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ### Added
 
+- **OpenAI GPT-5.6 chat catalog + `gpt-realtime-2.1` / `gpt-transcribe` pricing,
+  both SDKs** — pricing catalog and default-model updates for OpenAI's latest
+  releases, verified against the published rate card 2026-08-24. No enum
+  members removed; all additions.
+  - **Behaviour change — `OpenAILLM` default model is now `"gpt-5.6-luna"`**
+    (was `"gpt-4o-mini"`), in `getpatter.llm.openai.LLM` (Python) and
+    `getpatter/llm/openai.ts` (TS). Same default flows through the eval
+    `LLMJudge` (`--judge-model`), `PipelineStreamHandler`/`stream_handler.ts`,
+    and `test_mode.py`/`test-mode.ts`'s realtime-engine LLM fallback. Existing
+    callers who don't pass `model=` get the new model and new (lower) price on
+    upgrade.
+  - **`LLM_PRICING["openai"]` / `llmPricing.openai`** gains the GPT-5.6 family:
+    `gpt-5.6-sol` ($4/$20/$0.40 per 1M in/out/cached), `gpt-5.6-terra`
+    ($2/$12/$0.20), `gpt-5.6-luna` ($0.20/$1.20/$0.02), plus a bare `gpt-5.6`
+    alias entry (same rate as `-sol`) kept separate from the prefix-matched
+    dated-suffix ids.
+  - **`OpenAIRealtimeModel`** (Python `StrEnum` / TS const object) gains
+    `GPT_REALTIME_2_1` (`"gpt-realtime-2.1"`) and `GPT_REALTIME_2_1_MINI`
+    (`"gpt-realtime-2.1-mini"`), point releases of `gpt-realtime-2` /
+    `gpt-realtime-mini` at the same published per-token rates in
+    `DEFAULT_PRICING["openai_realtime"]`. `gpt-realtime-2` remains the
+    `OpenAIRealtime2` default; the new ids are opt-in only.
+  - **`OpenAITranscriptionModel`** gains `GPT_TRANSCRIBE`
+    (`"gpt-transcribe"`, $0.0045/min) and `GPT_LIVE_TRANSCRIBE`
+    (`"gpt-live-transcribe"`, $0.017/min), priced under both the
+    `openai_realtime` (inline Whisper-family) and `openai_transcribe`
+    provider tables.
+  `libraries/python/getpatter/{llm/openai.py,pricing.py,providers/openai_realtime.py,stream_handler.py,test_mode.py,evals/{cli.py,llm_judge.py}}`,
+  `libraries/typescript/src/{llm/openai.ts,pricing.ts,providers/openai-realtime.ts,stream-handler.ts,test-mode.ts,cli.ts,evals/llm-judge.ts}`,
+  docs updated in `docs/{python-sdk,typescript-sdk}/{engines,llm,stt,providers/openai-realtime,providers/openai-realtime-2}.mdx`.
+
 - **xAI (Grok) voice catalog wired into both SDKs** — the 26 built-in Grok
   voices (`eve` default, `ara`, `rex`, `sal`, `leo`, `carina`, ...) are now a
   typed, immutable catalog instead of docs-only prose:

--- a/docs/python-sdk/engines.mdx
+++ b/docs/python-sdk/engines.mdx
@@ -56,7 +56,7 @@ and converts on the carrier leg — you don't configure anything.
 | `voice` | `str` | `"alloy"` | One of `"alloy"`, `"ash"`, `"ballad"`, `"coral"`, `"echo"`, `"fable"`, `"nova"`, `"onyx"`, `"sage"`, `"shimmer"`, `"verse"`. |
 | `model` | `str` | `"gpt-realtime-mini"` | OpenAI Realtime model ID. See [supported models](/python-sdk/providers/openai-realtime#models). |
 | `reasoning_effort` | `"minimal" \| "low" \| "medium" \| "high" \| None` | `None` | Reasoning tier for `gpt-realtime-2`. `None` leaves the field unset (server default). OpenAI recommends `"low"` for production voice flows; higher tiers add measurable per-turn latency. No-op on models that ignore it. |
-| `input_audio_transcription_model` | `str \| None` | `None` | Override the Realtime session's `input_audio_transcription.model`. `None` keeps the adapter default (`"whisper-1"`). Use `"gpt-realtime-whisper"` for low-latency partials, `"gpt-4o-transcribe"` for higher accuracy. |
+| `input_audio_transcription_model` | `str \| None` | `None` | Override the Realtime session's `input_audio_transcription.model`. `None` keeps the adapter default (`"whisper-1"`). Use `"gpt-realtime-whisper"` or `"gpt-live-transcribe"` for low-latency partials, `"gpt-4o-transcribe"` or `"gpt-transcribe"` for higher accuracy. |
 
 ### Supported model identifiers
 
@@ -67,6 +67,8 @@ The `model` argument accepts any OpenAI Realtime model ID. Common values:
 | `"gpt-realtime-mini"` | Default. Lowest latency / lowest cost. |
 | `"gpt-realtime"` | GA realtime model (Aug 2025). |
 | `"gpt-realtime-2"` | Most-capable: stronger instruction following, configurable `reasoning_effort`, 128K context. |
+| `"gpt-realtime-2.1"` | Point release of `gpt-realtime-2`; same published per-token rates. |
+| `"gpt-realtime-2.1-mini"` | Point release of `gpt-realtime-mini`; same published per-token rates. |
 | `"gpt-4o-realtime-preview"` | Earlier preview line; ~10x the per-token cost of mini. |
 | `"gpt-4o-mini-realtime-preview"` | Earlier preview line. |
 
@@ -107,7 +109,7 @@ asyncio.run(main())
 |-----------|------|---------|-------------|
 | `api_key` | `str` | `""` | OpenAI API key. Reads from `OPENAI_API_KEY` when empty. |
 | `voice` | `str` | `"alloy"` | Same voice set as `OpenAIRealtime`. |
-| `model` | `str` | `"gpt-realtime-2"` | Pinned to the GA model. Override only if OpenAI ships future GA-shaped models. |
+| `model` | `str` | `"gpt-realtime-2"` | Pinned to the GA model. `"gpt-realtime-2.1"` is also available — pass `model="gpt-realtime-2.1"` to opt in. Override only if OpenAI ships future GA-shaped models. |
 | `reasoning_effort` | `"minimal" \| "low" \| "medium" \| "high" \| None` | `None` | `gpt-realtime-2` reasoning tier. `"low"` is OpenAI's recommendation for production voice flows. |
 | `input_audio_transcription_model` | `str \| None` | `None` | Override for `audio.input.transcription.model`. `None` keeps the adapter default (`"whisper-1"`). |
 

--- a/docs/python-sdk/llm.mdx
+++ b/docs/python-sdk/llm.mdx
@@ -59,14 +59,14 @@ All classes accept `api_key: str | None = None` and fall back to the listed env 
 
 ### OpenAILLM
 
-OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-4o-mini"`. For other OpenAI-compatible endpoints use the dedicated wrappers (`GroqLLM`, `CerebrasLLM`) — they subclass `OpenAILLMProvider` with the right `base_url`.
+OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-5.6-luna"` (GPT-5.6's cost-optimized tier). For other OpenAI-compatible endpoints use the dedicated wrappers (`GroqLLM`, `CerebrasLLM`) — they subclass `OpenAILLMProvider` with the right `base_url`.
 
 ```python
 from getpatter import OpenAILLM                    # flat
 from getpatter.llm import openai                   # namespaced
 
 llm = OpenAILLM()                                   # reads OPENAI_API_KEY
-llm = openai.LLM(api_key="sk-...", model="gpt-4o-mini")
+llm = openai.LLM(api_key="sk-...", model="gpt-5.6-luna")
 ```
 
 ### AnthropicLLM

--- a/docs/python-sdk/providers/openai-realtime-2.mdx
+++ b/docs/python-sdk/providers/openai-realtime-2.mdx
@@ -10,6 +10,8 @@ icon: "bolt"
 
 For the legacy beta endpoint and the lower-cost `gpt-realtime-mini` model, keep using [`OpenAIRealtime`](/python-sdk/providers/openai-realtime). The two engines coexist — pick `OpenAIRealtime2` only when you specifically want the GA endpoint or the `gpt-realtime-2` model.
 
+`gpt-realtime-2.1` — a point release of `gpt-realtime-2` at the same published rates — is also available; pass `model="gpt-realtime-2.1"` to opt in. `gpt-realtime-2` remains the default.
+
 <Note>
 The GA endpoint rejects the legacy `OpenAI-Beta: realtime=v1` header and expects `output_modalities`, nested `audio.{input,output}` blocks with MIME-type strings, and `session.type = "realtime"`. These wire-shape differences are why GA needs its own adapter — the beta `OpenAIRealtimeAdapter` cannot reach `gpt-realtime-2` reliably.
 </Note>

--- a/docs/python-sdk/providers/openai-realtime.mdx
+++ b/docs/python-sdk/providers/openai-realtime.mdx
@@ -19,6 +19,8 @@ Pass any of these to `model=` on `OpenAIRealtime(...)`. Pricing is auto-resolved
 | `"gpt-realtime-mini"` (default) | $10 / $20 | Fastest + cheapest. Production default for most voice flows. |
 | `"gpt-realtime"` | $32 / $64 | GA realtime model (Aug 2025). |
 | `"gpt-realtime-2"` | $32 / $64 | Most-capable. Stronger instruction following, 128K context, supports `reasoning_effort`. |
+| `"gpt-realtime-2.1"` | $32 / $64 | Point release of `gpt-realtime-2` — same published rates. |
+| `"gpt-realtime-2.1-mini"` | $10 / $20 | Point release of `gpt-realtime-mini` — same published rates. |
 | `"gpt-4o-realtime-preview"` | $100 / $200 | Earlier preview, retained for compatibility. |
 | `"gpt-4o-mini-realtime-preview"` | $10 / $20 | Earlier preview, retained for compatibility. |
 
@@ -60,7 +62,9 @@ The Realtime session can run an inline Whisper-family model on inbound audio so 
 | `"whisper-1"` (default) | $0.006/min | Established Whisper. Slower partials. |
 | `"gpt-4o-mini-transcribe"` | $0.003/min | Cheapest. |
 | `"gpt-4o-transcribe"` | $0.006/min | Higher accuracy. |
+| `"gpt-transcribe"` | $0.0045/min | Next-gen standalone transcription model. |
 | `"gpt-realtime-whisper"` | $0.017/min | Streaming-optimised. Lowest-latency partials. Use when you need fast deltas in the dashboard or for live captioning. |
+| `"gpt-live-transcribe"` | $0.017/min | Next-gen streaming-optimised transcription model. |
 
 Same enum form:
 

--- a/docs/python-sdk/stt.mdx
+++ b/docs/python-sdk/stt.mdx
@@ -135,6 +135,10 @@ stt = OpenAITranscribeSTT(api_key="sk-...", language="es")
 | `model` | `str` | `"gpt-4o-transcribe"` | Either `"gpt-4o-transcribe"` or `"gpt-4o-mini-transcribe"`. |
 | `response_format` | `str` | `"json"` | Pass `"verbose_json"` to expose segment-level confidence and timestamps. |
 
+<Note>
+OpenAI's pricing catalog also lists two newer transcription models: `gpt-transcribe` ($0.0045/min, successor to `gpt-4o-transcribe`) and `gpt-live-transcribe` ($0.017/min, streaming-optimised, successor to `gpt-realtime-whisper`). Both rates are in Patter's pricing catalog (`openai_transcribe` / `whisper` providers). `OpenAITranscribeSTT` does not yet accept them as a `model=` override — to route the Realtime engine's built-in transcription through them today, pass `input_audio_transcription_model="gpt-transcribe"` (or `"gpt-live-transcribe"`) on [`OpenAIRealtime`](/python-sdk/providers/openai-realtime#streaming-transcription).
+</Note>
+
 ## Cartesia
 
 Streaming STT using Cartesia's `ink-whisper`. See [Cartesia setup](/python-sdk/providers/cartesia).

--- a/docs/typescript-sdk/engines.mdx
+++ b/docs/typescript-sdk/engines.mdx
@@ -53,7 +53,7 @@ and converts on the carrier leg — you don't configure any of this.
 | `voice` | `string` | `"alloy"` | One of `"alloy"`, `"ash"`, `"ballad"`, `"coral"`, `"echo"`, `"sage"`, `"shimmer"`, `"verse"`. |
 | `model` | `string` | `"gpt-4o-mini-realtime-preview"` | OpenAI Realtime model ID. See [supported models](/typescript-sdk/providers/openai-realtime#models). |
 | `reasoningEffort` | `"minimal" \| "low" \| "medium" \| "high"` | — | Reasoning-effort tier for `gpt-realtime-2`. When omitted, the field is not sent and the server default applies. OpenAI recommends `"low"` for production voice. |
-| `inputAudioTranscriptionModel` | `string` | — | Override for the Realtime session's `input_audio_transcription.model`. Omit to keep `whisper-1`. |
+| `inputAudioTranscriptionModel` | `string` | — | Override for the Realtime session's `input_audio_transcription.model`. Omit to keep `whisper-1`. Use `"gpt-realtime-whisper"` or `"gpt-live-transcribe"` for low-latency partials, `"gpt-4o-transcribe"` or `"gpt-transcribe"` for higher accuracy. |
 
 ### Supported model identifiers
 
@@ -65,6 +65,8 @@ The `model` option accepts any OpenAI Realtime model ID. Common values:
 | `"gpt-realtime-mini"` | GA mini — recommended cheap default for new deployments. |
 | `"gpt-realtime"` | GA realtime model (Aug 2025). |
 | `"gpt-realtime-2"` | Most-capable: stronger instruction following, configurable `reasoningEffort`, 128K context. Use [`OpenAIRealtime2`](#openairealtime2) for the GA wire shape. |
+| `"gpt-realtime-2.1"` | Point release of `gpt-realtime-2`; same published per-token rates. |
+| `"gpt-realtime-2.1-mini"` | Point release of `gpt-realtime-mini`; same published per-token rates. |
 | `"gpt-4o-realtime-preview"` | Earlier preview line; ~10x the per-token cost of mini. |
 
 Pricing is auto-resolved per model — see [Metrics](/typescript-sdk/metrics). For `reasoningEffort`, transcription model, and the full configuration surface, see [OpenAI Realtime — full reference](/typescript-sdk/providers/openai-realtime).
@@ -92,9 +94,9 @@ await phone.serve({ agent });
 |-----------|------|---------|-------------|
 | `apiKey` | `string` | — | OpenAI API key. Reads from `OPENAI_API_KEY` when omitted. |
 | `voice` | `string` | `"alloy"` | Voice preset. |
-| `model` | `string` | `"gpt-realtime-2"` | GA Realtime model. |
+| `model` | `string` | `"gpt-realtime-2"` | GA Realtime model. `"gpt-realtime-2.1"` is also available — pass `model: "gpt-realtime-2.1"` to opt in. |
 | `reasoningEffort` | `"minimal" \| "low" \| "medium" \| "high"` | — | When omitted, the field is not sent and the server default applies. OpenAI recommends `"low"` for production voice. |
-| `inputAudioTranscriptionModel` | `string` | — | Override for `audio.input.transcription.model`. Omit to keep `whisper-1`. |
+| `inputAudioTranscriptionModel` | `string` | — | Override for `audio.input.transcription.model`. Omit to keep `whisper-1`. Use `"gpt-realtime-whisper"` or `"gpt-live-transcribe"` for low-latency partials, `"gpt-4o-transcribe"` or `"gpt-transcribe"` for higher accuracy. |
 
 <Note>
 The GA adapter pins `turn_detection.create_response: false` and `interrupt_response: false` in the `session.update` payload. Patter owns response creation (`response.create`) and barge-in cancellation explicitly so the hallucination filter and barge-in pipeline can decide per turn rather than letting the server VAD auto-trigger. See [`OpenAIRealtime2` — full reference](/typescript-sdk/providers/openai-realtime-2).

--- a/docs/typescript-sdk/llm.mdx
+++ b/docs/typescript-sdk/llm.mdx
@@ -56,13 +56,13 @@ All classes accept an options object with `apiKey?: string` and fall back to the
 
 ### OpenAILLM
 
-OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-4o-mini"`.
+OpenAI Chat Completions with streaming + tool calling. Default model `"gpt-5.6-luna"` (GPT-5.6's cost-optimized tier).
 
 ```typescript
 import { OpenAILLM } from "getpatter";
 
 const llm = new OpenAILLM();                              // reads OPENAI_API_KEY
-const llm2 = new OpenAILLM({ apiKey: "sk-...", model: "gpt-4o-mini" });
+const llm2 = new OpenAILLM({ apiKey: "sk-...", model: "gpt-5.6-luna" });
 ```
 
 ### AnthropicLLM

--- a/docs/typescript-sdk/providers/openai-realtime-2.mdx
+++ b/docs/typescript-sdk/providers/openai-realtime-2.mdx
@@ -10,6 +10,8 @@ icon: "bolt"
 
 For the legacy beta endpoint and the lower-cost `gpt-realtime-mini` model, keep using [`OpenAIRealtime`](/typescript-sdk/providers/openai-realtime). The two engines coexist — pick `OpenAIRealtime2` only when you specifically want the GA endpoint or the `gpt-realtime-2` model.
 
+`gpt-realtime-2.1` — a point release of `gpt-realtime-2` at the same published rates — is also available; pass `model: "gpt-realtime-2.1"` to opt in. `gpt-realtime-2` remains the default.
+
 <Note>
 The GA endpoint rejects the legacy `OpenAI-Beta: realtime=v1` header and expects `output_modalities`, nested `audio.{input,output}` blocks with MIME-type strings, and `session.type = "realtime"`. These wire-shape differences are why GA needs its own adapter — the beta `OpenAIRealtimeAdapter` cannot reach `gpt-realtime-2` reliably.
 </Note>

--- a/docs/typescript-sdk/providers/openai-realtime.mdx
+++ b/docs/typescript-sdk/providers/openai-realtime.mdx
@@ -20,6 +20,8 @@ Pass any of these to `model:` on `new OpenAIRealtime(...)`. Pricing is auto-reso
 | `"gpt-realtime-mini"` | $10 / $20 | GA mini — recommended cheap default for new deployments. Pass `model: "gpt-realtime-mini"` explicitly. |
 | `"gpt-realtime"` | $32 / $64 | GA realtime model (Aug 2025). |
 | `"gpt-realtime-2"` | $32 / $64 | Most-capable. Stronger instruction following, 128K context, supports `reasoningEffort`. Use the [`OpenAIRealtime2`](/typescript-sdk/providers/openai-realtime-2) engine for the GA wire shape. |
+| `"gpt-realtime-2.1"` | $32 / $64 | Point release of `gpt-realtime-2` — same published rates. |
+| `"gpt-realtime-2.1-mini"` | $10 / $20 | Point release of `gpt-realtime-mini` — same published rates. |
 | `"gpt-4o-realtime-preview"` | $100 / $200 | Earlier preview, retained for compatibility. |
 
 The same identifiers are exposed as a const object for editor autocomplete:
@@ -60,7 +62,9 @@ The Realtime session can run an inline Whisper-family model on inbound audio so 
 | `"whisper-1"` (default) | $0.006/min | Established Whisper. Slower partials. |
 | `"gpt-4o-mini-transcribe"` | $0.003/min | Cheapest. |
 | `"gpt-4o-transcribe"` | $0.006/min | Higher accuracy. |
+| `"gpt-transcribe"` | $0.0045/min | Next-gen standalone transcription model. |
 | `"gpt-realtime-whisper"` | $0.017/min | Streaming-optimised. Lowest-latency partials. Use when you need fast deltas in the dashboard or for live captioning. |
+| `"gpt-live-transcribe"` | $0.017/min | Next-gen streaming-optimised transcription model. |
 
 Same const-object form:
 

--- a/docs/typescript-sdk/stt.mdx
+++ b/docs/typescript-sdk/stt.mdx
@@ -120,6 +120,10 @@ const stt3 = new OpenAITranscribeSTT({ apiKey: "sk-...", language: "es" });
 | `model` | `string` | `"gpt-4o-transcribe"` | Either `"gpt-4o-transcribe"` or `"gpt-4o-mini-transcribe"`. |
 | `responseFormat` | `string` | `"json"` | Pass `"verbose_json"` to expose segment-level confidence and timestamps. |
 
+<Note>
+OpenAI's pricing catalog also lists two newer transcription models: `gpt-transcribe` ($0.0045/min, successor to `gpt-4o-transcribe`) and `gpt-live-transcribe` ($0.017/min, streaming-optimised, successor to `gpt-realtime-whisper`). Both rates are in Patter's pricing catalog (`openai_transcribe` / `whisper` providers). `OpenAITranscribeSTT` does not yet accept them as a `model` override — to route the Realtime engine's built-in transcription through them today, pass `inputAudioTranscriptionModel: "gpt-transcribe"` (or `"gpt-live-transcribe"`) on [`OpenAIRealtime`](/typescript-sdk/providers/openai-realtime#streaming-transcription).
+</Note>
+
 ## Cartesia
 
 Streaming STT using Cartesia's `ink-whisper`. See [Cartesia setup](/typescript-sdk/providers/cartesia).

--- a/libraries/python/getpatter/evals/cli.py
+++ b/libraries/python/getpatter/evals/cli.py
@@ -34,7 +34,7 @@ def build_eval_parser(subparsers: argparse._SubParsersAction) -> argparse.Argume
         help="Dotted import path to an async agent factory: module:callable",
     )
     run.add_argument(
-        "--judge-model", default="gpt-4o-mini", help="Model the LLM judge should use"
+        "--judge-model", default="gpt-5.6-luna", help="Model the LLM judge should use"
     )
     run.add_argument(
         "--pass-threshold", type=float, default=0.7, help="Score threshold for pass"

--- a/libraries/python/getpatter/evals/llm_judge.py
+++ b/libraries/python/getpatter/evals/llm_judge.py
@@ -35,7 +35,7 @@ class LLMJudge:
 
     def __init__(
         self,
-        model: str = "gpt-4o-mini",
+        model: str = "gpt-5.6-luna",
         api_key: str | None = None,
         pass_threshold: float = 0.7,
         backend: Any = None,

--- a/libraries/python/getpatter/llm/openai.py
+++ b/libraries/python/getpatter/llm/openai.py
@@ -18,7 +18,7 @@ class LLM(_OpenAILLM):
         from getpatter.llm import openai
 
         llm = openai.LLM()                            # reads OPENAI_API_KEY
-        llm = openai.LLM(api_key="sk-...", model="gpt-4o-mini")
+        llm = openai.LLM(api_key="sk-...", model="gpt-5.6-luna")
     """
 
     provider_key: ClassVar[str] = "openai"
@@ -27,7 +27,7 @@ class LLM(_OpenAILLM):
         self,
         api_key: str | None = None,
         *,
-        model: str = "gpt-4o-mini",
+        model: str = "gpt-5.6-luna",
         **kwargs,
     ) -> None:
         key = api_key or os.environ.get("OPENAI_API_KEY")

--- a/libraries/python/getpatter/pricing.py
+++ b/libraries/python/getpatter/pricing.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 PRICING_VERSION: str = "2026.3"
-PRICING_LAST_UPDATED: str = "2026-05-08"
+PRICING_LAST_UPDATED: str = "2026-08-24"
 
 
 def _resolve_provider_rates(provider_config: dict, model: str | None) -> dict:
@@ -122,6 +122,11 @@ DEFAULT_PRICING: dict[str, dict] = {
             "gpt-4o-mini-transcribe": {"price": 0.003},
             # Streaming Whisper variant used inside Realtime sessions.
             "gpt-realtime-whisper": {"price": 0.017},
+            # gpt-transcribe / gpt-live-transcribe — next-gen standalone/
+            # streaming transcription models. Source:
+            # https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+            "gpt-transcribe": {"price": 0.0045},
+            "gpt-live-transcribe": {"price": 0.017},
         },
     },
     # OpenAI standalone transcription endpoint (separate ``provider_key``
@@ -133,6 +138,9 @@ DEFAULT_PRICING: dict[str, dict] = {
             "gpt-4o-transcribe": {"price": 0.006},
             "gpt-4o-mini-transcribe": {"price": 0.003},
             "whisper-1": {"price": 0.006},
+            # Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+            "gpt-transcribe": {"price": 0.0045},
+            "gpt-live-transcribe": {"price": 0.017},
         },
     },
     # AssemblyAI Universal-Streaming: $0.15/hr = $0.0025/min
@@ -321,6 +329,33 @@ DEFAULT_PRICING: dict[str, dict] = {
                 "cached_audio_input_per_token": 0.0000004,
                 "cached_text_input_per_token": 0.0000004,
             },
+            # gpt-realtime-2.1: point release of gpt-realtime-2, same published
+            # per-token rates (audio in $32/M, audio out $64/M, text in $4/M,
+            # text out $24/M, cached $0.40/M). gpt-realtime-2 remains the
+            # SDK's realtime engine default — this entry only makes the rate
+            # resolvable when a caller opts into the newer model id. Source:
+            # https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+            "gpt-realtime-2.1": {
+                "audio_input_per_token": 0.000032,
+                "audio_output_per_token": 0.000064,
+                "text_input_per_token": 0.000004,
+                "text_output_per_token": 0.000024,
+                "cached_audio_input_per_token": 0.0000004,
+                "cached_text_input_per_token": 0.0000004,
+            },
+            # gpt-realtime-2.1-mini: point release of gpt-realtime-mini, same
+            # published per-token rates (audio in $10/M, audio out $20/M,
+            # text in $0.60/M, text out $2.40/M, cached audio $0.30/M, cached
+            # text $0.06/M). Source: https://developers.openai.com/api/docs/pricing
+            # (verified 2026-08-24).
+            "gpt-realtime-2.1-mini": {
+                "audio_input_per_token": 0.00001,
+                "audio_output_per_token": 0.00002,
+                "text_input_per_token": 0.0000006,
+                "text_output_per_token": 0.0000024,
+                "cached_audio_input_per_token": 0.0000003,
+                "cached_text_input_per_token": 0.00000006,
+            },
             # gpt-realtime-mini and gpt-4o-mini-realtime-preview share the
             # provider defaults. Listed explicitly so tooling can introspect.
             "gpt-realtime-mini": {
@@ -331,6 +366,10 @@ DEFAULT_PRICING: dict[str, dict] = {
                 "cached_audio_input_per_token": 0.0000003,
                 "cached_text_input_per_token": 0.00000006,
             },
+            # gpt-4o-mini-realtime-preview: LEGACY — no longer listed on
+            # https://developers.openai.com/api/docs/pricing as of 2026-08-24.
+            # Entry kept (rates unchanged since last verified) for existing
+            # callers; do not route new integrations to it.
             "gpt-4o-mini-realtime-preview": {
                 "audio_input_per_token": 0.00001,
                 "audio_output_per_token": 0.00002,
@@ -647,6 +686,15 @@ LLM_PRICING: dict[str, dict[str, dict[str, float]]] = {
         "gpt-4.1-mini": {"input": 0.40, "output": 1.60, "cache_read": 0.10},
         "o3": {"input": 2.00, "output": 8.00, "cache_read": 0.50},
         "o4-mini": {"input": 1.10, "output": 4.40, "cache_read": 0.275},
+        # GPT-5.6 family — Patter's chat LLM default is gpt-5.6-luna (see
+        # llm/openai.py). "gpt-5.6" is an alias for gpt-5.6-sol and is listed
+        # as its own key (not a prefix-derived match) so a caller passing the
+        # bare alias resolves correctly. Source:
+        # https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+        "gpt-5.6": {"input": 4.00, "output": 20.00, "cache_read": 0.40},  # alias for gpt-5.6-sol
+        "gpt-5.6-sol": {"input": 4.00, "output": 20.00, "cache_read": 0.40},
+        "gpt-5.6-terra": {"input": 2.00, "output": 12.00, "cache_read": 0.20},
+        "gpt-5.6-luna": {"input": 0.20, "output": 1.20, "cache_read": 0.02},
     },
     "anthropic": {
         "claude-opus-4-7": {

--- a/libraries/python/getpatter/providers/openai_realtime.py
+++ b/libraries/python/getpatter/providers/openai_realtime.py
@@ -42,6 +42,8 @@ class OpenAIRealtimeModel(StrEnum):
 
     GPT_REALTIME = "gpt-realtime"
     GPT_REALTIME_2 = "gpt-realtime-2"
+    GPT_REALTIME_2_1 = "gpt-realtime-2.1"
+    GPT_REALTIME_2_1_MINI = "gpt-realtime-2.1-mini"
     GPT_REALTIME_MINI = "gpt-realtime-mini"
     GPT_4O_REALTIME_PREVIEW = "gpt-4o-realtime-preview"
     GPT_4O_MINI_REALTIME_PREVIEW = "gpt-4o-mini-realtime-preview"
@@ -85,6 +87,8 @@ class OpenAITranscriptionModel(StrEnum):
     GPT_4O_TRANSCRIBE = "gpt-4o-transcribe"
     GPT_4O_MINI_TRANSCRIBE = "gpt-4o-mini-transcribe"
     GPT_REALTIME_WHISPER = "gpt-realtime-whisper"
+    GPT_TRANSCRIBE = "gpt-transcribe"
+    GPT_LIVE_TRANSCRIBE = "gpt-live-transcribe"
 
 
 class OpenAIRealtimeVADType(StrEnum):

--- a/libraries/python/getpatter/stream_handler.py
+++ b/libraries/python/getpatter/stream_handler.py
@@ -4167,7 +4167,7 @@ class PipelineStreamHandler(StreamHandler):
             tool_executor = ToolExecutor() if combined_tools else None
             llm_model = self.agent.model
             if "realtime" in llm_model:
-                llm_model = "gpt-4o-mini"
+                llm_model = "gpt-5.6-luna"
             self._llm_loop = LLMLoop(
                 openai_key=self._openai_key,
                 model=llm_model,

--- a/libraries/python/getpatter/test_mode.py
+++ b/libraries/python/getpatter/test_mode.py
@@ -107,7 +107,7 @@ class TestSession:
             tool_executor = ToolExecutor() if agent.tools else None
             llm_model = agent.model
             if "realtime" in llm_model:
-                llm_model = "gpt-4o-mini"
+                llm_model = "gpt-5.6-luna"
 
             # Resolve variables in system prompt
             resolved_prompt = agent.system_prompt

--- a/libraries/python/tests/test_evals.py
+++ b/libraries/python/tests/test_evals.py
@@ -55,6 +55,11 @@ async def test_llm_judge_parses_score_and_reasoning():
     assert result.reasoning == "great"
 
 
+def test_llm_judge_defaults_to_gpt_5_6_luna_when_model_omitted():
+    judge = LLMJudge()
+    assert judge.model == "gpt-5.6-luna"
+
+
 @pytest.mark.asyncio
 async def test_llm_judge_tolerates_code_fences():
     judge = LLMJudge(backend=FakeBackend({"score": 0.5, "passed": False, "reasoning": "meh"}))

--- a/libraries/python/tests/test_pricing.py
+++ b/libraries/python/tests/test_pricing.py
@@ -501,3 +501,132 @@ class TestLLMCostBilling:
         assert spec_cost == pytest.approx(0.99)
         assert ver_cost == pytest.approx(0.79)
         assert spec_cost > ver_cost
+
+
+class TestGpt56ChatPricing:
+    """GPT-5.6 chat LLM family — Patter's default is gpt-5.6-luna.
+
+    Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+    """
+
+    def test_gpt_5_6_sol_rate(self):
+        assert LLM_PRICING["openai"]["gpt-5.6-sol"] == {
+            "input": 4.0,
+            "output": 20.0,
+            "cache_read": 0.4,
+        }
+        cost = calculate_llm_cost("openai", "gpt-5.6-sol", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(4.0 + 20.0)
+
+    def test_gpt_5_6_terra_rate(self):
+        assert LLM_PRICING["openai"]["gpt-5.6-terra"] == {
+            "input": 2.0,
+            "output": 12.0,
+            "cache_read": 0.2,
+        }
+        cost = calculate_llm_cost("openai", "gpt-5.6-terra", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(2.0 + 12.0)
+
+    def test_gpt_5_6_luna_rate(self):
+        """luna is the chat LLM default (see getpatter/llm/openai.py)."""
+        assert LLM_PRICING["openai"]["gpt-5.6-luna"] == {
+            "input": 0.2,
+            "output": 1.2,
+            "cache_read": 0.02,
+        }
+        cost = calculate_llm_cost("openai", "gpt-5.6-luna", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(0.2 + 1.2)
+
+    def test_bare_alias_resolves_to_sol(self):
+        alias_cost = calculate_llm_cost("openai", "gpt-5.6", 1_000_000, 1_000_000)
+        sol_cost = calculate_llm_cost("openai", "gpt-5.6-sol", 1_000_000, 1_000_000)
+        assert alias_cost == pytest.approx(sol_cost)
+        assert alias_cost == pytest.approx(24.0)
+
+    def test_dated_luna_id_resolves_via_longest_prefix_not_bare_alias(self):
+        """``gpt-5.6-luna-2026-08`` starts with both ``gpt-5.6`` and
+        ``gpt-5.6-luna`` — the longer, more specific key must win.
+        """
+        cost = calculate_llm_cost("openai", "gpt-5.6-luna-2026-08", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(0.2 + 1.2)
+
+    def test_cached_tokens_bill_at_discounted_rate(self):
+        cost = calculate_llm_cost(
+            "openai", "gpt-5.6-luna", 0, 0, cache_read_tokens=1_000_000
+        )
+        assert cost == pytest.approx(0.02)
+
+
+class TestRealtime21Pricing:
+    """gpt-realtime-2.1 / gpt-realtime-2.1-mini — point releases of
+    gpt-realtime-2 / gpt-realtime-mini at the same published rates.
+
+    Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+    gpt-realtime-2 remains the SDK's realtime engine default.
+    """
+
+    def test_model_entries_present(self):
+        models = DEFAULT_PRICING["openai_realtime"]["models"]
+        assert "gpt-realtime-2.1" in models
+        assert "gpt-realtime-2.1-mini" in models
+
+    def test_gpt_realtime_2_1_matches_gpt_realtime_2_rates(self):
+        entry = DEFAULT_PRICING["openai_realtime"]["models"]["gpt-realtime-2.1"]
+        assert entry["text_input_per_token"] == pytest.approx(4.0 / 1_000_000)
+        assert entry["text_output_per_token"] == pytest.approx(24.0 / 1_000_000)
+        assert entry["audio_input_per_token"] == pytest.approx(32.0 / 1_000_000)
+        assert entry["audio_output_per_token"] == pytest.approx(64.0 / 1_000_000)
+        assert entry["cached_audio_input_per_token"] == pytest.approx(0.4 / 1_000_000)
+        assert entry["cached_text_input_per_token"] == pytest.approx(0.4 / 1_000_000)
+
+    def test_gpt_realtime_2_1_mini_matches_gpt_realtime_mini_rates(self):
+        entry = DEFAULT_PRICING["openai_realtime"]["models"]["gpt-realtime-2.1-mini"]
+        assert entry["text_input_per_token"] == pytest.approx(0.6 / 1_000_000)
+        assert entry["text_output_per_token"] == pytest.approx(2.4 / 1_000_000)
+        assert entry["audio_input_per_token"] == pytest.approx(10.0 / 1_000_000)
+        assert entry["audio_output_per_token"] == pytest.approx(20.0 / 1_000_000)
+        assert entry["cached_audio_input_per_token"] == pytest.approx(0.3 / 1_000_000)
+        assert entry["cached_text_input_per_token"] == pytest.approx(0.06 / 1_000_000)
+
+    def test_realtime_cost_auto_resolves_gpt_realtime_2_1(self):
+        pricing = merge_pricing(None)
+        usage = {
+            "input_token_details": {"audio_tokens": 1000, "text_tokens": 0},
+            "output_token_details": {"audio_tokens": 0, "text_tokens": 0},
+        }
+        cost = calculate_realtime_cost(usage, pricing, model="gpt-realtime-2.1")
+        assert cost == pytest.approx(0.032)
+
+    def test_realtime_cost_auto_resolves_gpt_realtime_2_1_mini(self):
+        pricing = merge_pricing(None)
+        usage = {
+            "input_token_details": {"audio_tokens": 1000, "text_tokens": 0},
+            "output_token_details": {"audio_tokens": 0, "text_tokens": 0},
+        }
+        cost = calculate_realtime_cost(usage, pricing, model="gpt-realtime-2.1-mini")
+        assert cost == pytest.approx(0.01)
+
+
+class TestGptTranscribeFamilyPricing:
+    """gpt-transcribe / gpt-live-transcribe — next-gen OpenAI transcription
+    models. Source: https://developers.openai.com/api/docs/pricing
+    (verified 2026-08-24).
+    """
+
+    def test_resolves_under_whisper_provider(self):
+        pricing = merge_pricing(None)
+        assert calculate_stt_cost(
+            "whisper", 60.0, pricing, model="gpt-transcribe"
+        ) == pytest.approx(0.0045)
+        assert calculate_stt_cost(
+            "whisper", 60.0, pricing, model="gpt-live-transcribe"
+        ) == pytest.approx(0.017)
+
+    def test_resolves_under_openai_transcribe_provider(self):
+        pricing = merge_pricing(None)
+        assert calculate_stt_cost(
+            "openai_transcribe", 60.0, pricing, model="gpt-transcribe"
+        ) == pytest.approx(0.0045)
+        assert calculate_stt_cost(
+            "openai_transcribe", 60.0, pricing, model="gpt-live-transcribe"
+        ) == pytest.approx(0.017)

--- a/libraries/python/tests/unit/test_llm_api.py
+++ b/libraries/python/tests/unit/test_llm_api.py
@@ -286,6 +286,19 @@ class TestFlatReExports:
         assert GoogleLLM is ns_google
 
 
+@pytest.mark.unit
+class TestOpenAILLMDefaultModel:
+    """``OpenAILLM`` (``getpatter.llm.openai.LLM``) defaults to gpt-5.6-luna."""
+
+    def test_defaults_to_gpt_5_6_luna_when_model_omitted(self) -> None:
+        llm = OpenAILLM(api_key="sk-x")
+        assert llm._model == "gpt-5.6-luna"
+
+    def test_honours_explicit_model_override(self) -> None:
+        llm = OpenAILLM(api_key="sk-x", model="gpt-5.6-sol")
+        assert llm._model == "gpt-5.6-sol"
+
+
 # ---------------------------------------------------------------------------
 # OpenAILLMProvider — sampling kwargs forwarding (Wave 10A refactor)
 # ---------------------------------------------------------------------------

--- a/libraries/typescript/src/cli.ts
+++ b/libraries/typescript/src/cli.ts
@@ -112,12 +112,12 @@ function parseArgs(argv: string[]): { port: number } {
 async function runEvalCommand(args: string[]): Promise<number> {
   if (args[0] !== 'run' || !args[1]) {
     console.log('Usage: getpatter eval run <suite> [--agent module:export]');
-    console.log('       [--judge-model gpt-4o-mini] [--pass-threshold 0.7] [--output report.json]');
+    console.log('       [--judge-model gpt-5.6-luna] [--pass-threshold 0.7] [--output report.json]');
     return 2;
   }
   const suitePath = args[1];
   let agentSpec = '';
-  let judgeModel = 'gpt-4o-mini';
+  let judgeModel = 'gpt-5.6-luna';
   let passThreshold = 0.7;
   let output = '';
   for (let i = 2; i < args.length; i++) {

--- a/libraries/typescript/src/evals/llm-judge.ts
+++ b/libraries/typescript/src/evals/llm-judge.ts
@@ -28,7 +28,7 @@ export interface JudgeBackend {
 
 /** Options for {@link LLMJudge}. Defaults match the Python SDK byte-for-byte. */
 export interface LLMJudgeOptions {
-  /** Model the judge should use. Default: ``gpt-4o-mini``. */
+  /** Model the judge should use. Default: ``gpt-5.6-luna``. */
   readonly model?: string;
   /** OpenAI API key. Falls back to ``OPENAI_API_KEY`` when unset. */
   readonly apiKey?: string;
@@ -46,7 +46,7 @@ export class LLMJudge {
   private readonly backend?: JudgeBackend;
 
   constructor(options: LLMJudgeOptions = {}) {
-    this.model = options.model ?? 'gpt-4o-mini';
+    this.model = options.model ?? 'gpt-5.6-luna';
     this.apiKey = options.apiKey;
     this.passThreshold = options.passThreshold ?? 0.7;
     this.backend = options.backend;

--- a/libraries/typescript/src/llm/openai.ts
+++ b/libraries/typescript/src/llm/openai.ts
@@ -5,7 +5,7 @@ import { OpenAILLMProvider as _OpenAILLM } from "../llm-loop";
 export interface OpenAILLMOptions {
   /** API key. Falls back to OPENAI_API_KEY env var when omitted. */
   apiKey?: string;
-  /** Chat Completions model id. Defaults to ``"gpt-4o-mini"``. */
+  /** Chat Completions model id. Defaults to ``"gpt-5.6-luna"``. */
   model?: string;
   /** Sampling temperature [0, 2]. */
   temperature?: number;
@@ -36,7 +36,7 @@ export interface OpenAILLMOptions {
  * ```ts
  * import * as openai from "getpatter/llm/openai";
  * const llm = new openai.LLM();                           // reads OPENAI_API_KEY
- * const llm = new openai.LLM({ apiKey: "sk-...", model: "gpt-4o-mini", temperature: 0.4 });
+ * const llm = new openai.LLM({ apiKey: "sk-...", model: "gpt-5.6-luna", temperature: 0.4 });
  * ```
  */
 export class LLM extends _OpenAILLM {
@@ -48,7 +48,7 @@ export class LLM extends _OpenAILLM {
         "OpenAI LLM requires an apiKey. Pass { apiKey: 'sk-...' } or set OPENAI_API_KEY.",
       );
     }
-    super(key, opts.model ?? "gpt-4o-mini", {
+    super(key, opts.model ?? "gpt-5.6-luna", {
       temperature: opts.temperature,
       maxTokens: opts.maxTokens,
       responseFormat: opts.responseFormat,

--- a/libraries/typescript/src/pricing.ts
+++ b/libraries/typescript/src/pricing.ts
@@ -19,7 +19,7 @@
 /** Pricing table version identifier, updated in lockstep with the Python SDK. */
 export const PRICING_VERSION = '2026.3';
 /** ISO date the pricing table was last refreshed against public provider rates. */
-export const PRICING_LAST_UPDATED = '2026-05-08';
+export const PRICING_LAST_UPDATED = '2026-08-24';
 
 /**
  * Billing units used by ``DEFAULT_PRICING`` entries. String values keep the
@@ -155,6 +155,11 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
       'gpt-4o-mini-transcribe': { price: 0.003 },
       // Streaming Whisper variant for Realtime sessions.
       'gpt-realtime-whisper': { price: 0.017 },
+      // gpt-transcribe / gpt-live-transcribe — next-gen standalone/streaming
+      // transcription models. Source: https://developers.openai.com/api/docs/pricing
+      // (verified 2026-08-24).
+      'gpt-transcribe': { price: 0.0045 },
+      'gpt-live-transcribe': { price: 0.017 },
     },
   },
   // OpenAI standalone transcription endpoint (separate provider_key from
@@ -166,6 +171,9 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
       'gpt-4o-transcribe': { price: 0.006 },
       'gpt-4o-mini-transcribe': { price: 0.003 },
       'whisper-1': { price: 0.006 },
+      // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+      'gpt-transcribe': { price: 0.0045 },
+      'gpt-live-transcribe': { price: 0.017 },
     },
   },
   // AssemblyAI Universal-Streaming — $0.15/hr = $0.0025/min
@@ -362,6 +370,32 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
         cached_audio_input_per_token: 0.0000004,
         cached_text_input_per_token: 0.0000004,
       },
+      // gpt-realtime-2.1: point release of gpt-realtime-2, same published
+      // per-token rates (audio in $32/M, audio out $64/M, text in $4/M,
+      // text out $24/M, cached $0.40/M). gpt-realtime-2 remains the SDK's
+      // realtime engine default — this entry only makes the rate resolvable
+      // when a caller opts into the newer model id.
+      // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+      'gpt-realtime-2.1': {
+        audio_input_per_token: 0.000032,
+        audio_output_per_token: 0.000064,
+        text_input_per_token: 0.000004,
+        text_output_per_token: 0.000024,
+        cached_audio_input_per_token: 0.0000004,
+        cached_text_input_per_token: 0.0000004,
+      },
+      // gpt-realtime-2.1-mini: point release of gpt-realtime-mini, same
+      // published per-token rates (audio in $10/M, audio out $20/M, text in
+      // $0.60/M, text out $2.40/M, cached audio $0.30/M, cached text $0.06/M).
+      // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+      'gpt-realtime-2.1-mini': {
+        audio_input_per_token: 0.00001,
+        audio_output_per_token: 0.00002,
+        text_input_per_token: 0.0000006,
+        text_output_per_token: 0.0000024,
+        cached_audio_input_per_token: 0.0000003,
+        cached_text_input_per_token: 0.00000006,
+      },
       // gpt-realtime-mini and gpt-4o-mini-realtime-preview share the
       // provider defaults. Listed explicitly so tooling can introspect.
       'gpt-realtime-mini': {
@@ -372,6 +406,10 @@ export const DEFAULT_PRICING: Record<string, ProviderPricing> = {
         cached_audio_input_per_token: 0.0000003,
         cached_text_input_per_token: 0.00000006,
       },
+      // gpt-4o-mini-realtime-preview: LEGACY — no longer listed on
+      // https://developers.openai.com/api/docs/pricing as of 2026-08-24.
+      // Entry kept (rates unchanged since last verified) for existing
+      // callers; do not route new integrations to it.
       'gpt-4o-mini-realtime-preview': {
         audio_input_per_token: 0.00001,
         audio_output_per_token: 0.00002,
@@ -791,6 +829,15 @@ export const llmPricing: Record<string, Record<string, LlmModelPricing>> = {
     'gpt-4.1-mini': { input: 0.40, output: 1.60, cache_read: 0.10 },
     'o3': { input: 2.00, output: 8.00, cache_read: 0.50 },
     'o4-mini': { input: 1.10, output: 4.40, cache_read: 0.275 },
+    // GPT-5.6 family — Patter's chat LLM default is gpt-5.6-luna (see
+    // llm/openai.ts). "gpt-5.6" is an alias for gpt-5.6-sol and is listed as
+    // its own key (not a prefix-derived match) so a caller passing the bare
+    // alias resolves correctly. Source:
+    // https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+    'gpt-5.6': { input: 4.00, output: 20.00, cache_read: 0.40 }, // alias for gpt-5.6-sol
+    'gpt-5.6-sol': { input: 4.00, output: 20.00, cache_read: 0.40 },
+    'gpt-5.6-terra': { input: 2.00, output: 12.00, cache_read: 0.20 },
+    'gpt-5.6-luna': { input: 0.20, output: 1.20, cache_read: 0.02 },
   },
 };
 

--- a/libraries/typescript/src/providers/openai-realtime.ts
+++ b/libraries/typescript/src/providers/openai-realtime.ts
@@ -51,6 +51,8 @@ export type OpenAIRealtimeAudioFormat =
 export const OpenAIRealtimeModel = {
   GPT_REALTIME: 'gpt-realtime',
   GPT_REALTIME_2: 'gpt-realtime-2',
+  GPT_REALTIME_2_1: 'gpt-realtime-2.1',
+  GPT_REALTIME_2_1_MINI: 'gpt-realtime-2.1-mini',
   GPT_REALTIME_MINI: 'gpt-realtime-mini',
   GPT_4O_REALTIME_PREVIEW: 'gpt-4o-realtime-preview',
   GPT_4O_MINI_REALTIME_PREVIEW: 'gpt-4o-mini-realtime-preview',
@@ -90,6 +92,8 @@ export const OpenAITranscriptionModel = {
   GPT_4O_TRANSCRIBE: 'gpt-4o-transcribe',
   GPT_4O_MINI_TRANSCRIBE: 'gpt-4o-mini-transcribe',
   GPT_REALTIME_WHISPER: 'gpt-realtime-whisper',
+  GPT_TRANSCRIBE: 'gpt-transcribe',
+  GPT_LIVE_TRANSCRIBE: 'gpt-live-transcribe',
 } as const;
 /** Union of {@link OpenAITranscriptionModel} string values. */
 export type OpenAITranscriptionModel =

--- a/libraries/typescript/src/stream-handler.ts
+++ b/libraries/typescript/src/stream-handler.ts
@@ -4026,8 +4026,8 @@ export class StreamHandler {
       const llmLabel = this.deps.agent.llm.constructor?.name ?? 'custom';
       getLogger().debug(`Built-in LLM loop active (pipeline, ${label}, llm=${llmLabel})`);
     } else if (!this.deps.onMessage && this.deps.config.openaiKey) {
-      let llmModel = this.deps.agent.model || 'gpt-4o-mini';
-      if (llmModel.includes('realtime')) llmModel = 'gpt-4o-mini';
+      let llmModel = this.deps.agent.model || 'gpt-5.6-luna';
+      if (llmModel.includes('realtime')) llmModel = 'gpt-5.6-luna';
       const augmentedTools = this.buildPipelineLlmTools();
       this.llmLoop = new LLMLoop(
         this.deps.config.openaiKey,

--- a/libraries/typescript/src/test-mode.ts
+++ b/libraries/typescript/src/test-mode.ts
@@ -68,8 +68,8 @@ export class TestSession {
     // Set up LLM loop if no onMessage and openaiKey is available
     let llmLoop: LLMLoop | null = null;
     if (!onMessage && openaiKey) {
-      let llmModel = agent.model || 'gpt-4o-mini';
-      if (llmModel.includes('realtime')) llmModel = 'gpt-4o-mini';
+      let llmModel = agent.model || 'gpt-5.6-luna';
+      if (llmModel.includes('realtime')) llmModel = 'gpt-5.6-luna';
 
       let resolvedPrompt = agent.systemPrompt;
       if (agent.variables) {

--- a/libraries/typescript/tests/pricing.test.ts
+++ b/libraries/typescript/tests/pricing.test.ts
@@ -448,3 +448,121 @@ describe('LLM cost billing — Cerebras + Groq silent under-billing regression',
     expect(specCost).toBeGreaterThan(verCost);
   });
 });
+
+describe('GPT-5.6 chat LLM pricing (Patter default: gpt-5.6-luna)', () => {
+  // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+  it('gpt-5.6-sol bills $4/M input, $20/M output, $0.40/M cached', () => {
+    expect(llmPricing.openai['gpt-5.6-sol']).toEqual({ input: 4.0, output: 20.0, cache_read: 0.4 });
+    const cost = calculateLlmCost('openai', 'gpt-5.6-sol', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(4.0 + 20.0, 6);
+  });
+
+  it('gpt-5.6-terra bills $2/M input, $12/M output, $0.20/M cached', () => {
+    expect(llmPricing.openai['gpt-5.6-terra']).toEqual({ input: 2.0, output: 12.0, cache_read: 0.2 });
+    const cost = calculateLlmCost('openai', 'gpt-5.6-terra', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(2.0 + 12.0, 6);
+  });
+
+  it('gpt-5.6-luna (the chat LLM default) bills $0.20/M input, $1.20/M output, $0.02/M cached', () => {
+    expect(llmPricing.openai['gpt-5.6-luna']).toEqual({ input: 0.2, output: 1.2, cache_read: 0.02 });
+    const cost = calculateLlmCost('openai', 'gpt-5.6-luna', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(0.2 + 1.2, 6);
+  });
+
+  it('"gpt-5.6" (bare alias) resolves to the same rate as gpt-5.6-sol', () => {
+    const aliasCost = calculateLlmCost('openai', 'gpt-5.6', 1_000_000, 1_000_000);
+    const solCost = calculateLlmCost('openai', 'gpt-5.6-sol', 1_000_000, 1_000_000);
+    expect(aliasCost).toBeCloseTo(solCost, 9);
+    expect(aliasCost).toBeCloseTo(24.0, 6);
+  });
+
+  it('a dated gpt-5.6-luna id resolves via longest-prefix match, not the bare alias', () => {
+    // "gpt-5.6-luna-2026-08" starts with both "gpt-5.6" and "gpt-5.6-luna" —
+    // the longer, more specific key must win so luna's cheap rate applies.
+    const cost = calculateLlmCost('openai', 'gpt-5.6-luna-2026-08', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(0.2 + 1.2, 6);
+  });
+
+  it('cached (read) tokens bill at the discounted rate', () => {
+    const cost = calculateLlmCost('openai', 'gpt-5.6-luna', 0, 0, 1_000_000);
+    expect(cost).toBeCloseTo(0.02, 6);
+  });
+});
+
+describe('gpt-realtime-2.1 / gpt-realtime-2.1-mini pricing', () => {
+  // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+  it('exposes gpt-realtime-2.1 and gpt-realtime-2.1-mini under openai_realtime.models', () => {
+    const models = DEFAULT_PRICING.openai_realtime.models!;
+    expect(models['gpt-realtime-2.1']).toBeDefined();
+    expect(models['gpt-realtime-2.1-mini']).toBeDefined();
+  });
+
+  it('gpt-realtime-2.1 matches gpt-realtime-2 published per-1M-token rates', () => {
+    const e = DEFAULT_PRICING.openai_realtime.models!['gpt-realtime-2.1'];
+    expect(e.text_input_per_token).toBeCloseTo(4 / 1_000_000, 12);
+    expect(e.text_output_per_token).toBeCloseTo(24 / 1_000_000, 12);
+    expect(e.audio_input_per_token).toBeCloseTo(32 / 1_000_000, 12);
+    expect(e.audio_output_per_token).toBeCloseTo(64 / 1_000_000, 12);
+    expect(e.cached_audio_input_per_token).toBeCloseTo(0.4 / 1_000_000, 12);
+    expect(e.cached_text_input_per_token).toBeCloseTo(0.4 / 1_000_000, 12);
+  });
+
+  it('gpt-realtime-2.1-mini matches gpt-realtime-mini published per-1M-token rates', () => {
+    const e = DEFAULT_PRICING.openai_realtime.models!['gpt-realtime-2.1-mini'];
+    expect(e.text_input_per_token).toBeCloseTo(0.6 / 1_000_000, 12);
+    expect(e.text_output_per_token).toBeCloseTo(2.4 / 1_000_000, 12);
+    expect(e.audio_input_per_token).toBeCloseTo(10 / 1_000_000, 12);
+    expect(e.audio_output_per_token).toBeCloseTo(20 / 1_000_000, 12);
+    expect(e.cached_audio_input_per_token).toBeCloseTo(0.3 / 1_000_000, 12);
+    expect(e.cached_text_input_per_token).toBeCloseTo(0.06 / 1_000_000, 12);
+  });
+
+  it('calculateRealtimeCost auto-resolves gpt-realtime-2.1 without an override', () => {
+    const pricing = mergePricing();
+    // 1000 audio input tokens at $32/M = $0.032
+    const cost = calculateRealtimeCost(
+      {
+        input_token_details: { audio_tokens: 1000, text_tokens: 0 },
+        output_token_details: { audio_tokens: 0, text_tokens: 0 },
+      },
+      pricing,
+      'gpt-realtime-2.1',
+    );
+    expect(cost).toBeCloseTo(0.032, 6);
+  });
+
+  it('calculateRealtimeCost auto-resolves gpt-realtime-2.1-mini without an override', () => {
+    const pricing = mergePricing();
+    // 1000 audio input tokens at $10/M = $0.01
+    const cost = calculateRealtimeCost(
+      {
+        input_token_details: { audio_tokens: 1000, text_tokens: 0 },
+        output_token_details: { audio_tokens: 0, text_tokens: 0 },
+      },
+      pricing,
+      'gpt-realtime-2.1-mini',
+    );
+    expect(cost).toBeCloseTo(0.01, 6);
+  });
+});
+
+describe('gpt-transcribe / gpt-live-transcribe pricing', () => {
+  // Source: https://developers.openai.com/api/docs/pricing (verified 2026-08-24).
+  it('resolves under the whisper provider', () => {
+    const pricing = mergePricing();
+    expect(calculateSttCost('whisper', 60, pricing, 'gpt-transcribe')).toBeCloseTo(0.0045, 6);
+    expect(calculateSttCost('whisper', 60, pricing, 'gpt-live-transcribe')).toBeCloseTo(0.017, 6);
+  });
+
+  it('resolves under the openai_transcribe provider', () => {
+    const pricing = mergePricing();
+    expect(calculateSttCost('openai_transcribe', 60, pricing, 'gpt-transcribe')).toBeCloseTo(
+      0.0045,
+      6,
+    );
+    expect(calculateSttCost('openai_transcribe', 60, pricing, 'gpt-live-transcribe')).toBeCloseTo(
+      0.017,
+      6,
+    );
+  });
+});

--- a/libraries/typescript/tests/unit/evals.test.ts
+++ b/libraries/typescript/tests/unit/evals.test.ts
@@ -43,6 +43,11 @@ describe('[unit] LLMJudge', () => {
     expect(result.reasoning).toBe('great');
   });
 
+  it('defaults to gpt-5.6-luna when model is omitted', () => {
+    const judge = new LLMJudge();
+    expect(judge.model).toBe('gpt-5.6-luna');
+  });
+
   it('tolerates code fences', async () => {
     const fenced = '```json\n{"score": 0.5, "passed": false, "reasoning": "meh"}\n```';
     const judge = new LLMJudge({

--- a/libraries/typescript/tests/unit/llm-api.test.ts
+++ b/libraries/typescript/tests/unit/llm-api.test.ts
@@ -371,4 +371,14 @@ describe("flat re-exports from getpatter (LLM)", () => {
     expect(new flat.CerebrasLLM()).toBeDefined();
     expect(new flat.GoogleLLM()).toBeDefined();
   });
+
+  it("OpenAILLM defaults to gpt-5.6-luna when model is omitted", () => {
+    const llm = new openaiLlm.LLM({ apiKey: "sk-x" });
+    expect(llm.model).toBe("gpt-5.6-luna");
+  });
+
+  it("OpenAILLM honours an explicit model override", () => {
+    const llm = new openaiLlm.LLM({ apiKey: "sk-x", model: "gpt-5.6-sol" });
+    expect(llm.model).toBe("gpt-5.6-sol");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds OpenAI's GPT-5.6 chat family to the pricing catalog (`gpt-5.6-sol`,
  `gpt-5.6-terra`, `gpt-5.6-luna`, plus a bare `gpt-5.6` alias) and switches
  `OpenAILLM`'s default model from `gpt-4o-mini` to `gpt-5.6-luna` in both
  SDKs — a behaviour change for any caller that omits `model=`, including the
  eval `LLMJudge` default, the pipeline `StreamHandler`/`TestSession`
  realtime-engine LLM fallback, and the `getpatter eval run --judge-model`
  CLI default.
- Adds `gpt-realtime-2.1` / `gpt-realtime-2.1-mini` to `OpenAIRealtimeModel`
  and the realtime pricing table — point releases of `gpt-realtime-2` /
  `gpt-realtime-mini` at the same published per-token rates. `gpt-realtime-2`
  stays the `OpenAIRealtime2` default; the new ids are opt-in only.
- Adds `gpt-transcribe` ($0.0045/min) and `gpt-live-transcribe` ($0.017/min)
  to `OpenAITranscriptionModel` and both the `openai_realtime` (inline
  Whisper-family) and `openai_transcribe` pricing tables. Note:
  `OpenAITranscribeSTT` doesn't yet accept these as a `model=` override
  (see Notes below) — route through `input_audio_transcription_model` on the
  Realtime engine instead.
- Bumps `PRICING_LAST_UPDATED` to `2026-08-24` in both SDKs; keeps
  `gpt-4o-mini-realtime-preview`'s entry with a comment flagging it's no
  longer listed on OpenAI's current pricing page but is retained unchanged
  for existing callers.
- No enum members removed and no public field renamed — purely additive to
  `OpenAIRealtimeModel` / `OpenAITranscriptionModel` plus the one default-model
  change called out above.
- Docs updated in both `docs/python-sdk/` and `docs/typescript-sdk/`
  (`engines.mdx`, `llm.mdx`, `stt.mdx`, `providers/openai-realtime.mdx`,
  `providers/openai-realtime-2.mdx`) to list the new model ids and rates.

## Verification

- Python: `test_pricing.py` gains 13 new tests across
  `TestGpt56ChatPricing` (5), `TestRealtime21Pricing` (6),
  `TestGptTranscribeFamilyPricing` (2); `test_evals.py` gains 1
  (`LLMJudge` default); `test_llm_api.py` gains 2
  (`TestOpenAILLMDefaultModel`) — 16 new Python tests total.
- TypeScript: `pricing.test.ts` gains 13 new tests (GPT-5.6 chat pricing 6,
  `gpt-realtime-2.1`/`-mini` pricing 5, `gpt-transcribe`/`gpt-live-transcribe`
  pricing 2); `evals.test.ts` gains 1; `llm-api.test.ts` gains 2 — 16 new
  TypeScript tests total.
- CI: see checks.

## Notes / follow-ups

- `OpenAITranscribeSTT` does not yet accept `gpt-transcribe` /
  `gpt-live-transcribe` as a `model=`/`model:` override, even though both
  rates are already in the pricing catalog under `openai_transcribe` — this
  gap is called out inline in `docs/{python-sdk,typescript-sdk}/stt.mdx`.
  Today the only way to route through these models is
  `input_audio_transcription_model` on the Realtime engine.
- `gpt-4o-mini-realtime-preview`'s pricing entry is flagged in a code
  comment (`pricing.py` / `pricing.ts`) as no longer listed on OpenAI's
  current published pricing page as of 2026-08-24; rates are kept unchanged
  from the last verified value since the SDK can't independently confirm
  them, and new integrations shouldn't be routed to it.
- No files in this diff cross the 800-line hard cap or the 500-line Patter
  preference on their own — all changes are additive entries inside existing
  catalog/enum files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
