### PR TITLE
feat(init): Telnyx STT/TTS parity in patter init wizard + README + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ TWILIO_AUTH_TOKEN=your-twilio-auth-token
 TWILIO_PHONE_NUMBER=+1xxxxxxxxxx
 
 # Telnyx (alternative to Twilio — full GA support for DTMF, transfer, recording)
+# The same TELNYX_API_KEY also powers TelnyxSTT and TelnyxTTS in pipeline mode
+# (on-network speech — single bill, no extra provider keys needed).
 # TELNYX_API_KEY=KEY...
 # TELNYX_CONNECTION_ID=...
 # TELNYX_PHONE_NUMBER=+1xxxxxxxxxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
   - Docs: `xai-tts.mdx` Voices section links the catalog and helpers in
     both SDKs.
 
+- **Telnyx STT/TTS parity in `patter init`** — the setup wizard now lists
+  `TelnyxSTT` and `TelnyxTTS` in the pipeline provider tables (both SDKs),
+  so picking Telnyx as the carrier no longer hides on-network speech as a
+  pipeline option. Both reuse `TELNYX_API_KEY` (the same key the carrier
+  already reads) and the existing `telnyx-ai` pip extra. README provider
+  table and `.env.example` updated to match.
+
 - **Fish Audio voice provider suite** — TTS (S2.1-Pro / S2-Pro) and ASR land in
   both SDKs, wired end-to-end with real pricing. One `FISH_AUDIO_API_KEY`
   covers both directions of the call:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Patter is the **full voice stack** between your application and the phone networ
 | Layer | Choose from |
 |---|---|
 | **LLM** — text generation | OpenAI · Anthropic · Google Gemini · Groq · Cerebras |
-| **STT** — speech-to-text | Deepgram · AssemblyAI · Cartesia · Soniox · Speechmatics · Whisper · Fish Audio |
+| **STT** — speech-to-text | Deepgram · AssemblyAI · Cartesia · Soniox · Speechmatics · Whisper · Fish Audio · Telnyx |
 | **TTS** — text-to-speech | ElevenLabs · OpenAI · Cartesia · LMNT · Rime · Telnyx · Fish Audio |
 | **Realtime** — all-in-one voice | OpenAI Realtime · Gemini Live · Ultravox · ElevenLabs ConvAI |
 | **Telephony** — phone carriers | Twilio · Telnyx · Plivo |

--- a/libraries/python/getpatter/init/cli.py
+++ b/libraries/python/getpatter/init/cli.py
@@ -141,6 +141,12 @@ PIPELINE_STT: dict[str, dict] = {
         "env": ("XAI_API_KEY",),
         "extra": "xai",
     },
+    "telnyx": {
+        "class": "TelnyxSTT",
+        "label": "Telnyx (on-network — telnyx/google/deepgram/azure)",
+        "env": ("TELNYX_API_KEY",),
+        "extra": "telnyx-ai",
+    },
 }
 DEFAULT_STT = "deepgram"
 
@@ -228,6 +234,12 @@ PIPELINE_TTS: dict[str, dict] = {
         "label": "xAI Grok",
         "env": ("XAI_API_KEY",),
         "extra": "xai",
+    },
+    "telnyx": {
+        "class": "TelnyxTTS",
+        "label": "Telnyx (NaturalHD — on-network)",
+        "env": ("TELNYX_API_KEY",),
+        "extra": "telnyx-ai",
     },
 }
 DEFAULT_TTS = "elevenlabs"

--- a/libraries/typescript/src/init/cli.ts
+++ b/libraries/typescript/src/init/cli.ts
@@ -131,6 +131,12 @@ const PIPELINE_STT: Record<string, ProviderEntry> = {
     env: ['XAI_API_KEY'],
     extra: 'xai',
   },
+  telnyx: {
+    cls: 'TelnyxSTT',
+    label: 'Telnyx (on-network — telnyx/google/deepgram/azure)',
+    env: ['TELNYX_API_KEY'],
+    extra: 'telnyx-ai',
+  },
 };
 const DEFAULT_STT = 'deepgram';
 
@@ -218,6 +224,12 @@ const PIPELINE_TTS: Record<string, ProviderEntry> = {
     label: 'xAI Grok (eve default)',
     env: ['XAI_API_KEY'],
     extra: 'xai',
+  },
+  telnyx: {
+    cls: 'TelnyxTTS',
+    label: 'Telnyx (NaturalHD — on-network)',
+    env: ['TELNYX_API_KEY'],
+    extra: 'telnyx-ai',
   },
 };
 const DEFAULT_TTS = 'elevenlabs';


### PR DESCRIPTION
## Summary

The `patter init` setup wizard lists Telnyx as a **carrier** but not as a pipeline **STT** or **TTS** provider, even though `TelnyxSTT` and `TelnyxTTS` ship in both SDKs, are exported from the package root, and have full docs pages (`docs/{python,typescript}-sdk/providers/telnyx-{stt,tts}.mdx`). Picking Telnyx as the carrier silently hides on-network speech as a pipeline option — a builder who chooses Telnyx for telephony has no idea they can also use Telnyx for STT/TTS on the same key, on the same bill, with no extra provider signup.

This PR closes that discoverability gap. It does **not** add new providers, new env vars, or new dependencies — `TelnyxSTT` and `TelnyxTTS` are already wired and exported. It only surfaces them in the wizard catalog, the README table, and `.env.example`.

## Changes

- **`libraries/python/getpatter/init/cli.py`** — add `telnyx` to `PIPELINE_STT` (class `TelnyxSTT`, env `TELNYX_API_KEY`, extra `telnyx-ai`) and `PIPELINE_TTS` (class `TelnyxTTS`, same env + extra).
- **`libraries/typescript/src/init/cli.ts`** — same two entries in the TS wizard's `PIPELINE_STT` and `PIPELINE_TTS` records (parity).
- **`README.md`** — add `Telnyx` to the STT provider row (was already in the TTS and Telephony rows).
- **`.env.example`** — two comment lines under the Telnyx block noting that the same `TELNYX_API_KEY` powers `TelnyxSTT` and `TelnyxTTS` in pipeline mode.
- **`CHANGELOG.md`** — entry under Unreleased.

## Why no new env vars or deps

Both providers reuse `TELNYX_API_KEY` (the same key the `Telnyx()` carrier already reads) and the existing `telnyx-ai` pip extra (`aiohttp>=3.10`). Verified against `libraries/python/getpatter/providers/telnyx_stt.py:102` and `telnyx_tts.py:67` (both take `api_key` as the first constructor arg) and `libraries/python/pyproject.toml` (`telnyx-ai = ["aiohttp>=3.10"]`).

## Pre-merge checklist

- [x] **Both SDKs updated** — matching Python and TypeScript wizard entries.
- [x] **`CHANGELOG.md` updated** — entry under Unreleased.
- [x] **No secrets, credentials, or real phone numbers / PII** — only placeholder values (`KEY...`, `+1xxxxxxxxxx`) and env var names.
- [x] **No external license headers or "ported from <repo>" provenance comments** in source files.
- [ ] **Local validation is green** — pre-commit and test suite not run locally (no pre-commit installed in this environment); Python syntax verified via `ast.parse`, no whitespace errors via `git diff --check`, no real secrets via grep scan. CI will run the full gate.

## Breaking change?

No. Adding entries to the wizard provider dicts only surfaces new choices in `patter init`; it does not change defaults (`DEFAULT_STT = "deepgram"`, `DEFAULT_TTS = "elevenlabs"` unchanged) or runtime behavior for existing users.

## Context

Follow-up to #103 (docs: Telnyx quickstart parity, merged May 25) and #106 (feat: Telnyx recording parity, merged May 25). The `patter init` wizard shipped in #191 (June 24, v0.6.9), after those PRs, so Telnyx STT/TTS was never wired into the wizard catalog.